### PR TITLE
Fix kill parameter to list signals.

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -122,7 +122,7 @@ $ jobs
 
 A special signal is `SIGKILL` since it cannot be captured by the process and it will always terminate it immediately. However, it can have bad side effects such as leaving orphaned children processes.
 
-You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -t`.
+You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -l`.
 
 
 # Terminal Multiplexers


### PR DESCRIPTION
`-t` isn't recognized argument by the `kill` program. Tested with bash, zsh built-in commands and the one usually found in `/bin/kill`.

I assume that the `-l` option was meant which lists available signal names.