### PR TITLE
placed license inside a href attribute tag

### DIFF
--- a/index.md
+++ b/index.md
@@ -97,6 +97,6 @@ AeroAstro](https://aeroastro.mit.edu/) for A/V equipment; and Brandi Adams and
 
 <div class="small center">
 <p><a href="https://github.com/missing-semester/missing-semester">Source code</a>.</p>
-<p>Licensed under CC BY-NC-SA.</p>
+<p>Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0">CC BY-NC-SA</a>.</p>
 <p>See <a href="/license/">here</a> for contribution &amp; translation guidelines.</p>
 </div>


### PR DESCRIPTION
The homepage footer was missing a link to the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License