### PR TITLE
Text inside pre is visible while printing as pdf.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -372,7 +372,7 @@ input[type=checkbox]:checked ~ .menu-label:after {
   h1.title { text-align: center; }
   h1, h2, h3, h4, h5, h6 { break-after: avoid-page; page-break-after: avoid; }
   #content hr:last-of-type { display: none; }
-  #content pre { break-inside: avoid-page; page-break-inside: avoid; }
+  #content pre { break-inside: avoid-page; page-break-inside: avoid; white-space: pre-wrap; }
   #content div.small:last-of-type { display: none; }
   a[href^="https://"]::after, a[href^="http://"]::after {
     content: "("attr(href)")"; font-family: monospace; margin: 0 .25em;


### PR DESCRIPTION
When printing as pdf some of the text inside pre tags was not visible due to overflow. This solves that, by making the text wrap inside pre tags when printing.