### PR TITLE
Describe the shell parameter $! correctly

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -64,7 +64,7 @@ We can then continue the paused job in the foreground or in the background using
 
 The [`jobs`](http://man7.org/linux/man-pages/man1/jobs.1p.html) command lists the unfinished jobs associated with the current terminal session.
 You can refer to those jobs using their pid (you can use [`pgrep`](http://man7.org/linux/man-pages/man1/pgrep.1.html) to find that out).
-More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` environment variable.
+More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` special parameter.
 
 One more thing to know is that the `&` suffix in a command will run the command in the background, giving you the prompt back, although it will still use the shell's STDOUT which can be annoying (use shell redirections in that case).
 


### PR DESCRIPTION
`$!` is a special parameter, not an environment variable.

"special parameter" is used in both the Open Group specification:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

and the bash documentation:
https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html