### PR TITLE
Add Tufte-style sidenotes and epigraphs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,6 +46,7 @@
 
   <link rel="stylesheet" href="/static/css/main.css">
   <link rel="stylesheet" href="/static/css/syntax.css">
+  <script defer src="/static/js/sidenotes.js"></script>
   <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900,200italic,300italic,400italic,600italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:200,300,400,500,600,700,900&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -153,10 +153,124 @@ hr {
 }
 
 blockquote {
-  padding: 0 0 0 1rem;
-  margin: 0.8rem 0;
-  color: #666;
-  border-left: 0.25rem solid #e5e5e5;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  background-color: rgba(36, 0, 140, 0.05);
+  border-left: 3px solid #24008c;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+blockquote.epigraph {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 1.5rem 0 1.5rem 1rem;
+}
+
+blockquote.epigraph p {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+
+blockquote.epigraph footer {
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+@media (min-width: 64rem) {
+  #content {
+    position: relative;
+  }
+
+  .sidenote-column {
+    position: absolute;
+    top: 0;
+    left: calc(100% + 1.5rem);
+    width: 14rem;
+  }
+
+  /* Hide inline sidenotes on desktop, show margin ones */
+  .sidenote-inline {
+    display: none;
+  }
+
+  .sidenote-margin {
+    position: absolute;
+    width: 100%;
+    padding: 0.2rem 0.5rem 0.5rem 0.5rem;
+    margin: 0;
+    font-size: 0.8rem;
+    color: #000;
+    background: none;
+    border: none;
+    border-left: 2px solid #54008c;
+  }
+
+  .sidenote-ref {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0.5rem 0;
+    width: 100%;
+    background-color: #e8e8e8;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    padding: 0.15rem 0.5rem;
+    box-sizing: border-box;
+  }
+
+  .sidenote-arrows {
+    color: #54008c;
+    letter-spacing: 0.1em;
+  }
+
+  .sidenote-label {
+    color: #666;
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+  }
+
+  .sidenote-num {
+    color: #54008c;
+    font-size: 0.65rem;
+    font-weight: bold;
+    margin-right: 0.15rem;
+    margin-bottom: 0.1rem;
+    display: block;
+  }
+
+  .sidenote-back {
+    color: #54008c;
+    text-decoration: none;
+    font-size: 0.9em;
+  }
+
+  .sidenote-back:hover {
+    text-decoration: underline;
+  }
+}
+
+@media (max-width: 63.99rem) {
+  /* Hide margin sidenotes and column on mobile, show inline ones */
+  .sidenote-column {
+    display: none;
+  }
+
+  .sidenote-inline {
+    display: block;
+    padding: 0.75rem 1rem;
+    margin: 1rem 0;
+    background-color: #faf8fc;
+    border-left: 3px solid #54008c;
+  }
+
+  .sidenote-ref {
+    display: none;
+  }
 }
 
 /* Classes */
@@ -370,12 +484,68 @@ input[type=checkbox]:checked ~ .menu-label:after {
     background: rgba(0, 0, 0, 0.5);
     border-left: 2px solid #A6E22E;
   }
+
+  blockquote {
+    background-color: rgba(166, 226, 46, 0.06);
+    border-left-color: #A6E22E;
+  }
+
+  .sidenote-margin {
+    color: #bbb;
+    border-left-color: #A6E22E;
+  }
+
+  .sidenote-inline {
+    border-left-color: #A6E22E;
+  }
+
+  .sidenote-ref {
+    background-color: #404040;
+  }
+
+  .sidenote-arrows {
+    color: #A6E22E;
+  }
+
+  .sidenote-label {
+    color: #aaa;
+  }
+
+  .sidenote-num {
+    color: #A6E22E;
+  }
+
+  .sidenote-back {
+    color: #A6E22E;
+  }
+}
+
+@media (prefers-color-scheme: dark) and (min-width: 64rem) {
+  .sidenote-margin {
+    background: none;
+    color: #ddd;
+  }
+}
+
+@media (prefers-color-scheme: dark) and (max-width: 63.99rem) {
+  .sidenote-inline {
+    background-color: rgba(166, 226, 46, 0.06);
+  }
 }
 
 @media print {
   #nav-bg, #logo, #top-nav { display: none; }
   h1.title ~ p.center.padded.bordered { display: none; }
   .youtube-wrapper { display: none; }
+  .sidenote-column { display: none; }
+  .sidenote-ref { display: none; }
+  .sidenote-inline {
+    display: block;
+    background: none;
+    border-left: 2px solid #999;
+    padding: 0 0 0 0.75rem;
+    margin: 1rem 0;
+  }
   html { font-size: 1em; font-family: sans-serif; }
   body { background: none; }
   #content { max-width: none; }

--- a/static/js/sidenotes.js
+++ b/static/js/sidenotes.js
@@ -1,0 +1,138 @@
+(function() {
+  'use strict';
+  var content = document.getElementById('content');
+  if (!content) return;
+
+  var blockquotes = content.querySelectorAll('blockquote');
+  if (blockquotes.length === 0) return;
+
+  // Create sidenote column container
+  var sidenoteColumn = document.createElement('div');
+  sidenoteColumn.className = 'sidenote-column';
+  content.appendChild(sidenoteColumn);
+
+  var sidenoteIndex = 1;
+  var sidenoteData = [];
+
+  function transformToEpigraph(blockquote) {
+    var html = blockquote.innerHTML.trim();
+
+    // Split on the last em-dash to separate quote from attribution
+    var dashIndex = html.lastIndexOf(' — ');
+    var quoteHtml, attributionHtml;
+    if (dashIndex !== -1) {
+      quoteHtml = html.substring(0, dashIndex);
+      attributionHtml = html.substring(dashIndex + 3).replace(/<\/p>\s*$/, '').trim();
+    } else {
+      quoteHtml = html;
+      attributionHtml = null;
+    }
+
+    // Strip the <p> wrapper and leading/trailing quotes
+    quoteHtml = quoteHtml.replace(/^<p>\s*/, '').replace(/\s*<\/p>$/, '');
+    quoteHtml = quoteHtml.replace(/^[""\u201C\u201D]/, '').replace(/[""\u201C\u201D]$/, '');
+
+    // Build the epigraph structure
+    blockquote.className = 'epigraph';
+    blockquote.innerHTML = '';
+
+    var quoteP = document.createElement('p');
+    quoteP.innerHTML = quoteHtml;
+    blockquote.appendChild(quoteP);
+
+    if (attributionHtml) {
+      var footer = document.createElement('footer');
+      footer.innerHTML = attributionHtml;
+      blockquote.appendChild(footer);
+    }
+  }
+
+  blockquotes.forEach(function(blockquote) {
+    var prevElement = blockquote.previousElementSibling;
+    if (!prevElement || prevElement.tagName === 'BLOCKQUOTE') return;
+
+    // Transform quotations (blockquotes starting with " or curly ") into epigraphs
+    var firstChar = blockquote.textContent.trim().charAt(0);
+    if (firstChar === '"' || firstChar === '\u201C') {
+      transformToEpigraph(blockquote);
+      return;
+    }
+
+    // Add reference marker before the blockquote
+    var ref = document.createElement('div');
+    ref.className = 'sidenote-ref';
+    ref.id = 'sidenote-ref-' + sidenoteIndex;
+    ref.setAttribute('data-sidenote', sidenoteIndex);
+    ref.innerHTML = '<span class="sidenote-arrows">›››</span><span class="sidenote-label">note ' + sidenoteIndex + '</span><span class="sidenote-arrows">›››</span>';
+    prevElement.parentNode.insertBefore(ref, blockquote);
+
+    // Mark original blockquote for mobile display
+    blockquote.classList.add('sidenote');
+    blockquote.classList.add('sidenote-inline');
+    blockquote.setAttribute('data-sidenote', sidenoteIndex);
+
+    // Clone blockquote for sidenote column (desktop display)
+    var clone = blockquote.cloneNode(true);
+    clone.classList.remove('sidenote-inline');
+    clone.classList.add('sidenote-margin');
+    clone.id = 'sidenote-' + sidenoteIndex;
+
+    // Add number to the clone
+    var noteNum = document.createElement('span');
+    noteNum.className = 'sidenote-num';
+    noteNum.textContent = sidenoteIndex;
+    clone.insertBefore(noteNum, clone.firstChild);
+
+    // Add back arrow to the clone
+    var backArrow = document.createElement('a');
+    backArrow.className = 'sidenote-back';
+    backArrow.href = '#sidenote-ref-' + sidenoteIndex;
+    backArrow.textContent = ' ↩';
+    backArrow.title = 'Back to note ' + sidenoteIndex;
+    var lastPara = clone.querySelector('p:last-of-type');
+    if (lastPara) {
+      lastPara.appendChild(backArrow);
+    } else {
+      clone.appendChild(backArrow);
+    }
+
+    // Click handler on ref bar to scroll to sidenote
+    ref.style.cursor = 'pointer';
+    ref.addEventListener('click', function(e) {
+      e.preventDefault();
+      var target = document.getElementById('sidenote-' + ref.getAttribute('data-sidenote'));
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+
+    sidenoteColumn.appendChild(clone);
+    sidenoteData.push({ ref: ref, sidenote: clone });
+    sidenoteIndex++;
+  });
+
+  // Position sidenotes vertically (only needed for desktop, CSS handles visibility)
+  function positionSidenotes() {
+    var contentRect = content.getBoundingClientRect();
+    var scrollY = window.pageYOffset || document.documentElement.scrollTop;
+    var lastBottom = 0;
+
+    sidenoteData.forEach(function(item) {
+      var refRect = item.ref.getBoundingClientRect();
+      var desiredTop = refRect.top + scrollY - contentRect.top - scrollY;
+      var actualTop = Math.max(desiredTop, lastBottom + 10);
+      item.sidenote.style.top = actualTop + 'px';
+      lastBottom = actualTop + item.sidenote.offsetHeight;
+    });
+  }
+
+  // Position after DOM is ready and after images load
+  positionSidenotes();
+  window.addEventListener('load', positionSidenotes);
+
+  document.querySelectorAll('img').forEach(function(img) {
+    if (!img.complete) {
+      img.addEventListener('load', positionSidenotes);
+    }
+  });
+})();


### PR DESCRIPTION
Markdown blockquotes (`>`) can now serve double duty: as margin notes
(sidenotes) and as styled quotations (epigraphs). Previously, creating
asides or pull-quotes required raw HTML tags that cluttered the markdown
and were easy to forget. Now the standard `>` syntax works for both.

The distinction is automatic based on content:
- Blockquotes starting with `"` become epigraphs with italicized text
  and attribution extracted from text after ` — `
- All other blockquotes become numbered sidenotes

Sidenotes appear in a right margin column on wide screens (≥64rem) and
collapse to inline styled blockquotes on narrower screens and in print.
Both features support dark mode.