### PR TITLE
Update shell-tools.md to use streamlined method for redirection

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -102,7 +102,7 @@ echo "Starting program at $(date)" # Date will be substituted
 echo "Running program $0 with $# arguments with pid $$"
 
 for file in "$@"; do
-    grep foobar "$file" > /dev/null 2> /dev/null
+    grep foobar "$file" &> /dev/null
     # When pattern is not found, grep has exit status 1
     # We redirect STDOUT and STDERR to a null register since we do not care about them
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Recent versions of bash provide a more streamlined method for performing standard output and standard error combined redirection:

`&>`

[The Linux Command Line](https://linuxcommand.org/tlcl.php) book, pages 57 - 58

FYI @anishathalye, @JJGO, @jonhoo, @bewuethr