### PR TITLE
Changed line 108 from, if [[ $? -ne 0 ]]; then, to, if [[ "$?" -ne 0 …

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -105,7 +105,7 @@ for file in "$@"; do
     grep foobar "$file" > /dev/null 2> /dev/null
     # When pattern is not found, grep has exit status 1
     # We redirect STDOUT and STDERR to a null register since we do not care about them
-    if [[ $? -ne 0 ]]; then
+    if [[ "$?" -ne 0 ]]; then
         echo "File $file does not have any foobar, adding one"
         echo "# foobar" >> "$file"
     fi


### PR DESCRIPTION
The "$?" variable without the quotes would cause the program to fail with an error. By changing it to "\$?", the program executes perfectly.