### PR TITLE
Add a really nice strace zine resource

### DIFF
--- a/_2020/debugging-profiling.md
+++ b/_2020/debugging-profiling.md
@@ -140,7 +140,7 @@ Even if what you are trying to debug is a black box binary there are tools that 
 Whenever programs need to perform actions that only the kernel can, they use [System Calls](https://en.wikipedia.org/wiki/System_call).
 There are commands that let you trace the syscalls your program makes. In Linux there's [`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) and macOS and BSD have [`dtrace`](http://dtrace.org/blogs/about/). `dtrace` can be tricky to use because it uses its own `D` language, but there is a wrapper called [`dtruss`](https://www.manpagez.com/man/1/dtruss/) that provides an interface more similar to `strace` (more details [here](https://8thlight.com/blog/colin-jones/2015/11/06/dtrace-even-better-than-strace-for-osx.html)).
 
-Below are some examples of using `strace` or `dtruss` to show [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) syscall traces for an execution of `ls`. For a deeper dive into `strace`, [this](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) is a good read.
+Below are some examples of using `strace` or `dtruss` to show [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) syscall traces for an execution of `ls`. For a deeper dive into `strace`, [this article](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) and [this zine](https://jvns.ca/strace-zine-unfolded.pdf) are good reads.
 
 ```bash
 # On Linux


### PR DESCRIPTION
Adding a link to [strace zine](https://jvns.ca/strace-zine-unfolded.pdf) from [jvns](https://jvns.ca/)' blog.

She has some interesting [resources](https://jvns.ca/categories/strace/) on practical strace usage, so I thought it might be a good pointer for readers.