### PR TITLE
found a typo in the "Aliases" section of command-line.md

### DIFF
--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -470,7 +470,7 @@ One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pa
 
 ## Aliases
 
-1. Create an alias `dc` that resolves to `cd` for when you type it wrongly.
+1. Create an alias `dc` that resolves to `cd` for when you type it wrong.
 
 1.  Run `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10`  to get your top 10 most used commands and consider writing shorter aliases for them. Note: this works for Bash; if you're using ZSH, use `history 1` instead of just `history`.
 


### PR DESCRIPTION
"Wrongly" is technically not incorrect in all contexts, but in this sentence, "wrong" is the appropriate form to use because it refers to the result (typing the wrong thing), not the manner of typing.