### PR TITLE
Fix a wrong usage of ! within double quotation marks

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -248,7 +248,7 @@ For now I am sticking with ripgrep (`rg`), given how fast and intuitive it is. S
 # Find all python files where I used the requests library
 rg -t py 'import requests'
 # Find all files (including hidden files) without a shebang line
-rg -u --files-without-match "^#!"
+rg -u --files-without-match "^#\!"
 # Find all matches of foo and print the following 5 lines
 rg foo -A 5
 # Print statistics of matches (# of matched lines and files )


### PR DESCRIPTION
In file `_2020/shell-tools.md`, a `\` should be added to the front of `!` inside `""`.