### PR TITLE
fix small typo in data-wrangling lecture

### DIFF
--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -116,7 +116,7 @@ you can pass `-E`.
 So, looking back at `/.*Disconnected from /`, we see that it matches
 any text that starts with any number of characters, followed by the
 literal string "Disconnected from &rdquo;. Which is what we wanted. But
-beware, regular expressions are trixy. What if someone tried to log in
+beware, regular expressions are tricky. What if someone tried to log in
 with the username "Disconnected from"? We'd have:
 
 ```


### PR DESCRIPTION
I've been following the Exercises in the Version Control lecture and went looking for a typo in the lecture notes so I could submit practice submitting a pull request.  I noticed the Data Wrangling lecture contains the word 'trixy' which I think should be 'tricky'.