### PR TITLE
Update shell-tools section to include reference to Fig autocomplete

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -188,6 +188,8 @@ Sometimes manpages can provide overly detailed descriptions of the commands, mak
 [TLDR pages](https://tldr.sh/) are a nifty complementary solution that focuses on giving example use cases of a command so you can quickly figure out which options to use.
 For instance, I find myself referring back to the tldr pages for [`tar`](https://tldr.ostera.io/tar) and [`ffmpeg`](https://tldr.ostera.io/ffmpeg) way more often than the manpages.
 
+Finally context-switching between your terminal and `man`, `--help`, and TLDR pages can be cumbersome. The tool, [Fig](https://fig.io) offers inline suggestions and descriptions for a CLI's subcommands, options, and arguments. It ranks suggestions by recency of use and like TLDR, includes suggestions for the most common workflows you do with a command.
+
 
 ## Finding files
 


### PR DESCRIPTION
[Fig](https://fig.io) adds visual autocomplete to your existing terminal. It uses its open source repository ([withfig/autocomplete](https://github.com/withfig/autocomplete)) of completions to generate suggestions for hundreds of CLI tools. 

It is used by thousands of people daily from beginners to seasoned shell veterans to make using the terminal / shell more efficient and discoverable. 

I think it is objectively a high value add for shell users with no down-sides and would therefore be an incredibly useful addition to the shell-tools section of missing-semester.