### PR TITLE
Replace link in Exercises with a more useful one

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -554,7 +554,7 @@ class website](https://github.com/missing-semester/missing-semester).
 1. Like many command line tools, Git provides a configuration file (or dotfile)
    called `~/.gitconfig`. Create an alias in `~/.gitconfig` so that when you
    run `git graph`, you get the output of `git log --all --graph --decorate
-   --oneline`. Information about git aliases can be found [here](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias).
+   --oneline`. Information about git aliases can be found [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
 1. You can define global ignore patterns in `~/.gitignore_global` after running
    `git config --global core.excludesfile ~/.gitignore_global`. Do this, and
    set up your global gitignore file to ignore OS-specific or editor-specific


### PR DESCRIPTION
Git Pro book chapter on aliases gives ready to use commands for making a new alias, while the alias.* section at the previously linked docs doesn't explain how to add a new alias at all.

The git docs on git-config.txt may bee good for reference, but not so good for learning something new.