### PR TITLE
Fix misleading description of git checkout command

### DIFF
--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -432,7 +432,7 @@ index 94bab17..f0013b2 100644
 - `git log --all --graph --decorate`: visualizes history as a DAG
 - `git diff <filename>`: show changes you made relative to the staging area
 - `git diff <revision> <filename>`: shows differences in a file between snapshots
-- `git checkout <revision>`: updates HEAD and current branch
+- `git checkout <revision>`: updates HEAD (and current branch if checking out a branch)
 
 ## Branching and merging
 


### PR DESCRIPTION
The current description of `git checkout <revision>` states it "updates HEAD and current branch", but this is only true when checking out a branch. When checking out a specific commit hash or tag, Git enters detached HEAD state and no branch is updated.

This change clarifies the behaviour.