### PR TITLE
Update course-shell.md - correct misuse of shell

### DIFF
--- a/_2020/course-shell.md
+++ b/_2020/course-shell.md
@@ -365,7 +365,7 @@ there.
  3. Use `touch` to create a new file called `semester` in `missing`.
  4. Write the following into that file, one line at a time:
     ```
-    #!/bin/sh
+    #!/bin/bash
     curl --head --silent https://missing.csail.mit.edu
     ```
     The first line might be tricky to get working. It's helpful to know that


### PR DESCRIPTION
In step 4 of the exercises, you mention the first line of the file and talk about how Bash interprets the shebang characters. Unfortunately /bin/sh is the POSIX compliant Bourne shell, Bash is the Bourne Again SHell and has extensions to the Bourne shell that do not exist in the Bourne shell. This corrects that misuse.

While /bin/sh is guaranteed to exist on all POSIX compliant operating systems and /bin/bash is not,  that's a different topic altogether.