### PR TITLE
Fix TOC entry for hammerspoon

### DIFF
--- a/_2020/potpourri.md
+++ b/_2020/potpourri.md
@@ -19,7 +19,7 @@ video:
 - [Window managers](#window-managers)
 - [VPNs](#vpns)
 - [Markdown](#markdown)
-- [Hammerspoon(desktop-automation-on-macOS)](#hammerspoon-desktop-automation-on-macos)
+- [Hammerspoon (desktop automation on macOS)](#hammerspoon-desktop-automation-on-macos)
 - [Booting + Live USBs](#booting--live-usbs)
 - [Docker, Vagrant, VMs, Cloud, OpenStack](#docker-vagrant-vms-cloud-openstack)
 - [Notebook programming](#notebook-programming)


### PR DESCRIPTION
Sorry, I forgot to add this to the previous PR. I hope it doesn't break whatever Markdown parser you use; should be Commonmark compliant.