### PR TITLE
fix typos

### DIFF
--- a/_2019/remote-machines.md
+++ b/_2019/remote-machines.md
@@ -69,7 +69,7 @@ comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the 
 ![Remote Port Forwarding](https://i.stack.imgur.com/4iK3b.png)
 
 
-The most common scenario is local port forwarding where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus to forward that to the local port `9999` we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `locahost:9999` in our local machine.
+The most common scenario is local port forwarding where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus to forward that to the local port `9999` we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `localhost:9999` in our local machine.
 
 ## Graphics Forwarding
 

--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -257,7 +257,7 @@ tell you about their preferred customizations. Yet another way to learn about
 customizations is to look through other people's dotfiles: you can find tons of
 [dotfiles
 repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on Github --- see the most popular one
+on GitHub --- see the most popular one
 [here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
 copy configurations though).
 [Here](https://dotfiles.github.io/) is another good resource on the topic.

--- a/_2020/potpourri.md
+++ b/_2020/potpourri.md
@@ -302,7 +302,7 @@ Some examples of things you can do with Hammerspoon:
 
 - Bind hotkeys to move windows to specific locations
 - Create a menu bar button that automatically lays out windows in a specific layout
-- Mute your speaker when you arrive in lab (by detecting the WiFi network)
+- Mute your speaker when you arrive in lab (by detecting the Wi-Fi network)
 - Show you a warning if you've accidentally taken your friend's power supply
 
 At a high level, Hammerspoon lets you run arbitrary Lua code, bound to menu


### PR DESCRIPTION
Fix typos in the following documents:
- `locahost` in `_2019/remote-machines.md`
- `Github` in `_2020/command-line.md`
- `WiFi` in `_2020/potpourri.md`