### PR TITLE
Private key path is expected after -i of ssh client

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -352,7 +352,7 @@ cat .ssh/id_ed25519.pub | ssh foobar@remote 'cat >> ~/.ssh/authorized_keys'
 A simpler solution can be achieved with `ssh-copy-id` where available:
 
 ```bash
-ssh-copy-id -i .ssh/id_ed25519.pub foobar@remote
+ssh-copy-id -i .ssh/id_ed25519 foobar@remote
 ```
 
 ## Copying files over SSH


### PR DESCRIPTION
According to `man ssh`. On macOS, if public key path is specified, user would come across `Permissions 0644 for '/Users/username/.ssh/id_ed25519.pub' are too open`.