### PR TITLE
Add a link to the Japanese translation

### DIFF
--- a/index.md
+++ b/index.md
@@ -71,6 +71,7 @@ benefit from these resources. You can find posts and discussion on
 
 - [Chinese (Simplified)](https://missing-semester-cn.github.io/)
 - [Chinese (Traditional)](https://missing-semester-zh-hant.github.io/)
+- [Japanese](https://missing-semester-jp.github.io/)
 - [Korean](https://missing-semester-kr.github.io/)
 - [Portuguese](https://missing-semester-pt.github.io/)
 - [Russian](https://missing-semester-rus.github.io/)


### PR DESCRIPTION
Thank you for this great material! Our team started to translate it into Japanese. I would appreciate it if you could add the link.

Web: https://missing-semester-jp.github.io/
GIthub: https://github.com/missing-semester-jp/missing-semester-jp.github.io

Best,
Yusuke