### PR TITLE
Add Github action workflow to lint prose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: 'Trigger: Push action'
+jobs:
+  write_good_job:
+    runs-on: ubuntu-latest
+    name: A job to lint Markdown files
+    steps:
+    - uses: actions/checkout@v2
+    - name: write-good action step
+      id: write-good
+      uses: tomwhross/write-good@v1
+    # Use the output from the `write-good` step
+    - name: Get the write-good output
+      run: echo "${{ steps.write-good.outputs.result }}"
+    - name: Post comment
+      uses: mshick/add-pr-comment@v1
+      if: ${{ steps.write-good.outputs.result }}
+      with:
+        message: |
+          ${{ steps.write-good.outputs.result }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+        allow-repeats: false # This is the default
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: write-good action step
       id: write-good
-      uses: tomwhross/write-good@v1
+      uses: tomwhross/write-good-action@v1
     # Use the output from the `write-good` step
     - name: Get the write-good output
       run: echo "${{ steps.write-good.outputs.result }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,4 @@
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 name: 'Trigger: Push action'
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 name: 'Trigger: Push action'
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: write-good action step
       id: write-good
-      uses: tomwhross/write-good-action@v1
+      uses: tomwhross/write-good-action@v1.2
     # Use the output from the `write-good` step
     - name: Get the write-good output
       run: echo "${{ steps.write-good.outputs.result }}"

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+So the cat was probably stolen

--- a/test.md
+++ b/test.md
@@ -1,1 +1,0 @@
-So the cat was probably stolen


### PR DESCRIPTION
Uses [the first action I've created and published](https://github.com/marketplace/actions/lint-markdown) to run write-good on Markdown files. Works well with `add-pr-comment` to have bot post a comment with the output from `write-good` if there is any. Purely informational; does not fail the check if output is generated.

 - use checkout to access repo files
 - use write-good-action to lint prose in Markdown files
 - use add-pr-comment to add comment to PR with write-good output if any
 - this will never reject a PR or commit based on write-good's output,
   this is informational only, and the PR author is free to ignore as
   write-good can be opinionated

<img width="750" alt="image" src="https://user-images.githubusercontent.com/69170368/98688129-89aeb100-2338-11eb-86df-0e84f8e37d1c.png">
