### PR TITLE
Add info for infinite recursion in macros section.

### DIFF
--- a/_2020/editors.md
+++ b/_2020/editors.md
@@ -392,7 +392,9 @@ better way of doing this", there probably is: look it up online.
 - Macros can be recursive
     - first clear the macro with `q{character}q`
     - record the macro, with `@{character}` to invoke the macro recursively
-    (will be a no-op until recording is complete)
+    (will be a no-op until recording is complete). Note however that although
+    it's legal for a macro to call another macro, calling itself runs
+    into infinite loop.
 - Example: convert xml to json ([file](/2020/files/example-data.xml))
     - Array of objects with keys "name" / "email"
     - Use a Python program?


### PR DESCRIPTION
When we say macros are recursive, we're perhaps implying that
a macro definition may refer to another macro but not itself.
Calling itself runs into infinite recursion.
Although not the official vim repo, see the details
[here.](https://github.com/VSCodeVim/Vim/issues/1309)
