### PR TITLE
Add the translate to Korean version

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,8 +70,8 @@ benefit from these resources. You can find posts and discussion on
 # Translations
 
 - [Chinese: missing-semester-cn.github.io](https://missing-semester-cn.github.io/)
-- [Turkish: missing-semester-tr.github.io](https://missing-semester-tr.github.io/)
 - [Korean: missing-semester-kr.github.io](https://missing-semester-kr.github.io/)
+- [Turkish: missing-semester-tr.github.io](https://missing-semester-tr.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.

--- a/index.md
+++ b/index.md
@@ -71,6 +71,7 @@ benefit from these resources. You can find posts and discussion on
 
 - [Chinese: missing-semester-cn.github.io](https://missing-semester-cn.github.io/)
 - [Turkish: missing-semester-tr.github.io](https://missing-semester-tr.github.io/)
+- [Korean: missing-semester-kr.github.io](https://missing-semester-kr.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.


### PR DESCRIPTION
Hi!

First of all, I want to say "Thank you" to share this class. 👏🏿👏🏼👏🏾👏🏻👏🏽

I forked this repository and started to translate Korean: [https://missing-semester-kr.github.io](https://missing-semester-kr.github.io). Like @hasantezcan, I also translated the main, about, lecture pages. And I will share this class and translated version to my community, then I would like to translate it with community members.

Korean repo: [https://github.com/missing-semester-kr/missing-semester-kr.github.io](https://github.com/missing-semester-kr/missing-semester-kr.github.io)
Korean site: [https://missing-semester-kr.github.io](https://missing-semester-kr.github.io)