### PR TITLE
Typo in command-line.md

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -406,7 +406,7 @@ An additional advantage of using the `~/.ssh/config` file over aliases  is that 
 
 Note that the `~/.ssh/config` file can be considered a dotfile, and in general it is fine for it to be included with the rest of your dotfiles. However, if you make it public, think about the information that you are potentially providing strangers on the internet: addresses of your servers, users, open ports, &c. This may facilitate some types of attacks so be thoughtful about sharing your SSH configuration.
 
-Server side configuration is usually specified in `/etc/ssh/sshd_config`. Here you can make changes like disabling password authentication, changing ssh ports, enabling X11 forwarding, &c. You can specify config settings in a per user basis.
+Server side configuration is usually specified in `/etc/ssh/sshd_config`. Here you can make changes like disabling password authentication, changing ssh ports, enabling X11 forwarding, &c. You can specify config settings on a per user basis.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Fixed a typo in command-lind.md
Specifically, under SSH configuration, changed "You can specify config settings **in** a per user basis." to "You can specify config settings **on** a per user basis."