### PR TITLE
Clarify global gitignore file must be manually created

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -560,8 +560,11 @@ class website](https://github.com/missing-semester/missing-semester).
    alias. Information about git aliases can be found
    [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
 1. You can define global ignore patterns in` ~/.gitignore_global` after running
-   `git config --global core.excludesfile ~/.gitignore_global`. This sets the location of the global ignore file that Git will use, but you still need to manually create the file at that path. Set up your global gitignore file to ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
-2. Fork the [repository for the class
+   `git config --global core.excludesfile ~/.gitignore_global`. This sets the 
+   location of the global ignore file that Git will use, but you still need to 
+   manually create the file at that path. Set up your global gitignore file to
+   ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
+1. Fork the [repository for the class
    website](https://github.com/missing-semester/missing-semester), find a typo
    or some other improvement you can make, and submit a pull request on GitHub
    (you may want to look at [this](https://github.com/firstcontributions/first-contributions)).

--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -559,11 +559,9 @@ class website](https://github.com/missing-semester/missing-semester).
    the `~/.gitconfig` file, or you can use the `git config` command to add the
    alias. Information about git aliases can be found
    [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
-1. You can define global ignore patterns in `~/.gitignore_global` after running
-   `git config --global core.excludesfile ~/.gitignore_global`. Do this, and
-   set up your global gitignore file to ignore OS-specific or editor-specific
-   temporary files, like `.DS_Store`.
-1. Fork the [repository for the class
+1. You can define global ignore patterns in` ~/.gitignore_global` after running
+   `git config --global core.excludesfile ~/.gitignore_global`. This sets the location of the global ignore file that Git will use, but you still need to manually create the file at that path. Set up your global gitignore file to ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
+2. Fork the [repository for the class
    website](https://github.com/missing-semester/missing-semester), find a typo
    or some other improvement you can make, and submit a pull request on GitHub
    (you may want to look at [this](https://github.com/firstcontributions/first-contributions)).


### PR DESCRIPTION
This PR clarifies the documentation around configuring a global .gitignore file using `git config --global core.excludesfile`. The previous wording may have implied that the file is created automatically by the command. The updated text makes it explicit that the file must be manually created and populated with ignore patterns.

[Reference](https://stackoverflow.com/questions/7335420/global-git-ignore#:~:text=Important%3A%20The%20above%20commands%20will%20only%20set%20the%20location%20of%20the%20ignore%20file%20that%20git%20will%20use.%20The%20file%20has%20to%20still%20be%20manually%20created%20in%20that%20location%20and%20populated%20with%20the%20ignore%20list.%20(from%20muruge%27s%20comment))