### PR TITLE
Add Git's master-to-main change information

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -197,8 +197,8 @@ because humans aren't good at remembering strings of 40 hexadecimal characters.
 Git's solution to this problem is human-readable names for SHA-1 hashes, called
 "references". References are pointers to commits. Unlike objects, which are
 immutable, references are mutable (can be updated to point to a new commit).
-For example, the `master` reference usually points to the latest commit in the
-main branch of development.
+For example, the `master` ([now renamed to `main`](https://github.com/github/renaming.git)) 
+reference usually points to the latest commit in the main branch of development.
 
 ```
 references = map<string, string>


### PR DESCRIPTION
I study The Missing Semester of Your CS Education and this is my contributing practice with git. I add the information that Git changed its default reference from `master` to `main`. 
Love your course ❤️ 