### PR TITLE
change `.zhistory` to `.zsh_history`

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -281,7 +281,7 @@ It can be enabled in [zsh](https://github.com/zsh-users/zsh-autosuggestions) and
 
 You can modify your shell's history behavior, like preventing commands with a leading space from being included. This comes in handy when you are typing commands with passwords or other bits of sensitive information.
 To do this, add `HISTCONTROL=ignorespace` to your `.bashrc` or `setopt HIST_IGNORE_SPACE` to your `.zshrc`.
-If you make the mistake of not adding the leading space, you can always manually remove the entry by editing your `.bash_history` or `.zhistory`.
+If you make the mistake of not adding the leading space, you can always manually remove the entry by editing your `.bash_history` or `.zsh_history`.
 
 ## Directory Navigation
 


### PR DESCRIPTION
I found that the history of zsh on my Mac is `zsh_history`, not `zhistory`.