### PR TITLE
Fix: Add missing Quote

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -383,7 +383,7 @@ The most common scenario is local port forwarding, where a service in the remote
 
 We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like
 ```bash
-alias my_server="ssh -i ~/.id_ed25519 --port 2222 -L 9999:localhost:8888 foobar@remote_server
+alias my_server="ssh -i ~/.id_ed25519 --port 2222 -L 9999:localhost:8888 foobar@remote_server"
 ```
 
 However, there is a better alternative using `~/.ssh/config`.


### PR DESCRIPTION
The alias example missed its closing double-quote. 