### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates weekly
+    schedule:
+      interval: "weekly"
+    # Combine updates into groups
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Implements automatic updates for non-standard GitHub Actions.

See the [Scientific Python Development Guide](https://learn.scientific-python.org/development/guides/gha-basic/#updating) for more information.