### PR TITLE
Fix background style on merging branches diagram

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -109,11 +109,13 @@ these branches may be merged to create a new snapshot that incorporates both of
 the features, producing a new history that looks like this, with the newly
 created merge commit shown in bold:
 
-<pre>
+<pre class="highlight">
+<code>
 o <-- o <-- o <-- o <---- <strong>o</strong>
             ^            /
              \          v
               --- o <-- o
+</code>
 </pre>
 
 Commits in Git are immutable. This doesn't mean that mistakes can't be


### PR DESCRIPTION
On the [version control page](https://missing.csail.mit.edu/2020/version-control/) the merging branches diagram looks different than all the others and is hard to read (2nd diagram in image). 

![image](https://user-images.githubusercontent.com/1371996/99447628-44b4ec80-28ed-11eb-98f6-2c6e17827255.png)

This PR brings it in line with all the other diagrams on the page so now it looks like this: 

![image](https://user-images.githubusercontent.com/1371996/99447780-4e3e5480-28ed-11eb-8497-8af5482c3785.png)
