### PR TITLE
find: give working PNG→JPG examples for both GNU and BSD find

### DIFF
--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -209,8 +209,9 @@ This property can be incredibly helpful to simplify what could be fairly monoton
 ```bash
 # Delete all files with .tmp extension
 find . -name '*.tmp' -exec rm {} \;
+
 # Find all PNG files and convert them to JPG
-find . -name '*.png' -exec convert {} {}.jpg \;
+find . -name '*.png' -exec magick {} {}.jpg \;
 ```
 
 Despite `find`'s ubiquitousness, its syntax can sometimes be tricky to remember.


### PR DESCRIPTION
Replaced the broken `find … convert {} {}.jpg` example.
Added two working commands
Switched from the deprecated convert binary to ImageMagick 7’s magick front-end.

The previous example generated file.png.jpg.
Using magick avoids the name clash with macOS’ /usr/bin/convert and reflects current ImageMagick practice.