### PR TITLE
Add Thai translation site

### DIFF
--- a/index.md
+++ b/index.md
@@ -108,6 +108,7 @@ benefit from these resources. You can find posts and discussion on
 - [Persian](https://missing-semester-fa.github.io/)
 - [German](https://missing-semester-de.github.io/)
 - [Bengali](https://missing-semester-bn.github.io/)
+- [Thai](https://missing-semester-th.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.


### PR DESCRIPTION
# Description

- Provided Thai version for The Missing Semester
- Focusing on 2026 only
- Translation on all sections inside 2026

Source: https://github.com/missing-semester-th