### PR TITLE
incorrect link in exercises: terminal multiplexer

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -466,7 +466,7 @@ One way to achieve this is to use the [`wait`](http://man7.org/linux/man-pages/m
 
 ## Terminal multiplexer
 
-1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/).
+1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
 
 ## Aliases
 


### PR DESCRIPTION
Second link in Exercises: Terminal multiplexer is a duplicate of the first link.
Currently, both point to https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/
Did you mean to direct the second link (about customizing your tmux conf) to the sequel blog post from the Ham Vocke at https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/ ?