### PR TITLE
Update data-wrangling.md -- clarify wording

### DIFF
--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -439,5 +439,4 @@ ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
    data. If you're fetching HTML data,
    [`pup`](https://github.com/EricChiang/pup) might be helpful. For JSON
    data, try [`jq`](https://stedolan.github.io/jq/). Find the min and
-   max of one column in a single command, and the sum of the difference
-   between the two columns in another.
+   max of one column in a single command, and the difference of the sum of each column in another.

--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -439,4 +439,5 @@ ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
    data. If you're fetching HTML data,
    [`pup`](https://github.com/EricChiang/pup) might be helpful. For JSON
    data, try [`jq`](https://stedolan.github.io/jq/). Find the min and
-   max of one column in a single command, and the difference of the sum of each column in another.
+   max of one column in a single command, and the difference of the sum
+   of each column in another.


### PR DESCRIPTION
I initially re-read the "sum of the difference between the two columns" a few times. Subtracting each row individually across the columns and then summing is equivalent to summing each column and then subtracting, so I figured changing the wording could be useful for others. Let me know if I am misunderstanding the exercise provided.

the sum of the difference between the two columns
-->
the difference of the sum of each column