### PR TITLE
Make Code Quality share with Q&A instead

### DIFF
--- a/_2026/agentic-coding.md
+++ b/_2026/agentic-coding.md
@@ -1,7 +1,7 @@
 ---
 layout: lecture
 title: "Agentic Coding"
-date: 2026-01-22
+date: 2026-01-21
 ready: true
 ---
 

--- a/_2026/beyond-code.md
+++ b/_2026/beyond-code.md
@@ -1,7 +1,7 @@
 ---
 layout: lecture
-title: "Beyond the Code + Q&A"
-date: 2026-01-23
+title: "Beyond the Code"
+date: 2026-01-22
 ready: true
 ---
 
@@ -9,21 +9,11 @@ ready: true
 This page is under construction for the IAP 2026 offering of Missing Semester.
 </span>
 
-# Beyond the Code
-
-In the first half of this lecture, we'll cover essential soft skills, including:
+In this lecture, we'll cover essential soft skills, including:
 
 - Documentation: writing great READMEs, comments, and commit messages
 - Open-source community norms, how to report issues, how to structure pull requests
 - AI etiquette
-
-# Q&A
-
-In the second half, we will cover student questions. Please submit your questions in advance of the lecture:
-
-**<https://forms.gle/4jnhiok72KQUD3Tn7>**
-
-See [here](/2020/qa/) for the Q&A from the previous offering of this course.
 
 {% comment %}
 lecturer: Jon

--- a/_2026/code-quality-plus-qa.md
+++ b/_2026/code-quality-plus-qa.md
@@ -1,7 +1,7 @@
 ---
 layout: lecture
-title: "Code Quality and Continuous Integration"
-date: 2026-01-21
+title: "Code Quality and Continuous Integration + Q&A"
+date: 2026-01-23
 ready: true
 ---
 
@@ -96,6 +96,18 @@ Write a Python-style regex pattern that matches the requested path from log line
 
 169.254.1.1 - - [09/Jan/2026:21:28:51 +0000] "GET /feed.xml HTTP/2.0" 200 2995 "-" "python-requests/2.32.3"
 ```
+
+# Q&A
+
+{% comment %}
+lecturer: everyone
+{% endcomment %}
+
+In the second half, we will cover student questions. Please submit your questions in advance of the lecture:
+
+**<https://forms.gle/4jnhiok72KQUD3Tn7>**
+
+See [here](/2020/qa/) for the Q&A from the previous offering of this course.
 
 # Exercises
 


### PR DESCRIPTION
Shift the schedule so Q&A coincides with the Code Quality lecture instead of Beyond the Code. This gives Beyond the Code a full hour (which it will need) while CQ/CI, which has a lot more content available online, gets the 30m slot.

Also shifts the lectures around such that Anish doesn't have to teach on Thursday.

- Agentic Coding: Jan 22 → Jan 21
- Beyond the Code: Jan 23 → Jan 22 (without Q&A)
- Code Quality + Q&A: Jan 21 → Jan 23 (with Q&A added)