### PR TITLE
Fix duplicate “the” in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml) [![Links Status](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml)
 
-Website for the [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/) class!
+Official Website for [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/) class!
 
 Contributions are most welcome! If you have edits or new content to add, please
 open an issue or submit a pull request.


### PR DESCRIPTION
Hello, I have noticed that the first sentence of your ```README.md``` , currently reads:

> Website for the [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/) class!

I am creating this pull requrest aimed at fixing this small grammatical typo in the README (“the The”) and slightly improving the opening sentence by adding “Official” for clarity.

There are functional changes, it is just a minor documentation polish to improve readability for first-time visitors.