### PR TITLE
Debugging-Profiling - fix exercise autonumbers and indenting

### DIFF
--- a/_2020/debugging-profiling.md
+++ b/_2020/debugging-profiling.md
@@ -475,16 +475,15 @@ If there aren't any you can execute some harmless commands such as `sudo ls` and
 
 1. Install [`shellcheck`](https://www.shellcheck.net/) and try checking the following script. What is wrong with the code? Fix it. Install a linter plugin in your editor so you can get your warnings automatically.
 
-
-```bash
-#!/bin/sh
-## Example: a typical script with several problems
-for f in $(ls *.m3u)
-do
-  grep -qi hq.*mp3 $f \
-    && echo -e 'Playlist $f contains a HQ file in mp3 format'
-done
-```
+   ```bash
+   #!/bin/sh
+   ## Example: a typical script with several problems
+   for f in $(ls *.m3u)
+   do
+     grep -qi hq.*mp3 $f \
+       && echo -e 'Playlist $f contains a HQ file in mp3 format'
+   done
+   ```
 
 1. (Advanced) Read about [reversible debugging](https://undo.io/resources/reverse-debugging-whitepaper/) and get a simple example working using [`rr`](https://rr-project.org/) or [`RevPDB`](https://morepypy.blogspot.com/2016/07/reverse-debugging-for-python.html).
 ## Profiling
@@ -493,25 +492,25 @@ done
 
 1. Here's some (arguably convoluted) Python code for computing Fibonacci numbers using a function for each number.
 
-```python
-#!/usr/bin/env python
-def fib0(): return 0
+   ```python
+   #!/usr/bin/env python
+   def fib0(): return 0
 
-def fib1(): return 1
+   def fib1(): return 1
 
-s = """def fib{}(): return fib{}() + fib{}()"""
+   s = """def fib{}(): return fib{}() + fib{}()"""
 
-if __name__ == '__main__':
+   if __name__ == '__main__':
 
-    for n in range(2, 10):
-        exec(s.format(n, n-1, n-2))
-    # from functools import lru_cache
-    # for n in range(10):
-    #     exec("fib{} = lru_cache(1)(fib{})".format(n, n))
-    print(eval("fib9()"))
-```
+       for n in range(2, 10):
+           exec(s.format(n, n-1, n-2))
+       # from functools import lru_cache
+       # for n in range(10):
+       #     exec("fib{} = lru_cache(1)(fib{})".format(n, n))
+       print(eval("fib9()"))
+   ```
 
-Put the code into a file and make it executable. Install [`pycallgraph`](http://pycallgraph.slowchop.com/en/master/). Run the code as is with `pycallgraph graphviz -- ./fib.py` and check the `pycallgraph.png` file. How many times is `fib0` called?. We can do better than that by memoizing the functions. Uncomment the commented lines and regenerate the images. How many times are we calling each `fibN` function now?
+   Put the code into a file and make it executable. Install [`pycallgraph`](http://pycallgraph.slowchop.com/en/master/). Run the code as is with `pycallgraph graphviz -- ./fib.py` and check the `pycallgraph.png` file. How many times is `fib0` called?. We can do better than that by memoizing the functions. Uncomment the commented lines and regenerate the images. How many times are we calling each `fibN` function now?
 
 1. A common issue is that a port you want to listen on is already taken by another process. Let's learn how to discover that process pid. First execute `python -m http.server 4444` to start a minimal web server listening on port `4444`. On a separate terminal run `lsof | grep LISTEN` to print all listening processes and ports. Find that process pid and terminate it by running `kill <PID>`.
 


### PR DESCRIPTION
Exercises numbers were incorrect because the code blocks were not indented. This PR indents the code blocks and post-block exercise text so that Markdown interprets the numbered lists correctly. Only the debugging-profiling.md page has been edited.