### PR TITLE
spelling mistake,it was written massage i corrected to message

### DIFF
--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -50,7 +50,7 @@ ssh myserver 'journalctl | grep sshd | grep "Disconnected from"' | less
 
 Why the additional quoting? Well, our logs may be quite large, and it's
 wasteful to stream it all to our computer and then do the filtering.
-Instead, we can do the filtering on the remote server, and then massage
+Instead, we can do the filtering on the remote server, and then message
 the data locally. `less` gives us a "pager" that allows us to scroll up
 and down through the long output. To save some additional traffic while
 we debug our command-line, we can even stick the current filtered logs


### PR DESCRIPTION
'Why the additional quoting? Well, our logs may be quite large, and it's
wasteful to stream it all to our computer and then do the filtering.
Instead, we can do the filtering on the remote server, and then message
the data locally. `less` gives us a "pager" that allows us to scroll up
and down through the long output. To save some additional traffic while
we debug our command-line, we can even stick the current filtered logs
into a file so that we don't have to access the network while
developing:'    in this paragraph there was spelling mistake of message .