### PR TITLE
Update Vim binding for Jupyter

### DIFF
--- a/_2020/editors.md
+++ b/_2020/editors.md
@@ -358,7 +358,7 @@ popular ones are
 [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en)
 for Google Chrome and [Tridactyl](https://github.com/tridactyl/tridactyl) for
 Firefox. You can even get Vim bindings in [Jupyter
-notebooks](https://github.com/lambdalisue/jupyter-vim-binding).
+notebooks](https://github.com/jupyterlab-contrib/jupyterlab-vim).
 Here is a [long list](https://reversed.top/2016-08-13/big-list-of-vim-like-software) of software with vim-like keybindings.
 
 # Advanced Vim


### PR DESCRIPTION
Hi, I updated the link to the Vim binding for Jupyter Notebook because the old link points to an archived repository. 

The new link points to an extension that works for both Jupyter Notebook and Jupyter Lab. 