### PR TITLE
Add plural to parent variable

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -136,7 +136,7 @@ type tree = map<string, tree | blob>
 
 // a commit has parents, metadata, and the top-level tree
 type commit = struct {
-    parent: array<commit>
+    parents: array<commit>
     author: string
     message: string
     snapshot: tree


### PR DESCRIPTION
Add a plural to the parent variable in the version control lecture. It is more coherent with the surrounding text always using plural.