### PR TITLE
Fix filename in the text to match the example

### DIFF
--- a/_2020/metaprogramming.md
+++ b/_2020/metaprogramming.md
@@ -96,7 +96,7 @@ make: *** No rule to make target 'plot-data.png', needed by 'paper.pdf'.  Stop.
 ```
 
 Hmm, interesting, there _is_ a rule to make `plot-data.png`, but it is a
-pattern rule. Since the source files do not exist (`foo.dat`), `make`
+pattern rule. Since the source files do not exist (`data.dat`), `make`
 simply states that it cannot make that file. Let's try creating all the
 files:
 


### PR DESCRIPTION
Because `plot-data.png` depends on `data.dat` in a pattern rule, here it should also be `data.dat` but not `foot.dat`.