### PR TITLE
docs: clarify wording in about.md (IAP 2020 description)

### DIFF
--- a/about.md
+++ b/about.md
@@ -29,8 +29,8 @@ To help remedy this, we are running a class that covers all the topics we
 consider crucial to be an effective computer scientist and programmer. The
 class is pragmatic and practical, and it provides hands-on introduction to
 tools and techniques that you can immediately apply in a wide variety of
-situations you will encounter. The class is being run during MIT's "Independent
-Activities Period" in January 2020 — a one-month semester that features shorter
+situations you will encounter. The class was taught during MIT's Independent
+Activities Period (IAT) in January 2020 — a one-month term that features shorter
 student-run classes. While the lectures themselves are only available to MIT
 students, we will provide all lecture materials along with video recordings of
 lectures to the public.


### PR DESCRIPTION
Small editorial change to improve clarity in the "About" page.

- Change past-tense phrasing to reflect that the class occurred in January 2020.
- Expand "Independent Activities Period" to "IAP".
- Replace "one-month semester" with "one-month term" for wording clarity.

No functional changes; documentation-only.
