### PR TITLE
Fix typo (`locahost` to `localhost`)

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -376,7 +376,7 @@ comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the 
 **Remote Port Forwarding**
 ![Remote Port Forwarding](https://i.stack.imgur.com/4iK3b.png  "Remote Port Forwarding")
 
-The most common scenario is local port forwarding, where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example, if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus, to forward that to the local port `9999`, we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `locahost:9999` in our local machine.
+The most common scenario is local port forwarding, where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example, if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus, to forward that to the local port `9999`, we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `localhost:9999` in our local machine.
 
 
 ## SSH Configuration


### PR DESCRIPTION
Fixing a typo as a part of an exercise. Thank you for this great course :)