### PR TITLE
Fix description of "git diff <filename>"

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -428,7 +428,7 @@ index 94bab17..f0013b2 100644
     - Even more reasons to write [good commit messages](https://chris.beams.io/posts/git-commit/)!
 - `git log`: shows a flattened log of history
 - `git log --all --graph --decorate`: visualizes history as a DAG
-- `git diff <filename>`: show changes you made relative to the staging area for the next commit
+- `git diff <filename>`: show changes you made relative to the staging area
 - `git diff <revision> <filename>`: shows differences in a file between snapshots
 - `git checkout <revision>`: updates HEAD and current branch
 

--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -95,7 +95,7 @@ something like this:
 
 ```
 o <-- o <-- o <-- o
-            ^  
+            ^
              \
               --- o <-- o
 ```
@@ -428,7 +428,7 @@ index 94bab17..f0013b2 100644
     - Even more reasons to write [good commit messages](https://chris.beams.io/posts/git-commit/)!
 - `git log`: shows a flattened log of history
 - `git log --all --graph --decorate`: visualizes history as a DAG
-- `git diff <filename>`: show differences since the last commit
+- `git diff <filename>`: show changes you made relative to the staging area for the next commit
 - `git diff <revision> <filename>`: shows differences in a file between snapshots
 - `git checkout <revision>`: updates HEAD and current branch
 


### PR DESCRIPTION
The description of "git diff \<filename\>" was not correct. If you made some changes since last commit but have already staged it, then "git diff" will not show anything. Reference: [git-scm.com/docs/git-diff](url)