### PR TITLE
fix typo in _2020/data-wrangling.md

### DIFF
--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -110,7 +110,7 @@ you can pass `-E`.
 
 So, looking back at `/.*Disconnected from /`, we see that it matches
 any text that starts with any number of characters, followed by the
-literal string "Disconnected from ". Which is what we wanted. But
+literal string "Disconnected from". Which is what we wanted. But
 beware, regular expressions are trixy. What if someone tried to log in
 with the username "Disconnected from"? We'd have:
 


### PR DESCRIPTION
Delete a redundant whitespace here, so it will become a closing quotation mark instead of a open one.
![image](https://user-images.githubusercontent.com/28699492/82747911-4d11ec00-9dd0-11ea-9828-b7a8c2dd0be7.png)
