### PR TITLE
link to info about ssh-agent is incorrect

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -492,7 +492,7 @@ Let's get you up to speed with dotfiles.
 
 Install a Linux virtual machine (or use an already existing one) for this exercise. If you are not familiar with virtual machines check out [this](https://hibbard.eu/install-ubuntu-virtual-box/) tutorial for installing one.
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -o -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent` , more info [here](https://www.ssh.com/ssh/agents).
+1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -o -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent` , more info [here](https://www.ssh.com/ssh/agent).
 1. Edit `.ssh/config` to have an entry as follows
 
 ```bash


### PR DESCRIPTION
linked url: https://www.ssh.com/ssh/agents
correct url: https://www.ssh.com/ssh/agent