### PR TITLE
Feature: Show URL after Links in Print View

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -373,5 +373,7 @@ input[type=checkbox]:checked ~ .menu-label:after {
   #content hr:last-of-type { display: none; }
   #content pre { break-inside: avoid-page; page-break-inside: avoid; }
   #content div.small:last-of-type { display: none; }
-  a::after { content: "("attr(href)")"; font-family: monospace; margin: 0 .25em; }
+  a[href^="https://"]::after, a[href^="http://"]::after {
+    content: "("attr(href)")"; font-family: monospace; margin: 0 .25em;
+  }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -373,4 +373,5 @@ input[type=checkbox]:checked ~ .menu-label:after {
   #content hr:last-of-type { display: none; }
   #content pre { break-inside: avoid-page; page-break-inside: avoid; }
   #content div.small:last-of-type { display: none; }
+  a::after { content: "("attr(href)")"; font-family: monospace; margin: 0 .25em; }
 }


### PR DESCRIPTION
Added CSS rule to print the URL after an external link in print view.
This might come in handy as some people still like to print out their stuff.