### PR TITLE
Added Vietnamese translation site link

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,6 +74,7 @@ benefit from these resources. You can find posts and discussion on
 - [Korean](https://missing-semester-kr.github.io/)
 - [Spanish](https://missing-semester-esp.github.io/)
 - [Turkish](https://missing-semester-tr.github.io/)
+- [Vietnamese](https://missing-semester-vn.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.


### PR DESCRIPTION
Hi, thank you for the awesome course materials, they are really helpful for us student.
I started the translation of the website into Vietnamese (finished about.md).

The translation repo can be found at https://github.com/missing-semester-vn/missing-semester-vn.github.io
and the Vietnamese website is at https://missing-semester-vn.github.io/

Other Vietnameses, you are welcome to contribute too!