### PR TITLE
Add link to Git alias section in exercise

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -554,7 +554,7 @@ class website](https://github.com/missing-semester/missing-semester).
 1. Like many command line tools, Git provides a configuration file (or dotfile)
    called `~/.gitconfig`. Create an alias in `~/.gitconfig` so that when you
    run `git graph`, you get the output of `git log --all --graph --decorate
-   --oneline`.
+   --oneline`. Information about git aliases can be found [here](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias).
 1. You can define global ignore patterns in `~/.gitignore_global` after running
    `git config --global core.excludesfile ~/.gitignore_global`. Do this, and
    set up your global gitignore file to ignore OS-specific or editor-specific


### PR DESCRIPTION
There is no explanation for how to add aliases to the git config
given in the course, so having a link to gits documentation might
help guide students.

This commit is done as a part of [exercise 7][1].

[1]: https://missing.csail.mit.edu/2020/version-control/#exercises