### PR TITLE
Use --no-echo for R option

### DIFF
--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -341,7 +341,7 @@ ssh myserver journalctl
  | grep "Disconnected from"
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
  | sort | uniq -c
- | awk '{print $1}' | R --slave -e 'x <- scan(file="stdin", quiet=TRUE); summary(x)'
+ | awk '{print $1}' | R --no-echo -e 'x <- scan(file="stdin", quiet=TRUE); summary(x)'
 ```
 
 R is another (weird) programming language that's great at data analysis


### PR DESCRIPTION
As of spring 2020, the command-line option --slave is deprecated.
(https://github.com/wch/r-source/blob/trunk/src/main/CommandLineArgs.c#L156-L158)
Using --no-echo would make R run as quietly as possible, and be
understandable to programming students. (https://www.mankier.com/1/R)