### PR TITLE
Add Kannada translation for 2026 lecture content

### DIFF
--- a/_2026/agentic-coding.md
+++ b/_2026/agentic-coding.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Agentic Coding"
+title: "ಏಜೆಂಟಿಕ್ ಕೋಡಿಂಗ್"
 description: >
-  Learn how to use AI coding agents effectively for software development tasks.
+  ಸಾಫ್ಟ್‌ವೇರ್ ಅಭಿವೃದ್ಧಿ ಕಾರ್ಯಗಳಲ್ಲಿ AI coding agents ಅನ್ನು ಪರಿಣಾಮಕಾರಿಯಾಗಿ ಹೇಗೆ ಬಳಸುವುದು ಎಂಬುದನ್ನು ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec7.png
 date: 2026-01-21
 ready: true
@@ -11,9 +11,9 @@ video:
   id: sTdz6PZoAnw
 ---
 
-Coding agents are conversational AI models with access to tools such as reading/writing files, web search, and invoking shell commands. They live either in the IDE or in standalone command-line or GUI tools. Coding agents are highly autonomous and powerful tools, enabling a wide variety of use cases.
+Coding agents ಎಂದರೆ files ಓದುವುದು/ಬರೆಯುವುದು, web search, ಮತ್ತು shell commands ಅನ್ನು ಚಾಲನೆ ಮಾಡುವಂತಹ tools ಗೆ ಪ್ರವೇಶವಿರುವ conversational AI models. ಇವು IDE ಒಳಗೇ ಇರಬಹುದು ಅಥವಾ standalone command-line/GUI tools ರೂಪದಲ್ಲಿರಬಹುದು. Coding agents ಹೆಚ್ಚಿನ ಮಟ್ಟದಲ್ಲಿ autonomous ಮತ್ತು ಶಕ್ತಿಶಾಲಿ ಸಾಧನಗಳಾಗಿದ್ದು, ಬಹು ವಿಧದ ಬಳಕೆ ಸಂದರ್ಭಗಳನ್ನು ಬೆಂಬಲಿಸುತ್ತವೆ.
 
-This lecture builds on the AI-powered development material from the [Development Environment and Tools](/2026/development-environment/) lecture. As a quick demo, let's continue with the example from the [AI-powered development](/2026/development-environment/#ai-powered-development) section:
+ಈ ಉಪನ್ಯಾಸವು [Development Environment and Tools](/2026/development-environment/) ಉಪನ್ಯಾಸದ AI-powered development ವಿಷಯದ ಮೇಲೆ ಮುಂದುವರೆಯುತ್ತದೆ. ತ್ವರಿತ demoಗಾಗಿ, [AI-powered development](/2026/development-environment/#ai-powered-development) ವಿಭಾಗದ ಉದಾಹರಣೆಯನ್ನು ಮುಂದುವರಿಸೋಣ:
 
 ```python
 from urllib.request import urlopen
@@ -30,49 +30,49 @@ def extract(content: str) -> list[str]:
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
 ```
 
-We can try prompting a coding agent with the following task:
+ಈ ಕಾರ್ಯವನ್ನು coding agent ಗೆ prompt ಆಗಿ ಹೀಗೆ ನೀಡಬಹುದು:
 
 ```
 Turn this into a proper command-line program, with argparse for argument parsing. Add type annotations, and make sure the program passes type checking.
 ```
 
-The agent will read the file to understand it, then make some edits, and finally invoke the type checker to make sure the type annotations are correct. If it makes a mistake such that it fails type checking, it will likely iterate, though this is a simple task so that is unlikely to happen. Because coding agents have access to tools that may be harmful, by default, agent harnesses prompt the user to confirm tool calls.
+Agent ಮೊದಲು file ಓದಿ ಅರ್ಥಮಾಡಿಕೊಳ್ಳುತ್ತದೆ, ನಂತರ ಅಗತ್ಯ edits ಮಾಡುತ್ತದೆ, ಕೊನೆಯಲ್ಲಿ type annotations ಸರಿಯೇ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸಲು type checker ಅನ್ನು ಚಾಲನೆ ಮಾಡುತ್ತದೆ. type checking ವಿಫಲವಾಗುವ ತಪ್ಪು ಮಾಡಿದರೆ, ಸಾಮಾನ್ಯವಾಗಿ ಅದು iterate ಮಾಡುತ್ತದೆ. ಈ task ಸರಳವಾದುದರಿಂದ ಅದು ಸಂಭವಿಸುವ ಸಾಧ್ಯತೆ ಕಡಿಮೆ. Coding agents ಗೆ ಹಾನಿಕಾರಕವಾಗಬಹುದಾದ tools ಗೆ ಪ್ರವೇಶ ಇರುವುದರಿಂದ, default ಆಗಿ agent harnesses tool calls ಗೆ user confirmation ಕೇಳುತ್ತವೆ.
 
-> If the coding agent makes a mistake --- for example, if you have the `mypy` binary available directly on `$PATH` but the agent tries calling `python -m mypy` --- you can give it text feedback to help it course correct.
+> Coding agent ತಪ್ಪು ಮಾಡಿದರೆ - ಉದಾಹರಣೆಗೆ `$PATH` ನಲ್ಲಿ `mypy` binary ನೇರವಾಗಿ ಲಭ್ಯವಾಗಿದ್ದರೂ agent `python -m mypy` ಅನ್ನು ಪ್ರಯತ್ನಿಸಿದರೆ - ನೀವು text feedback ನೀಡಿ ಅದನ್ನು ಸರಿಯಾದ ದಾರಿಗೆ ತಿರುಗಿಸಬಹುದು.
 
-Coding agents support multi-turn interaction, so you can iterate on work over a back-and-forth conversation with the agent. You can even interrupt the agent if it's going down the wrong track. One helpful mental model might be that of a manager of an intern: the intern will do the nitty gritty work, but will require guidance, and will occasionally do the wrong thing and need to be corrected.
+Coding agents multi-turn interaction ಅನ್ನು ಬೆಂಬಲಿಸುತ್ತವೆ. ಹಾಗಾಗಿ agent ಜೊತೆ ಹಿಂತಿರುಗಿ ಮಾತನಾಡುತ್ತಾ ಕೆಲಸವನ್ನು ಹಂತ ಹಂತವಾಗಿ ಮುಂದುವರಿಸಬಹುದು. Agent ತಪ್ಪು ದಿಕ್ಕಿನಲ್ಲಿ ಹೋಗುತ್ತಿದ್ದರೆ ಮಧ್ಯದಲ್ಲೇ interrupt ಕೂಡ ಮಾಡಬಹುದು. ಉಪಯುಕ್ತ mental model ಎಂದರೆ intern ಅನ್ನು ನಿರ್ವಹಿಸುವ manager: intern ಸೂಕ್ಷ್ಮ ಕೆಲಸ ಮಾಡುತ್ತಾನೆ, ಆದರೆ ಮಾರ್ಗದರ್ಶನ ಬೇಕಾಗುತ್ತದೆ, ಕೆಲವೊಮ್ಮೆ ತಪ್ಪು ಮಾಡುತ್ತಾನೆ ಮತ್ತು ತಿದ್ದುವಿಕೆ ಅಗತ್ಯವಾಗುತ್ತದೆ.
 
-> For a more illustrative demo, try asking the agent as a follow-up to run the resulting script. Observe the outputs, and try asking it to make a change (e.g., ask it to include only absolute URLs).
+> ಇನ್ನಷ್ಟು ಸ್ಪಷ್ಟ demoಗಾಗಿ, follow-up ಆಗಿ agent ಗೆ ಫಲಿತ script ಅನ್ನು run ಮಾಡಲು ಹೇಳಿ. outputs ನೋಡಿ, ಬಳಿಕ ಬದಲಾವಣೆ ಕೇಳಿ (ಉದಾ: absolute URLs ಮಾತ್ರ ಸೇರಿಸು ಎಂದು).
 
-# How AI models and agents work
+# AI models ಮತ್ತು agents ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ
 
-Fully explaining the inner workings of modern [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) and infrastructure such as agent harnesses is beyond the scope of this course. However, having a high-level understanding of some of the key ideas is helpful for effectively _using_ this bleeding edge technology and understanding its limitations.
+ಆಧುನಿಕ [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) ಗಳ ಒಳಾಂಗಣ ಕಾರ್ಯವಿಧಾನ ಮತ್ತು agent harnesses ಮೊದಲಾದ infrastructure ಅನ್ನು ಸಂಪೂರ್ಣವಾಗಿ ವಿವರಿಸುವುದು ಈ ಕೋರ್ಸ್ ವ್ಯಾಪ್ತಿಗೆ ಹೊರತಾಗಿದೆ. ಆದರೂ, ಈ cutting-edge ತಂತ್ರಜ್ಞಾನವನ್ನು ಪರಿಣಾಮಕಾರಿಯಾಗಿ _ಬಳಸಲು_ ಮತ್ತು ಅದರ ಮಿತಿಗಳನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಕೆಲವು ಪ್ರಮುಖ ಕಲ್ಪನೆಗಳ high-level ತಿಳುವಳಿಕೆ ಉಪಯುಕ್ತ.
 
-LLMs can be viewed as modeling the probability distribution of completion strings (outputs) given prompt strings (inputs). LLM inference (what happens when you, e.g., supply a query to a conversational chat app) _samples_ from this probability distribution. LLMs have a fixed _context window_, the maximum length of the input and output strings.
+LLMs ಅನ್ನು prompt strings (inputs) ನೀಡಿದಾಗ completion strings (outputs) ಗಳ probability distribution ಅನ್ನು ಮಾದರಿಪಡಿಸುವ ವ್ಯವಸ್ಥೆಯಾಗಿ ನೋಡಬಹುದು. LLM inference (ಉದಾ: conversational chat app ಗೆ ನೀವು query ಕೊಟ್ಟಾಗ ನಡೆಯುವುದು) ಈ probability distribution ಇಂದ _sample_ ಮಾಡುತ್ತದೆ. LLMs ಗೆ ಸ್ಥಿರ _context window_ ಇರುತ್ತದೆ - input ಮತ್ತು output strings ನ ಗರಿಷ್ಠ ಒಟ್ಟು ಉದ್ದ.
 
 {% comment %}
 > In mathematical notation, the LLM models the probability distribution $\pi_\theta$ of completions $y$ conditioned on prompts $x$, and we sample from this distribution: $\hat{y} \sim \pi_\theta(\cdot \mid x)$.
 {% endcomment %}
 
-AI tools such as conversational chat and coding agents build on top of this primitive. For multi-turn interactions, chat apps and agents use turn markers and supply the entire conversation history as the prompt string every time there is a new user prompt, invoking LLM inference once per user prompt. For tool-calling agents, the harness interprets certain LLM outputs as requests to invoke a tool, and the harness supplies the results of the tool call back to the model as part of the prompt string (so LLM inference runs again every time there is a tool call/response). The core concepts in tool-calling agents can be [implemented in 200 lines of code](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/).
+Conversational chat ಮತ್ತು coding agents ಮೊದಲಾದ AI tools ಈ ಮೂಲ ಘಟಕದ ಮೇಲೆ ನಿರ್ಮಿಸಲ್ಪಟ್ಟಿವೆ. Multi-turn interactions ಗಾಗಿ, chat apps ಮತ್ತು agents turn markers ಬಳಸುತ್ತವೆ ಮತ್ತು ಪ್ರತಿಯೊಂದು ಹೊಸ user prompt ಗೆ ಸಂಪೂರ್ಣ conversation history ನ್ನೇ prompt string ಆಗಿ ಕಳುಹಿಸುತ್ತವೆ; ಅಂದರೆ ಪ್ರತಿ user prompt ಗೆ LLM inference ಒಮ್ಮೆ ನಡೆಯುತ್ತದೆ. Tool-calling agents ನಲ್ಲಿ, harness ಕೆಲವು LLM outputs ಅನ್ನು tool invoke requests ಆಗಿ ಅರ್ಥಮಾಡಿಕೊಳ್ಳುತ್ತದೆ; ನಂತರ tool call ಫಲಿತಾಂಶವನ್ನು prompt string ಭಾಗವಾಗಿ model ಗೆ ಹಿಂತಿರುಗಿಸುತ್ತದೆ (ಹೀಗಾಗಿ ಪ್ರತಿಯೊಂದು tool call/response ಗೆ LLM inference ಮತ್ತೆ ನಡೆಯುತ್ತದೆ). Tool-calling agents ನ ಮೂಲ ಕಲ್ಪನೆಗಳನ್ನು [200 lines of code](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/) ನಲ್ಲಿ implement ಮಾಡಬಹುದು.
 
 ## Privacy
 
-Most AI coding tools in their standard configurations send a lot of your data to the cloud. Sometimes the harness runs locally while LLM inference runs in the cloud, other times even more of the software is running in the cloud (and, e.g., the service provider might effectively get a copy of your entire repository as well as all interactions you have with the AI tool).
+ಬಹುತೇಕ AI coding tools ತಮ್ಮ ಸಾಮಾನ್ಯ configurations ನಲ್ಲಿ ನಿಮ್ಮ data ಯ ದೊಡ್ಡ ಭಾಗವನ್ನು cloud ಗೆ ಕಳುಹಿಸುತ್ತವೆ. ಕೆಲವೊಮ್ಮೆ harness local ನಲ್ಲಿ ನಡೆಯುತ್ತದೆ ಆದರೆ LLM inference cloud ನಲ್ಲಿ ನಡೆಯುತ್ತದೆ. ಇನ್ನು ಕೆಲವೊಮ್ಮೆ software ನ ಇನ್ನಷ್ಟು ಭಾಗ cloud ನಲ್ಲೇ ನಡೆಯಬಹುದು (ಉದಾ: service provider ಗೆ ನಿಮ್ಮ ಸಂಪೂರ್ಣ repository ನ ಪ್ರತಿಯೇ ಸಿಗುವ ಮಟ್ಟಿಗೆ, ಜೊತೆಗೆ AI tool ಜೊತೆಗಿನ interactions ಕೂಡ).
 
-There are open-source AI coding tools and open-source LLMs that are pretty good (though not quite as good as the proprietary models), but at the present, for most users, running bleeding-edge open LLMs locally will be infeasible due to hardware limitations.
+Open-source AI coding tools ಮತ್ತು open-source LLMs ಉತ್ತಮ ಮಟ್ಟದಲ್ಲಿವೆ (proprietary models ಮಟ್ಟಕ್ಕೆ ಇನ್ನೂ ಸಂಪೂರ್ಣವಾಗಿ ಸಮಾನವಲ್ಲ). ಆದರೆ ಪ್ರಸ್ತುತ ಬಹುತೇಕ ಬಳಕೆದಾರರಿಗೆ hardware ಮಿತಿಗಳ ಕಾರಣ bleeding-edge open LLMs ಅನ್ನು local ನಲ್ಲಿ ನಡೆಸುವುದು ಪ್ರಾಯೋಗಿಕವಾಗಿಲ್ಲ.
 
-# Use cases
+# ಬಳಕೆ ಸಂದರ್ಭಗಳು
 
-Coding agents can be helpful for a wide variety of tasks. Some examples:
+Coding agents ವಿವಿಧ ರೀತಿಯ ಕಾರ್ಯಗಳಿಗೆ ಸಹಾಯಕ. ಕೆಲವು ಉದಾಹರಣೆಗಳು:
 
-- **Implementing new features.** As in the example above, you can ask a coding agent to implement a feature. Giving a good specification is more of an art than a science at this point; you want the input to the agent to be descriptive enough so that the agent does what you want it to do (at least heading in the right direction so you can iterate), but not overly descriptive to the point where you're doing too much work yourself. Test-driven development can be particularly effective: write tests (or use the coding agent to help you write tests), audit them to ensure they capture what you want, and then ask the coding agent to implement the feature. Models are continually improving, so you'll have to keep your intuition up-to-date on what the models are capable of.
-    > We used Claude Code to [implement](https://github.com/missing-semester/missing-semester/pull/345) these Tufte-style sidenotes.
+- **ಹೊಸ features ಜಾರಿಗೊಳಿಸುವುದು.** ಮೇಲಿನ ಉದಾಹರಣೆಯಂತೆ coding agent ಗೆ feature implement ಮಾಡಲು ಕೇಳಬಹುದು. ಉತ್ತಮ specification ಬರೆಯುವುದು ಈಗಲೂ ಕಲೆ ಮತ್ತು ವಿಜ್ಞಾನ ಮಿಶ್ರಣದ ವಿಷಯ. Agent ಗೆ ಸಾಕಷ್ಟು ವಿವರಣಾತ್ಮಕ input ನೀಡಬೇಕು, ಆಗ ಅದು ನಿಮ್ಮ ದಿಕ್ಕಿನಲ್ಲಿ ಕೆಲಸ ಆರಂಭಿಸುತ್ತದೆ (ಮುಂದೆ iterate ಮಾಡಬಹುದು). ಆದರೆ ಅತಿಯಾಗಿ ವಿವರಿಸಿದರೆ ನೀವು ಮಾಡಬೇಕಾದ ಕೆಲಸವೇ ಹೆಚ್ಚು ಆಗುತ್ತದೆ. Test-driven development ಇಲ್ಲಿ ಪರಿಣಾಮಕಾರಿ: tests ಬರೆಯಿರಿ (ಅಥವಾ tests ಬರೆಯಲು coding agent ನೆರವು ಬಳಸಿ), ಅವು ನಿಮ್ಮ ನಿರೀಕ್ಷೆಗಳನ್ನು ಹಿಡಿದಿವೆಯೇ ಎಂದು ಪರಿಶೀಲಿಸಿ, ಬಳಿಕ feature implement ಮಾಡಲು agent ಗೆ ಕೇಳಿ. Models ನಿರಂತರವಾಗಿ ಸುಧಾರಿಸುತ್ತಿರುವುದರಿಂದ, ಅವುಗಳ ಸಾಮರ್ಥ್ಯದ ಬಗ್ಗೆ ನಿಮ್ಮ ಅಂದಾಜನ್ನು ನಿರಂತರವಾಗಿ ನವೀಕರಿಸಬೇಕು.
+    > ನಾವು Claude Code ಬಳಸಿ ಈ Tufte-ಶೈಲಿಯ sidenotes ಅನ್ನು [implement](https://github.com/missing-semester/missing-semester/pull/345) ಮಾಡಿದ್ದೇವೆ.
 {%- comment %}
 No need to demo this, since the intro of a lecture was a small demo of adding a new feature.
 {% endcomment %}
-- **Fixing errors.** If you have errors from your compiler, linter, type checker, or tests, you can ask your agent to correct them, for example with a prompt like "fix the issues with mypy". Coding models are particularly effective when you can get them in a feedback loop, so try to set things up so that the model can run the failing check directly, which will let it iterate autonomously. If this is impractical, you can give the model feedback manually.
-    > On commit [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) of the missing-semester repo, we prompted Claude Code with "Review the agentic coding lecture for typos and grammatical issues" and subsequently asked it to fix the issues it found, which were committed in [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637).
+- **ದೋಷ ಸರಿಪಡಿಸುವುದು.** Compiler, linter, type checker, ಅಥವಾ tests ನಿಂದ errors ಬಂದರೆ agent ಗೆ ಅವನ್ನು ಸರಿಪಡಿಸಲು ಕೇಳಬಹುದು, ಉದಾ: "fix the issues with mypy" ಎಂಬ prompt. Coding models feedback loop ನಲ್ಲಿ ವಿಶೇಷವಾಗಿ ಪರಿಣಾಮಕಾರಿಯಾಗುತ್ತವೆ. ಆದ್ದರಿಂದ ಸಾಧ್ಯವಾದರೆ model ಗೆ failing check ನ್ನೇ ನೇರವಾಗಿ run ಮಾಡಲು ಅವಕಾಶ ಕೊಡಿ, ಆಗ ಅದು ಸ್ವಯಂಚಾಲಿತವಾಗಿ iterate ಮಾಡಬಹುದು. ಅದು ಸಾಧ್ಯವಿಲ್ಲದಿದ್ದರೆ manual feedback ಕೊಡಬಹುದು.
+    > missing-semester repo ಯ [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) commit ನಲ್ಲಿ ನಾವು Claude Code ಗೆ "Review the agentic coding lecture for typos and grammatical issues" ಎಂದು prompt ನೀಡಿದ್ದೆವು. ನಂತರ ಅದು ಕಂಡುಹಿಡಿದ ಸಮಸ್ಯೆಗಳನ್ನು ಸರಿಪಡಿಸಲು ಕೇಳಿದ್ದೇವೆ. ಅವು [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637) ನಲ್ಲಿ commit ಆಗಿವೆ.
 {%- comment %}
 Demo a coding agent fixing the bug in https://github.com/anishathalye/dotbot/commit/cef40c902ef0f52f484153413142b5154bbc5e99.
 
@@ -88,18 +88,18 @@ Can prompt coding agent with:
 
 Get it to commit the changes.
 {% endcomment %}
-- **Refactoring.** You can use coding agents to refactor code in various ways, from simple tasks like renaming a method (this kind of refactoring is also supported by [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers)) to more complex tasks like breaking out functionality into a separate module.
-    > We used Claude Code to [split](https://github.com/missing-semester/missing-semester/pull/344) agentic coding into its own lecture.
+- **Refactoring.** Coding agents ಬಳಸಿ ವಿವಿಧ ರೀತಿಯ refactoring ಮಾಡಬಹುದು - method rename ಮಾಡುವ ಸರಳ ಕೆಲಸದಿಂದ (ಇದು [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers) ಮೂಲಕವೂ ಸಾಧ್ಯ) ಹಿಡಿದು, functionality ಅನ್ನು ಪ್ರತ್ಯೇಕ module ಗೆ ಬೇರ್ಪಡಿಸುವಂತಹ ಸಂಕೀರ್ಣ ಕೆಲಸಗಳವರೆಗೆ.
+    > ನಾವು Claude Code ಬಳಸಿ agentic coding ಅನ್ನು ಸ್ವತಂತ್ರ ಉಪನ್ಯಾಸವಾಗಿ [split](https://github.com/missing-semester/missing-semester/pull/344) ಮಾಡಿದ್ದೇವೆ.
 {%- comment %}
 Show usage in Missing Semester, point out that the agent did make some mistakes.
 {% endcomment %}
-- **Code review.** You can ask coding agents to review code. You can give them basic guidance, like "review my latest changes that are not yet committed". If you want to review a pull request and your coding agent supports web fetch, or you have command-line tools like the [GitHub CLI](https://cli.github.com/) installed, you might even be able to ask the coding agent "Review the pull request {link}" and it'll handle it from there.
+- **Code review.** Coding agents ಗೆ code review ಮಾಡಲು ಕೇಳಬಹುದು. ಉದಾ: "review my latest changes that are not yet committed" ಎಂಬ ಸರಳ ಮಾರ್ಗದರ್ಶನ ನೀಡಿ. Pull request review ಮಾಡಲು coding agent ಗೆ web fetch support ಇದ್ದರೆ, ಅಥವಾ [GitHub CLI](https://cli.github.com/) ಮೊದಲಾದ command-line tools ಇದ್ದರೆ, "Review the pull request {link}" ಎಂದು ಕೇಳಿದರೂ ಅದು ಉಳಿದುದನ್ನು ನಿರ್ವಹಿಸಬಹುದು.
 {%- comment %}
 In Porcupine repo, prompt agent with:
 
     Review this PR: https://github.com/anishathalye/porcupine/pull/39
 {% endcomment %}
-- **Code understanding.** You can ask a coding agent questions about a codebase, which can be particularly helpful for onboarding.
+- **Code understanding.** Codebase ಬಗ್ಗೆ coding agent ಗೆ ಪ್ರಶ್ನೆ ಕೇಳಬಹುದು. ಹೊಸ project ಗೆ onboarding ಆಗುವಾಗ ಇದು ವಿಶೇಷವಾಗಿ ಸಹಾಯಕ.
 {%- comment %}
 Some prompts to try in the missing-semester repo:
 
@@ -107,38 +107,38 @@ Some prompts to try in the missing-semester repo:
 
     How are the social preview cards implemented?
 {% endcomment %}
-- **As a shell.** You can ask the coding agent to use a particular tool to solve a task, so you can invoke a shell command using natural language, such as "use the find command to find all files older than 30 days" or "use mogrify to resize all the jpgs to 50% of their original size".
+- **Shell ಆಗಿ ಬಳಸುವುದು.** ನಿರ್ದಿಷ್ಟ task ಗೆ ಒಂದು tool ಬಳಸುವಂತೆ coding agent ಗೆ ಕೇಳಬಹುದು. ಹಾಗಾಗಿ natural language ಬಳಸಿ shell command ಕಾರ್ಯಗತಗೊಳಿಸಬಹುದು, ಉದಾ: "use the find command to find all files older than 30 days" ಅಥವಾ "use mogrify to resize all the jpgs to 50% of their original size".
 {%- comment %}
 In Dotbot repo, prompt agent with:
 
     Use the ag command to find all Python renaming imports
 {% endcomment %}
-- **Vibe coding.** Agents are powerful enough that you can implement some applications without writing a single line of code yourself.
-    > [Here is an example](https://github.com/cleanlab/office-presence-dashboard) of a real-world project that one of the instructors vibe-coded.
+- **Vibe coding.** Agents ಈಗ ಇಷ್ಟು ಶಕ್ತಿಶಾಲಿಯಾಗಿವೆ ಎಂದು ನೀವು ಸ್ವತಃ ಒಂದು ಸಾಲು code ಕೂಡ ಬರೆಯದೇ ಕೆಲವು applications ನಿರ್ಮಿಸಬಹುದು.
+    > instructor ಗಳಲ್ಲಿ ಒಬ್ಬರು vibe-coded ಮಾಡಿದ ನೈಜ project ಉದಾಹರಣೆ [ಇಲ್ಲಿ](https://github.com/cleanlab/office-presence-dashboard).
 {%- comment %}
 In missing-semester repo, prompt agent with:
 
     Make this site look retro.
 {% endcomment %}
 
-# Advanced agents
+# ಮುಂದುವರಿದ agents
 
-Here, we give a brief overview of some more advanced usage patterns and capabilities of coding agents.
+ಇಲ್ಲಿ coding agents ನ ಕೆಲವು ಮುಂದುವರಿದ usage patterns ಮತ್ತು ಸಾಮರ್ಥ್ಯಗಳ ಸಂಕ್ಷಿಪ್ತ ಅವಲೋಕನ:
 
-- **Reusable prompts.** Create reusable prompts or templates. For example, you can write a detailed prompt to do code review in a particular way, and save that as a reusable prompt.
-- **Parallel agents.** Coding agents can be slow: you can prompt the agent, and it can work at a problem for tens of minutes. You can run multiple copies of agents at the same time, either working on the same task (LLMs are stochastic, so it can be helpful to run the same thing multiple times and take the best solution) or different tasks (e.g., implement two non-overlapping features at the same time). To keep the different agents' changes from interfering with each other, you can use [git worktrees](https://git-scm.com/docs/git-worktree), which we cover in the lecture on [version control](/2026/version-control/).
-- **MCPs.** MCP, which stands for _Model Context Protocol_, is an open protocol that you can use to connect your coding agents with tools. For example, this [Notion MCP server](https://github.com/makenotion/notion-mcp-server) can let your agent read/write Notion docs, enabling use cases like "read the spec linked in {Notion doc}, draft an implementation plan as a new page in Notion, and then implement a prototype". For discovering MCPs, you can use directories like [Pulse](https://www.pulsemcp.com/servers) and [Glama](https://glama.ai/mcp/servers).
-- **Context management.** As we noted [above](#how-ai-models-and-agents-work), the LLMs that underlie coding agents have a limited _context window_. Effective use of coding agents necessitates making good use of context. You want to make sure the agent has access to the information it needs, but avoid unnecessary context to avoid overflowing the context window or degrading the performance of the model (which tends to happen as context size grows, even if it doesn't overflow the context window). Agent harnesses automatically supply, and to some degree, manage context, but a lot of control is left to the user.
-    - **Clearing the context window.** The most basic control, coding agents support clearing the context window (starting a new conversation), which you should do for unrelated queries.
-    - **Rewinding the conversation.** Some coding agents support undoing steps in the conversation history. Rather than give a follow-up message steering the agent in a different direction, in situations where an "undo" makes more sense, this more effectively manages context.
+- **Reusable prompts.** ಮರುಬಳಕೆಯ prompts/templates ರಚಿಸಿ. ಉದಾ: ನಿರ್ದಿಷ್ಟ ಶೈಲಿಯಲ್ಲಿ code review ಮಾಡಲು ವಿವರವಾದ prompt ಬರೆದು reuse ಮಾಡಬಹುದು.
+- **Parallel agents.** Coding agents ನಿಧಾನವಾಗಿರಬಹುದು - prompt ಕೊಟ್ಟ ಬಳಿಕ ಕೆಲವೊಮ್ಮೆ ದಶಕ ನಿಮಿಷಗಳವರೆಗೆ ಕೆಲಸ ಮಾಡಬಹುದು. ಒಂದೇ ಸಮಯದಲ್ಲಿ ಹಲವು agent instances ನಡೆಸಬಹುದು: ಒಂದೇ task ಮೇಲೆ (LLMs stochastic ಆದ್ದರಿಂದ ಒಂದೇ task ಹಲವು ಬಾರಿ ನಡೆಸಿ ಉತ್ತಮ ಉತ್ತರ ಆಯ್ಕೆ ಮಾಡಬಹುದು) ಅಥವಾ ಬೇರೆ tasks ಮೇಲೆ (ಉದಾ: ಒಟ್ಟಿಗೆ ಎರಡು non-overlapping features implement ಮಾಡುವುದು). Agents ಒಂದರ ಬದಲಾವಣೆ ಮತ್ತೊಂದಕ್ಕೆ ಅಡ್ಡಿಯಾಗದಂತೆ [git worktrees](https://git-scm.com/docs/git-worktree) ಬಳಸಬಹುದು; ಇದನ್ನು [version control](/2026/version-control/) ಉಪನ್ಯಾಸದಲ್ಲಿ ನೋಡುತ್ತೇವೆ.
+- **MCPs.** MCP ಅಂದರೆ _Model Context Protocol_ - coding agents ಅನ್ನು tools ಜೊತೆ ಸಂಪರ್ಕಿಸಲು open protocol. ಉದಾ: ಈ [Notion MCP server](https://github.com/makenotion/notion-mcp-server) ಮೂಲಕ agent Notion docs ಓದಲು/ಬರೆಯಲು ಸಾಧ್ಯವಾಗುತ್ತದೆ. ಆಗ "{Notion doc} ನಲ್ಲಿ link ಆಗಿರುವ spec ಓದಿ, Notion ನಲ್ಲಿ ಹೊಸ page ಆಗಿ implementation plan draft ಮಾಡಿ, ನಂತರ prototype implement ಮಾಡು" ಎಂಬ use case ಸಾಧ್ಯ. MCPs ಕಂಡುಹಿಡಿಯಲು [Pulse](https://www.pulsemcp.com/servers), [Glama](https://glama.ai/mcp/servers) ಮೊದಲಾದ directories ಉಪಯುಕ್ತ.
+- **Context management.** [ಮೇಲೆ](#ai-models-ಮತ್ತು-agents-ಹೇಗೆ-ಕೆಲಸ-ಮಾಡುತ್ತವೆ) ಹೇಳಿದಂತೆ coding agents ಆಧಾರವಾದ LLMs ಗೆ ಸೀಮಿತ _context window_ ಇದೆ. Coding agents ಅನ್ನು ಪರಿಣಾಮಕಾರಿಯಾಗಿ ಬಳಸಲು context ನ ಸರಿಯಾದ ನಿರ್ವಹಣೆ ಅಗತ್ಯ. Agent ಗೆ ಬೇಕಾದ ಮಾಹಿತಿ ಸಿಗಬೇಕು, ಆದರೆ ಅನಗತ್ಯ context ತಪ್ಪಿಸಬೇಕು - ಇಲ್ಲವಾದರೆ context window overflow ಆಗಬಹುದು ಅಥವಾ model performance ಕುಸಿಯಬಹುದು (window ತುಂಬದಿದ್ದರೂ context ಬೆಳೆಯುತ್ತಲೇ ಹೋದರೆ ಇದು ಸಾಮಾನ್ಯ). Agent harnesses context ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನೀಡುತ್ತವೆ ಮತ್ತು ಕೆಲವು ಮಟ್ಟಿಗೆ ನಿರ್ವಹಿಸುತ್ತವೆ, ಆದರೆ ಬಳಕೆದಾರನ ಕೈಯಲ್ಲಿಯೂ ಸಾಕಷ್ಟು ನಿಯಂತ್ರಣ ಇರುತ್ತದೆ.
+    - **Context window clear ಮಾಡುವುದು.** ಅತ್ಯಂತ ಮೂಲ ನಿಯಂತ್ರಣ - coding agents context window clear ಮಾಡುವುದು (ಹೊಸ conversation ಆರಂಭಿಸುವುದು) ಬೆಂಬಲಿಸುತ್ತವೆ. ಸಂಬಂಧವಿಲ್ಲದ ಹೊಸ ಪ್ರಶ್ನೆಗಳಿಗೆ ಇದು ಉತ್ತಮ.
+    - **Conversation rewind ಮಾಡುವುದು.** ಕೆಲವು coding agents conversation history ಯ ಹಂತಗಳನ್ನು undo ಮಾಡಲು ಅವಕಾಶ ಕೊಡುತ್ತವೆ. Agent ಅನ್ನು ಬೇರೆ ದಾರಿಗೆ ನಡೆಸಲು follow-up message ಕೊಡುವುದಕ್ಕಿಂತ, undo ಸೂಕ್ತವಾಗಿರುವ ಸಂದರ್ಭಗಳಲ್ಲಿ ಇದು context management ಗೆ ಹೆಚ್ಚು ಪರಿಣಾಮಕಾರಿ.
 {%- comment %}
 Make up a quick demo.
 {% endcomment %}
-    - **Compaction.** To enable conversations of unbounded length, coding agents support context _compaction_: if the conversation history grows too long, they will automatically call an LLM to summarize the prefix of the conversation, and replace the conversation history with the summary. Some agents give control to the user to invoke compaction when desired.
+    - **Compaction.** ಅಸೀಮ ಉದ್ದದ conversations ಗೆ coding agents context _compaction_ ಬೆಂಬಲಿಸುತ್ತವೆ: conversation history ಬಹಳ ಉದ್ದವಾದರೆ prefix ಭಾಗವನ್ನು summarize ಮಾಡಲು ಮತ್ತೊಂದು LLM ಅನ್ನು ಕರೆಯುತ್ತಾರೆ, ನಂತರ ಮೂಲ history ಬದಲು summary ಇಡುತ್ತಾರೆ. ಕೆಲವು agents ಬಳಕೆದಾರರಿಗೆ ಬೇಕಾದಾಗ compaction invoke ಮಾಡಲು ನಿಯಂತ್ರಣ ನೀಡುತ್ತವೆ.
 {%- comment %}
 Show `/compact` in Claude Code, show full summary.
 {% endcomment %}
-    - **llms.txt.** The `/llms.txt` file is a proposed [standard](https://llmstxt.org/) location for a document meant for LLMs to use at inference time. Products (e.g., [cursor.com/llms.txt](https://cursor.com/llms.txt)), software libraries (e.g., [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), and APIs (e.g., [apify.com/llms.txt](https://apify.com/llms.txt)) might have `llms.txt` files that are handy for development. Such documents are more information dense per token, and so they are more context-efficient than asking your coding agent to fetch and read an HTML page. External documentation is handy when a coding agent doesn't have built-in knowledge about a dependency you are trying to use (e.g., because it was published after the LLM's knowledge cutoff).
+    - **llms.txt.** `/llms.txt` file ಎಂದರೆ inference ಸಮಯದಲ್ಲಿ LLMs ಬಳಕೆಗಾಗಿ ನಿರ್ದಿಷ್ಟಪಡಿಸಿದ [standard](https://llmstxt.org/) ಸ್ಥಳ. Products (ಉದಾ: [cursor.com/llms.txt](https://cursor.com/llms.txt)), libraries (ಉದಾ: [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), APIs (ಉದಾ: [apify.com/llms.txt](https://apify.com/llms.txt)) ಇತ್ಯಾದಿಗಳಲ್ಲಿ `llms.txt` files ಇರಬಹುದು. ಇವು token ಗೆ ಹೆಚ್ಚಿನ ಮಾಹಿತಿ ಸಾಂದ್ರತೆಯನ್ನು ನೀಡುವುದರಿಂದ context-efficient ಆಗಿವೆ; coding agent ಗೆ HTML page fetch/read ಮಾಡಿಸುವುದಕ್ಕಿಂತ ಉತ್ತಮ. External documentation ವಿಶೇಷವಾಗಿ agent ಗೆ dependency ಬಗ್ಗೆ built-in ಜ್ಞಾನ ಇಲ್ಲದಾಗ ಉಪಯುಕ್ತ (ಉದಾ: dependency LLM knowledge cutoff ಬಳಿಕ ಪ್ರಕಟವಾಗಿದ್ದರೆ).
 {%- comment %}
 Side-by-side comparison in an empty repo (on Desktop or some other self-contained place, with `git init` run in it):
 
@@ -148,7 +148,7 @@ Side-by-side comparison in an empty repo (on Desktop or some other self-containe
 
 Not sure why the agent doesn't do this by default. You'd probably put that last sentence in a CLAUDE.md file.
 {% endcomment %}
-    - **AGENTS.md.** Most coding agents support [AGENTS.md](https://agents.md/) or similar (e.g., Claude Code looks for `CLAUDE.md`) as a README for coding agents. When the agent starts, it pre-fills the context with the entire contents of `AGENTS.md`. You can use this to give the agent advice that is common across sessions (e.g., instruct it to always run the type-checker after making code changes, explain how to run unit tests, or provide links to third-party docs that the agent can browse). Some coding agents can auto-generate this file (e.g., the `/init` command in Claude Code). See [here](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) for a real-world example of an `AGENTS.md`.
+    - **AGENTS.md.** ಹೆಚ್ಚಿನ coding agents [AGENTS.md](https://agents.md/) ಅಥವಾ ಅದರ ಸಮಾನ ಫೈಲ್‌ಗಳನ್ನು (ಉದಾ: Claude Code ನಲ್ಲಿ `CLAUDE.md`) coding agents ಗಾಗಿ README ಆಗಿ ಬೆಂಬಲಿಸುತ್ತವೆ. Agent ಪ್ರಾರಂಭವಾದಾಗ `AGENTS.md` ಸಂಪೂರ್ಣ ವಿಷಯವನ್ನು context ನಲ್ಲಿ ಪೂರ್ವಭರ್ತಿಯಾಗಿ ಸೇರಿಸುತ್ತದೆ. Session ಗಳಾದ್ಯಂತ ಸಾಮಾನ್ಯವಾಗಿರುವ ಮಾರ್ಗದರ್ಶನ ಇಲ್ಲಿ ಕೊಡಬಹುದು (ಉದಾ: code changes ನಂತರ type-checker ಸದಾ run ಮಾಡು, unit tests ಹೇಗೆ run ಮಾಡುವುದು ಹೇಳು, ಅಥವಾ agent browse ಮಾಡಬಹುದಾದ third-party docs links ಕೊಡು). ಕೆಲವು coding agents ಈ file ಅನ್ನು auto-generate ಮಾಡುತ್ತವೆ (ಉದಾ: Claude Code ನ `/init` command). ನೈಜ-world `AGENTS.md` ಉದಾಹರಣೆಗೆ [ಇಲ್ಲಿ](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) ನೋಡಿ.
 {%- comment %}
 Dotbot example, CLAUDE.md that includes @DEVELOPMENT.md and says to always run the type checker and code formatter after making any changes to Python code.
 
@@ -158,30 +158,30 @@ Example prompt, off of master:
 
 This is something that'll be fast, for demonstration purposes.
 {% endcomment %}
-    - **Skills.** Content in the `AGENTS.md` is always loaded, in its entirety, into the context window of an agent. _Skills_ add one level of indirection to avoid context bloat: you can provide the agent with a list of skills along with descriptions, and the agent can "open" the skill (load it into its context window) as desired.
-    - **Subagents.** Some coding agents let you define subagents, which are agents for task-specific workflows. The top-level coding agent can invoke a sub-agent to complete a particular task, which enables both the top-level agent and subagent to more effectively manage context. The top-level agent's context isn't bloated with everything the subagent sees, and the subagent can get just the context it needs for its task. As one example, some coding agents implement web research as a subagent: the top-level agent will pose a query to the subagent, which will run web search, retrieve individual web pages, analyze them, and provide an answer to the query to the top-level agent. This way, the top-level agent doesn't have its context bloated by the full content of all retrieved web pages, and the subagent doesn't have in its context the rest of the conversation history of the top-level agent.
+    - **Skills.** `AGENTS.md` ನಲ್ಲಿರುವ ವಿಷಯವು ಯಾವಾಗಲೂ ಸಂಪೂರ್ಣವಾಗಿ context window ಗೆ ಲೋಡ್ ಆಗುತ್ತದೆ. _Skills_ ಇದನ್ನು ನಿಯಂತ್ರಿಸಲು ಒಂದು ಹೆಚ್ಚುವರಿ indirection ಕೊಡುತ್ತವೆ: skill descriptions ಜೊತೆ skills ಪಟ್ಟಿ ನೀಡಬಹುದು; ನಂತರ agent ಅಗತ್ಯವಿದ್ದಾಗ ಆಯ್ದ skill ಅನ್ನು "open" ಮಾಡಿ context ಗೆ ಲೋಡ್ ಮಾಡಬಹುದು.
+    - **Subagents.** ಕೆಲವು coding agents task-specific workflows ಗಾಗಿ subagents ವ್ಯಾಖ್ಯಾನಿಸಲು ಅವಕಾಶ ಕೊಡುತ್ತವೆ. Top-level agent ನಿರ್ದಿಷ್ಟ task ಪೂರ್ಣಗೊಳಿಸಲು subagent ಅನ್ನು invoke ಮಾಡಬಹುದು. ಇದರಿಂದ top-level agent ಮತ್ತು subagent ಎರಡೂ context ಅನ್ನು ಉತ್ತಮವಾಗಿ ನಿರ್ವಹಿಸಬಹುದು. Top-level agent context ಗೆ subagent ನೋಡಿದ ಎಲ್ಲವೂ ತುಂಬುವುದಿಲ್ಲ; subagent ಗೆ ಅದರ task ಗೆ ಬೇಕಾದ context ಮಾತ್ರ ಸಿಗುತ್ತದೆ. ಉದಾ: ಕೆಲವು coding agents web research ಅನ್ನು subagent ರೂಪದಲ್ಲಿ ಜಾರಿಗೊಳಿಸುತ್ತವೆ - top-level agent query ಕೇಳುತ್ತದೆ, subagent web search ನಡೆಸಿ, pages ತಂದು, ಅವನ್ನು ವಿಶ್ಲೇಷಿಸಿ, top-level agent ಗೆ ಉತ್ತರ ನೀಡುತ್ತದೆ. ಇದರಿಂದ top-level agent context ಗೆ pages ಗಳ ಸಂಪೂರ್ಣ ವಿಷಯ ತುಂಬುವುದಿಲ್ಲ; ಹಾಗೆಯೇ subagent context ಗೆ top-level agent ನ ಉಳಿದ conversation history ಕೂಡ ತುಂಬುವುದಿಲ್ಲ.
 
-For many of the advanced features that require writing prompts (e.g., skills or subagents), you can use LLMs to get you started. Some coding agents even have built-in support for doing this. For example, Claude Code can generate a subagent from a short prompt (invoke `/agents` and create a new agent). Try creating a subagent with this prompt:
+Prompts ಬರೆಯುವ ಅಗತ್ಯವಿರುವ ಮುಂದುವರಿದ features ಗಳಲ್ಲಿ (ಉದಾ: skills, subagents), LLMs ಅನ್ನು ಆರಂಭಿಕ draft ಗಾಗಿ ಬಳಸಬಹುದು. ಕೆಲವು coding agents ನಲ್ಲಿ ಇದಕ್ಕೆ built-in support ಇರುತ್ತದೆ. ಉದಾ: Claude Code ನಲ್ಲಿ ಚಿಕ್ಕ prompt ನಿಂದ subagent ರಚಿಸಬಹುದು (`/agents` invoke ಮಾಡಿ ಹೊಸ agent ರಚಿಸಿ). ಈ prompt ಪ್ರಯತ್ನಿಸಿ:
 
 ```
 A Python code checking agent that uses `mypy` and `ruff` to type-check, lint, and format *check* any files that have been modified from the last git commit.
 ```
 
-Then, you can use the top-level agent to explicitly invoke the subagent with a message like "use the code checker subagent". You might also be able to get the top-level agent to automatically invoke the subagent when appropriate, for example, after modifying any Python files.
+ನಂತರ top-level agent ಗೆ "use the code checker subagent" ಎಂಬ ಸಂದೇಶ ನೀಡಿ subagent ಅನ್ನು ಸ್ಪಷ್ಟವಾಗಿ invoke ಮಾಡಬಹುದು. Python files ಬದಲಾಯಿಸಿದ ನಂತರ top-level agent ಸ್ವಯಂಚಾಲಿತವಾಗಿ subagent invoke ಮಾಡುವಂತೆ ಕೂಡ ಕೆಲವು ಸಂದರ್ಭಗಳಲ್ಲಿ ಮಾಡಬಹುದು.
 
-# What to watch out for
+# ಗಮನಿಸಬೇಕಾದ ವಿಷಯಗಳು
 
-AI tools can make mistakes. They are built on LLMs, which are just probabilistic next-token-prediction models. They are not "intelligent" in the same way as humans. Review AI output for correctness and security bugs. Sometimes verifying code can be harder than writing the code yourself; for critical code, consider writing it by hand. AI can go down rabbit holes and try to gaslight you; be aware of debugging spirals. Don't use AI as a crutch, and be wary of overreliance or having a shallow understanding. There's still a huge class of programming tasks that AI is still incapable of doing. Computational thinking is still valuable.
+AI tools ತಪ್ಪು ಮಾಡುತ್ತವೆ. ಇವು LLMs ಮೇಲೆ ನಿರ್ಮಿತವಾಗಿವೆ; LLMs ಅಂದರೆ probabilistic next-token-prediction models ಮಾತ್ರ. ಇವು ಮಾನವರಂತೆ "intelligent" ಅಲ್ಲ. AI output ಅನ್ನು correctness ಮತ್ತು security bugs ದೃಷ್ಟಿಯಿಂದ ಪರಿಶೀಲಿಸಿ. ಕೆಲವು ಸಂದರ್ಭಗಳಲ್ಲಿ code verify ಮಾಡುವುದು ಅದನ್ನು ಕೈಯಿಂದ ಬರೆಯುವುದಕ್ಕಿಂತ ಕಷ್ಟವಾಗಬಹುದು. ಅತ್ಯಂತ ಪ್ರಮುಖ code ಗಾಗಿ ಕೈಯಿಂದ ಬರೆಯುವುದನ್ನು ಪರಿಗಣಿಸಿ. AI ಕೆಲವೊಮ್ಮೆ rabbit hole ಗೆ ಹೋಗಬಹುದು ಮತ್ತು ತಪ್ಪು ದಾರಿಗೆಳೆಯುವ ಉತ್ತರ ಕೊಡಬಹುದು - debugging spiral ಗಳ ಬಗ್ಗೆ ಎಚ್ಚರವಾಗಿರಿ. AI ಅನ್ನು crutch ಆಗಿ ಬಳಸಬೇಡಿ; ಅತಿಯಾದ ಅವಲಂಬನೆ ಅಥವಾ ಮೇಲ್ಮೈ ತಿಳುವಳಿಕೆ ಅಪಾಯಕಾರಿ. ಇನ್ನೂ ಅನೇಕ programming tasks ಗಳನ್ನು AI ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ. Computational thinking ಇನ್ನೂ ಅತ್ಯಂತ ಮೌಲ್ಯಯುತ.
 
-# Recommended software
+# ಶಿಫಾರಸು ಮಾಡಿದ software
 
-Many IDEs / AI coding extensions include coding agents (see recommendations from the [development environment lecture](/2026/development-environment/)). Other popular coding agents include Anthropic's [Claude Code](https://www.claude.com/product/claude-code), OpenAI's [Codex](https://openai.com/codex/), and open-source agents like [opencode](https://github.com/anomalyco/opencode).
+ಹಲವಾರು IDEs / AI coding extensions ಗಳಲ್ಲಿ coding agents ಒಳಗೊಂಡಿರುತ್ತವೆ ([development environment lecture](/2026/development-environment/) ಶಿಫಾರಸುಗಳನ್ನು ನೋಡಿ). ಇತರೆ ಜನಪ್ರಿಯ coding agents: Anthropic ನ [Claude Code](https://www.claude.com/product/claude-code), OpenAI ನ [Codex](https://openai.com/codex/), ಮತ್ತು [opencode](https://github.com/anomalyco/opencode) ಮೊದಲಾದ open-source agents.
 
-# Exercises
+# ವ್ಯಾಯಾಮಗಳು
 
-1. Compare the experience of coding by hand, using AI autocomplete, inline chat, and agents by doing the same programming task four times. The best candidate is a small-sized feature from a project you're already working on. If you're looking for other ideas, you could consider completing "good first issue" style tasks in open-source projects on GitHub, or [Advent of Code](https://adventofcode.com/) or [LeetCode](https://leetcode.com/) problems.
-1. Use an AI coding agent to navigate an unfamiliar codebase. This is best done in the context of wanting to debug or add a new feature to a project you actually care about. If you don't have any that come to mind, try using an AI agent to understand how security-related features work in the [opencode](https://github.com/anomalyco/opencode) agent.
-1. Vibe code a small app from scratch. Do not write a single line of code by hand.
-1. For your coding agent of choice, create and test an `AGENTS.md` (or analogous for your agent of choice, such as `CLAUDE.md`), a reusable prompt (e.g., [custom slash command in Claude Code](https://code.claude.com/docs/en/slash-commands) or [custom prompts in Codex](https://developers.openai.com/codex/custom-prompts)), a skill (e.g., [skill in Claude Code](https://code.claude.com/docs/en/skills) or [skill in Codex](https://developers.openai.com/codex/skills/)), and a subagent (e.g., [subagent in Claude Code](https://code.claude.com/docs/en/sub-agents)). Think about when you'd want to use one of these versus another. Note that your coding agent of choice might not support some of these functionalities; you can either skip them, or try a different coding agent that has support.
-1. Use a coding agent to accomplish the same goal as in the Markdown bullet points regex exercise from the [Code Quality lecture](/2026/code-quality/). Does it complete the tasks via direct file edits? What are the downsides and limitations of an agent editing the file directly to complete such a task? Figure out how to prompt the agent such that it doesn't complete the task via direct file edits. Hint: ask the agent to use one of the command-line tools mentioned in the [first lecture](/2026/course-shell/).
-1. Most coding agents support a form of "yolo mode" (e.g., in Claude Code, `--dangerously-skip-permissions`). It is not secure to use this mode directly, but it may be acceptable to run a coding agent in an isolated environment like a virtual machine or container and then enable autonomous operation. Get this setup running on your machine. Documentation such as [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) or [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/claude-code/) may come in handy. There is more than one way to set this up.
+1. ಒಂದೇ programming task ಅನ್ನು ನಾಲ್ಕು ಬಾರಿ ಮಾಡಿ - ಕೈಯಿಂದ coding, AI autocomplete, inline chat, ಮತ್ತು agents ಬಳಸಿ - ಅನುಭವವನ್ನು ಹೋಲಿಸಿ. ಉತ್ತಮ ಆಯ್ಕೆ ಎಂದರೆ ನೀವು ಈಗಾಗಲೇ ಕೆಲಸ ಮಾಡುತ್ತಿರುವ project ನ ಒಂದು ಸಣ್ಣ feature. ಇನ್ನಷ್ಟು ಕಲ್ಪನೆಗಳಿಗಾಗಿ GitHub open-source projects ನಲ್ಲಿ "good first issue" ಶೈಲಿಯ tasks, ಅಥವಾ [Advent of Code](https://adventofcode.com/) / [LeetCode](https://leetcode.com/) ಸಮಸ್ಯೆಗಳು ಪ್ರಯತ್ನಿಸಬಹುದು.
+1. ಅಪರಿಚಿತ codebase ಅನ್ವೇಷಿಸಲು AI coding agent ಬಳಸಿ. ಇದು ನೀವು ನಿಜವಾಗಿಯೂ ಕಾಳಜಿ ಇರುವ project ನಲ್ಲಿ bug debug ಮಾಡಬೇಕು ಅಥವಾ ಹೊಸ feature ಸೇರಿಸಬೇಕು ಎಂಬ ಸಂದರ್ಭದಲ್ಲೇ ಉತ್ತಮ. ಅಂತಹ project ನೆನಪಿಗೆ ಬರದಿದ್ದರೆ, [opencode](https://github.com/anomalyco/opencode) agent ನಲ್ಲಿ security-ಸಂಬಂಧಿತ features ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ ಎಂದು AI agent ಮೂಲಕ ಅರ್ಥಮಾಡಿಕೊಳ್ಳಿ.
+1. ಸಣ್ಣ app ಅನ್ನು ಆರಂಭದಿಂದ vibe code ಮಾಡಿ. ಕೈಯಿಂದ ಒಂದು ಸಾಲು code ಕೂಡ ಬರೆಯಬೇಡಿ.
+1. ನಿಮ್ಮ ಇಷ್ಟದ coding agent ಗಾಗಿ `AGENTS.md` (ಅಥವಾ ಅದರ ಸಮಾನ file, ಉದಾ: `CLAUDE.md`) ರಚಿಸಿ ಮತ್ತು ಪರೀಕ್ಷಿಸಿ; ಜೊತೆಗೆ reusable prompt (ಉದಾ: [custom slash command in Claude Code](https://code.claude.com/docs/en/slash-commands) ಅಥವಾ [custom prompts in Codex](https://developers.openai.com/codex/custom-prompts)), skill (ಉದಾ: [skill in Claude Code](https://code.claude.com/docs/en/skills) ಅಥವಾ [skill in Codex](https://developers.openai.com/codex/skills/)), ಮತ್ತು subagent (ಉದಾ: [subagent in Claude Code](https://code.claude.com/docs/en/sub-agents)) ಪ್ರಯತ್ನಿಸಿ. ಯಾವ ಸಂದರ್ಭದಲ್ಲೇನು ಬಳಸಬೇಕು ಎಂಬುದನ್ನು ಚಿಂತಿಸಿ. ನಿಮ್ಮ ಆಯ್ಕೆ coding agent ಕೆಲವು features ಬೆಂಬಲಿಸದೇ ಇರಬಹುದು; ಅಂಥದ್ದಾದರೆ ಅವನ್ನು ಬಿಟ್ಟುಬಿಡಿ ಅಥವಾ ಬೆಂಬಲವಿರುವ ಬೇರೆ agent ಪ್ರಯತ್ನಿಸಿ.
+1. [Code Quality lecture](/2026/code-quality/) ನ Markdown bullet points regex exercise ನಲ್ಲಿ ಇರುವಂತೆಯೇ coding agent ಬಳಸಿ ಒಂದೇ ಗುರಿ ಸಾಧಿಸಿ. ಅದು task ಅನ್ನು direct file edits ಮೂಲಕ ಪೂರ್ಣಗೊಳಿಸುತ್ತದೆಯೇ? ಆ ರೀತಿಯಲ್ಲಿ agent ನೇರವಾಗಿ file edit ಮಾಡುವುದರ ದೋಷಗಳು ಮತ್ತು ಮಿತಿಗಳು ಯಾವುವು? Direct file edits ಮಾಡದೆ task ಮುಗಿಸುವಂತೆ prompt ಹೇಗೆ ನೀಡಬೇಕು ಎಂದು ಕಂಡುಹಿಡಿಯಿರಿ. ಸೂಚನೆ: [first lecture](/2026/course-shell/) ನಲ್ಲಿ ಹೇಳಿದ command-line tools ಗಳಲ್ಲಿ ಒಂದನ್ನು ಬಳಸುವಂತೆ ಕೇಳಿ.
+1. ಹೆಚ್ಚಿನ coding agents ಗಳಲ್ಲಿ "yolo mode" ಇರುವ ಒಂದು ರೂಪ ಇರುತ್ತದೆ (ಉದಾ: Claude Code ನಲ್ಲಿ `--dangerously-skip-permissions`). ಈ mode ಅನ್ನು ನೇರವಾಗಿ ಬಳಸುವುದು ಸುರಕ್ಷಿತವಲ್ಲ. ಆದರೆ virtual machine ಅಥವಾ container ಮೊದಲಾದ isolated environment ನಲ್ಲಿ coding agent ನಡೆಸಿ autonomous operation ಸಕ್ರಿಯಗೊಳಿಸುವುದು ಒಪ್ಪಿಕೊಳ್ಳಬಹುದಾದ ಮಾರ್ಗವಾಗಬಹುದು. ಈ setup ಅನ್ನು ನಿಮ್ಮ ಯಂತ್ರದಲ್ಲಿ ಚಾಲನೆ ಮಾಡಿ. [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) ಅಥವಾ [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/claude-code/) ಮೊದಲಾದ docs ಸಹಾಯಕವಾಗಬಹುದು. ಇದನ್ನು ಹೊಂದಿಸಲು ಒಂದಕ್ಕಿಂತ ಹೆಚ್ಚು ವಿಧಾನಗಳಿವೆ.

--- a/_2026/beyond-code.md
+++ b/_2026/beyond-code.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Beyond the Code"
+title: "ಕೋಡ್‌ನಾಚೆ"
 description: >
-  Learn about essential soft skills including documentation, open-source community norms, and AI etiquette.
+  ದಸ್ತಾವೇಜೀಕರಣ, open-source ಸಮುದಾಯದ ನಡವಳಿಕೆ ಮಾನದಂಡಗಳು, ಮತ್ತು AI etiquette ಸೇರಿದಂತೆ ಅಗತ್ಯ soft skills ಕುರಿತು ತಿಳಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec8.png
 date: 2026-01-22
 ready: true
@@ -11,408 +11,361 @@ video:
   id: 2DOEATfXT8k
 ---
 
-Being a good software engineer isn't just about writing code that
-works. It's about writing code that others (including future you) can
-understand, maintain, and build upon. It's about communicating
-clearly, contributing thoughtfully, and being a good citizen in the
-ecosystems you participate in—whether open source or proprietary.
+ಒಬ್ಬ ಉತ್ತಮ software engineer ಆಗಿರುವುದು, ಕೆಲಸ ಮಾಡುವ code ಬರೆಯುವುದರಷ್ಟೇ ಅಲ್ಲ.
+ಇತರರು (ಭವಿಷ್ಯದ ನೀವು ಸಹ) ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು, ನಿರ್ವಹಿಸಲು, ಮತ್ತು ಅದೇ ಮೇಲೇ ನಿರ್ಮಿಸಲು
+ಸಾಧ್ಯವಾಗುವ code ಬರೆಯುವುದೂ ಅದರಲ್ಲಿ ಸೇರಿದೆ. ಸ್ಪಷ್ಟವಾಗಿ ಸಂವಹನ ಮಾಡುವುದು,
+ವಿಚಾರಪೂರ್ವಕವಾಗಿ ಕೊಡುಗೆ ನೀಡುವುದು, ಮತ್ತು ನೀವು ಭಾಗವಹಿಸುವ ecosystem ಗಳಲ್ಲಿ -
+ಅವು open source ಆಗಿರಲಿ ಅಥವಾ proprietary ಆಗಿರಲಿ - ಉತ್ತಮ ನಾಗರಿಕರಂತೆ ನಡೆದುಕೊಳ್ಳುವುದೂ
+ಅಷ್ಟೇ ಮುಖ್ಯ.
 
-# One-way communication
+# ಏಕದಿಶ ಸಂವಹನ
 
-Much of software engineering involves writing for people who lack your
-current context: teammates who join later, maintainers who inherit
-your code, or yourself in six months when you've forgotten why you
-made a particular choice. A key piece of advice for all this kind of
-writing is that your goal is to capture and convey the *why*, not just
-the *what*. The what tends to be self-explanatory, while the *why* is
-hard-earned knowledge that is easily lost to time.
+software engineering ನ ಬಹುಪಾಲು ಕೆಲಸವು ನಿಮ್ಮ ಇಂದಿನ ಸಂದರ್ಭ ತಿಳಿಯದ ಜನರಿಗಾಗಿ
+ಬರೆಯುವುದನ್ನು ಒಳಗೊಂಡಿದೆ: ನಂತರ ಸೇರಿಕೊಳ್ಳುವ teammates, ನಿಮ್ಮ code ಅನ್ನು
+ಪಾರಂಪರ್ಯವಾಗಿ ಸ್ವೀಕರಿಸುವ maintainers, ಅಥವಾ ಆರು ತಿಂಗಳ ನಂತರ ನೀವು ಏಕೆ ಒಂದು
+ನಿರ್ದಿಷ್ಟ ಆಯ್ಕೆಯನ್ನು ಮಾಡಿದ್ದೀರಿ ಎಂಬುದನ್ನೇ ಮರೆತಿರುವ ನಿಮ್ಮದೇ ಸ್ವರೂಪ. ಇಂತಹ ಬರವಣಿಗೆಯ
+ಮುಖ್ಯ ಸಲಹೆ ಏನೆಂದರೆ - ನಿಮ್ಮ ಗುರಿ ಕೇವಲ *what* ಅನ್ನು ದಾಖಲಿಸುವುದಲ್ಲ, *why* ಅನ್ನು ಹಿಡಿದು
+ಸ್ಪಷ್ಟವಾಗಿ ಹಂಚುವುದಾಗಿರಬೇಕು. *what* ಸಾಮಾನ್ಯವಾಗಿ code ನಿಂದಲೇ ಗೊತ್ತಾಗುತ್ತದೆ; *why* ಮಾತ್ರ
+ಕಷ್ಟಪಟ್ಟು ಗಳಿಸಿದ ಜ್ಞಾನವಾಗಿದ್ದು, ಕಾಲಕ್ರಮೇಣ ಸುಲಭವಾಗಿ ಕಳೆದುಹೋಗುತ್ತದೆ.
 
-Perhaps the most common form of engineer-to-engineer communication
-(apart from the code itself) is code comments. I've personally found
-that a lot of code comments are useless. But they don't have to be! Good
-comments explain things that the code itself cannot: *why* something is
-done a particular way, not *how* it works (which is what the code
-shows). They can save hours of confusion, while bad comments add noise
-or, worse, mislead.
+ಬಹುಶಃ engineer-to-engineer ಸಂವಹನದ ಅತ್ಯಂತ ಸಾಮಾನ್ಯ ರೂಪ (code ನ ಹೊರತಾಗಿ)
+code comments ಆಗಿದೆ. ನನ್ನ ಅನುಭವದಲ್ಲಿ ಅನೇಕ code comments ಉಪಯೋಗಕಾರಿಯಾಗಿಲ್ಲ.
+ಆದರೆ ಅದು ಅನಿವಾರ್ಯವಲ್ಲ. ಉತ್ತಮ comments ಗಳು code ತಾನೇ ಹೇಳಲಾರದ ಸಂಗತಿಗಳನ್ನು
+ವಿವರಿಸುತ್ತವೆ: ಯಾವುದನ್ನಾದರೂ ನಿರ್ದಿಷ್ಟ ರೀತಿಯಲ್ಲಿ *ಏಕೆ* ಮಾಡಲಾಗಿದೆ ಎಂಬುದನ್ನು, ಅದು *ಹೇಗೆ*
+ಕೆಲಸ ಮಾಡುತ್ತದೆ ಎಂಬುದನ್ನು ಅಲ್ಲ (ಅದನ್ನು code ತೋರಿಸುತ್ತದೆ). ಉತ್ತಮ comments ಗಳು
+ಗಂಟೆಗಳ ಗೊಂದಲ ತಪ್ಪಿಸುತ್ತವೆ; ದುರ್ಬಲ comments ಗಳು ಶಬ್ದ ಮಾತ್ರ ಹೆಚ್ಚಿಸಬಹುದು,
+ಅಥವಾ ಇನ್ನೂ ಕೆಟ್ಟದಾಗಿ ತಪ್ಪುದಾರಿಗೆ ನಡೆಸಬಹುದು.
 
-Types of comments that are nearly always worthwhile:
+ತೀರಾ ಬಹುಶಃ ಯಾವಾಗಲೂ ಉಪಯುಕ್ತವಾಗಿರುವ comment ಪ್ರಕಾರಗಳು:
 
-- **TODOs**: Mark incomplete or unpolished code, but leave enough
-  context for someone else to understand what's outstanding and why it
-  was deferred. "TODO: optimize" is useless; "TODO: this O(n²) loop is
-  fine for `n<100`, but will need indexing if we scale" is actionable.
-- **References**: Link to external sources when code implements an
-  algorithm from a paper, adapts code from elsewhere, or encodes
-  behaviour specified in documentation. Use permalinks. Note any
-  divergences from the reference.
-- **Correctness arguments**: Explain *why* non-trivial code produces
-  correct results. The code shows the steps; a comment explains why
-  those steps work.
-- **Hard-learned lessons**: If you spent 30+ minutes debugging something
-  and the fix is a non-obvious incantation, document it. Your past self
-  didn't realize it was needed; future readers won't either.
-- **Rationale for constants**: Magic numbers deserve explanation. Why
-  1492? Why 16 bits? Was it chosen randomly, derived from testing, or
-  required for correctness? Even "chosen arbitrarily" is useful
-  information.
-- **Load-bearing choices**: If correctness depends on a
-  seemingly-innocent implementation detail (e.g., "must be a BTreeSet
-  because iteration order matters below"), call it out explicitly.
-- **"Why not"s**: When you deliberately avoid the obvious approach,
-  explain why. Otherwise someone will "fix" it later and break things.
+- **TODOs**: ಅಪೂರ್ಣ ಅಥವಾ ಇನ್ನೂ ತಿದ್ದಬೇಕಿರುವ code ಅನ್ನು ಗುರುತಿಸಿ; ಆದರೆ ಉಳಿದಿರುವ
+  ಕೆಲಸ ಏನು ಮತ್ತು ಅದು ಏಕೆ ಮುಂದೂಡಲಾಯಿತು ಎಂಬುದನ್ನು ಮತ್ತೊಬ್ಬರು ಅರ್ಥಮಾಡಿಕೊಳ್ಳುವಷ್ಟು
+  ಸಂದರ್ಭವನ್ನು ನೀಡಿ. "TODO: optimize" ಉಪಯೋಗವಿಲ್ಲ; "TODO: this O(n²) loop is
+  fine for `n<100`, but will need indexing if we scale" ಕಾರ್ಯಗತಗೊಳ್ಳುವ ಸೂಚನೆ.
+- **References**: code ಯಾವುದೇ paper ನ algorithm ಅನ್ನು ಜಾರಿಗೊಳಿಸಿದಾಗ, ಬೇರೆಡೆಗಿನ
+  code ಅನ್ನು ಹೊಂದಾಣಿಕೆ ಮಾಡಿದಾಗ, ಅಥವಾ documentation ನಿರ್ದಿಷ್ಟಪಡಿಸಿದ behaviour ಅನ್ನು
+  ಒಳಗೊಂಡಿದ್ದಾಗ, ಹೊರಗಿನ ಮೂಲಗಳಿಗೆ link ನೀಡಿ. permalinks ಬಳಸಿ. reference ನಿಂದ ಇರುವ
+  ಭಿನ್ನತೆಗಳನ್ನು ಸ್ಪಷ್ಟವಾಗಿ ನಮೂದಿಸಿ.
+- **Correctness arguments**: ಸರಳವಲ್ಲದ code ಸರಿಯಾದ ಫಲಿತಾಂಶ ನೀಡುತ್ತದೆ ಎಂಬುದನ್ನು *ಏಕೆ*
+  ಎಂದು ವಿವರಿಸಿ. code ಕ್ರಮಗಳನ್ನು ತೋರಿಸುತ್ತದೆ; comment ಆ ಕ್ರಮಗಳು ಏಕೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ
+  ಎಂಬುದನ್ನು ಹೇಳುತ್ತದೆ.
+- **Hard-learned lessons**: ಯಾವುದನ್ನಾದರೂ debug ಮಾಡಲು 30+ ನಿಮಿಷ ತೆಗೆದುಕೊಂಡು,
+  ಪರಿಹಾರವು ತಕ್ಷಣ ಗೋಚರಿಸದ incantation ಆಗಿದ್ದರೆ, ಅದನ್ನು ದಾಖಲಿಸಿ. ಹಳೆಯ ನಿಮಗೆ ಅದು
+  ಬೇಕೆಂದು ತಿಳಿದಿರಲಿಲ್ಲ; ಭವಿಷ್ಯದ ಓದುಗರಿಗೂ ಹಾಗೆಯೇ ಇರಬಹುದು.
+- **Rationale for constants**: Magic numbers ಗೆ ವಿವರಣೆ ಅಗತ್ಯ. 1492 ಏಕೆ? 16 bits ಏಕೆ?
+  ಅದು ಯಾದೃಚ್ಛಿಕವಾಗಿ ಆಯ್ಕೆ ಮಾಡಲ್ಪಟ್ಟದೇ, testing ನಿಂದ ಬಂದದೇ, ಅಥವಾ correctness ಗೆ ಅವಶ್ಯವೇ?
+  "chosen arbitrarily" ಎಂಬ ಮಾಹಿತಿ ಸಹ ಉಪಯುಕ್ತವೇ.
+- **Load-bearing choices**: correctness ತೋರಿಕೆಗೆ ಸಾಮಾನ್ಯ implementation detail ಮೇಲೆ
+  ಅವಲಂಬಿತವಾಗಿದ್ದರೆ (ಉದಾ., "must be a BTreeSet because iteration order matters below"),
+  ಅದನ್ನು ಸ್ಪಷ್ಟವಾಗಿ ಹೇಳಿ.
+- **"Why not"s**: ನೀವು ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಸ್ಪಷ್ಟವಾಗಿ ಕಾಣುವ ವಿಧಾನವನ್ನು ತಪ್ಪಿಸಿದರೆ, ಏಕೆ ಎಂದು
+  ವಿವರಿಸಿ. ಇಲ್ಲದಿದ್ದರೆ ನಂತರ ಯಾರಾದರೂ ಅದನ್ನು "ಸರಿಪಡಿಸಲು" ಹೋಗಿ ವ್ಯವಸ್ಥೆ ಹಾಳು ಮಾಡಬಹುದು.
 
-READMEs (you have one, right?) are also a common first touch-point with
-other developers. A good one answers four questions immediately: What
-does this do? Why should I care? How do I use it? How do I install it?
-In that order. Structure it like a funnel: a one-liner and maybe a
-visual demo at the top so someone can decide in seconds if this solves
-their problem, then progressively add depth. Show usage before
-installation — people want to see what they're getting before committing
-to setup steps.
+READMEs (ನಿಮ್ಮದೂ ಇದೆ, ಅಲ್ಲವೇ?) ಕೂಡ ಇತರ developers ಗೆ ಸಾಮಾನ್ಯವಾಗಿ ಮೊದಲ ಸ್ಪರ್ಶಬಿಂದು.
+ಒಂದು ಉತ್ತಮ README ತಕ್ಷಣ ನಾಲ್ಕು ಪ್ರಶ್ನೆಗಳಿಗೆ ಉತ್ತರಿಸಬೇಕು: ಇದು ಏನು ಮಾಡುತ್ತದೆ? ನಾನು
+ಇದನ್ನು ಏಕೆ ಗಮನಿಸಬೇಕು? ಇದನ್ನು ಹೇಗೆ ಬಳಸುವುದು? ಇದನ್ನು ಹೇಗೆ install ಮಾಡುವುದು? ಇದೇ ಕ್ರಮದಲ್ಲಿ.
+ಇದನ್ನು funnel ಮಾದರಿಯಲ್ಲಿ ರೂಪಿಸಿ: ಮೇಲ್ಭಾಗದಲ್ಲಿ ಒಂದು one-liner ಮತ್ತು ಸಾಧ್ಯವಾದರೆ ಒಂದು
+visual demo ಇರಿ, ಇದರಿಂದ ಯಾರಾದರೂ ಕೆಲವೇ ಕ್ಷಣಗಳಲ್ಲಿ ಇದರಿಂದ ತಮ್ಮ ಸಮಸ್ಯೆ ಬಗೆಹರಿಯುತ್ತದೆಯೇ
+ಎಂದು ನಿರ್ಧರಿಸಬಹುದು. ನಂತರ ಹಂತ ಹಂತವಾಗಿ ಆಳವಾದ ವಿವರ ಸೇರಿಸಿ. installation ಗಿಂತ ಮೊದಲು usage
+ತೋರಿಸಿ - setup ಹಂತಗಳಿಗೆ ಬದ್ಧರಾಗುವ ಮೊದಲು ಅವರು ಏನು ಪಡೆಯುತ್ತಿದ್ದಾರೆ ಎಂಬುದು ಜನರಿಗೆ ತಿಳಿಯಬೇಕಿರುತ್ತದೆ.
 
-Commit messages are another kind of "writing for others" that is often
-neglected. They are often written as "fixed blah" or "added foo", and
-while that may be sufficient in some cases, it's easy to forget that
-they form the historical record of *why* the codebase evolved the way it
-did. When someone (including you!) runs `git blame` trying to understand
-a confusing change, good commit messages should give them answers.
+commit messages ಕೂಡ ಬಹುಸಾರಿ ನಿರ್ಲಕ್ಷ್ಯಗೊಳ್ಳುವ "ಇತರರಿಗಾಗಿ ಬರವಣಿಗೆ"ಯ ಪ್ರಮುಖ ರೂಪ.
+ಅವುಗಳನ್ನು ಅನೇಕ ಬಾರಿ "fixed blah" ಅಥವಾ "added foo" ಎಂಬಂತೆ ಬರೆಯಲಾಗುತ್ತದೆ. ಕೆಲ ಸಂದರ್ಭದಲ್ಲಿ
+ಅದು ಸಾಕಾಗಬಹುದು, ಆದರೆ codebase ಏಕೆ ಈ ರೀತಿಯಲ್ಲಿ ಬದಲಾಗಿದೆ ಎಂಬ *ಇತಿಹಾಸದ ದಾಖಲೆಯನ್ನು* ಅವೇ
+ನಿರ್ಮಿಸುತ್ತವೆ ಎಂಬುದನ್ನು ಮರೆತಬಾರದು. ಯಾರಾದರೂ (ನಿಮ್ಮೂ ಸೇರಿ) ಗೊಂದಲಕಾರಿ ಬದಲಾವಣೆಯನ್ನು
+ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು `git blame` ಚಲಾಯಿಸಿದಾಗ, ಉತ್ತಮ commit messages ಉತ್ತರಗಳನ್ನು ನೀಡಬೇಕು.
 
-In general, the body should answer:
-- What problem forced this change?
-- What alternatives did you consider?
-- What are the trade-offs or implications?
-- What might be surprising about this approach?
+ಸಾಮಾನ್ಯವಾಗಿ commit body ಈ ಪ್ರಶ್ನೆಗಳಿಗೆ ಉತ್ತರಿಸಬೇಕು:
+- ಈ ಬದಲಾವಣೆಯನ್ನು ಅನಿವಾರ್ಯಗೊಳಿಸಿದ ಸಮಸ್ಯೆ ಯಾವುದು?
+- ನೀವು ಯಾವ ಪರ್ಯಾಯಗಳನ್ನು ಪರಿಗಣಿಸಿದ್ದೀರಿ?
+- trade-offs ಅಥವಾ implications ಯಾವುವು?
+- ಈ ವಿಧಾನದಲ್ಲಿ ಅಚ್ಚರಿಯಾಯಕವೆನಿಸಬಹುದಾದ ಅಂಶ ಏನು?
 
-> Obviously you should scale detail with complexity. A one-line typo fix
-> needs only a subject. A subtle race condition fix that took hours to
-> debug deserves paragraphs explaining the problem and solution.
+> ಸ್ಪಷ್ಟವಾಗಿಯೇ, ವಿವರದ ಪ್ರಮಾಣವನ್ನು complexity ಗೆ ಅನುಗುಣವಾಗಿ ಹೊಂದಿಸಬೇಕು.
+> ಒಂದು ಸಾಲಿನ typo fix ಗೆ subject ಸಾಲು ಸಾಕು. ಹಲವು ಗಂಟೆಗಳ debug ನಂತರ ಸರಿಪಡಿಸಿದ
+> ಸೂಕ್ಷ್ಮ race condition ಗೆ ಸಮಸ್ಯೆ ಮತ್ತು ಪರಿಹಾರವನ್ನು ವಿವರಿಸುವ ಕೆಲವು ಪ್ಯಾರಾಗ್ರಾಫ್‌ಗಳು
+> ಬೇಕಾಗುತ್ತವೆ.
 
-For complex changes, it can be useful to follow a Problem → Solution →
-Implications structure: Start with the forcing function or limitation,
-then explain what changed and the key design decisions, and then list
-noteworthy consequences (positive and negative). That last part is
-particularly important; real engineering involves balancing concerns,
-and documenting that a trade-off was intentional prevents future
-developers from thinking you missed the problem.
+ಸಂಕೀರ್ಣ ಬದಲಾವಣೆಗಳಲ್ಲಿ Problem → Solution → Implications ರಚನೆ ಅನುಸರಿಸುವುದು ಉಪಯುಕ್ತ.
+ಮೊದಲಿಗೆ ಬದಲಾವಣೆಯನ್ನು ಒತ್ತಾಯಿಸಿದ ಕಾರಣ ಅಥವಾ ಮಿತಿ ಏನು ಎಂಬುದರಿಂದ ಪ್ರಾರಂಭಿಸಿ; ನಂತರ ಏನು
+ಬದಲಾಗಿದೆ ಮತ್ತು ಪ್ರಮುಖ design ನಿರ್ಣಯಗಳು ಯಾವುವು ಎಂದು ವಿವರಿಸಿ; ಕೊನೆಯಲ್ಲಿ ಗಮನಾರ್ಹ
+ಪರಿಣಾಮಗಳನ್ನು (ಧನಾತ್ಮಕ ಹಾಗೂ ಋಣಾತ್ಮಕ) ಪಟ್ಟಿ ಮಾಡಿ. ಈ ಕೊನೆಯ ಭಾಗ ಅತ್ಯಂತ ಪ್ರಮುಖ.
+ನಿಜವಾದ engineering ಅನೇಕ ಚಿಂತೆಗಳ ಸಮತೋಲನವಾಗಿದ್ದು, trade-off ಉದ್ದೇಶಿತವಾಗಿತ್ತು ಎಂದು
+ದಾಖಲಿಸಿದರೆ, ಭವಿಷ್ಯದ developers ನೀವು ಸಮಸ್ಯೆಯನ್ನು ಗಮನಿಸದೆ ಬಿಟ್ಟಿದ್ದೀರಿ ಎಂದು ಭಾವಿಸುವುದಿಲ್ಲ.
 
-LLMs _can_ be helpful in writing commit messages. However, if you simply
-point one at your change and ask it to write the commit message for the
-change, the LLM will only have access to the _what_, not the _why_. And
-the resulting commit message will thus be mostly descriptive (the
-opposite of what we want!). If you used an LLM to help you make the
-change in the first place, asking the LLM to write the commit in that
-same session can be a much better option since your conversation with
-the LLM is inherently a rich source of context about the change!
-Otherwise, or in addition, a useful trick is to specifically tell the
-LLM you'd like a commit message focused on the "why" (and other nuances
-from the notes above), and then _tell it to query you for missing
-context_. Essentially, you're acting like a MCP "tool" for the coding
-agent that it can use to "read" context.
+commit messages ಬರೆಯುವಲ್ಲಿ LLMs _ಉಪಯುಕ್ತ_ವಾಗಬಹುದು. ಆದರೆ ನಿಮ್ಮ ಬದಲಾವಣೆಯನ್ನು ಮಾತ್ರ
+ತೋರಿಸಿ commit message ಬರೆಯಲು ಹೇಳಿದರೆ, LLM ಗೆ _what_ ಮಾತ್ರ ಗೋಚರಿಸುತ್ತದೆ, _why_ ಅಲ್ಲ.
+ಫಲವಾಗಿ ಸಿಗುವ commit message ಬಹುತೇಕ ವರ್ಣನಾತ್ಮಕವಾಗಿರುತ್ತದೆ (ನಮಗೆ ಬೇಕಾದುದಕ್ಕೆ ವಿರೋಧವಾಗಿ).
+ಬದಲಾವಣೆಯನ್ನು ಮಾಡಿಸುವಲ್ಲೇ ನೀವು LLM ಸಹಾಯ ಪಡೆದಿದ್ದರೆ, ಅದೇ session ನಲ್ಲಿ commit ಕೂಡ ಅದರಿಂದ
+ಬರೆಯಿಸಿಕೊಳ್ಳುವುದು ಹೆಚ್ಚು ಉತ್ತಮ - ಏಕೆಂದರೆ ನಿಮ್ಮ ಸಂಭಾಷಣೆ ಬದಲಾವಣೆಯ ಕುರಿತ ಸಮೃದ್ಧ context
+ಒದಗಿಸುತ್ತದೆ. ಇದಲ್ಲದೇ, ಅಥವಾ ಇದರ ಜೊತೆಗೆ, "why" ಕೇಂದ್ರಿತ commit message ಬೇಕು (ಮೇಲಿನ
+ಸೂಚನೆಗಳಲ್ಲಿನ ಇತರೆ ಸೂಕ್ಷ್ಮಾಂಶಗಳೂ ಸೇರಿ) ಎಂದು LLM ಗೆ ಸ್ಪಷ್ಟವಾಗಿ ಹೇಳಿ; ನಂತರ _ಕಡಿಮೆಯಿರುವ
+ಸಂದರ್ಭಕ್ಕಾಗಿ ನಿಮಗೇ ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳಲು ಅದಕ್ಕೆ ಸೂಚಿಸಿ_. ಅರ್ಥಾತ್, coding agent ಗೆ context
+"read" ಮಾಡಲು ಬಳಸಬಹುದಾದ MCP "tool" ಆಗಿ ನೀವು ತಾವೇ ವರ್ತಿಸುತ್ತಿದ್ದೀರಿ.
 
-As your changes get more complex, make sure to also break up commits
-logically (`git add -p` is your friend). Each commit should represent
-one coherent change that could be understood and reviewed independently.
-Don't mix refactoring with new features or combine unrelated bug fixes,
-as this muddies the story for which changes fixed what problem, and will
-almost certainly slow down the eventual review of your changes. It also
-gives you superpowers through `git bisect`, but that's a story for
-another time.
+ನಿಮ್ಮ ಬದಲಾವಣೆಗಳು ಹೆಚ್ಚು ಸಂಕೀರ್ಣವಾಗುತ್ತಾ ಹೋದಂತೆ commits ಅನ್ನು ತಾರ್ಕಿಕವಾಗಿ ವಿಭಜಿಸುತ್ತಿರುವುದನ್ನು
+ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ (`git add -p` ನಿಮಗೆ ಸಹಕಾರಿ). ಪ್ರತಿಯೊಂದು commit ಸ್ವತಂತ್ರವಾಗಿ ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು
+ಮತ್ತು review ಮಾಡಲು ಸಾಧ್ಯವಾಗುವ ಒಂದು ಸಮ್ಮೇಳಿತ ಬದಲಾವಣೆಯನ್ನು ಪ್ರತಿನಿಧಿಸಬೇಕು. refactoring ಅನ್ನು
+ಹೊಸ features ಜೊತೆ ಮಿಶ್ರಣ ಮಾಡಬೇಡಿ; ಸಂಬಂಧವಿಲ್ಲದ bug fixes ಗಳನ್ನು ಸೇರಿಸಬೇಡಿ. ಹೀಗೆ ಮಾಡಿದರೆ ಯಾವ
+ಬದಲಾವಣೆಯಿಂದ ಯಾವ ಸಮಸ್ಯೆ ಬಗೆಹರಿಯಿತು ಎಂಬ ಕಥನ ಅಸ್ಪಷ್ಟವಾಗುತ್ತದೆ ಮತ್ತು ಅಂತಿಮ review ಬಹುಶಃ ನಿಧಾನಗೊಳ್ಳುತ್ತದೆ.
+ಇದು `git bisect` ಮೂಲಕ ನಿಮಗೆ ವಿಶೇಷ ಶಕ್ತಿ ಕೂಡ ನೀಡುತ್ತದೆ, ಆದರೆ ಅದು ಮತ್ತೊಂದು ಸಂದರ್ಭದ ಕಥೆ.
 
-> One note as you start being more diligent about technical writing, and
-> using it more extensively, make sure you respect the reader. It's easy
-> to end up over-explaining once you start, but you have to resist that
-> urge lest the reader read _none_ of what you've written. Explain the
-> "why" and trust them to figure out the "how" for their situation.
+> technical writing ಬಗ್ಗೆ ನೀವು ಹೆಚ್ಚು ಶ್ರದ್ಧೆ ತೋರಲಾರಂಭಿಸಿದಾಗ, ಮತ್ತು ಅದನ್ನು ಹೆಚ್ಚು
+> ವ್ಯಾಪಕವಾಗಿ ಬಳಸಲು ಪ್ರಾರಂಭಿಸಿದಾಗ, ಓದುಗರಿಗೆ ಗೌರವ ಕೊಡುವುದನ್ನು ಮರೆಯಬೇಡಿ. ಒಮ್ಮೆ ಆರಂಭಿಸಿದ
+> ನಂತರ ಅತಿಯಾಗಿ ವಿವರಿಸುವ ಪ್ರವೃತ್ತಿ ಸುಲಭವಾಗಿ ಬರುತ್ತದೆ. ಆದರೆ ಓದುಗರು ನಿಮ್ಮ ಬರಹವನ್ನೇ
+> _ಓದದೆ_ ಬಿಡುವ ಪರಿಸ್ಥಿತಿ ಬರದಂತೆ ಆ ಪ್ರವೃತ್ತಿಯನ್ನು ನಿಯಂತ್ರಿಸಬೇಕು. "why" ಅನ್ನು ವಿವರಿಸಿ,
+> ಮತ್ತು "how" ಅನ್ನು ತಮ್ಮ ಸಂದರ್ಭಕ್ಕೆ ತಕ್ಕಂತೆ ಅವರು ಕಂಡುಕೊಳ್ಳುತ್ತಾರೆ ಎಂಬ ನಂಬಿಕೆ ಇರಿ.
 
-# Collaboration
+# ಸಹಯೋಗ
 
-As engineers, we may spend a large part of our job coding at our own
-keyboard, but a sizeable chunk of our time is also taken up by
-communicating with others. That time is usually split into collaboration
-and education, and the payoff from investing in getting better at both is
-significant.
+engineers ಆಗಿರುವ ನಾವು ಕೆಲಸದ ಬಹುಭಾಗವನ್ನು ನಮ್ಮದೇ keyboard ಮುಂದೆ coding ಮಾಡುವುದರಲ್ಲಿ
+ಕಳೆಯಬಹುದು. ಆದರೆ ನಮ್ಮ ಸಮಯದ ಮಹತ್ತರ ಭಾಗ ಇತರರೊಂದಿಗೆ ಸಂವಹನದಲ್ಲಿಯೂ ಹೋಗುತ್ತದೆ. ಆ ಸಮಯವು
+ಸಾಮಾನ್ಯವಾಗಿ collaboration ಮತ್ತು education ಗಳಾಗಿ ವಿಭಜಿತವಾಗಿರುತ್ತದೆ; ಇವೆರಡರಲ್ಲೂ ಉತ್ತಮವಾಗಲು
+ಹೂಡಿಕೆ ಮಾಡುವುದರಿಂದ ದೊರೆಯುವ ಪ್ರಯೋಜನ ಗಮನಾರ್ಹವಾಗಿದೆ.
 
-## Contributing
+## ಕೊಡುಗೆ ನೀಡುವುದು
 
-Whether you are submitting a bug report, contributing a simple bug fix,
-or implementing a huge feature, it's worth keeping in mind that there
-are usually orders of magnitude more users than there are contributors,
-and an order of magnitude more contributors than there are maintainers.
-As a result, maintainer time is highly oversubscribed. If you want to
-increase the likelihood that your contribution goes somewhere
-productive, you have to ensure that your contributions carry a high
-signal-to-noise ratio and are worth the maintainers' time.
+ನೀವು bug report ಸಲ್ಲಿಸುತ್ತಿರಲಿ, ಸರಳ bug fix ನೀಡುತ್ತಿರಲಿ, ಅಥವಾ ದೊಡ್ಡ feature ಒಂದನ್ನು
+ಅಮಲುಗೊಳಿಸುತ್ತಿರಲಿ - ಒಂದು ಸಂಗತಿ ನೆನಪಿನಲ್ಲಿ ಇರಲಿ: ಸಾಮಾನ್ಯವಾಗಿ users ಸಂಖ್ಯೆ contributors ಗಿಂತ
+ಅನೇಕ ಪಟ್ಟು ಹೆಚ್ಚು; contributors ಸಂಖ್ಯೆ maintainers ಗಿಂತಲೂ ಒಂದು ಹಂತ ಹೆಚ್ಚು. ಇದರಿಂದ maintainer
+ಸಮಯವು ಬಹಳ ಮಟ್ಟಿಗೆ ಒತ್ತಡದಲ್ಲಿರುತ್ತದೆ. ನಿಮ್ಮ ಕೊಡುಗೆ ಪರಿಣಾಮಕಾರಿಯಾಗಿ ಮುಂದುವರಿಯುವ ಸಾಧ್ಯತೆಯನ್ನು
+ಹೆಚ್ಚಿಸಲು, ನಿಮ್ಮ ಕೊಡುಗೆಗೆ ಹೆಚ್ಚಿನ signal-to-noise ratio ಇರಬೇಕು ಮತ್ತು ಅದು maintainers ಸಮಯಕ್ಕೆ
+ತಕ್ಕ ಮೌಲ್ಯ ಹೊಂದಿರಬೇಕು.
 
-For example, a good bug report respects the maintainer's time by
-providing everything needed to understand and reproduce the problem:
+ಉದಾಹರಣೆಗೆ, ಉತ್ತಮ bug report ಒಂದು maintainer ಸಮಯಕ್ಕೆ ಗೌರವ ತೋರಿಸುವಂತೆ, ಸಮಸ್ಯೆಯನ್ನು
+ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಮತ್ತು ಮರುಉತ್ಪಾದಿಸಲು ಅಗತ್ಯವಿರುವ ಎಲ್ಲ ಮಾಹಿತಿಯನ್ನು ಒದಗಿಸುತ್ತದೆ:
 
-- **Environment**: OS, version numbers, relevant configuration
+- **Environment**: OS, version numbers, ಸಂಬಂಧಿತ configuration
 - **What you expected** vs **what actually happened**
-- **Steps to reproduce**: Be specific. "Click the button" is less useful
-  than "Click the Submit button on the /settings page while logged in as
-  an admin."
-- **What you've already tried**: This prevents duplicate suggestions and
-  shows you've done some investigation
+- **Steps to reproduce**: ಸ್ಪಷ್ಟವಾಗಿರಿ. "Click the button" ಗಿಂತ,
+  "admin ಆಗಿ login ಆಗಿರುವಾಗ /settings page ನಲ್ಲಿ Submit button ಕ್ಲಿಕ್ ಮಾಡಿ."
+  ಹೆಚ್ಚು ಉಪಯುಕ್ತ.
+- **What you've already tried**: ಇದು ಅದೇ ರೀತಿಯ ಪುನರಾವರ್ತಿತ ಸಲಹೆಗಳನ್ನು ತಪ್ಪಿಸುತ್ತದೆ
+  ಮತ್ತು ನೀವು ಕೆಲವು ತನಿಖೆ ನಡೆಸಿದ್ದೀರಿ ಎಂಬುದನ್ನು ತೋರಿಸುತ್ತದೆ
 
-> If you find a security vulnerability, don't post it publicly. Contact
-> the maintainers privately first and give them reasonable time to fix
-> it before disclosure. Many projects have a SECURITY.md file or
-> similar for this purpose.
+> ನೀವು security vulnerability ಕಂಡುಹಿಡಿದರೆ, ಅದನ್ನು ಸಾರ್ವಜನಿಕವಾಗಿ ಪೋಸ್ಟ್ ಮಾಡಬೇಡಿ.
+> ಮೊದಲು maintainers ಅನ್ನು ಖಾಸಗಿವಾಗಿ ಸಂಪರ್ಕಿಸಿ, ಮತ್ತು ಬಹಿರಂಗಪಡಿಸುವುದಕ್ಕೆ ಮುನ್ನ ಅದನ್ನು
+> ಸರಿಪಡಿಸಲು ಅವರಿಗೆ ಸಮಂಜಸವಾದ ಸಮಯ ನೀಡಿ. ಅನೇಕ projects ಗಳು ಈ ಉದ್ದೇಶಕ್ಕಾಗಿ
+> SECURITY.md ಅಥವಾ ಸಮಾನ ದಾಖಲೆ ಹೊಂದಿರುತ್ತವೆ.
 
-**Make sure you search for existing issues.** Your bug or feature
-request may already be reported, and it's far better to add information
-to existing discussions rather than creating duplicates. Not to mention,
-it reduces noise for the maintainers.
+**ಈಗಾಗಲೇ ಇರುವ issues ಗಳನ್ನು ಹುಡುಕುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.** ನಿಮ್ಮ bug ಅಥವಾ feature
+request ಈಗಾಗಲೇ ವರದಿಯಾಗಿರಬಹುದು; ಅಂಥ ಸಂದರ್ಭದಲ್ಲಿ duplicate issue ತೆರೆವುದಕ್ಕಿಂತ,
+ಇದ್ದ ಚರ್ಚೆಗೆ ಹೊಸ ಮಾಹಿತಿಯನ್ನು ಸೇರಿಸುವುದು ಬಹಳ ಉತ್ತಮ. ಇದರಿಂದ maintainers ಗೆ ಶಬ್ದವೂ ಕಡಿಮೆ.
 
-Minimal reproducible examples are gold, if you can come up with one.
-They save the maintainer a huge amount of time and effort, and
-reliably reproducing the bug is often the hardest part of fixing it. Not
-to mention, the effort you put into isolating the problem often helps
-you understand it better too, and sometimes leads you to find a fix
-yourself.
+minimal reproducible examples ಸಿದ್ಧಪಡಿಸಲು ಸಾಧ್ಯವಾದರೆ ಅದು ಅಮೂಲ್ಯ. ಅವು maintainer ಗೆ
+ಅಪಾರ ಸಮಯ ಮತ್ತು ಪರಿಶ್ರಮ ಉಳಿಸುತ್ತವೆ; bug ಅನ್ನು ವಿಶ್ವಾಸಾರ್ಹವಾಗಿ ಮರುಉತ್ಪಾದಿಸುವುದು ಬಹುಸಾರಿ
+ಅದನ್ನು ಸರಿಪಡಿಸುವಲ್ಲಿ ಅತೀ ಕಠಿಣ ಹಂತವಾಗಿರುತ್ತದೆ. ಜೊತೆಗೆ, ಸಮಸ್ಯೆಯನ್ನು ಪ್ರತ್ಯೇಕಿಸಲು ನೀವು ಮಾಡುವ
+ಪ್ರಯತ್ನದಿಂದ ಅದರ ಕುರಿತು ನಿಮ್ಮ ಅರಿವು ಹೆಚ್ಚುತ್ತದೆ; ಕೆಲವೊಮ್ಮೆ ಪರಿಹಾರವನ್ನೇ ನೀವು ಕಂಡುಕೊಳ್ಳಬಹುದು.
 
-If you don't hear back right away, keep in mind that maintainers are
-often volunteers with limited time. If you're waiting for a reply from
-them, a polite follow-up after a couple weeks is fine; daily pings are
-not. Similarly, "me too" comments, or bug reports that are just a
-copy-paste of some terminal output tend to be a net-negative in terms of
-getting traction for your issue.
+ನಿಮಗೆ ತಕ್ಷಣ ಪ್ರತಿಕ್ರಿಯೆ ಬರದಿದ್ದರೆ, maintainers ಬಹುಸಾರಿ ಸೀಮಿತ ಸಮಯ ಹೊಂದಿರುವ volunteers
+ಎಂಬುದನ್ನು ಮನದಲ್ಲಿಡಿ. ಉತ್ತರಕ್ಕಾಗಿ ಕಾಯುತ್ತಿರುವಾಗ, ಒಂದು-ಎರಡು ವಾರಗಳ ನಂತರ ಸೌಜನ್ಯಪೂರ್ವಕ follow-up
+ಸರಿ; ಪ್ರತಿದಿನ ping ಮಾಡುವುದು ಸೂಕ್ತವಲ್ಲ. ಅದೇ ರೀತಿ, "me too" comments, ಅಥವಾ terminal output ನ
+copy-paste ಮಾತ್ರ ಹೊಂದಿರುವ bug reports - ನಿಮ್ಮ issue ಗೆ ಗಮನ ಸೆಳೆಯುವ ದೃಷ್ಟಿಯಲ್ಲಿ ಸಾಮಾನ್ಯವಾಗಿ
+ಪ್ರತಿಕೂಲ ಪರಿಣಾಮ ಉಂಟುಮಾಡುತ್ತವೆ.
 
-If you're looking to make a code contribution, you'll also want to
-familiarize yourself with the contribution guidelines. Many projects
-have a `CONTRIBUTING.md` — follow it. You'll also usually want to start
-small; a typo fix or documentation improvement is a great first
-contribution as it helps you learn the project's processes without also
-having to go through lots of back and forth on the content.
+code contribution ಮಾಡಲು ಬಯಸುತ್ತಿದ್ದರೆ, contribution guidelines ಅನ್ನು ಪರಿಚಯಿಸಿಕೊಳ್ಳಿ.
+ಅನೇಕ projects ಗಳಲ್ಲಿ `CONTRIBUTING.md` ಇರುತ್ತದೆ - ಅದನ್ನು ಅನುಸರಿಸಿ. ಸಾಮಾನ್ಯವಾಗಿ ಸಣ್ಣದಾಗಿ
+ಆರಂಭಿಸುವುದು ಉತ್ತಮ; typo fix ಅಥವಾ documentation ಸುಧಾರಣೆ ಮೊದಲ ಕೊಡುಗೆಯಾಗಿ ತುಂಬಾ ಚೆನ್ನಾಗಿರುತ್ತದೆ,
+ಏಕೆಂದರೆ ವಿಷಯದ ಕುರಿತು ದೀರ್ಘ back-and-forth ಇಲ್ಲದೆ project ಪ್ರಕ್ರಿಯೆಗಳನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಅದು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
 
-> Check what license the project uses, as any code you contribute will
-> fall under the same license. In particular, look out for copyleft
-> licenses (like GPL), which requires derivatives to also be open source
-> and may have implications for your employer if you touch it!
-> [choosealicense.com](https://choosealicense.com/) has more useful
-> information.
+> project ಯಾವ license ಬಳಕೆ ಮಾಡುತ್ತದೆ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸಿ, ಏಕೆಂದರೆ ನೀವು ಕೊಡುವ ಯಾವುದೇ
+> code ಅದೇ license ಅಡಿಯಲ್ಲಿ ಬರುತ್ತದೆ. ವಿಶೇಷವಾಗಿ copyleft licenses (ಉದಾ., GPL) ಬಗ್ಗೆ
+> ಎಚ್ಚರಿಕೆಯಾಗಿರಿ - ಅವು derivative works ಕೂಡ open source ಆಗಿರಬೇಕು ಎಂದು ಬೇಡಿಕೆ ಇಡುತ್ತವೆ,
+> ಮತ್ತು ನೀವು ಅದರಲ್ಲಿ ಪಾಲ್ಗೊಂಡರೆ ನಿಮ್ಮ employer ಮೇಲೂ ಅದರ ಪರಿಣಾಮ ಇರಬಹುದು.
+> [choosealicense.com](https://choosealicense.com/) ನಲ್ಲಿ ಹೆಚ್ಚಿನ ಉಪಯುಕ್ತ ಮಾಹಿತಿ ಇದೆ.
 
-When you've decided to open a pull request ("PR"), first make sure you
-isolate the change you actually want to be accepted. If your PR changes
-lots of other unrelated things at the same time, chances are the
-reviewer will send it back to you asking you to clean it up. This is
-similar to how you should break down your git commits into semantically
-related chunks.
+ನೀವು pull request ("PR") ತೆರೆಯಲು ನಿರ್ಧರಿಸಿದಾಗ, ಮೊದಲು ನೀವು ಅಂಗೀಕಾರ ಪಡೆಯಲು ಬಯಸುವ
+ಬದಲಾವಣೆಯನ್ನು ಪ್ರತ್ಯೇಕಿಸಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ. ನಿಮ್ಮ PR ಒಂದೇ ವೇಳೆ ಅನೇಕ ಸಂಬಂಧವಿಲ್ಲದ
+ವಿಷಯಗಳನ್ನು ಬದಲಿಸಿದರೆ, reviewer ಅದನ್ನು ಸ್ವಚ್ಛಗೊಳಿಸಲು ಹಿಂದಿರುಗಿಸುವ ಸಾಧ್ಯತೆ ಹೆಚ್ಚು. ಇದು ನೀವು
+git commits ಅನ್ನು ಅರ್ಥಪೂರ್ಣ ಸಂಬಂಧಿತ ಭಾಗಗಳಿಗೆ ವಿಭಜಿಸಬೇಕಾದ ವಿಧಾನಕ್ಕೆ ಸಮಾನ.
 
-In some cases, if you have many seemingly-disparate changes but
-they're all needed to enable one feature, it may be okay to open a
-larger PR that captures all the changes. However, in this case, commit
-hygiene is particularly important so that maintainers have the option
-to review the change "commit by commit".
+ಕೆಲ ಸಂದರ್ಭಗಳಲ್ಲಿ, ಬಾಹ್ಯವಾಗಿ ಸಂಬಂಧವಿಲ್ಲದಂತೆ ಕಾಣುವ ಹಲವಾರು ಬದಲಾವಣೆಗಳಿದ್ದರೂ, ಅವೆಲ್ಲವೂ
+ಒಂದು feature ಸಕ್ರಿಯಗೊಳಿಸಲು ಅಗತ್ಯವಾಗಿದ್ದರೆ, ಅವನ್ನೆಲ್ಲ ಒಳಗೊಂಡ ದೊಡ್ಡ PR ತೆరవುವುದು ಸರಿಯಾಗಬಹುದು.
+ಆದರೆ ಅಂಥ ಸಂದರ್ಭಗಳಲ್ಲಿ commit hygiene ವಿಶೇಷವಾಗಿ ಮುಖ್ಯ - maintainers ಗೆ ಬದಲಾವಣೆಯನ್ನು
+"commit by commit" ಆಗಿ review ಮಾಡುವ ಅವಕಾಶ ದೊರಕಬೇಕು.
 
-Next, make sure you explain the "why" behind the change well. Don't just
-describe _what_ changed — explain _why_ the change is needed and _why_
-this is a good way to address the problem. You should also proactively
-call out parts of the change that warrant special attention in the
-review, if any. Depending on `CONTRIBUTING.md` and the nature of your
-change, reviewers may also expect to see additional information like
-trade-offs you made or how to test the change.
+ಮುಂದೆ, ಬದಲಾವಣೆಯ ಹಿಂದಿನ "why" ಯನ್ನು ಸ್ಪಷ್ಟವಾಗಿ ವಿವರಿಸಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.
+_what_ ಮಾತ್ರ ಹೇಳಬೇಡಿ - ಈ ಬದಲಾವಣೆ ಏಕೆ ಅಗತ್ಯ ಮತ್ತು ಸಮಸ್ಯೆಗೆ ಇದು ಏಕೆ ಸೂಕ್ತ ವಿಧಾನ ಎಂಬುದನ್ನು
+ವಿವರಿಸಿ. review ವೇಳೆ ವಿಶೇಷ ಗಮನಕ್ಕೆ ಪಾತ್ರವಾಗುವ ಭಾಗಗಳಿದ್ದರೆ, ಅವನ್ನು ನೀವು ಮುಂಚಿತವಾಗಿಯೇ
+ಸೂಚಿಸಬೇಕು. `CONTRIBUTING.md` ಮತ್ತು ನಿಮ್ಮ ಬದಲಾವಣೆಯ ಸ್ವಭಾವವನ್ನು ಅವಲಂಬಿಸಿ, ನೀವು ಮಾಡಿದ
+trade-offs ಅಥವಾ ಬದಲಾವಣೆಯನ್ನು ಹೇಗೆ test ಮಾಡುವುದು ಇತ್ಯಾದಿ ಹೆಚ್ಚುವರಿ ಮಾಹಿತಿಯನ್ನೂ reviewers ನಿರೀಕ್ಷಿಸಬಹುದು.
 
-> We recommend contributing back to upstream projects rather than
-> "forking" the project, at least as a first approach. Forking (license
-> permitting) should be reserved for when the contributions you want to
-> make are out of scope for the original project. If you do fork, make
-> sure you acknowledge the original project!
+> ಮೊದಲ ವಿಧಾನವಾಗಿ ಕನಿಷ್ಠ upstream projects ಗೆ ಹಿಂದಿರುಗಿ ಕೊಡುಗೆ ನೀಡುವುದನ್ನು ನಾವು
+> ಶಿಫಾರಸು ಮಾಡುತ್ತೇವೆ; project ಅನ್ನು "fork" ಮಾಡುವುದು ಅಂತಿಮ ಆಯ್ಕೆಯಾಗಿರಲಿ. Forking (license
+> ಅನುಮತಿ ಇದ್ದರೆ) ನೀವು ನೀಡಬಯಸುವ ಕೊಡುಗೆಗಳು ಮೂಲ project ವ್ಯಾಪ್ತಿಗೆ ಹೊರಗಿರುವಾಗ ಮಾತ್ರ
+> ಬಳಸಬೇಕು. fork ಮಾಡಿದರೆ, ಮೂಲ project ಗೆ ಸರಿಯಾದ ಮಾನ್ಯತೆ ನೀಡುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.
 
-AI makes it incredibly easy to generate plausible-looking code and PRs
-quickly, but this doesn't excuse you from understanding what you're
-contributing. Submitting AI-generated code you can't explain burdens
-maintainers with reviewing and potentially maintaining code that even
-its author doesn't understand. It's fine to use AI to help you
-identify issues and produce fixes/features, **so long as you still do
-the due diligence** to polish it into a worthwhile contribution, rather
-than passing that work on to the (already-overloaded) maintainers.
+AI ಬಳಸಿ ದೃಷ್ಟಿಗೆ ನಂಬಬಹುದಾದ code ಮತ್ತು PRs ಅನ್ನು ವೇಗವಾಗಿ ರಚಿಸುವುದು ಅತೀ ಸುಲಭವಾಗಿದೆ.
+ಆದರೂ ನೀವು ಏನು ಕೊಡುಗೆ ನೀಡುತ್ತಿದ್ದೀರಿ ಎಂಬುದನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳುವ ಹೊಣೆಗಾರಿಕೆಯಿಂದ ಅದು ವಿನಾಯಿತಿ
+ಕೊಡುವುದಿಲ್ಲ. ನೀವು ವಿವರಿಸಲಾರದ AI-generated code ಅನ್ನು ಸಲ್ಲಿಸುವುದು, ಅದರ ಲೇಖಕನೇ ಸಂಪೂರ್ಣವಾಗಿ
+ಅರ್ಥಮಾಡಿಕೊಳ್ಳದ code ಅನ್ನು review ಮತ್ತು ನಿರ್ವಹಿಸುವ ಭಾರವನ್ನು maintainers ಮೇಲೆ ಹಾಕುತ್ತದೆ.
+issues ಗುರುತಿಸಲು ಮತ್ತು fixes/features ಸಿದ್ಧಪಡಿಸಲು AI ಬಳಸದರಲ್ಲಿ ತೊಂದರೆಯಿಲ್ಲ - **ಆದರೆ ನೀವು
+ಅಗತ್ಯ due diligence ಮಾಡಿಯೇ** ಅದನ್ನು ಮೌಲ್ಯಯುತ ಕೊಡುಗೆಯಾಗಿ ಮೆರುಗುಗೊಳಿಸಬೇಕು; ಈಗಾಗಲೇ ಒತ್ತಡದಲ್ಲಿರುವ
+maintainers ಮೇಲೆ ಆ ಕೆಲಸವನ್ನು ಹೊರೆ ಹಾಕಬಾರದು.
 
-Remember that for maintainers, accepting a PR means accepting long-term
-responsibility. They will be maintaining this code long after the
-contributor has moved on, and so may decline changes that are
-well-intentioned but don't fit the project's direction, add complexity
-they don't want to maintain, or where the need simply isn't sufficiently
-well-documented. It's on _you_ as the contributor to make the case for
-why the accepting the contribution is worth the maintenance burden.
+maintainers ದೃಷ್ಟಿಯಿಂದ PR ಸ್ವೀಕರಿಸುವುದೆಂದರೆ ದೀರ್ಘಕಾಲಿಕ ಹೊಣೆಗಾರಿಕೆಯನ್ನು ಸ್ವೀಕರಿಸುವುದೇ.
+contributor ಮುಂದೆ ಸಾಗಿದ ನಂತರವೂ ಅವರು ಈ code ಅನ್ನು ನಿರ್ವಹಿಸಬೇಕಾಗುತ್ತದೆ. ಆದ್ದರಿಂದ ಒಳ್ಳೆಯ
+ಉದ್ದೇಶದಿಂದ ಬಂದಿದ್ದರೂ project ದಿಕ್ಕಿಗೆ ಹೊಂದದ, ಅವರು ನಿರ್ವಹಿಸಲು ಬಯಸದ complexity ಸೇರಿಸುವ,
+ಅಥವಾ ಅಗತ್ಯತೆಯ ದಾಖಲೆ ಸಾಕಷ್ಟು ಸ್ಪಷ್ಟವಿಲ್ಲದ ಬದಲಾವಣೆಗಳನ್ನು ಅವರು ತಿರಸ್ಕರಿಸಬಹುದು. ಕೊಡುಗೆಯನ್ನು
+ಸ್ವೀಕರಿಸುವುದು maintenance burden ಗೆ ತಕ್ಕ ಮೌಲ್ಯ ಕೊಡುತ್ತದೆ ಎಂಬ ದೃಢವಾದ ಕಾರಣವನ್ನು ಮಂಡಿಸುವುದು
+contributor ಆಗಿರುವ _ನಿಮ್ಮ_ ಜವಾಬ್ದಾರಿ.
 
-> When receiving feedback on a PR, remember that your code is not you!
-> Reviewers are trying to make the code better, not criticizing you
-> personally. Ask clarifying questions if you disagree — you might learn
-> something, or maybe they will.
+> PR ಬಗ್ಗೆ feedback ಸ್ವೀಕರಿಸುವಾಗ ನಿಮ್ಮ code ಎಂದರೆ ನೀವು ಅಲ್ಲ ಎಂಬುದನ್ನು ನೆನಪಿಡಿ.
+> reviewers code ಉತ್ತಮಗೊಳಿಸಲು ಪ್ರಯತ್ನಿಸುತ್ತಿದ್ದಾರೆ; ಅವರು ವೈಯಕ್ತಿಕವಾಗಿ ನಿಮ್ಮನ್ನು ಟೀಕಿಸುತ್ತಿಲ್ಲ.
+> ಒಪ್ಪಂದವಿಲ್ಲದಿದ್ದರೆ ಸ್ಪಷ್ಟೀಕರಣ ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳಿ - ನಿಮಗೂ ಹೊಸದಾಗಿ ಕಲಿಯಬಹುದು, ಅಥವಾ ಅವರಿಗೆ.
 
-## Reviewing
+## ವಿಮರ್ಶೆ
 
-You might think code review is something senior developers do, but
-you'll likely be asked to review code much earlier than you expect, and
-your perspective is valuable. Fresh eyes catch things that experienced
-developers overlook, and questions from someone less familiar with the
-code often reveal assumptions that should be documented or simplified.
+code review ಎನ್ನುವುದು senior developers ಮಾತ್ರ ಮಾಡುವ ಕೆಲಸ ಎಂದು ನೀವು ಭಾವಿಸಬಹುದು.
+ಆದರೆ ನೀವು ನಿರೀಕ್ಷಿಸುವುದಕ್ಕಿಂತ ಬಹಳ ಬೇಗ ನಿಮಗೆ review ಮಾಡಲು ಕೇಳಲಾಗುವ ಸಾಧ್ಯತೆ ಇದೆ,
+ಮತ್ತು ನಿಮ್ಮ ದೃಷ್ಟಿಕೋನ ಮೌಲ್ಯಯುತ. ಹೊಸ ಕಣ್ಣುಗಳು ಅನುಭವಿಗಳ ಗಮನ ತಪ್ಪಿದ ವಿಷಯಗಳನ್ನು ಹಿಡಿಯುತ್ತವೆ;
+code ಬಗ್ಗೆ ಕಡಿಮೆ ಪರಿಚಯವಿರುವವರ ಪ್ರಶ್ನೆಗಳು ದಾಖಲೆ ಮಾಡಬೇಕಾದ ಅಥವಾ ಸರಳಗೊಳಿಸಬೇಕಾದ ಅಡಗಿದ
+ಅನುಮಾನಗಳನ್ನು ಬಹಿರಂಗಪಡಿಸುತ್ತವೆ.
 
-Review is also one of the fastest ways to learn. You'll see how others
-approach problems, pick up patterns and idioms, and develop intuition
-for what makes code readable. Beyond personal growth, reviews catch bugs
-before they reach production, spread knowledge across the team, and
-improve code quality through collaboration. They are not merely
-bureaucratic overhead.
+review ಕಲಿಯುವ ಅತ್ಯಂತ ವೇಗವಾದ ಮಾರ್ಗಗಳಲ್ಲಿ ಒಂದಾಗಿದೆ. ಇತರರು ಸಮಸ್ಯೆಗಳನ್ನು ಹೇಗೆ ಎದುರಿಸುತ್ತಾರೆ
+ಎಂಬುದನ್ನು ನೀವು ನೋಡುತ್ತೀರಿ; patterns ಮತ್ತು idioms ಗಳನ್ನು ಕಲಿಯುತ್ತೀರಿ; code ಓದಿಸಿಕೊಳ್ಳುವಂತೆ
+ಮಾಡುವುದೇನು ಎಂಬುದರ ಬಗ್ಗೆ ಒಳನೋಟ ಬೆಳೆಸುತ್ತೀರಿ. ವೈಯಕ್ತಿಕ ಬೆಳವಣಿಗೆಯ ಹೊರತಾಗಿ, reviews ಗಳು
+bugs ಅನ್ನು production ತಲುಪುವ ಮುನ್ನ ಹಿಡಿಯುತ್ತವೆ, ತಂಡದೊಳಗಿನ ಜ್ಞಾನ ಹಂಚಿಕೆಯನ್ನು ಹೆಚ್ಚಿಸುತ್ತವೆ,
+ಮತ್ತು collaboration ಮುಖಾಂತರ code ಗುಣಮಟ್ಟವನ್ನು ಉತ್ತಮಗೊಳಿಸುತ್ತವೆ. ಅವು ಕೇವಲ ಆಡಳಿತಾತ್ಮಕ
+ರೂಪರೇಷೆ ಅಲ್ಲ.
 
-Good code review is a skill you need to hone over time, but there are
-some tips that can make them much better much faster:
+ಉತ್ತಮ code review ಎನ್ನುವುದು ಕಾಲಕ್ರಮೇಣ ತಿದ್ದಿಕೊಳ್ಳಬೇಕಾದ ಕೌಶಲ್ಯ. ಆದರೂ ಅದನ್ನು ಬೇಗನೆ
+ಗಣನೀಯವಾಗಿ ಉತ್ತಮಗೊಳಿಸುವ ಕೆಲವು ಸಲಹೆಗಳಿವೆ:
 
-- **Review the code, not the person**:
-  "This function is confusing" vs "You wrote confusing code."
-- **Prefer actionable comments**:
-  "Can you replace these globals with a config dataclass" is an easier
-  comment to address than "Don't use globals here"
-- **Ask questions rather than making demands**:
-  "What happens if X is null here?" invites discussion better than
-  "Handle the null case."
-- **Explain the "why"**:
-  "Consider using a constant here" is less useful than "Consider using a
-  constant here so we can easily adjust the timeout based on
-  environment."
-- **Distinguish blocking issues from suggestions**:
-  Be clear about what must change versus what's a matter of preference.
-- **Acknowledge what's good**:
-  Pointing out clever solutions or clean implementations is encouraging
-  and helps the author know what to continue doing.
-- **Know when to stop**:
-  Contributors only have so much time and patience, and it's not always
-  best spent handling all the nits. Focus on the big things, and
-  consider tidying up nits yourself after the fact.
+- **ವಿಮರ್ಶೆ code ಗೆ ಇರಲಿ, ವ್ಯಕ್ತಿಗೆ ಅಲ್ಲ**:
+  "This function is confusing" ಎಂಬ ಹೇಳಿಕೆ, "You wrote confusing code."
+  ಎನ್ನುವುದಕ್ಕಿಂತ ಉತ್ತಮ.
+- **ಅಮಲುಗೊಳಿಸಬಹುದಾದ comments ನೀಡಿ**:
+  "Don't use globals here" ಎನ್ನುವುದಕ್ಕಿಂತ, "Can you replace these globals
+  with a config dataclass" ಎಂಬುದು ಪರಿಹರಿಸಲು ಸುಲಭ.
+- **ಆಜ್ಞೆಯ ಬದಲು ಪ್ರಶ್ನೆ ಕೇಳಿ**:
+  "Handle the null case." ಎನ್ನುವುದಕ್ಕಿಂತ, "What happens if X is null here?"
+  ಚರ್ಚೆಗೆ ಉತ್ತಮವಾಗಿ ಆಹ್ವಾನಿಸುತ್ತದೆ.
+- **"why" ಅನ್ನು ವಿವರಿಸಿ**:
+  "Consider using a constant here" ಎನ್ನುವುದಕ್ಕಿಂತ, "ಪರಿಸರದ ಆಧಾರದ ಮೇಲೆ
+  timeout ಅನ್ನು ಸುಲಭವಾಗಿ ಬದಲಾಯಿಸಲು ಇಲ್ಲಿ constant ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ."
+  ಎಂಬುದು ಹೆಚ್ಚು ಉಪಯುಕ್ತ.
+- **blocking issues ಮತ್ತು suggestions ಬೇರ್ಪಡಿಸಿ**:
+  ಕಡ್ಡಾಯವಾಗಿ ಬದಲಿಸಬೇಕಾದದ್ದು ಯಾವುದು, ವೈಯಕ್ತಿಕ ಅಭಿರುಚಿ ಯಾವುದು ಎಂಬುದನ್ನು ಸ್ಪಷ್ಟಪಡಿಸಿ.
+- **ಒಳ್ಳೆಯ ಭಾಗವನ್ನೂ ಗುರುತಿಸಿ**:
+  ಚಾಕಚಕ್ಯ ಪರಿಹಾರಗಳು ಅಥವಾ ಸ್ವಚ್ಛ implementation ಗಳನ್ನು ಸೂಚಿಸುವುದು ಪ್ರೋತ್ಸಾಹಕಾರಿ,
+  ಮತ್ತು ಲೇಖಕರು ಮುಂದುವರಿಸಬೇಕಾದ ಉತ್ತಮ ಕ್ರಮಗಳನ್ನು ತಿಳಿಯಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
+- **ಎಲ್ಲಿ ನಿಲ್ಲಬೇಕು ಎಂಬುದನ್ನು ತಿಳಿ**:
+  contributors ಗೆ ಸಮಯ ಮತ್ತು ಸಹನಶೀಲತೆ ಸೀಮಿತ. ಎಲ್ಲಾ nits ಮೇಲೆ ಸಮಯ ವ್ಯಯಿಸುವುದು ಯಾವಾಗಲೂ
+  ಉತ್ತಮವಲ್ಲ. ದೊಡ್ಡ ವಿಷಯಗಳಿಗೆ ಗಮನ ನೀಡಿ; nits ಅನ್ನು ನಂತರ ನೀವು ತಾವೇ ತಿದ್ದುವ ಸಾಧ್ಯತೆಯನ್ನೂ ಪರಿಗಣಿಸಿ.
 
-> AI tools can catch certain issues, but they're not a substitute for
-> human review. They miss context, don't understand product
-> requirements, and can confidently suggest wrong things. They're worth
-> using as a first pass, but not a replacement for thoughtful human
-> review.
+> AI tools ಕೆಲವು issues ಹಿಡಿಯಬಹುದು; ಆದರೆ human review ಗೆ ಅವು ಪರ್ಯಾಯವಲ್ಲ.
+> ಅವುಗಳಿಗೆ context ತಪ್ಪಬಹುದು, product requirements ಸಂಪೂರ್ಣವಾಗಿ ಅರ್ಥವಾಗದೆ ಇರಬಹುದು,
+> ಮತ್ತು ತಪ್ಪಾದ ಸಲಹೆಯನ್ನೇ ವಿಶ್ವಾಸದಿಂದ ನೀಡಬಹುದು. ಮೊದಲ pass ಆಗಿ ಬಳಸುವುದು ಉಪಯುಕ್ತ,
+> ಆದರೆ ಚಿಂತಿತ ಮಾನವೀಯ review ಅನ್ನು ಬದಲಿಸಲು ಅಲ್ಲ.
 
-# Education
+# ಶಿಕ್ಷಣ
 
-A lot of our non-coding time as engineers is spent either asking or
-answering questions, possibly a mixture of both; during collaboration,
-in dialogue with peers, or while trying to learn. Asking good questions
-is a skill that makes you better at learning from anyone, not just
-perfect explainers. Julia Evans has some excellent blog posts on "[How
-to ask good questions](https://jvns.ca/blog/good-questions/)" and "[How
-to get useful answers to your
+engineers ಆಗಿರುವ ನಮ್ಮ non-coding ಸಮಯದ ದೊಡ್ಡ ಭಾಗ ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳುವುದಲ್ಲ ಅಥವಾ ಉತ್ತರಿಸುವುದಲ್ಲ,
+ಅಥವಾ ಎರಡರ ಮಿಶ್ರಣದಲ್ಲೇ ಕಳೆಯುತ್ತದೆ - collaboration ವೇಳೆ, peers ಜೊತೆ ಸಂವಾದದಲ್ಲಿ, ಅಥವಾ ಕಲಿಯುವ
+ಪ್ರಯತ್ನದಲ್ಲಿ. ಉತ್ತಮ ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳುವುದು, ಅತ್ಯುತ್ತಮವಾಗಿ ವಿವರಿಸುವವರಿಂದ ಮಾತ್ರವಲ್ಲ, ಯಾರಿಂದ ಬೇಕಾದರೂ
+ಉತ್ತಮವಾಗಿ ಕಲಿಯಲು ಸಹಾಯ ಮಾಡುವ ಕೌಶಲ್ಯ. Julia Evans ಅವರ "[How to ask good
+questions](https://jvns.ca/blog/good-questions/)" ಮತ್ತು "[How to get useful answers to your
 questions](https://jvns.ca/blog/2021/10/21/how-to-get-useful-answers-to-your-questions/)"
-that are worth reading.
+ಬ್ಲಾಗ್ ಲೇಖನಗಳು ಓದಲು ಬಹಳ ಉಪಯುಕ್ತ.
 
-Some particularly valuable pieces of advice are:
+ವಿಶೇಷವಾಗಿ ಮೌಲ್ಯಯುತವಾದ ಕೆಲವು ಸಲಹೆಗಳು:
 
-- **State your understanding first**: Say what you think you know and
-  ask "is that right?" This helps the answerer identify your actual
-  knowledge gaps.
-- **Ask yes/no questions**: "Is X true?" prevents tangential
-  explanations and usually prompts useful elaboration anyway.
-- **Be specific**: "How do SQL joins work?" is too vague. "Does a LEFT
-  JOIN include rows where the right table has no match?" is answerable.
-- **Admit when you don't understand**: Interrupt to ask about unfamiliar
-  terms. This reflects confidence, not weakness. Similarly, if they ask
-  questions of you that you do not know the answer to, it's best to say
-  "I don't know", and possibly follow up with "but I think ..." or even
-  "but I can find out".
-- **Don't accept incomplete answers**: Keep asking follow-ups until you
-  actually understand.
-- **Do some research first**: Basic investigation helps you ask more
-  targeted questions (though casual questions among colleagues are
-  fine).
+- **State your understanding first**: ನೀವು ತಿಳಿದಿದ್ದೀರಿ ಎಂದು ಭಾವಿಸುವುದನ್ನು ಮೊದಲು ಹೇಳಿ,
+  ನಂತರ "is that right?" ಎಂದು ಕೇಳಿ. ಇದರಿಂದ ಉತ್ತರಿಸುವವರಿಗೆ ನಿಮ್ಮ ನಿಜವಾದ knowledge gaps
+  ಗುರುತಿಸಲು ಸುಲಭವಾಗುತ್ತದೆ.
+- **Ask yes/no questions**: "Is X true?" ಎಂಬ ಪ್ರಶ್ನೆ ಅನಗತ್ಯ ಬೇರೆ ದಿಕ್ಕಿನ ವಿವರಣೆಗಳನ್ನು
+  ಕಡಿಮೆ ಮಾಡುತ್ತದೆ, ಮತ್ತು ಸಾಮಾನ್ಯವಾಗಿ ಉಪಯುಕ್ತ ವಿಸ್ತೃತ ಉತ್ತರಕ್ಕೂ ದಾರಿಯಿಡುತ್ತದೆ.
+- **Be specific**: "How do SQL joins work?" ಬಹಳ ಅಸ್ಪಷ್ಟ. "Does a LEFT
+  JOIN include rows where the right table has no match?" ಉತ್ತರಿಸಬಹುದಾದ ಪ್ರಶ್ನೆ.
+- **Admit when you don't understand**: ಪರಿಚಯವಿಲ್ಲದ ಪದಗಳು ಬಂದರೆ ಮಧ್ಯೆಯಲ್ಲಿ ಕೇಳಿ.
+  ಇದು ದುರ್ಬಲತೆ ಅಲ್ಲ, ಆತ್ಮವಿಶ್ವಾಸದ ಸೂಚನೆ. ಅದೇ ರೀತಿ, ನಿಮಗೆ ಉತ್ತರ ತಿಳಿಯದ ಪ್ರಶ್ನೆ ಕೇಳಿದರೆ,
+  "I don't know" ಎಂದು ಹೇಳುವುದು ಉತ್ತಮ; ಅಗತ್ಯವಿದ್ದರೆ "but I think ..." ಅಥವಾ
+  "but I can find out" ಎಂದು ಮುಂದುವರಿಯಬಹುದು.
+- **Don't accept incomplete answers**: ನಿಮಗೆ ವಾಸ್ತವವಾಗಿ ಅರ್ಥವಾಗುವವರೆಗೂ follow-up ಪ್ರಶ್ನೆಗಳನ್ನು
+  ಕೇಳುತ್ತಿರಿ.
+- **Do some research first**: ಮೂಲಭೂತ ಹುಡುಕಾಟ ಮಾಡಿದರೆ ಹೆಚ್ಚು targeted ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳಬಹುದು
+  (ಆದರೆ ಸಹೋದ್ಯೋಗಿಗಳ ಮಧ್ಯೆ casual ಪ್ರಶ್ನೆಗಳು ಸಹ ಸಮಂಜಸವೇ).
 
-Remember: well-crafted questions benefit entire communities. They
-surface hidden assumptions that others need to understand too.
+ಗಮನದಲ್ಲಿರಲಿ: ಚೆನ್ನಾಗಿ ರೂಪುಗೊಂಡ ಪ್ರಶ್ನೆಗಳು ಸಮಗ್ರ ಸಮುದಾಯಕ್ಕೂ ಉಪಕಾರ. ಇತರರೂ ಅರ್ಥಮಾಡಿಕೊಳ್ಳಬೇಕಾದ
+ಅಡಗಿದ ಊಹೆಗಳನ್ನು ಅವು ಮೇಲಕ್ಕೆ ತರುತ್ತವೆ.
 
-> Note that this advice applies just as much when communicating with
-> LLMs!
+> ಈ ಸಲಹೆ LLMs ಜೊತೆ ಸಂವಹನ ಮಾಡುವ ಸಂದರ್ಭದಲ್ಲಿಯೂ ಸಮಾನವಾಗಿ ಅನ್ವಯಿಸುತ್ತದೆ.
 
-# AI etiquette
+# AI ಶಿಷ್ಟಾಚಾರ
 
-With the growing use of LLMs and AI across software engineering, the
-social and professional norms around are still in flux. We already
-covered many of the tactical considerations in the [agentic coding
-lecture](/2026/agentic-coding/), but there are also "softer" parts of
-their use that are worth discussing.
+software engineering ಕ್ಷೇತ್ರದಲ್ಲಿ LLMs ಮತ್ತು AI ಬಳಕೆ ಹೆಚ್ಚುತ್ತಿರುವ ಹಿನ್ನೆಲೆ, ಅದರ ಸುತ್ತಲಿನ
+ಸಾಮಾಜಿಕ ಮತ್ತು ವೃತ್ತಿಪರ norms ಇನ್ನೂ ರೂಪುಗೊಳ್ಳುವ ಹಂತದಲ್ಲಿವೆ. [agentic coding
+lecture](/2026/agentic-coding/) ನಲ್ಲಿ tactical ವಿಚಾರಗಳನ್ನು ನಾವು ಈಗಾಗಲೇ ನೋಡಿದ್ದೇವೆ; ಆದರೆ
+ಅವುಗಳ ಬಳಕೆಯ "soft" ಅಂಶಗಳ ಬಗ್ಗೆ ಚರ್ಚಿಸುವುದೂ ಮಹತ್ವದ್ದು.
 
-The first of these is that when AI meaningfully contributed to your
-work, **disclose it**. This isn't about shame — it's about honesty,
-setting appropriate expectations, and ensuring the resulting work gets
-the appropriate level of review. It's also worthwhile to disclose which
-_parts_ you use AI for — there's a meaningful distinction between "this
-whole thing is vibecoded" and "I wrote this backup tool and used an LLM
-to style the web frontend". For example, we've used LLMs to help write
-some of these lecture notes, including proofreading, brainstorming, and
-generating first drafts of code snippets and exercises.
+ಇದಲ್ಲಿನ ಮೊದಲ ವಿಚಾರ: AI ನಿಮ್ಮ ಕೆಲಸಕ್ಕೆ ಅರ್ಥಪೂರ್ಣವಾಗಿ ಕೊಡುಗೆ ನೀಡಿದರೆ, **ಅದನ್ನು ಬಹಿರಂಗಪಡಿಸಿ**.
+ಇದು ಲಜ್ಜೆಯ ವಿಷಯವಲ್ಲ - ಪ್ರಾಮಾಣಿಕತೆ, ಸಮಂಜಸ ನಿರೀಕ್ಷೆ ನಿರ್ಮಾಣ, ಮತ್ತು ಫಲಿತಾಂಶದ ಕೆಲಸಕ್ಕೆ ಸೂಕ್ತ
+ಮಟ್ಟದ review ಸಿಗುವಂತೆ ಮಾಡುವ ವಿಷಯ. AI ಅನ್ನು ಯಾವ _ಭಾಗಗಳ_ಗಾಗಿ ಬಳಸಿದ್ದೀರಿ ಎಂಬುದನ್ನೂ
+ಹೇಳುವುದು ಒಳಿತು - "this whole thing is vibecoded" ಮತ್ತು "I wrote this backup tool and used an LLM
+to style the web frontend" ನಡುವಿನ ವ್ಯತ್ಯಾಸ ಅರ್ಥಪೂರ್ಣ. ಉದಾಹರಣೆಗೆ, ಈ lecture notes ನಲ್ಲಿ
+proofreading, brainstorming, ಮತ್ತು code snippets ಹಾಗೂ exercises ಗಳ first drafts ರಚಿಸಲು ನಾವು
+LLMs ಬಳಸಿದ್ದೇವೆ.
 
-You'll also want to follow the norms of the teams and projects you're
-contributing to here. Some teams have stricter policies around the use
-of AI than others (e.g., for compliance or data residency reasons), and
-you don't want to accidentally run afoul of that. Being open about your
-use helps prevent potentially costly mistakes.
+ನೀವು ಕೊಡುಗೆ ನೀಡುತ್ತಿರುವ teams ಮತ್ತು projects ಗಳ norms ಅನ್ನು ಅನುಸರಿಸುವುದು ಸಹ ಅಗತ್ಯ.
+ಕೆಲವು ತಂಡಗಳಲ್ಲಿ AI ಬಳಕೆಗೆ ಇತರರಿಗಿಂತ ಕಠಿಣ policies ಇರುತ್ತವೆ (ಉದಾ., compliance ಅಥವಾ
+data residency ಕಾರಣಗಳಿಂದ), ಮತ್ತು ತಪ್ಪಾಗಿ ಅವುಗಳಿಗೆ ವಿರುದ್ಧವಾಗಿ ನಡೆದುಕೊಳ್ಳಲು ನೀವು ಬಯಸುವುದಿಲ್ಲ.
+ನಿಮ್ಮ ಬಳಕೆಯ ಬಗ್ಗೆ ಮುಕ್ತವಾಗಿ ಹೇಳುವುದರಿಂದ ದುಬಾರಿ ತಪ್ಪುಗಳನ್ನು ಮುಂಚಿತವಾಗಿ ತಪ್ಪಿಸಬಹುದು.
 
-> If you're aiming to learn as part of the work you're doing, keep in
-> mind that if you have AI do all or most of the work for you can be
-> self-defeating; you're likely to learn more about prompting (and maybe
-> reviewing AI output) than the task itself. Especially when you're
-> learning, the point may be the journey, not the destination, so using
-> AI to "get the solution quickly" is an anti-goal.
+> ನೀವು ಮಾಡುತ್ತಿರುವ ಕೆಲಸದ ಭಾಗವಾಗಿ ಕಲಿಯುವುದು ಗುರಿಯಾಗಿದ್ದರೆ, ಎಲ್ಲಾ ಅಥವಾ ಹೆಚ್ಚಿನ ಕೆಲಸವನ್ನು
+> AI ಮೂಲಕ ಮಾಡಿಸುವುದು ಸ್ವತಃ ವಿಫಲತೆಯತ್ತ ಕೊಂಡೊಯ್ಯಬಹುದು. ಆಗ ನೀವು ಕೆಲಸದ ವಿಷಯಕ್ಕಿಂತ prompting
+> (ಮತ್ತು ಬಹುಶಃ AI output review) ಬಗ್ಗೆ ಹೆಚ್ಚು ಕಲಿಯುವ ಸಾಧ್ಯತೆ ಇದೆ. ವಿಶೇಷವಾಗಿ ಕಲಿಯುವ ಹಂತದಲ್ಲಿ,
+> ಗುರಿ ಅಂತಿಮ ಉತ್ತರಕ್ಕಿಂತ ಪಯಣವೇ ಆಗಿರಬಹುದು; ಆದ್ದರಿಂದ AI ಮೂಲಕ "get the solution quickly"
+> ಮಾಡುವುದು anti-goal ಆಗಬಹುದು.
 
-A related concern comes up in interviews and other assessment
-situations. These are often intended to specifically evaluate _your_
-skills and abilities, not those of an LLM. More companies now allow you
-to use LLMs and other AI-assisted tooling in interviews as long as you
-let them observe those interactions as part of the interview (i.e., they
-are evaluating your skill in making use of those tools too!), but those
-are still in the minority. If you are unsure about whether AI assistance
-is in scope for a particular task, ask!
+ಇದರೊಂದಿಗೆ ಸಂಬಂಧಿತ ಮತ್ತೊಂದು ಪ್ರಶ್ನೆ interviews ಮತ್ತು ಇತರೆ assessment ಸಂದರ್ಭಗಳಲ್ಲಿ ಬರುತ್ತದೆ.
+ಇವು ಸಾಮಾನ್ಯವಾಗಿ _ನಿಮ್ಮ_ ಕೌಶಲ್ಯ ಮತ್ತು ಸಾಮರ್ಥ್ಯವನ್ನು ಅಳೆಯಲು ರೂಪುಗೊಂಡಿರುತ್ತವೆ, LLM ನದು ಅಲ್ಲ.
+ಕೆಲವು ಕಂಪನಿಗಳು ಈಗ interviews ನಲ್ಲಿ LLMs ಮತ್ತು AI-assisted tools ಬಳಕೆಗೆ ಅವಕಾಶ ನೀಡುತ್ತಿವೆ -
+ಆದರೆ ಆ ಸಂವಹನವನ್ನು ಸಂದರ್ಶನದ ಭಾಗವಾಗಿ ಅವಲೋಕಿಸಲು ಅವಕಾಶ ನೀಡಿದಾಗ ಮಾತ್ರ (ಅಂದರೆ, ಆ tools ಅನ್ನು
+ಬಳಸುವ ನಿಮ್ಮ ಕೌಶಲ್ಯವನ್ನೂ ಅವು ಮೌಲ್ಯಮಾಪನ ಮಾಡುತ್ತವೆ). ಆದಾಗ್ಯೂ, ಇವು ಇನ್ನೂ ಅಲ್ಪಸಂಖ್ಯೆಯಲ್ಲಿವೆ.
+ನಿರ್ದಿಷ್ಟ ಕೆಲಸಕ್ಕೆ AI ಸಹಾಯ ವ್ಯಾಪ್ತಿಯಲ್ಲಿದೆಯೇ ಎಂಬ ಅನುಮಾನ ಇದ್ದರೆ, ಕೇಳಿ.
 
-> It should go without saying that if an assessment situation explicitly
-> calls for no external tools, no LLMs, etc., you should not use them.
-> Trying to do so discretely without getting caught **will** come back
-> to bite you.
+> assessment ಪರಿಸ್ಥಿತಿಯಲ್ಲಿ ಹೊರಗಿನ tools ಬೇಡ, LLMs ಬೇಡ ಎಂದು ಸ್ಪಷ್ಟವಾಗಿ ಹೇಳಿದ್ದರೆ,
+> ಅವನ್ನು ಬಳಸಬಾರದು ಎಂಬುದು ಸ್ವಯಂಸ್ಪಷ್ಟ. ಹಿಡಿಯಿಸಿಕೊಳ್ಳದೆ ಸದ್ದಿಲ್ಲದೆ ಬಳಸಲು ಪ್ರಯತ್ನಿಸುವುದು
+> **ಖಚಿತವಾಗಿಯೂ** ನಂತರ ನಿಮಗೆ ಪ್ರತಿಕೂಲವಾಗಿ ಪರಿಣಾಮ ಬೀರುತ್ತದೆ.
 
-# Exercises
+# ಅಭ್ಯಾಸಗಳು
 
-1. Browse the source code of a well-known project (e.g.,
-   [Redis](https://github.com/redis/redis) or
-   [curl](https://github.com/curl/curl)). Find examples of some of the
-   comment types mentioned in the lecture: a useful TODO, a reference to
-   external documentation, a "why not" comment explaining an avoided
-   approach, or a hard-learned lesson. What would be lost if that
-   comment was not there?
+1. ಪ್ರಸಿದ್ಧ project ಒಂದರ source code ಅನ್ನು ಪರಿಶೀಲಿಸಿ (ಉದಾ.,
+   [Redis](https://github.com/redis/redis) ಅಥವಾ
+   [curl](https://github.com/curl/curl)). lecture ನಲ್ಲಿ ಉಲ್ಲೇಖಿಸಿದ comment ಪ್ರಕಾರಗಳ
+   ಕೆಲವು ಉದಾಹರಣೆಗಳನ್ನು ಕಂಡುಹಿಡಿಯಿರಿ: ಉಪಯುಕ್ತ TODO, external documentation ಗೆ reference,
+   ತಪ್ಪಿಸಲಾದ ವಿಧಾನವನ್ನು ವಿವರಿಸುವ "why not" comment, ಅಥವಾ hard-learned lesson. ಆ
+   comment ಇಲ್ಲದಿದ್ದರೆ ಯಾವ ಮಾಹಿತಿ ಕಳೆದುಹೋಗುತ್ತಿತ್ತು?
 
-1. Pick an open-source project you're interested in and look at its
-   recent commit history (`git log`). Find one commit with a good
-   message that explains *why* the change was made, and one with a weak
-   message that only describes *what* changed. For the weak one, look at
-   the diff (`git show <hash>`) and try to write a better commit message
-   following the Problem → Solution → Implications structure. Notice how
-   much work is required to reassemble the necessary context after the
-   fact!
+1. ನಿಮಗೆ ಆಸಕ್ತಿಯಿರುವ open-source project ಒಂದನ್ನು ಆಯ್ಕೆ ಮಾಡಿ, ಅದರ ಇತ್ತೀಚಿನ commit
+   history (`git log`) ನೋಡಿ. ಬದಲಾವಣೆ *ಏಕೆ* ಮಾಡಲಾಯಿತು ಎಂಬುದನ್ನು ಹೇಳುವ ಉತ್ತಮ message ಇರುವ
+   ಒಂದು commit ಮತ್ತು *ಏನು* ಬದಲಾಯಿತು ಎಂಬುದಷ್ಟೇ ಹೇಳುವ ದುರ್ಬಲ message ಇರುವ ಮತ್ತೊಂದು commit
+   ಆಯ್ಕೆಮಾಡಿ. ದುರ್ಬಲ message ಇರುವ commit ಗಾಗಿ, diff (`git show <hash>`) ನೋಡಿ,
+   Problem → Solution → Implications ರಚನೆ ಅನುಸರಿಸಿ ಉತ್ತಮ commit message ಬರೆಯಲು ಪ್ರಯತ್ನಿಸಿ.
+   ನಂತರದ ಹಂತದಲ್ಲಿ ಅಗತ್ಯ context ಪುನರ್‌ರಚಿಸಲು ಎಷ್ಟು ಶ್ರಮ ಬೇಕಾಗುತ್ತದೆ ಎಂದು ಗಮನಿಸಿ.
 
-1. Compare the READMEs of three GitHub projects with 1000+ stars. Are
-   all of them equally useful? Look for things that come across mostly
-   as noise to you as a lesson for future READMEs you write yourself.
+1. 1000+ stars ಹೊಂದಿರುವ ಮೂರು GitHub projects ಗಳ READMEs ಹೋಲಿಸಿ. ಅವೆಲ್ಲವೂ ಸಮಾನವಾಗಿ
+   ಉಪಯುಕ್ತವೇ? ಭವಿಷ್ಯದಲ್ಲಿ ನೀವು ಬರೆಯುವ READMEs ಗಾಗಿ ಪಾಠವಾಗಿ, ನಿಮಗೆ ಮುಖ್ಯವಾಗಿ noise ಆಗಿ
+   ಕಾಣುವ ಅಂಶಗಳನ್ನು ಗುರುತಿಸಿ.
 
-1. Find an open issue on a project you use (check the "good first issue"
-   or "help wanted" labels if they have it). Evaluate the issue against
-   the criteria from the lecture: does it seem like it values the
-   maintainer's time and contains all the information necessary to debug
-   it, or do you expect that the maintainer may need to go multiple
-   rounds of questions with the submitter to get to the root problem?
+1. ನೀವು ಬಳಸುವ project ಒಂದರಲ್ಲಿ open issue ಹುಡುಕಿ (ಇದ್ದರೆ "good first issue" ಅಥವಾ
+   "help wanted" labels ಪರಿಶೀಲಿಸಿ). lecture ಮಾನದಂಡಗಳ ವಿರುದ್ಧ issue ಅನ್ನು ಮೌಲ್ಯಮಾಪನ ಮಾಡಿ:
+   ಅದು maintainer ಸಮಯಕ್ಕೆ ಮೌಲ್ಯ ನೀಡುವಂತಿದೆಯೇ ಮತ್ತು debug ಮಾಡಲು ಅಗತ್ಯ ಎಲ್ಲ ಮಾಹಿತಿ ಇದೆಯೇ?
+   ಅಥವಾ ಮೂಲ ಸಮಸ್ಯೆಗೆ ತಲುಪಲು maintainer ಗೆ submitter ಜೊತೆ ಹಲವಾರು ಸುತ್ತಿನ ಪ್ರಶ್ನೋತ್ತರ ಬೇಕಾಗುತ್ತದೆ
+   ಎಂದು ನಿಮಗೆ ಅನಿಸುತ್ತಿದೆಯೇ?
 
-1. Think of a bug you've encountered in software you use (or find one in
-   an issue tracker). Practice creating a minimal reproducible example:
-   strip away everything unrelated to the bug until you have the
-   smallest case that still demonstrates the problem. Write up what you
-   removed and why.
+1. ನೀವು ಬಳಸುವ software ನಲ್ಲಿ ಎದುರಿಸಿದ bug ಒಂದನ್ನು ನೆನಪಿಸಿಕೊಳ್ಳಿ (ಅಥವಾ issue tracker ನಲ್ಲಿ
+  ೊಂದನ್ನು ಕಂಡುಹಿಡಿಯಿರಿ). minimal reproducible example ರಚಿಸುವ ಅಭ್ಯಾಸ ಮಾಡಿ: ಸಮಸ್ಯೆಗೆ ಸಂಬಂಧಿಸದ
+   ಎಲ್ಲವನ್ನೂ ತೆಗೆದುಹಾಕಿ, ಸಮಸ್ಯೆಯನ್ನು ಇನ್ನೂ ತೋರಿಸುವ ಅತಿ ಚಿಕ್ಕ ಪ್ರಕರಣ ಮಾತ್ರ ಉಳಿಯುವವರೆಗೆ ಸರಳಗೊಳಿಸಿ.
+   ನೀವು ಏನು ತೆಗೆದಿರಿ ಮತ್ತು ಏಕೆ ತೆಗೆದಿರಿ ಎಂದು ಬರೆಯಿರಿ.
 
-1. Find a merged pull request on a project you're familiar with that has
-   substantive review comments (not just "LGTM"). Read through the
-   review. Were all the comments equally productive? If you were the PR
-   author, how would you find the experience of getting all those
-   comments?
+1. ನಿಮಗೆ ಪರಿಚಿತವಾದ project ಒಂದರಲ್ಲಿ substantive review comments ಹೊಂದಿರುವ ("LGTM" ಮಾತ್ರವಲ್ಲ)
+   merged pull request ಒಂದನ್ನು ಹುಡುಕಿ. review ಸಂಪೂರ್ಣವಾಗಿ ಓದಿ. ಎಲ್ಲಾ comments ಸಮಾನವಾಗಿ
+   ಉತ್ಪಾದಕವಾಗಿದ್ದವೆಯೇ? ನೀವು PR author ಆಗಿದ್ದರೆ, ಇಷ್ಟು comments ಪಡೆಯುವ ಅನುಭವವನ್ನು ಹೇಗೆ
+   ಅನುಭವಿಸುತ್ತಿದ್ದಿರಿ?
 
-1. Go to Stack Overflow and find a question in a technology you know
-   that has a highly-voted answer. Then find one that was closed or
-   heavily downvoted. Compare them against the advice from the lecture;
-   was it predictable which question would get better answers?
+1. Stack Overflow ಗೆ ಹೋಗಿ, ನಿಮಗೆ ತಿಳಿದಿರುವ technology ಯೊಂದರಲ್ಲಿ highly-voted answer ಹೊಂದಿರುವ
+   ಪ್ರಶ್ನೆ ಒಂದನ್ನು ಹುಡುಕಿ. ನಂತರ closed ಆಗಿರುವ ಅಥವಾ ಹೆಚ್ಚು downvoted ಆಗಿರುವ ಮತ್ತೊಂದು ಪ್ರಶ್ನೆ
+   ಹುಡುಕಿ. lecture ಸಲಹೆಗಳ ದೃಷ್ಟಿಯಲ್ಲಿ ಎರಡನ್ನೂ ಹೋಲಿಸಿ; ಯಾವ ಪ್ರಶ್ನೆಗೆ ಉತ್ತಮ ಉತ್ತರ ಸಿಗಬಹುದು ಎಂಬುದು
+   ಮುಂಚಿತವಾಗಿ ಊಹಿಸಬಹುದಾಗಿತ್ತೇ?

--- a/_2026/code-quality.md
+++ b/_2026/code-quality.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Code Quality"
+title: "ಕೋಡ್ ಗುಣಮಟ್ಟ"
 description: >
-  Learn about formatting, linting, testing, continuous integration, and more.
+  formatting, linting, testing, continuous integration ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಷಯಗಳನ್ನು ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec9.png
 date: 2026-01-23
 ready: true
@@ -11,38 +11,38 @@ video:
   id: XBiLUNx84CQ
 ---
 
-There are a variety of tools and techniques that support developers in writing high-quality code. In this lecture, we'll cover:
+ಉನ್ನತ ಗುಣಮಟ್ಟದ code ಬರೆಯಲು developers ಗೆ ನೆರವಾಗುವ ಹಲವು tools ಮತ್ತು ತಂತ್ರಗಳಿವೆ. ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ನಾವು ಇವುಗಳನ್ನು ನೋಡೋಣ:
 
-- [Formatting](#formatting)
-- [Linting](#linting)
-- [Testing](#testing)
+- [ಫಾರ್ಮ್ಯಾಟಿಂಗ್](#formatting)
+- [ಲಿಂಟಿಂಗ್](#linting)
+- [ಟೆಸ್ಟಿಂಗ್](#testing)
 - [Pre-commit hooks](#pre-commit-hooks)
 - [Continuous integration](#continuous-integration)
 - [Command runners](#command-runners)
 
-As a bonus topic, we'll also cover [regular expressions](#regular-expressions), a cross-cutting topic that has applications in code quality (e.g., for running a subset of tests that match a pattern) as well as other domains like IDEs (e.g., for search and replace).
+ಅತಿರಿಕ್ತ ವಿಷಯವಾಗಿ [regular expressions](#regular-expressions) ಕೂಡ ನೋಡೋಣ. ಇದು ಹಲವಾರು ಕ್ಷೇತ್ರಗಳಿಗೆ ಅನ್ವಯಿಸುವ ವಿಷಯ - code quality ಯಲ್ಲಿ (ಉದಾ: pattern ಗೆ ಹೊಂದುವ tests subset ಮಾತ್ರ run ಮಾಡುವುದು) ಹಾಗೆಯೇ IDE ಗಳಲ್ಲಿ (ಉದಾ: search and replace) ಸಹ ಬಳಸಲಾಗುತ್ತದೆ.
 
-Many of these tools will be language-specific (e.g., the [Ruff](https://docs.astral.sh/ruff/) linter/formatter for Python). In some cases, tools will support multiple languages (e.g., the [Prettier](https://prettier.io/) code formatter). The concepts, however, are near universal --- you can find code formatters, linters, testing libraries, and so on for any programming language.
+ಈ tools ಗಳಲ್ಲಿ ಅನೇಕವು language-specific ಆಗಿರುತ್ತವೆ (ಉದಾ: Python ಗೆ [Ruff](https://docs.astral.sh/ruff/) linter/formatter). ಕೆಲವು tools ಬಹುಭಾಷಾ ಬೆಂಬಲ ಕೊಡುತ್ತವೆ (ಉದಾ: [Prettier](https://prettier.io/) code formatter). ಆದರೆ ಕಲ್ಪನೆಗಳು ಬಹುತೇಕ ವಿಶ್ವವ್ಯಾಪಕ - ಯಾವುದೇ programming language ಗೆ code formatter, linter, testing library ಇತ್ಯಾದಿ ಸಿಗುತ್ತವೆ.
 
 # Formatting
 
-Code auto-formatters automatically prettify surface syntax. This way, you can focus on the more deep and challenging problems, while the auto-formatting tool handles mundane details such as consistency of `'` versus `"` syntax for strings, having spaces surrounding binary operators (`x + y` instead of `x+y`), having `import` statements in sorted order, and avoiding over-length lines. One major benefit of code formatters is that they standardize code style across all developers working on a codebase.
+Code auto-formatters ಮೂಲ syntax ನ presentation ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸುಂದರಗೊಳಿಸುತ್ತವೆ. ಇದರಿಂದ ನೀವು ಗಂಭೀರ ಮತ್ತು ಸವಾಲಿನ ಸಮಸ್ಯೆಗಳಿಗೆ ಗಮನಕೊಡಬಹುದು; meanwhile formatter `'` vs `"` string syntax consistency, binary operators ಸುತ್ತ spaces (`x+y` ಬದಲು `x + y`), `import` statements ಕ್ರಮ, ಮತ್ತು ಅತಿದೀರ್ಘ lines ತಪ್ಪಿಸುವುದು ಮೊದಲಾದ ಸಾಮಾನ್ಯ ವಿವರಗಳನ್ನು ನೋಡಿಕೊಳ್ಳುತ್ತದೆ. Code formatters ನ ಪ್ರಮುಖ ಲಾಭವೆಂದರೆ codebase ಮೇಲೆ ಕೆಲಸ ಮಾಡುವ developers ಎಲ್ಲರಿಗೂ ಏಕಸಮಾನ code style ಒದಗಿಸುವುದು.
 
-Some tools such as Prettier are [highly configurable](https://prettier.io/docs/configuration); you should check in the configuration file into [version control](/2026/version-control/) for your project. Other tools, such as [Black](https://github.com/psf/black) and [gofmt](https://pkg.go.dev/cmd/gofmt) have limited or no configurability, to reduce [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
+Prettier ಮೊದಲಾದ ಕೆಲವು tools [ಹೆಚ್ಚು configurable](https://prettier.io/docs/configuration). Project configuration file ಅನ್ನು [version control](/2026/version-control/) ನಲ್ಲಿ commit ಮಾಡಬೇಕು. [Black](https://github.com/psf/black), [gofmt](https://pkg.go.dev/cmd/gofmt) ಮೊದಲಾದ tools ನಲ್ಲಿ configurability ಕಡಿಮೆ ಅಥವಾ ಇಲ್ಲ - [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality) ಕಡಿಮೆ ಮಾಡಲು ಇದು ಉದ್ದೇಶಿತ.
 
-You can set up [IDE integration](/2026/development-environment/#code-intelligence-and-language-servers) with your code formatter, so that your code will be auto-formatted as you type or when you save a file. You can also add an [EditorConfig](https://editorconfig.org/) file to your project, which communicates to your IDE certain project-level settings like indent size for each file type.
+Code formatter ಗೆ [IDE integration](/2026/development-environment/#code-intelligence-and-language-servers) ಸಕ್ರಿಯಗೊಳಿಸಿದರೆ type ಮಾಡುವಾಗ ಅಥವಾ file save ಮಾಡುವಾಗ code auto-format ಆಗುತ್ತದೆ. Project ಗೆ [EditorConfig](https://editorconfig.org/) file ಸೇರಿಸಬಹುದು. ಇದರಿಂದ file type ಪ್ರಕಾರ indent size ಮುಂತಾದ project-level settings IDE ಗೆ ತಿಳಿಯುತ್ತದೆ.
 
 # Linting
 
-Linters run static analysis (analyze your code without running it) to find antipatterns and potential issues in your code. These tools go deeper than autoformatters, looking beyond surface syntax. The level of depth of analysis varies by tool.
+Linters static analysis (code run ಮಾಡದೆ code ವಿಶ್ಲೇಷಣೆ) ನಡೆಸಿ antipatterns ಮತ್ತು ಸಾಧ್ಯ ಸಮಸ್ಯೆಗಳನ್ನು ಪತ್ತೆಹಿಡಿಯುತ್ತವೆ. ಈ tools autoformatters ಗಿಂತ ಆಳವಾದ ಮಟ್ಟದಲ್ಲಿ ಕೆಲಸ ಮಾಡುತ್ತವೆ - surface syntax ನಾಚೆಗೆ ಹೋಗಿ ವಿಶ್ಲೇಷಿಸುತ್ತವೆ. Analysis ಆಳವು tool ಪ್ರಕಾರ ಬದಲಾಗುತ್ತದೆ.
 
-Linters come equipped with lists of _rules_, with presets that can be configured on a project-level basis. Some linter rules produce false positives, so you can disable them on a per-file or per-line basis.
+Linters ನಲ್ಲಿ _rules_ ಪಟ್ಟಿಗಳು ಮತ್ತು project ಮಟ್ಟದಲ್ಲಿ configure ಮಾಡಬಹುದಾದ presets ಇರುತ್ತವೆ. ಕೆಲವು rules false positives ನೀಡಬಹುದು; ಆಗ ಅವನ್ನು per-file ಅಥವಾ per-line ಆಧಾರದ ಮೇಲೆ disable ಮಾಡಬಹುದು.
 
-Good linters will have built-in help or documentation that explains each linter rule --- what the rule is looking for, why it's bad, and what's a better alternative for the code pattern. For example, see the documentation for the [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) rule in [Ruff](https://docs.astral.sh/ruff/) which catches unnecessarily nested `if` statements in Python code.
+ಉತ್ತಮ linters ನಲ್ಲಿ ಪ್ರತಿಯೊಂದು rule ಗಾಗಿ built-in help/documentation ಇರುತ್ತದೆ - rule ಏನು ಹುಡುಕುತ್ತದೆ, ಅದು ಯಾಕೆ ದುರ್ಬಲ pattern, ಉತ್ತಮ ಪರ್ಯಾಯ ಏನು ಎಂಬುದು ಸ್ಪಷ್ಟವಾಗಿರುತ್ತದೆ. ಉದಾಹರಣೆಗೆ Python ನಲ್ಲಿ ಅನಾವಶ್ಯಕ nested `if` statements ಹಿಡಿಯುವ [Ruff](https://docs.astral.sh/ruff/) ನ [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) rule documentation ನೋಡಿ.
 
-Some linters can not only flag issues but also automatically fix certain issues for you.
+ಕೆಲವು linters ಸಮಸ್ಯೆಗಳನ್ನು flag ಮಾಡುವುದಷ್ಟೇ ಅಲ್ಲ, ಕೆಲವು ದೋಷಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸರಿಪಡಿಸಿಯೂ ಬಿಡುತ್ತವೆ.
 
-Aside from language-specific linters, another tool that might come in handy is [semgrep](https://github.com/semgrep/semgrep), a "semantic grep" tool that works at the AST level (rather than character level, like grep) and supports many languages. You can use semgrep to easily write custom linter rules for your projects. For example, if you wanted to prevent the dangerous `subprocess.Popen(..., shell=True)` in Python, you could find that code pattern with:
+Language-specific linters ಹೊರತುಪಡಿಸಿ ಉಪಯುಕ್ತ tool ಆಗಿ [semgrep](https://github.com/semgrep/semgrep) ಅನ್ನು ನೋಡಬಹುದು. ಇದು AST ಮಟ್ಟದಲ್ಲಿ ಕೆಲಸ ಮಾಡುವ "semantic grep" (character ಮಟ್ಟದಲ್ಲಿ grep ಮಾಡುವುದಕ್ಕಿಂತ ಉನ್ನತ) ಮತ್ತು ಅನೇಕ ಭಾಷೆಗಳನ್ನು ಬೆಂಬಲಿಸುತ್ತದೆ. Projects ಗಾಗಿ custom linter rules ಬರೆಯಲು semgrep ಸೂಕ್ತ. ಉದಾ: Python ನಲ್ಲಿ ಅಪಾಯಕಾರಿ `subprocess.Popen(..., shell=True)` ಬಳಕೆಯನ್ನು ತಡೆಯಲು ಈ pattern ಹುಡುಕಬಹುದು:
 
 ```bash
 semgrep -l python -e "subprocess.Popen(..., shell=True, ...)"
@@ -50,85 +50,85 @@ semgrep -l python -e "subprocess.Popen(..., shell=True, ...)"
 
 # Testing
 
-Software testing is a standard technique to increase your confidence in the correctness of your code. You write code, and then you write code that exercises the code you wrote and raises an error if the code doesn't work as expected.
+Software testing ಎಂದರೆ ನಿಮ್ಮ code ಸರಿಯೇ ಎಂಬ ವಿಶ್ವಾಸವನ್ನು ಹೆಚ್ಚಿಸುವ ಮಾನದಂಡ ತಂತ್ರ. ನೀವು code ಬರೆಯುತ್ತೀರಿ; ಬಳಿಕ ಅದೇ code ನ ವರ್ತನೆಯನ್ನು exercise ಮಾಡುವ test code ಬರೆಯುತ್ತೀರಿ. ನಿರೀಕ್ಷಿತಂತೆ ಕೆಲಸ ಮಾಡದಿದ್ದರೆ tests ದೋಷವನ್ನು ಎತ್ತುತ್ತವೆ.
 
-You can write tests for chunks of code at different levels of granularity: _unit tests_ for individual functions, _integration tests_ for interaction between modules or services, and _functional tests_ for end-to-end scenarios. You can do _test-driven development_, where you write tests before you write any implementation code. When you find bugs in your code, you can write _regression tests_, so you'll catch if the functionality ever breaks in the future. You can write _property-based tests_, pioneered in [QuickCheck](https://hackage.haskell.org/package/QuickCheck) in Haskell, and implemented in many libraries, like [Hypothesis](https://hypothesis.readthedocs.io/) for Python. Which approach to testing is right depends on your project; likely, you will adopt some combination.
+ವಿವಿಧ granularities ನಲ್ಲಿ tests ಬರೆಯಬಹುದು: ಪ್ರತ್ಯೇಕ functions ಗಾಗಿ _unit tests_, modules/services ನಡುವಿನ ಸಂವಹನಕ್ಕೆ _integration tests_, end-to-end ಸಂದರ್ಭಗಳಿಗೆ _functional tests_. ನೀವು _test-driven development_ ಅನುಸರಿಸಬಹುದು - implementation ಮುಂಚೆ tests ಬರೆಯುವುದು. Bug ಸಿಕ್ಕಾಗ _regression tests_ ಸೇರಿಸಿ ಮುಂದೆಯೂ ಅದೇ ಸಮಸ್ಯೆ ಮರಳಿ ಬಾರದಂತೆ ನೋಡಬಹುದು. [QuickCheck](https://hackage.haskell.org/package/QuickCheck) ಮೂಲಕ ಪ್ರಸಿದ್ಧಿಯಾದ _property-based tests_ (Python ನಲ್ಲಿ [Hypothesis](https://hypothesis.readthedocs.io/) ಹಾಗೆ) ಬರೆಯಬಹುದು. ಯಾವ ವಿಧಾನ ಸೂಕ್ತ ಎಂಬುದು project ಅವಲಂಬಿತ; ಬಹುಪಾಲು ಸಂದರ್ಭಗಳಲ್ಲಿ ಮಿಶ್ರ ವಿಧಾನ ಬಳಸಲಾಗುತ್ತದೆ.
 
-If your program has external dependencies like a database or web API, it may be helpful to _mock_ those dependencies in your tests, rather than have your code interact with third-party dependencies at test time.
+ನಿಮ್ಮ program ಗೆ database ಅಥವಾ web API ಮೊದಲಾದ external dependencies ಇದ್ದರೆ, test ಸಮಯದಲ್ಲಿ third-party dependency ಜೊತೆ ನೇರ ಸಂಪರ್ಕ ಮಾಡುವ ಬದಲು ಅವನ್ನು _mock_ ಮಾಡುವುದು ಸಹಾಯಕ.
 
 ## Code coverage
 
-Code coverage is a metric by which you can measure how good your tests are. Code coverage looks at which lines of your code are executed when your tests are run, so you can ensure you are covering all code paths. Code coverage tools can show you line-by-line coverage to guide you in writing tests. Services such as [Codecov](https://app.codecov.io) provide web interfaces for tracking and viewing code coverage over the history of a project.
+Code coverage ಎಂದರೆ tests ಗುಣಮಟ್ಟವನ್ನು ಅಳೆಯುವ metric. Tests run ಆಗುವಾಗ code ನ ಯಾವ lines execute ಆಗುತ್ತವೆ ಎಂದು coverage ನೋಡುತ್ತದೆ; ಇದರಿಂದ ಎಲ್ಲಾ code paths cover ಆಗುತ್ತಿವೆಯೇ ಎಂದು ಖಚಿತಪಡಿಸಬಹುದು. Coverage tools line-by-line ಮಾಹಿತಿ ತೋರಿಸಿ tests ಬರೆಯುವ ದಾರಿಗೆ ಮಾರ್ಗದರ್ಶನ ಕೊಡುತ್ತವೆ. [Codecov](https://app.codecov.io) ಮೊದಲಾದ services project ಇತಿಹಾಸದ coverage ಅನ್ನು track/view ಮಾಡಲು web interfaces ಒದಗಿಸುತ್ತವೆ.
 
-Like any metric, code coverage is not perfect; don't over-index on coverage, focus on writing high-quality tests.
+ಯಾವ metric ಆದರೂ code coverage ಪರಿಪೂರ್ಣವಲ್ಲ. Coverage ಸಂಖ್ಯೆಯ ಮೇಲಷ್ಟೇ ಗಮನಕೊಡಬೇಡಿ; ಉನ್ನತ ಗುಣಮಟ್ಟದ tests ಬರೆಯುವುದರ ಮೇಲೆ ಗಮನಹರಿಸಿ.
 
 # Pre-commit hooks
 
-Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), made easier by the [pre-commit](https://pre-commit.com/) framework, automatically run user-specified code prior to every Git commit. Projects commonly use pre-commit hooks to run formatters and linters, and sometimes tests, automatically before every commit, to ensure that committed code matches the project code style and is free of certain issues.
+Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) - [pre-commit](https://pre-commit.com/) framework ಮೂಲಕ ಸುಲಭವಾಗುವ ವಿಧಾನ - ಪ್ರತಿಯೊಂದು Git commit ಮೊದಲು user-ನಿರ್ಧರಿತ code ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಓಡಿಸುತ್ತವೆ. Projects ಗಳು ಸಾಮಾನ್ಯವಾಗಿ formatters, linters, ಕೆಲವೊಮ್ಮೆ tests ಕೂಡ commit ಮೊದಲು run ಆಗುವಂತೆ pre-commit hooks ಬಳಸುತ್ತವೆ. ಉದ್ದೇಶ: commit ಆಗುವ code project style ಗೆ ಹೊಂದಿಕೆಯಾಗಿರಲಿ ಮತ್ತು ನಿರ್ದಿಷ್ಟ ಸಮಸ್ಯೆಗಳಿಲ್ಲದಿರಲಿ.
 
 # Continuous integration
 
-Continuous integration (CI) services like [GitHub Actions](https://github.com/features/actions) can run scripts for you every time you push code (or on every pull request, or on a schedule). Developers commonly use CI services to run code quality tools including formatters, linters, and tests. For compiled languages, you can ensure code compiles; for statically typed languages, you can make sure it type checks. Running CI every push of new commits can catch errors introduced into the main version of the code; running on pull requests can catch issues with contributor submissions; running on a schedule can catch issues with external dependencies (e.g., a developer accidentally releases a breaking change as [semver-compatible](/2026/shipping-code/#releases--versioning)).
+[GitHub Actions](https://github.com/features/actions) ಮೊದಲಾದ Continuous integration (CI) services, ನೀವು code push ಮಾಡಿದಾಗ (ಅಥವಾ pull request ಗಳಲ್ಲಿ, ಅಥವಾ schedule ಪ್ರಕಾರ) scripts run ಮಾಡಬಹುದು. Developers ಸಾಮಾನ್ಯವಾಗಿ CI ನಲ್ಲಿ formatters, linters, tests ಮುಂತಾದ code quality tools run ಮಾಡುತ್ತಾರೆ. Compiled languages ಗಾಗಿ code compile ಆಗುತ್ತದೆಯೇ ಪರಿಶೀಲಿಸಬಹುದು; statically typed languages ಗಾಗಿ type checking ಖಚಿತಪಡಿಸಬಹುದು. ಹೊಸ commits ಪ್ರತಿ push ಗೆ CI ಓಡಿಸಿದರೆ main branch ಗೆ ಸೇರಿದ ದೋಷಗಳು ಹಿಡಿಯುತ್ತವೆ. Pull requests ಮೇಲೆ run ಮಾಡಿದರೆ contributor submissions ಸಮಸ್ಯೆಗಳು ಪತ್ತೆಯಾಗುತ್ತವೆ. Schedule ಮೇಲೆ run ಮಾಡಿದರೆ external dependency issues ಹಿಡಿಯಬಹುದು (ಉದಾ: ಯಾರಾದರೂ ತಪ್ಪಾಗಿ [semver-compatible](/2026/shipping-code/#releases--versioning) ಆಗಿದೆ ಎಂದು breaking change release ಮಾಡುವುದು).
 
-Because CI scripts run separately from developer machines, you can easily run long-running jobs there. This can be leveraged, for example, to run a _matrix_ of tests across different operating systems and programming language versions to ensure that the software works properly across all of them.
+CI scripts developer machine ನಿಂದ ಪ್ರತ್ಯೇಕವಾಗಿ ನಡೆಯುವುದರಿಂದ, ದೀರ್ಘ ಸಮಯ ತೆಗೆದುಕೊಳ್ಳುವ jobs ಅನ್ನು ಸುಲಭವಾಗಿ ಅಲ್ಲಿ ಓಡಿಸಬಹುದು. ಉದಾ: software ವಿವಿಧ operating systems ಮತ್ತು programming language versions ಗಳಲ್ಲಿ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತದೆಯೇ ಎಂದು ಪರೀಕ್ಷಿಸಲು _matrix_ tests run ಮಾಡಬಹುದು.
 
-Generally, the script running in CI will not directly make changes to your code: it will run tools in "check-only" mode rather than "fix" mode, so for example, the auto-formatter will raise an error when the code is not compliant with the format.
+ಸಾಮಾನ್ಯವಾಗಿ CI script ನಿಮ್ಮ code ನ್ನೇ ನೇರವಾಗಿ ಬದಲಾಯಿಸುವುದಿಲ್ಲ: "fix" mode ಬದಲು "check-only" mode ನಲ್ಲಿ tools run ಆಗುತ್ತವೆ. ಉದಾ: auto-formatter format ಗೆ ಅನುಗುಣವಾಗದ code ಕಂಡರೆ error ನೀಡುತ್ತದೆ.
 
-Repositories often include [status badges](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) in their README, showing CI status and other information such as code coverage. For example, below is Missing Semester's current build status.
+Repositories ನಲ್ಲಿ ಸಾಮಾನ್ಯವಾಗಿ README ಯಲ್ಲಿ [status badges](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) ಇರುತ್ತವೆ - CI status ಮತ್ತು code coverage ಮುಂತಾದ ಮಾಹಿತಿ ತೋರಿಸಲು. ಉದಾಹರಣೆಗೆ ಕೆಳಗೆ Missing Semester ನ build status ಇದೆ.
 
 [![Build Status](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml) [![Links Status](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml)
 
-> Our [links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml), which uses the [proof-html](https://github.com/anishathalye/proof-html) GitHub Action is often failing, usually due to issues with third-party websites. Still, it has helped us catch and fix many broken links (sometimes due to typos, most of the time due to websites moving around content without adding redirects or websites disappearing).
+> [links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml) (ಇದು [proof-html](https://github.com/anishathalye/proof-html) GitHub Action ಬಳಸುತ್ತದೆ) ಮೂರನೇ ಪಕ್ಷದ websites ಸಮಸ್ಯೆಗಳ ಕಾರಣದಿಂದ ಆಗಾಗ ವಿಫಲವಾಗುತ್ತದೆ. ಆದರೂ, ಇದು ಅನೇಕ broken links ಹಿಡಿದು ಸರಿಪಡಿಸಲು ಸಹಾಯಮಾಡಿದೆ (ಕೆಲವೊಮ್ಮೆ typos, ಹೆಚ್ಚುಸಾರಿ redirects ಇಲ್ಲದೆ website content ಸ್ಥಳಾಂತರಿಸುವುದು ಅಥವಾ websites ಅಳಿದುಹೋಗುವುದು).
 
-A good way to learn the particulars of CI services, formatters, linters, and testing libraries is by example. Find high-quality open-source projects on GitHub---the more similar to your project in programming language, domain, size and scope, and so on, the better---and study their `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md`, and other relevant files.
+CI services, formatters, linters, testing libraries ಮುಂತಾದವುಗಳ ನಿಖರ ಬಳಕೆ ಕಲಿಯಲು ಉತ್ತಮ ವಿಧಾನ ಎಂದರೆ ಉದಾಹರಣೆಗಳಿಂದ ಕಲಿಯುವುದು. GitHub ನಲ್ಲಿ ಉತ್ತಮ open-source projects ಹುಡುಕಿ - programming language, domain, project size/scope ಹೀಗೆ ನಿಮ್ಮ project ಗೆ ಹೆಚ್ಚು ಹತ್ತಿರ ಇರುವುದಾದಷ್ಟು ಉತ್ತಮ - ನಂತರ ಅವುಗಳ `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md` ಮತ್ತು ಸಂಬಂಧಿತ files ಅಧ್ಯಯನ ಮಾಡಿ.
 
 ## Continuous deployment
 
-Continuous deployment makes use of CI infrastructure to actually _deploy_ changes. For example, the Missing Semester repository uses continuous deployment to GitHub pages so that whenever we `git push` updated lecture notes, the site is automatically built and deployed. You can build other types of [artifacts](/2026/shipping-code/) in CI, such as binaries for applications or Docker images for services.
+Continuous deployment ಎಂದರೆ CI infrastructure ಬಳಸಿ ಬದಲಾವಣೆಗಳನ್ನು ನೇರವಾಗಿ _deploy_ ಮಾಡುವುದು. ಉದಾ: Missing Semester repository GitHub Pages ಗೆ continuous deployment ಬಳಸುತ್ತದೆ. ಹೀಗಾಗಿ lecture notes update ಮಾಡಿ `git push` ಮಾಡಿದಾಗ site ಸ್ವಯಂಚಾಲಿತವಾಗಿ build ಆಗಿ deploy ಆಗುತ್ತದೆ. CI ನಲ್ಲಿ applications ಗಾಗಿ binaries ಅಥವಾ services ಗಾಗಿ Docker images ಮೊದಲಾದ ಬೇರೆ [artifacts](/2026/shipping-code/) ಕೂಡ build ಮಾಡಬಹುದು.
 
 # Command runners
 
-Command runners like [just](https://github.com/casey/just) simplify the task of running commands in the context of a project. As you build up code quality infrastructure for your project, you don't want to make your developers memorize commands like `uv run ruff check --fix`. With a command runner, this can turn into `just lint`, and you can have analogous invocations like `just format`, `just typecheck`, etc., for all the different tools a developer might want to run for your project.
+[just](https://github.com/casey/just) ಮೊದಲಾದ command runners project context ನಲ್ಲಿ commands run ಮಾಡುವುದನ್ನು ಸುಲಭಗೊಳಿಸುತ್ತವೆ. Project ಗೆ code quality infrastructure ಹೆಚ್ಚಾದಂತೆ `uv run ruff check --fix` ರೀತಿಯ commands developers ನೆನಪಿಡಬೇಕಾಗದಂತೆ ಮಾಡುವುದು ಮುಖ್ಯ. Command runner ಇದ್ದರೆ ಇದೇ ಕೆಲಸ `just lint` ಆಗಬಹುದು. ಅದೇ ರೀತಿ `just format`, `just typecheck` ಇತ್ಯಾದಿ invocations ರಚಿಸಿ developer ಬೇಕಾದ tools ಎಲ್ಲಕ್ಕೂ ಸರಳ entry point ಕೊಡಬಹುದು.
 
-Some language-specific project or package managers have built-in support for such functionality, which means you don't need to use a language-agnostic tool like `just`. For example, the `scripts` section of a `package.json` for [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) and the `tool.hatch.envs.*.scripts` sections of a `pyproject.toml` for [Hatch](https://hatch.pypa.io/) (Python) support this functionality.
+ಕೆಲವು language-specific project/package managers ನಲ್ಲಿ ಈ functionality built-in ಇರುತ್ತದೆ. ಅಂಥ ಸಂದರ್ಭಗಳಲ್ಲಿ `just` ಹಾಗೆ language-agnostic tool ಬೇಕಾಗುವುದಿಲ್ಲ. ಉದಾ: [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) ಯ `package.json` ನಲ್ಲಿ `scripts` ವಿಭಾಗ ಮತ್ತು [Hatch](https://hatch.pypa.io/) (Python) ಯ `pyproject.toml` ನಲ್ಲಿ `tool.hatch.envs.*.scripts` ವಿಭಾಗಗಳು ಈ ಕೆಲಸ ಮಾಡುತ್ತವೆ.
 
 # Regular expressions
 
-_Regular expressions_, commonly abbreviated as "regex", is a language used to represent sets of strings. Regex patterns are commonly used for pattern matching in various contexts such as command-line tools and IDEs. For example, [ag](https://github.com/ggreer/the_silver_searcher) supports regex patterns for codebase-wide search (e.g., `ag "import .* as .*"` will find all renamed imports in Python), and [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) supports a `-run [regexp]` option for selecting a subset of tests. Furthermore, programming languages have built-in support or third-party libraries for regular expression matching, so you can use regexes for functionality such as pattern matching, validation, and parsing.
+_Regular expressions_ (ಸಾಮಾನ್ಯವಾಗಿ "regex") ಎಂದರೆ strings ಸಮೂಹಗಳನ್ನು ಪ್ರತಿನಿಧಿಸುವ ಭಾಷೆ. Regex patterns ಅನ್ನು command-line tools, IDEs ಸೇರಿದಂತೆ ಹಲವು ಸಂದರ್ಭಗಳಲ್ಲಿ pattern matching ಗಾಗಿ ಬಳಸುತ್ತಾರೆ. ಉದಾ: [ag](https://github.com/ggreer/the_silver_searcher) codebase-wide search ಗೆ regex ಬೆಂಬಲಿಸುತ್ತದೆ (`ag "import .* as .*"` Python ನಲ್ಲಿ renamed imports ಎಲ್ಲವನ್ನೂ ಹುಡುಕುತ್ತದೆ), ಮತ್ತು [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) ನಲ್ಲಿ tests subset ಆಯ್ಕೆ ಮಾಡಲು `-run [regexp]` ಆಯ್ಕೆ ಇದೆ. ಜೊತೆಗೆ programming languages ನಲ್ಲಿ regex matching ಗೆ built-in support ಅಥವಾ third-party libraries ಇರುವುದರಿಂದ pattern matching, validation, parsing ಮುಂತಾದ ಕಾರ್ಯಗಳಲ್ಲಿ regex ಉಪಯೋಗಿಸಬಹುದು.
 
-To help build intuition, below are some examples of regex patterns. In this lecture, we use [Python regex syntax](https://docs.python.org/3/library/re.html). There are many flavors of regex, with slight variation between them, especially in the more sophisticated functionality. You can use an online regex tester like [regex101](https://regex101.com/) to develop and debug regular expressions.
+ಅನುವೈಜ್ಞಾನಿಕ ಗ್ರಹಿಕೆಗೆ ಕೆಲವು regex pattern ಉದಾಹರಣೆಗಳು ಕೆಳಗೆ. ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ [Python regex syntax](https://docs.python.org/3/library/re.html) ಬಳಸುತ್ತೇವೆ. Regex ಗೆ ಹಲವು flavors ಇದ್ದು, ವಿಶೇಷವಾಗಿ advanced features ನಲ್ಲಿ ಸಣ್ಣ ವ್ಯತ್ಯಾಸಗಳಿವೆ. Regex patterns ರಚನೆ/debug ಮಾಡಲು [regex101](https://regex101.com/) ಮೊದಲಾದ online tester ಉಪಯುಕ್ತ.
 
-- `abc` --- matches the literal "abc".
-- `missing|semester` --- matches the string "missing" or the string "semester".
-- `\d{4}-\d{2}-\d{2}` --- matches dates in YYYY-MM-DD format, such as "2026-01-14". Beyond ensuring that the string consists of four digits, a dash, two digits, a dash, and two digits, this does not validate the date, so "2026-01-99" matches this regex pattern too.
-- `.+@.+` --- matches email addresses, strings that contain some text, then an "@", and then some more text. This does only the most basic validation and matches strings like "nonsense@@@email". A regex that matches email addresses with no false positives or negatives [exists](https://pdw.ex-parrot.com/Mail-RFC822-Address.html) but is impractical.
+- `abc` - literal "abc" ಗೆ match ಆಗುತ್ತದೆ.
+- `missing|semester` - "missing" ಅಥವಾ "semester" string ಗೆ match ಆಗುತ್ತದೆ.
+- `\d{4}-\d{2}-\d{2}` - YYYY-MM-DD ದಿನಾಂಕ ಮಾದರಿಗೆ match (ಉದಾ: "2026-01-14"). ಇದು ರೂಪವಷ್ಟೇ ಪರಿಶೀಲಿಸುತ್ತದೆ; ನಿಜವಾದ ದಿನಾಂಕ ಮಾನ್ಯತೆ ಪರಿಶೀಲಿಸುವುದಿಲ್ಲ. ಆದ್ದರಿಂದ "2026-01-99" ಕೂಡ match ಆಗುತ್ತದೆ.
+- `.+@.+` - ಕೆಲವು ಪಠ್ಯ + `@` + ಇನ್ನಷ್ಟು ಪಠ್ಯ ಇರುವ email-like strings ಗೆ match. ಇದು ಅತ್ಯಂತ ಮೂಲ ಪರಿಶೀಲನೆ ಮಾತ್ರ; "nonsense@@@email" ಕೂಡ match ಆಗುತ್ತದೆ. False positives/negatives ಇಲ್ಲದ email regex [ಇದೆ](https://pdw.ex-parrot.com/Mail-RFC822-Address.html), ಆದರೆ ಪ್ರಾಯೋಗಿಕವಾಗಿ ಬಳಸಲು ಕಷ್ಟ.
 
 ## Regex syntax
 
-You can find a comprehensive guide to regex syntax in [this documentation](https://docs.python.org/3/library/re.html#regular-expression-syntax) (or one of many other resources available online). Here are some of the basic building blocks:
+Regex syntax ಗೆ ಸಮಗ್ರ ಮಾರ್ಗದರ್ಶಿ [ಈ documentation](https://docs.python.org/3/library/re.html#regular-expression-syntax) ನಲ್ಲಿ ಸಿಗುತ್ತದೆ (ಆನ್‌ಲೈನಿನಲ್ಲಿ ಇಂತಹ ಹಲವಾರು ಸಂಪನ್ಮೂಲಗಳಿವೆ). ಮೂಲ ಕಟ್ಟುಗಲ್ಲುಗಳು:
 
-- `abc` matches the literal string, when the characters have no special meaning (in this example, "abc")
-- `.` matches any single character
-- `[abc]` matches a single character contained in the brackets (in this example, "a", "b", or "c")
-- `[^abc]` matches a single character except those contained in the brackets (e.g., "d")
-- `[a-f]` matches a single character contained in the range indicated in the brackets (e.g., "c", but not "q")
-- `a|b` matches either pattern (e.g., "a" or "b")
-- `\d` matches any digit character (e.g., "3")
-- `\w` matches any word character (e.g., "x")
-- `\b` matches any word _boundary_ (e.g., in the string "missing semester", matches just before the "m", just after the "g", just before the "s", and just after the "r")
-- `(...)` matches the group of a pattern
-- `...?` matches zero or one of a pattern, such as `words?` to match "word" or "words"
-- `...*` matches any number of a pattern, such as `.*` to match any number of any character
-- `...+` matches one or more of a pattern, such as `\d+` to match any non-zero number of digits
-- `...{N}` matches exactly N of a pattern, such as `\d{4}` for 4 digits
-- `\.` matches a literal "."
-- `\\` matches a literal "\\"
-- `^` matches the start of the line
-- `$` matches the end of the line
+- `abc` - characters ಗೆ ವಿಶೇಷ ಅರ್ಥ ಇಲ್ಲದಿದ್ದರೆ literal string ಗೆ match (ಈ ಉದಾಹರಣೆಯಲ್ಲಿ "abc")
+- `.` - ಯಾವುದೇ ಒಂದು character ಗೆ match
+- `[abc]` - brackets ಒಳಗಿನ ಒಂದೇ character ಗೆ match (ಈ ಉದಾಹರಣೆಯಲ್ಲಿ "a", "b", ಅಥವಾ "c")
+- `[^abc]` - brackets ಒಳಗಿನವುಗಳನ್ನು ಹೊರತುಪಡಿಸಿದ ಒಂದೇ character ಗೆ match (ಉದಾ: "d")
+- `[a-f]` - ಸೂಚಿಸಿದ range ಒಳಗಿನ ಒಂದೇ character ಗೆ match (ಉದಾ: "c", ಆದರೆ "q" ಅಲ್ಲ)
+- `a|b` - ಯಾವುದಾದರೂ pattern ಗೆ match (ಉದಾ: "a" ಅಥವಾ "b")
+- `\d` - ಯಾವುದೇ digit character ಗೆ match (ಉದಾ: "3")
+- `\w` - ಯಾವುದೇ word character ಗೆ match (ಉದಾ: "x")
+- `\b` - word _boundary_ ಗೆ match (ಉದಾ: "missing semester" ನಲ್ಲಿ "m" ಮುಂಚೆ, "g" ನಂತರ, "s" ಮುಂಚೆ, "r" ನಂತರ)
+- `(...)` - pattern group ಗೆ match
+- `...?` - pattern ನ zero ಅಥವಾ one occurrence ಗೆ match. ಉದಾ: `words?` - "word" ಅಥವಾ "words"
+- `...*` - pattern ನ ಯಾವುದೇ ಸಂಖ್ಯೆಯ occurrences ಗೆ match. ಉದಾ: `.*` - ಯಾವುದೇ characters ಯಾವುದೇ ಸಂಖ್ಯೆಯಲ್ಲಿ
+- `...+` - pattern ನ one or more occurrences ಗೆ match. ಉದಾ: `\d+` - ಒಂದು ಅಥವಾ ಹೆಚ್ಚು digits
+- `...{N}` - pattern ನ ನಿಖರ N occurrences ಗೆ match. ಉದಾ: `\d{4}` - 4 digits
+- `\.` - literal `.` ಗೆ match
+- `\\` - literal `\` ಗೆ match
+- `^` - line ಆರಂಭಕ್ಕೆ match
+- `$` - line ಅಂತ್ಯಕ್ಕೆ match
 
 ## Capture groups and references
 
-If you use regex groups `(...)`, you can refer to sub-parts of the match for extraction or search-and-replace purposes. For example, to extract just the month from a YYYY-MM-DD style date, you can use the following Python code:
+Regex groups `(...)` ಬಳಸಿದಾಗ match ನ ಉಪಭಾಗಗಳನ್ನು extraction ಅಥವಾ search-and-replace ಗಾಗಿ reference ಮಾಡಬಹುದು. ಉದಾ: YYYY-MM-DD ದಿನಾಂಕದಲ್ಲಿ ತಿಂಗಳ ಭಾಗ ಮಾತ್ರ ತೆಗೆಯಲು Python code:
 
 ```python
 >>> import re
@@ -136,17 +136,17 @@ If you use regex groups `(...)`, you can refer to sub-parts of the match for ext
 '01'
 ```
 
-In your text editor, you can use reference capture groups in replace patterns. The syntax might vary between IDEs. For example, in VS Code, you can use variables like `$1`, `$2`, etc., and in Vim, you can use `\1`, `\2`, etc., to reference groups.
+Text editor ನಲ್ಲಿ replace patterns ಗೆ capture group references ಬಳಸಬಹುದು. Syntax IDE ಪ್ರಕಾರ ಬದಲಾಗಬಹುದು. ಉದಾ: VS Code ನಲ್ಲಿ `$1`, `$2`, ... ಬಳಸಬಹುದು; Vim ನಲ್ಲಿ `\1`, `\2`, ... ಬಳಸಬಹುದು.
 
 ## Limitations
 
-[Regular languages](https://en.wikipedia.org/wiki/Regular_language) are powerful but limited; there are classes of strings that cannot be expressed as a standard regex (e.g., it is [not possible](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) to write a regular expression that matches the set of strings {a^n b^n \| n &ge; 0}, the set of strings of a number of "a"s followed by the same number of "b"s; more practically, languages like HTML are not regular languages). In practice, modern regex engines support features like lookahead and backreferences that extend support beyond regular languages, and they are practically extremely useful, but it is important to know that they are still limited in their expressive power. For more sophisticated languages, you might need to reach for a more capable type of parser (for one example, see [pyparsing](https://github.com/pyparsing/pyparsing), a [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) parser).
+[Regular languages](https://en.wikipedia.org/wiki/Regular_language) ಶಕ್ತಿಶಾಲಿಯಾದರೂ ಮಿತಿಗಳಿವೆ. ಕೆಲವು string classes ಅನ್ನು standard regex ಮೂಲಕ ವ್ಯಕ್ತಪಡಿಸಲಾಗುವುದಿಲ್ಲ (ಉದಾ: {a^n b^n \| n &ge; 0} ಸೆಟ್‌ಗೆ regex ಬರೆಯುವುದು [ಸಾಧ್ಯವಿಲ್ಲ](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) - ಅಂದರೆ ಕೆಲವು "a"ಗಳ ನಂತರ ಅದೇ ಸಂಖ್ಯೆಯ "b"ಗಳು; ಹಾಗೆಯೇ HTML ಮೊದಲಾದ ಭಾಷೆಗಳು regular languages ಅಲ್ಲ). ಪ್ರಾಯೋಗಿಕವಾಗಿ modern regex engines lookahead, backreferences ಮೊದಲಾದ features ಮೂಲಕ regular languages ಗಿಂತ ಮುಂದೆ ಬೆಂಬಲ ಕೊಡುತ್ತವೆ ಮತ್ತು ಬಹಳ ಉಪಯುಕ್ತ. ಆದರೆ expressive power ಇನ್ನೂ ಮಿತಿಯಲ್ಲಿದೆ ಎಂಬುದನ್ನು ತಿಳಿದುಕೊಳ್ಳುವುದು ಮುಖ್ಯ. ಹೆಚ್ಚು ಸಂಕೀರ್ಣ ಭಾಷೆಗಳಿಗೆ, ಹೆಚ್ಚು ಸಾಮರ್ಥ್ಯವಿರುವ parser ಅಗತ್ಯವಾಗಬಹುದು (ಉದಾ: [pyparsing](https://github.com/pyparsing/pyparsing), ಒಂದು [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) parser).
 
 ## Learning regex
 
-We recommend learning the fundamentals (what we have covered in this lecture), and then looking at regex references as you need them, rather than memorizing the entirety of the language.
+ನಮ್ಮ ಶಿಫಾರಸು: ಮೊದಲು ಮೂಲಭುತಗಳು (ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ನೋಡಿದ ವಿಷಯಗಳು) ಚೆನ್ನಾಗಿ ಕಲಿಯಿರಿ, ನಂತರ ಅಗತ್ಯವಿದ್ದಾಗ regex references ನೋಡುತ್ತಾ ಮುಂದುವರಿಯಿರಿ. ಸಂಪೂರ್ಣ ಭಾಷೆಯನ್ನು ಮನಪಾಠ ಮಾಡಬೇಕಾಗಿಲ್ಲ.
 
-Conversational AI tools can be effective at helping you generating regex patterns. For example, try prompting your favorite LLM with the following query:
+Conversational AI tools regex patterns ರಚಿಸಲು ಸಹಾಯಕ. ಉದಾ: ನಿಮ್ಮ ಇಷ್ಟದ LLM ಗೆ ಈ query ನೀಡಿ:
 
 ```
 Write a Python-style regex pattern that matches the requested path from log lines from Nginx. Here is an example log line:
@@ -154,13 +154,13 @@ Write a Python-style regex pattern that matches the requested path from log line
 169.254.1.1 - - [09/Jan/2026:21:28:51 +0000] "GET /feed.xml HTTP/2.0" 200 2995 "-" "python-requests/2.32.3"
 ```
 
-# Exercises
+# ವ್ಯಾಯಾಮಗಳು
 
-1. Configure a formatter, linter, and pre-commit hooks for a project you're working on. If you have lots of errors: autoformatting should take care of the format errors. For the linter errors, try using an [AI agent](/2026/agentic-coding/) to fix all the linter errors. Make sure the AI agent can run the linter and observe the results, so that it can run in an iterative loop to fix all the issues. Check the results carefully to ensure the AI doesn't break your code!
-1. Learn a testing library for a language you know and write a unit test for a project you're working on. Run a code coverage tool, generate an HTML-formatted coverage report, and observe the results. Can you find the lines that are covered? Your code coverage will likely be very low. Try manually writing some tests to improve it. Try using an [AI agent](/2026/agentic-coding/) to improve coverage; make sure the coding agent can run tests with coverage and produce a line-by-line coverage report, so it knows where to focus. Are the AI-generated tests actually good?
-1. Set up continuous integration to run on every push for a project you're working on. Have CI run formatting, linting, and tests. Break your code on purpose (e.g., introduce a linter violation), and ensure that CI catches it.
-1. Try writing a [regex pattern](#regular-expressions) and use the `grep` [command-line tool](/2026/course-shell/) to find occurrences of `subprocess.Popen(..., shell=True)` in your code. Now, try to "break" the regex pattern. Does [semgrep](#linting) still successfully match the dangerous code that trips up your grep invocation?
-1. Practice regex search-and-replace in your IDE or text editor by replacing the `-` [Markdown bullet markers](https://spec.commonmark.org/0.31.2/#bullet-list-marker) with `*` bullet markers in [these lecture notes](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md). Note that just replacing all the "-" characters in the file would be incorrect, as there are many uses of that character that are not bullet markers.
-1. Write a regex to capture from JSON structures of the form `{"name": "Alyssa P. Hacker", "college": "MIT"}` the name (e.g., `Alyssa P. Hacker`, in this example). Hint: in your first attempt, you might end up writing a regex that extracts `Alyssa P. Hacker", "college": "MIT`; read about greedy quantifiers in the [Python regex docs](https://docs.python.org/3/library/re.html) to figure out how to fix it.
-    1. Make the regex pattern work even in situations where the name has a `"` character in it (double quotes can be escaped in JSON with `\"`).
-    1. We do **not** recommend using regular expressions for sophisticated parsing problems in practice. Figure out how to use your programming language's JSON parser for this task. Write a command-line program that takes as input, on stdin, a JSON structure of the form described above, and output, on stdout, the name. You should only need a couple lines of code to do this. In Python, you can do it easily in one line of code beyond `import json`.
+1. ನೀವು ಕೆಲಸ ಮಾಡುತ್ತಿರುವ project ಗೆ formatter, linter, pre-commit hooks configure ಮಾಡಿ. ದೋಷಗಳು ಹೆಚ್ಚು ಇದ್ದರೆ autoformatting ಬಹುಪಾಲು format errors ಸರಿಪಡಿಸುತ್ತದೆ. Linter errors ಗಾಗಿ [AI agent](/2026/agentic-coding/) ಬಳಸಿ ಎಲ್ಲವನ್ನು ಸರಿಪಡಿಸಲು ಪ್ರಯತ್ನಿಸಿ. Agent ಗೆ linter run ಮಾಡಿ ಫಲಿತಾಂಶ ನೋಡುವ ಅವಕಾಶ ಕೊಡಿ, ಆಗ iterative loop ಮೂಲಕ ಎಲ್ಲಾ issues ಸರಿಪಡಿಸಬಹುದು. ಫಲಿತಾಂಶವನ್ನು ಜಾಗ್ರತೆಯಿಂದ ಪರಿಶೀಲಿಸಿ - AI ನಿಮ್ಮ code ಅನ್ನು ಹಾಳು ಮಾಡದಂತೆ ನೋಡಿಕೊಳ್ಳಿ.
+1. ನಿಮಗೆ ಪರಿಚಿತ programming language ನಲ್ಲಿ ಒಂದು testing library ಕಲಿತು, ನಿಮ್ಮ project ಗೆ unit test ಬರೆಯಿರಿ. Coverage tool run ಮಾಡಿ HTML-formatted coverage report ರಚಿಸಿ ಫಲಿತಾಂಶ ನೋಡಿ. ಯಾವ lines cover ಆಗಿವೆ ಎಂದು ಕಾಣುತ್ತದೆಯೇ? ಆರಂಭದಲ್ಲಿ coverage ಕಡಿಮೆ ಇರಬಹುದು. ಕೈಯಿಂದ ಕೆಲವು tests ಬರೆಯಿ coverage ಹೆಚ್ಚಿಸಿ. ನಂತರ [AI agent](/2026/agentic-coding/) ಬಳಸಿ coverage ಸುಧಾರಿಸಲು ಪ್ರಯತ್ನಿಸಿ; coding agent ಗೆ coverage ಜೊತೆಗೆ tests run ಮಾಡಲು ಮತ್ತು line-by-line report ರಚಿಸಲು ಅವಕಾಶ ಇರಲಿ. AI ರಚಿಸಿದ tests ನಿಜವಾಗಿಯೂ ಉತ್ತಮವಾಗಿವೆಯೇ?
+1. ನೀವು ಕೆಲಸ ಮಾಡುತ್ತಿರುವ project ನಲ್ಲಿ ಪ್ರತಿಯೊಂದು push ಗೆ run ಆಗುವಂತೆ continuous integration ಹೊಂದಿಸಿ. CI ನಲ್ಲಿ formatting, linting, tests run ಆಗಲಿ. ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ code break ಮಾಡಿ (ಉದಾ: linter violation ಸೇರಿಸಿ) ಮತ್ತು CI ಅದನ್ನು ಹಿಡಿಯುತ್ತದೆಯೇ ದೃಢಪಡಿಸಿ.
+1. ಒಂದು [regex pattern](#regular-expressions) ಬರೆಯಿರಿ ಮತ್ತು `grep` [command-line tool](/2026/course-shell/) ಬಳಸಿ ನಿಮ್ಮ code ನಲ್ಲಿ `subprocess.Popen(..., shell=True)` occurrences ಹುಡುಕಿ. ನಂತರ ಆ regex pattern ಅನ್ನು "break" ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ. ನಿಮ್ಮ grep invocation ತಪ್ಪಿಸುವ ಅಪಾಯಕಾರಿ code ಅನ್ನು [semgrep](#linting) ಇನ್ನೂ ಸರಿಯಾಗಿ ಪತ್ತೆಹಿಡಿಯುತ್ತದೆಯೇ?
+1. ನಿಮ್ಮ IDE/text editor ನಲ್ಲಿ regex search-and-replace ಅಭ್ಯಾಸ ಮಾಡಿ: [Markdown bullet markers](https://spec.commonmark.org/0.31.2/#bullet-list-marker) ಆಗಿರುವ `-` ಅನ್ನು `*` ಗೆ ಬದಲಿಸಿ ([ಈ lecture notes](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md) ನಲ್ಲಿ). file ನಲ್ಲಿರುವ ಎಲ್ಲ `-` characters ಬದಲಿಸಿದರೆ ತಪ್ಪು, ಏಕೆಂದರೆ ಅವುಗಳಲ್ಲಿ ಬಹಳವು bullet markers ಅಲ್ಲ.
+1. `{"name": "Alyssa P. Hacker", "college": "MIT"}` ರೂಪದ JSON ನಲ್ಲಿ name (`Alyssa P. Hacker`) ಹಿಡಿಯುವ regex ಬರೆಯಿರಿ. ಸೂಚನೆ: ಮೊದಲ ಪ್ರಯತ್ನದಲ್ಲಿ `Alyssa P. Hacker", "college": "MIT` ವರೆಗೂ ಹಿಡಿಯುವ greedy pattern ಬರೆಯುವ ಸಾಧ್ಯತೆ ಇದೆ; ಇದನ್ನು ಸರಿಪಡಿಸಲು [Python regex docs](https://docs.python.org/3/library/re.html) ನಲ್ಲಿ greedy quantifiers ಬಗ್ಗೆ ಓದಿ.
+    1. name ಒಳಗೆ `"` (JSON escaped double quotes) ಇದ್ದರೂ ಕೆಲಸ ಮಾಡುವಂತೆ regex pattern ಸುಧಾರಿಸಿ.
+    1. ಪ್ರಾಯೋಗಿಕವಾಗಿ sophisticated parsing ಸಮಸ್ಯೆಗಳಿಗೆ regular expressions ಬಳಸುವುದನ್ನು ನಾವು **ಶಿಫಾರಸು ಮಾಡುವುದಿಲ್ಲ**. ಈ ಕೆಲಸಕ್ಕೆ ನಿಮ್ಮ programming language ನ JSON parser ಹೇಗೆ ಬಳಸುವುದು ಎಂದು ಕಂಡುಹಿಡಿಯಿರಿ. ಮೇಲ್ಕಂಡ ರೂಪದ JSON ಅನ್ನು stdin ಮೂಲಕ ಸ್ವೀಕರಿಸಿ, name ಅನ್ನು stdout ಗೆ ಮುದ್ರಿಸುವ command-line program ಬರೆಯಿರಿ. ಇದಕ್ಕೆ ಕೆಲವೇ ಸಾಲುಗಳ code ಸಾಕು. Python ನಲ್ಲಿ `import json` ಹೊರತುಪಡಿಸಿ ಒಂದು ಸಾಲಿನಲ್ಲಿ ಮಾಡಬಹುದು.

--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Command-line Environment"
+title: "ಕಮಾಂಡ್-ಲೈನ್ ಪರಿಸರ"
 description: >
-  Learn how command-line programs work, including input/output streams, environment variables, and remote machines with SSH.
+  input/output streams, environment variables, ಮತ್ತು SSH ಬಳಸಿ remote machines ಜೊತೆಗೆ ಹೇಗೆ ಕೆಲಸ ಮಾಡುವುದು ಎಂಬುದನ್ನು ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec2.png
 date: 2026-01-13
 ready: true
@@ -11,24 +11,25 @@ video:
   id: ccBGsPedE9Q
 ---
 
-As we covered in the previous lecture, most shells are not a mere launcher to start up other programs,
-but in practice they provide an entire programming language full of common patterns and abstractions.
-However, unlike the majority of programming languages, in shell scripting everything is designed around running programs and getting them to communicate with each other simply and efficiently.
+ಹಿಂದಿನ ಉಪನ್ಯಾಸದಲ್ಲಿ ನೋಡಿದಂತೆ, ಬಹುತೇಕ shells ಗಳು ಇತರೆ programs ಅನ್ನು ಶುರು ಮಾಡುವ launcher ಮಾತ್ರವಲ್ಲ.
+ಪ್ರಯೋಗದಲ್ಲಿ ಅವು ಸಾಮಾನ್ಯ patterns ಮತ್ತು abstractions ಗಳಿಂದ ತುಂಬಿದ ಪೂರ್ಣ programming language ಒದಗಿಸುತ್ತವೆ.
+ಆದರೆ, ಬಹುತೇಕ programming languages ಗಳಿಗಿಂತ ಭಿನ್ನವಾಗಿ, shell scripting ನಲ್ಲಿ ಎಲ್ಲವೂ programs ಅನ್ನು ಓಡಿಸುವುದು ಮತ್ತು ಅವು ಪರಸ್ಪರ ಸರಳವಾಗಿ ಹಾಗೂ ಪರಿಣಾಮಕಾರಿಯಾಗಿ ಸಂವಹನ ಮಾಡುವುದರ ಸುತ್ತ ವಿನ್ಯಾಸಗೊಂಡಿದೆ.
 
-In particular, shell scripting is tightly bound by _conventions_. For a command line interface (CLI) program to play nicely within the broader shell environment there are some common patterns that it needs to follow.
-We will now cover many of the concepts required to understand how command line programs work as well as ubiquitous conventions on how to use and configure them.
+ವಿಶೇಷವಾಗಿ, shell scripting ಬಹಳ ಮಟ್ಟಿಗೆ _conventions_ ಗಳ ಮೇಲೆ ಅವಲಂಬಿತವಾಗಿದೆ.
+ಒಂದು command line interface (CLI) program ವಿಶಾಲವಾದ shell ಪರಿಸರದಲ್ಲಿ ಚೆನ್ನಾಗಿ ಕೆಲಸ ಮಾಡಲು, ಅದು ಕೆಲವು ಸಾಮಾನ್ಯ patterns ಅನ್ನು ಅನುಸರಿಸಬೇಕು.
+ಈಗ command line programs ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ ಹಾಗೂ ಅವನ್ನು ಹೇಗೆ ಬಳಸಬೇಕು ಮತ್ತು configure ಮಾಡಬೇಕು ಎಂಬುದಕ್ಕೆ ಅಗತ್ಯವಾದ ಪ್ರಮುಖ ಕಲ್ಪನೆಗಳನ್ನು ನೋಡೋಣ.
 
-# The Command Line Interface
+# ಕಮಾಂಡ್ ಲೈನ್ ಇಂಟರ್ಫೇಸ್
 
-Writing a function in most programming languages looks something like:
+ಹೆಚ್ಚಿನ programming languages ಗಳಲ್ಲಿ function ಬರೆಯುವ ವಿಧಾನ ಹೀಗಿರುತ್ತದೆ:
 
 ```
 def add(x: int, y: int) -> int:
     return x + y
 ```
 
-Here we can explicitly see the inputs and the outputs of the program.
-In contrast, shell scripts can look quite different at first glance.
+ಇಲ್ಲಿ program ನ inputs ಮತ್ತು outputs ಅನ್ನು ಸ್ಪಷ್ಟವಾಗಿ ನೋಡಬಹುದು.
+ಇದಕ್ಕೆ ವಿರುದ್ಧವಾಗಿ, shell scripts ಮೊದಲ ನೋಡಿಗೆ ವಿಭಿನ್ನವಾಗಿ ಕಾಣಬಹುದು.
 
 ```shell
 #!/usr/bin/env bash
@@ -46,7 +47,7 @@ else
 fi
 ```
 
-To properly understand what is going in scripts like this one we first need to introduce a few concepts that appear often when shell programs communicate with each other or with the shell environment:
+ಇಂತಹ script ಗಳಲ್ಲಿ ಏನಾಗುತ್ತಿದೆ ಎಂಬುದನ್ನು ಸರಿಯಾಗಿ ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು, shell programs ಪರಸ್ಪರ ಅಥವಾ shell ಪರಿಸರದೊಂದಿಗೆ ಸಂವಹನ ಮಾಡುವಾಗ ಮತ್ತೆ ಮತ್ತೆ ಕಾಣಿಸುವ ಕೆಲವು ಕಲ್ಪನೆಗಳನ್ನು ಮೊದಲು ತಿಳಿದುಕೊಳ್ಳಬೇಕು:
 
 - Arguments
 - Streams
@@ -56,29 +57,31 @@ To properly understand what is going in scripts like this one we first need to i
 
 ## Arguments
 
-Shell programs receive a list of arguments when they are executed.
-Arguments are plain strings in shell, and it is up to the program how to interpret them.
-For instance when we do `ls -l folder/`, we are executing the program `/bin/ls` with arguments `['-l', 'folder/']`.
+shell programs execute ಆಗುವಾಗ arguments ಗಳ ಪಟ್ಟಿಯನ್ನು ಸ್ವೀಕರಿಸುತ್ತವೆ.
+Shell ನಲ್ಲಿ arguments ಸಾಮಾನ್ಯ strings ಮಾತ್ರ - ಅವನ್ನು ಹೇಗೆ ಅರ್ಥಮಾಡಿಕೊಳ್ಳಬೇಕು ಎಂಬುದು program ಮೇಲೇ ಅವಲಂಬಿತವಾಗಿರುತ್ತದೆ.
+ಉದಾಹರಣೆಗೆ `ls -l folder/` ಅನ್ನು ಓಡಿಸಿದಾಗ, ನಾವು `/bin/ls` program ಅನ್ನು `['-l', 'folder/']` arguments ಜೊತೆಗೆ execute ಮಾಡುತ್ತೇವೆ.
 
-From within a shell script we access these via special shell syntax.
-To access the first argument we access the variable `$1`, second argument `$2` and so on and so forth until `$9`. To access all arguments as a list we use `$@` and to retrieve the number of arguments `$#`. Additionally we can also access the name of the program with `$0`.
+ಒಂದು shell script ಒಳಗಿಂದ ಇವುಗಳನ್ನು ವಿಶೇಷ shell syntax ಮೂಲಕ ಪ್ರವೇಶಿಸುತ್ತೇವೆ.
+ಮೊದಲ argument ಗೆ `$1`, ಎರಡನೇ argument ಗೆ `$2`, ಹೀಗೆ `$9` ವರೆಗೆ.
+ಎಲ್ಲ arguments ಅನ್ನು list ಆಗಿ ಪಡೆಯಲು `$@`, ಮತ್ತು arguments ಸಂಖ್ಯೆ ಪಡೆಯಲು `$#` ಬಳಸುತ್ತೇವೆ.
+ಹಾಗೆಯೇ program ಹೆಸರು `$0` ಮೂಲಕ ಲಭ್ಯ.
 
-For most programs the arguments will consist of a mixture of _flags_ and regular strings.
-Flags can be identified because they are preceded by a dash (`-`) or double-dash (`--`).
-Flags are usually optional and their role is to modify the behavior of the program.
-For example `ls -l` changes how `ls` formats its output.
+ಹೆಚ್ಚಿನ programs ನಲ್ಲಿ arguments ಗಳು _flags_ ಮತ್ತು ಸಾಮಾನ್ಯ strings ಮಿಶ್ರಣವಾಗಿರುತ್ತವೆ.
+Flags ಗಳು dash (`-`) ಅಥವಾ double-dash (`--`) ಇಂದ ಆರಂಭವಾಗುವುದರಿಂದ ಗುರುತಿಸಬಹುದು.
+Flags ಸಾಮಾನ್ಯವಾಗಿ optional ಆಗಿದ್ದು program ನ behavior ಅನ್ನು ಬದಲಿಸಲು ಉಪಯೋಗವಾಗುತ್ತವೆ.
+ಉದಾಹರಣೆಗೆ `ls -l` ನಲ್ಲಿ `-l`, `ls` output format ಅನ್ನು ಬದಲಿಸುತ್ತದೆ.
 
-You will see double dash flags with long names like `--all`, and single dash flags like `-a`, which are most often followed by a single letter.
-The same option might be specified in both formats, `ls -a` and `ls --all` are equivalent.
-Single dash flags are often grouped, so `ls -l -a` and `ls -la` are also equivalent.
-The order of flags usually doesn't matter either, `ls -la` and `ls -al` produce the same result.
-Some flags are quite prevalent and as you get more familiar with the shell environment you'll intuitively reach for them, for example (`--help`, `--verbose`, `--version`).
+`--all` ಮೊದಲಾದ long flags ಮತ್ತು `-a` ಮೊದಲಾದ single-letter flags ಎರಡನ್ನೂ ನೋಡುತ್ತೀರಿ.
+ಅದೇ option ಎರಡೂ ರೂಪಗಳಲ್ಲಿ ಬರಬಹುದು - `ls -a` ಮತ್ತು `ls --all` ಸಮಾನ.
+Single dash flags ಅನ್ನು ಸಾಮಾನ್ಯವಾಗಿ ಗುಂಪುಗೊಳಿಸುತ್ತಾರೆ, ಹಾಗಾಗಿ `ls -l -a` ಮತ್ತು `ls -la` ಕೂಡ ಸಮಾನ.
+Flags ಕ್ರಮ ಬಹುಸಾರಿ ಮುಖ್ಯವಾಗುವುದಿಲ್ಲ - `ls -la` ಹಾಗೂ `ls -al` ಒಂದೇ ಫಲಿತಾಂಶ ಕೊಡುತ್ತವೆ.
+ಕೆಲವು flags ಬಹಳ ಸಾಮಾನ್ಯ - ಉದಾ: `--help`, `--verbose`, `--version`.
 
-> Flags are a first good example of shell conventions. The shell language does not require that our program uses `-` or `--` in this particular way.
-Nothing prevents us from writing a program with syntax `myprogram +myoption myfile`, but it would lead to confusion since the expectation is that we use dashes.
-> In practice, most programming languages provide CLI flag parsing libraries (e.g. `argparse` in python to parse arguments with the dash syntax).
+> Flags ಗಳು shell conventions ಗೆ ಉತ್ತಮ ಮೊದಲ ಉದಾಹರಣೆ. Shell ಭಾಷೆ ನಿಮ್ಮ program ಕಡ್ಡಾಯವಾಗಿ `-` ಅಥವಾ `--` ನ್ನೇ ಈ ರೀತಿಯಲ್ಲಿ ಬಳಸಬೇಕು ಎಂದು ಹೇಳುವುದಿಲ್ಲ.
+`myprogram +myoption myfile` ಎಂಬ syntax ಕೂಡ technically ಸಾಧ್ಯ. ಆದರೆ ಜನರ ನಿರೀಕ್ಷೆ dashes ಆಗಿರುವುದರಿಂದ ಅದು ಗೊಂದಲ ಉಂಟುಮಾಡುತ್ತದೆ.
+> ಪ್ರಾಯೋಗಿಕವಾಗಿ, ಹೆಚ್ಚಿನ programming languages CLI flag parsing libraries ಒದಗಿಸುತ್ತವೆ (ಉದಾ. Python ನಲ್ಲಿ `argparse`).
 
-Another common convention in CLI programs is for programs to accept a variable number of arguments of the same type. When given arguments in this way the command performs the same operation on each one of them.
+CLI programs ನಲ್ಲಿ ಇನ್ನೊಂದು ಸಾಮಾನ್ಯ convention ಎಂದರೆ ಒಂದೇ ರೀತಿಯ ಅನೇಕ arguments ಸ್ವೀಕರಿಸುವುದು. ಈ ರೀತಿಯಲ್ಲಿ arguments ಕೊಟ್ಟಾಗ command ಪ್ರತಿಯೊಂದರ ಮೇಲೂ ಅದೇ ಕಾರ್ಯಾಚರಣೆ ನಡೆಸುತ್ತದೆ.
 
 ```shell
 mkdir src
@@ -87,10 +90,10 @@ mkdir docs
 mkdir src docs
 ```
 
-This syntax sugar might seem unnecessary at first, but it becomes really powerful when combined with _globbing_.
-Globbing or globs are special patterns that the shell will expand before calling the program.
+ಮೊದಲಿಗೆ ಈ syntax sugar ಅನಾವಶ್ಯಕವಾಗಿ ಕಾಣಬಹುದು, ಆದರೆ _globbing_ ಜೊತೆಗೆ ಬಳಸಿದಾಗ ಇದು ಬಹಳ ಶಕ್ತಿಶಾಲಿ.
+Globbing ಅಥವಾ globs ಎಂದರೆ shell program ಅನ್ನು ಕರೆಯುವ ಮೊದಲು ವಿಸ್ತರಿಸುವ ವಿಶೇಷ patterns.
 
-Say we wanted to delete all .py files in the current folder nonrecursively. From what we learned in the previous lecture we could achieve this by running
+ಈಗಿರುವ folder ನಲ್ಲಿ non-recursive ಆಗಿ ಎಲ್ಲಾ `.py` files ಅಳಿಸಬೇಕೆಂದು ಕಲ್ಪಿಸೋಣ. ಹಿಂದಿನ ಉಪನ್ಯಾಸದ ಆಧಾರದ ಮೇಲೆ ಹೀಗೆ ಮಾಡಬಹುದು:
 
 ```shell
 for file in $(ls | grep -P '\.py$'); do
@@ -98,16 +101,16 @@ for file in $(ls | grep -P '\.py$'); do
 done
 ```
 
-But we can replace that with just `rm *.py`!
+ಆದರೆ ಇದನ್ನು `rm *.py` ಅಷ್ಟಕ್ಕೆ ಸರಳಗೊಳಿಸಬಹುದು.
 
-When we type `rm *.py` into the terminal, the shell will not call the `/bin/rm` program with arguments `['*.py']`.
-Instead, the shell will search for files in the current folder matching the pattern `*.py` where `*` can match any string of zero or more characters of any type.
-So if our folder has `main.py` and `utils.py` then the `rm` program will receive arguments `['main.py', 'utils.py']`.
+ನಾವು terminal ನಲ್ಲಿ `rm *.py` type ಮಾಡಿದಾಗ, shell `/bin/rm` ಅನ್ನು `['*.py']` arguments ಜೊತೆ ಕರೆಯುವುದಿಲ್ಲ.
+ಅದರ ಬದಲು, shell ಪ್ರಸ್ತುತ folder ನಲ್ಲಿ `*.py` pattern ಗೆ ಹೊಂದುವ files ಹುಡುಕುತ್ತದೆ; ಇಲ್ಲಿ `*` ಎಂದರೆ zero ಅಥವಾ ಹೆಚ್ಚು ಯಾವುದೇ characters.
+ಅದೇ folder ನಲ್ಲಿ `main.py` ಮತ್ತು `utils.py` ಇದ್ದರೆ `rm` program ಗೆ `['main.py', 'utils.py']` arguments ಸಿಗುತ್ತವೆ.
 
-The most common globs you will find are wildcards `*` (zero or more of anything), `?` (exactly one of anything) and curly braces.
-Curly braces `{}` expand a comma-separated list of patterns into multiple arguments.
+ಸಾಮಾನ್ಯ globs: wildcard `*` (ಯಾವುದೇ zero ಅಥವಾ ಹೆಚ್ಚು), `?` (ಯಾವುದೇ ಒಂದು), ಮತ್ತು curly braces.
+Curly braces `{}` comma-separated patterns ಅನ್ನು ಅನೇಕ arguments ಆಗಿ ವಿಸ್ತರಿಸುತ್ತವೆ.
 
-In practice, globs are best understood with motivating examples.
+ಪ್ರಯೋಗದಲ್ಲಿ globs ಅನ್ನು examples ಮೂಲಕ ಅರ್ಥಮಾಡಿಕೊಳ್ಳುವುದು ಉತ್ತಮ.
 
 ```shell
 touch folder/{a,b,c}.py
@@ -127,25 +130,24 @@ mv *{.py,.sh} folder
 # Will move all *.py and *.sh files
 ```
 
-> Some shells (e.g. zsh) support even more advanced forms of globbing such as `**` that will expand to include recursive paths. So `rm **/*.py` will delete all .py files recursively.
-
+> ಕೆಲವು shells (ಉದಾ. zsh) ಇನ್ನಷ್ಟು advanced globbing ರೂಪಗಳನ್ನು support ಮಾಡುತ್ತವೆ - ಉದಾಹರಣೆಗೆ `**` recursive paths ಗೆ ವಿಸ್ತರಿಸುತ್ತದೆ. ಹಾಗಾಗಿ `rm **/*.py` ಎಲ್ಲಾ `.py` files ಅನ್ನು recursive ಆಗಿ ಅಳಿಸುತ್ತದೆ.
 
 ## Streams
 
-Whenever we execute a program pipeline like
+ನಾವು ಈ ರೀತಿಯ program pipeline execute ಮಾಡಿದಾಗ:
 
 ```shell
 cat myfile | grep -P '\d+' | uniq -c
 ```
 
-we see that the `grep` program is communicating with both the `cat` and `uniq` programs.
+`grep` program `cat` ಮತ್ತು `uniq` ಎರಡರೊಂದಿಗೆ ಸಂವಹನ ಮಾಡುತ್ತಿರುವುದನ್ನು ನೋಡುತ್ತೇವೆ.
 
-An important observation here is that all three programs are executing at once.
-Namely, the shell is not first calling cat, then grep, and then uniq.
-Instead, all three programs are being spawned and the shell is connecting the output of cat to the input of grep and the output of grep to the input of uniq.
-When using the pipe operator `|`, the shell operates on streams of data that flow from one program to the next in the chain.
+ಇಲ್ಲಿ ಪ್ರಮುಖ ಗಮನಿಸಬೇಕಾದ ಅಂಶ ಎಂದರೆ ಮೂರೂ programs ಒಂದೇ ಸಮಯದಲ್ಲಿ ನಡೆಯುತ್ತವೆ.
+ಅಂದರೆ shell ಮೊದಲು `cat`, ನಂತರ `grep`, ನಂತರ `uniq` ಅನ್ನು ಕ್ರಮವಾಗಿ ಮುಗಿಸಿ ಕರೆಯುವುದಿಲ್ಲ.
+ಬದಲಾಗಿ ಮೂರನ್ನೂ spawn ಮಾಡಿ, `cat` ನ output ಅನ್ನು `grep` ನ input ಗೆ, `grep` ನ output ಅನ್ನು `uniq` ನ input ಗೆ ಜೋಡಿಸುತ್ತದೆ.
+`|` pipe operator ಬಳಸಿದಾಗ data streams ಒಂದರಿಂದ ಮತ್ತೊಂದಕ್ಕೆ ಹರಿಯುತ್ತವೆ.
 
-We can demonstrate this concurrency, all commands in a pipeline start immediately:
+ಈ concurrency ಅನ್ನು ತೋರಿಸಲು, pipeline ನಲ್ಲಿರುವ commands ಎಲ್ಲವೂ ತಕ್ಷಣ ಶುರುವಾಗುತ್ತವೆ:
 
 ```console
 $ (sleep 15 && cat numbers.txt) | grep -P '^\d$' | sort | uniq  &
@@ -158,9 +160,11 @@ $ ps | grep -P '(sleep|cat|grep|sort|uniq)'
   32948 pts/1    00:00:00 grep
 ```
 
-We can see that all processes but `cat` are running right away. The shell spawns all processes and connects their streams before any of them finish. `cat` will only get started once sleep finishes, and the output of `cat` will be sent to grep and so on and so forth.
+ಇಲ್ಲಿ `cat` ಹೊರತುಪಡಿಸಿ ಉಳಿದ processes ತಕ್ಷಣ ಆರಂಭವಾಗಿರುವುದನ್ನು ನೋಡಬಹುದು.
+Shell ಎಲ್ಲಾ processes ಅನ್ನು ಮೊದಲು spawn ಮಾಡಿ streams ಅನ್ನು connect ಮಾಡುತ್ತದೆ. `sleep` ಮುಗಿದ ನಂತರವೇ `cat` ಶುರುವಾಗುತ್ತದೆ; ನಂತರ ಅದರ output `grep` ಗೆ ಹೋಗುತ್ತದೆ, ಹೀಗೆ ಮುಂದುವರಿಯುತ್ತದೆ.
 
-Every program has an input stream, labeled stdin (for standard input). When piping, stdin is connected automatically. Within a script, many programs accept `-` as a filename to mean "read from stdin":
+ಪ್ರತಿ program ಗೆ `stdin` (standard input) ಎಂಬ input stream ಇರುತ್ತದೆ. Pipe ಮಾಡಿದಾಗ ಇದು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಜೋಡಣೆಯಾಗುತ್ತದೆ.
+Script ಒಳಗೆ ಅನೇಕ programs `-` ಅನ್ನು filename ಆಗಿ ತೆಗೆದುಕೊಂಡು "stdin ನಿಂದ ಓದಿ" ಎಂದು ಅರ್ಥಮಾಡಿಕೊಳ್ಳುತ್ತವೆ:
 
 ```shell
 # These are equivalent when data comes from a pipe
@@ -168,9 +172,9 @@ echo "hello" | grep "hello"
 echo "hello" | grep "hello" -
 ```
 
-Similarly, every program has two output streams: stdout and stderr.
-The standard output is the one most commonly encountered and it is the one that is used for piping the output of the program to the next command in the pipeline.
-The standard error is an alternative stream that is intended for programs to report warnings and other types of issues, without that output getting parsed by the next command in the chain.
+ಹಾಗೆಯೇ ಪ್ರತಿಯೊಂದು program ಗೆ ಎರಡು output streams ಇವೆ: `stdout` ಮತ್ತು `stderr`.
+`stdout` ಸಾಮಾನ್ಯ output - pipeline ನಲ್ಲಿ ಮುಂದಿನ command ಗೆ ಇದೇ ಹೋಗುತ್ತದೆ.
+`stderr` warnings ಹಾಗೂ errors ಗಾಗಿ; ಇದರಿಂದ ಆ output ಮುಂದಿನ command ಪಾರ್ಸ್ ಮಾಡುವ data ಯಲ್ಲಿ ಮಿಶ್ರಣವಾಗುವುದಿಲ್ಲ.
 
 ```console
 $ ls /nonexistent
@@ -182,7 +186,7 @@ $ ls /nonexistent 2>/dev/null
 # No output - stderr was redirected to /dev/null
 ```
 
-The shell provides syntax for redirecting these streams. Here are some illustrative examples.
+ಈ streams redirect ಮಾಡಲು shell syntax ಕೊಡುತ್ತದೆ. ಕೆಲವು ಉದಾಹರಣೆಗಳು:
 
 ```shell
 # Redirect stdout to a file (overwrite)
@@ -204,26 +208,27 @@ grep "pattern" < input.txt
 cmd > /dev/null 2>&1
 ```
 
-Another powerful tool that exemplifies the Unix philosophy is [`fzf`](https://github.com/junegunn/fzf), a fuzzy finder. It reads lines from stdin and provides an interactive interface to filter and select:
+Unix philosophy ಯನ್ನು ಚೆನ್ನಾಗಿ ತೋರಿಸುವ ಮತ್ತೊಂದು tool ಎಂದರೆ [`fzf`](https://github.com/junegunn/fzf) - ಒಂದು fuzzy finder.
+ಇದು stdin ನಿಂದ lines ಓದಿ, filter/select ಮಾಡಲು interactive interface ಒದಗಿಸುತ್ತದೆ:
 
 ```console
 $ ls | fzf
 $ cat ~/.bash_history | fzf
 ```
 
-`fzf` can be integrated with many shell operations. We'll see more uses of it when we discuss shell customization.
-
+`fzf` ಅನ್ನು shell operations ಜೊತೆ ಹಲವಾರು ರೀತಿಯಲ್ಲಿ integrate ಮಾಡಬಹುದು. Shell customization ವಿಷಯದಲ್ಲಿ ಇದನ್ನು ಮತ್ತಷ್ಟು ನೋಡೋಣ.
 
 ## Environment variables
 
-To assign variables in bash we use the syntax `foo=bar`, and then access the value of the variable with the `$foo` syntax.
-Note that `foo = bar` is invalid syntax as the shell will parse it as calling the program `foo` with arguments `['=', 'bar']`.
-In shell scripting the role of the space character is to perform argument splitting.
-This behavior can be confusing and tricky to get used to, so keep it in mind.
+bash ನಲ್ಲಿ variables assign ಮಾಡಲು `foo=bar` syntax ಬಳಸುತ್ತೇವೆ; value ಪಡೆಯಲು `$foo` ಬಳಕೆ.
+`foo = bar` invalid syntax - ಏಕೆಂದರೆ shell ಅದನ್ನು `foo` program ಅನ್ನು `['=', 'bar']` arguments ಜೊತೆ ಕರೆಯುವಂತೆ ಪಾರ್ಸ್ ಮಾಡುತ್ತದೆ.
+Shell scripting ನಲ್ಲಿ space character argument splitting ಗಾಗಿ ಬಳಸಲಾಗುತ್ತದೆ.
+ಈ behavior ಆರಂಭದಲ್ಲಿ ಗೊಂದಲಕಾರಿ ಆಗಬಹುದು - ಗಮನದಲ್ಲಿಡಿ.
 
-Shell variables do not have types, they are all strings.
-Note that when writing string expressions in the shell single and double quotes are not interchangeable.
-Strings delimited with `'` are literal strings and will not expand variables, perform command substitution, or process escape sequences, whereas `"` delimited strings will.
+Shell variables ಗೆ types ಇರುವುದಿಲ್ಲ - ಎಲ್ಲವೂ strings.
+Shell ನಲ್ಲಿ single quotes ಮತ್ತು double quotes ಪರಸ್ಪರ ಬದಲಾಯಿಸಬಹುದಾದವುಗಳಲ್ಲ ಎಂಬುದನ್ನು ಗಮನಿಸಿ.
+`'` ಒಳಗಿನ strings literal ಆಗಿರುತ್ತವೆ - variable expansion, command substitution, escape processing ಇಲ್ಲ.
+`"` ಒಳಗಿನ strings ನಲ್ಲಿ ಇವು ನಡೆಯುತ್ತವೆ.
 
 ```shell
 foo=bar
@@ -233,32 +238,34 @@ echo '$foo'
 # prints $foo
 ```
 
-To capture the output of a command into a variable we use _command substitution_.
-When we execute
+command output ಅನ್ನು variable ಗೆ ಹಿಡಿಯಲು _command substitution_ ಬಳಸುತ್ತೇವೆ.
+ನಾವು ಹೀಗೆ ಮಾಡಿದಾಗ:
+
 ```shell
 files=$(ls)
 echo "$files" | grep README
 echo "$files" | grep ".py"
 ```
-the output (concretely the stdout) of ls is placed into the variable `$files` which we can access later.
-The content of the `$files` variable does include the newlines from the ls output, which is how programs like `grep` know to operate on each item independently.
 
-A lesser known similar feature is _process substitution_, `<( CMD )` will execute `CMD` and place the output in a temporary file and substitute the `<()` with that file's name.
-This is useful when commands expect values to be passed by file instead of by STDIN.
-For example, `diff <(ls src) <(ls docs)` will show differences between files in dirs `src` and `docs`.
+`ls` ನ output (`stdout`) `$files` variable ಗೆ ಸೇರುತ್ತದೆ; ನಂತರ ಅದನ್ನು ಬಳಸಬಹುದು.
+`$files` ಒಳಗೆ newline ಗಳು ಉಳಿಯುತ್ತವೆ, ಆದ್ದರಿಂದ `grep` ಹಾಗೆ commands ಪ್ರತಿ item ಮೇಲೆ ಪ್ರತ್ಯೇಕವಾಗಿ ಕಾರ್ಯನಿರ್ವಹಿಸಬಹುದು.
 
-Whenever a shell program calls another program it passes along a set of variables that are often referred to as _environment variables_.
-From within a shell we can find the current environment variables by running `printenv`.
-To pass an environment variable explicitly we can prepend a command with a variable assignment
+ಇದಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಇನ್ನೊಂದು feature _process substitution_. `<( CMD )` ಅಂದರೆ `CMD` execute ಆಗಿ output temporary file ಗೆ ಹೋಗುತ್ತದೆ; `<()` ಆ file ಹೆಸರಿನಿಂದ substitute ಆಗುತ್ತದೆ.
+STDIN ಬದಲು file path ಬೇಕು ಎನ್ನುವ commands ಗೆ ಇದು ಉಪಯುಕ್ತ.
+ಉದಾ: `diff <(ls src) <(ls docs)` ನಿಂದ `src` ಮತ್ತು `docs` dirs ನಡುವಿನ ವ್ಯತ್ಯಾಸ ನೋಡಬಹುದು.
 
-> Environment variables are conventionally written in ALL_CAPS (e.g., `HOME`, `PATH`, `DEBUG`). This is a convention, not a technical requirement, but following it helps distinguish environment variables from local shell variables which are typically lowercase.
+ಒಂದು shell program ಇನ್ನೊಂದು program ಅನ್ನು ಕರೆಯುವಾಗ, ಕೆಲವು variables ಕೂಡ pass ಮಾಡುತ್ತದೆ; ಇವನ್ನೇ ಸಾಮಾನ್ಯವಾಗಿ _environment variables_ ಎನ್ನುತ್ತೇವೆ.
+ಪ್ರಸ್ತುತ environment variables ನೋಡಲು `printenv` ಬಳಸಬಹುದು.
+ಒಂದು command ಗೆ ಮಾತ್ರ environment variable ಕೊಡುವುದಕ್ಕೆ command ಮುಂದೆ assignment ಮಾಡಬಹುದು.
+
+> Environment variables ಅನ್ನು ಸಾಮಾನ್ಯವಾಗಿ ALL_CAPS ನಲ್ಲಿ ಬರೆಯುತ್ತಾರೆ (ಉದಾ: `HOME`, `PATH`, `DEBUG`). ಇದು technical requirement ಅಲ್ಲ, ಆದರೆ local shell variables (ಸಾಮಾನ್ಯವಾಗಿ lowercase) ಇಂದ ಬೇರ್ಪಡಿಸಲು ಸಹಾಯಕ.
 
 ```shell
 TZ=Asia/Tokyo date  # prints the current time in Tokyo
 echo $TZ  # this will be empty, since TZ was only set for the child command
 ```
 
-Alternatively, we can use the `export` built-in function that will modify our current environment and thus all child processes will inherit the variable:
+ಅಥವಾ `export` built-in ಬಳಸಿ current environment ಅನ್ನು ಬದಲಿಸಬಹುದು; ಆಗ ಮುಂದಿನ child processes ಎಲ್ಲವೂ ಅದನ್ನು inherit ಮಾಡುತ್ತವೆ:
 
 ```shell
 export DEBUG=1
@@ -267,23 +274,23 @@ bash -c 'echo $DEBUG'
 # prints 1
 ```
 
-To delete a variable use the `unset` built-in command, e.g. `unset DEBUG`.
+variable ತೆಗೆದುಹಾಕಲು `unset` built-in command - ಉದಾ: `unset DEBUG`.
 
-> Environment variables are another shell convention. They can be used to modify the behavior of many programs implicitly rather than explicitly. For example, the shell sets the `$HOME` environment variable with the path of the home folder of the current user. Then programs can access this variable to get this information instead of requiring an explicit `--home /home/alice`. Another common example is `$TZ`, which many programs use to format dates and times according to the specified timezone.
+> Environment variables ಕೂಡ shell convention ಆಗಿವೆ. ಅವುಗಳನ್ನು ಬಳಸಿ ಅನೇಕ programs ನ behavior ಅನ್ನು explicit flags ಇಲ್ಲದೆ implicit ಆಗಿ ಬದಲಿಸಬಹುದು. ಉದಾಹರಣೆಗೆ shell `$HOME` variable ನಲ್ಲಿ current user home path ಇಡುತ್ತದೆ. Programs ಇದನ್ನೇ ಓದಿ ಮಾಹಿತಿ ಪಡೆಯಬಹುದು; `--home /home/alice` ಅಂಥ explicit flag ಬೇಕಾಗುವುದಿಲ್ಲ. ಇದೇ ರೀತಿಯಾಗಿ `$TZ` ಅನ್ನು ಹಲವು programs date/time formatting ಗೆ ಬಳಸುತ್ತವೆ.
 
 ## Return codes
 
-As we saw earlier, the main output of a shell program is conveyed through the stdout/stderr streams and filesystem side effects.
+ಹಿಂದೆ ನೋಡಿದಂತೆ, shell program ನ ಪ್ರಮುಖ output `stdout/stderr` streams ಮತ್ತು filesystem side effects ಮೂಲಕ ವ್ಯಕ್ತವಾಗುತ್ತದೆ.
 
-By default a shell script will return exit code zero.
-The convention is that zero means everything went well whereas nonzero means some issues were encountered.
-To return a nonzero exit code we have to use the `exit NUM` shell built-in.
-We can access the return code of the last command that was run by accessing the special variable `$?`.
+default ಆಗಿ shell script exit code zero ಹಿಂತಿರುಗಿಸುತ್ತದೆ.
+Convention ಪ್ರಕಾರ zero ಅಂದರೆ ಯಶಸ್ಸು, nonzero ಅಂದರೆ ಕೆಲವು ಸಮಸ್ಯೆಗಳು ಎದುರಾದವು.
+nonzero code ಹಿಂತಿರುಗಿಸಲು `exit NUM` built-in ಬಳಕೆ.
+ಕೊನೆಯ command ನ return code ಅನ್ನು `$?` ಮೂಲಕ ಪಡೆಯಬಹುದು.
 
-The shell has boolean operators `&&` and `||` for performing AND and OR operations respectively.
-Unlike those encountered in regular programming languages, the ones in the shell operate on the return code of programs.
-Both of these are [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators.
-This means that they can be used to conditionally run commands based on the success or failure of previous commands, where success is determined based on whether the return code is zero or not. Some examples:
+shell ನಲ್ಲಿ `&&` ಮತ್ತು `||` boolean operators ಇವೆ.
+ಸಾಮಾನ್ಯ programming languages ಗಿಂತ ವಿಭಿನ್ನವಾಗಿ, shell ನಲ್ಲಿ ಇವು programs return codes ಮೇಲೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತವೆ.
+ಇವೆರಡೂ [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators.
+ಅಂದರೆ ಹಿಂದಿನ command ಯಶಸ್ಸು (exit code 0) ಅಥವಾ ವಿಫಲತೆ ಆಧರಿಸಿ ಮುಂದಿನ command conditionally execute ಮಾಡಬಹುದು.
 
 ```shell
 # echo will only run if grep succeeds (finds a match)
@@ -299,7 +306,7 @@ true && echo "This will always print"
 false || echo "This will always print"
 ```
 
-The same principle applies to `if` and `while` statements, they both use return codes to make decisions:
+ಈದೇ ತತ್ವ `if` ಮತ್ತು `while` statements ಗಳಿಗೂ ಅನ್ವಯಿಸುತ್ತದೆ - ನಿರ್ಧಾರ return code ಆಧರಿಸಿ ತೆಗೆದುಕೊಳ್ಳಲಾಗುತ್ತದೆ:
 
 ```shell
 # if uses the return code of the condition command (0 = true, nonzero = false)
@@ -315,9 +322,9 @@ done < file.txt
 
 ## Signals
 
-In some cases you will need to interrupt a program while it is executing, for instance if a command is taking too long to complete.
-The simplest way to interrupt a program is to press `Ctrl-C` and the command will probably stop.
-But how does this actually work and why does it sometimes fail to stop the process?
+ಕೆಲವೊಮ್ಮೆ program ನಡೆಯುತ್ತಿರುವಾಗ ಅದನ್ನು interrupt ಮಾಡಬೇಕಾಗುತ್ತದೆ - ಉದಾ: command ಹೆಚ್ಚು ಸಮಯ ತೆಗೆದುಕೊಳ್ಳುವುದಾದರೆ.
+ಅತ್ಯಂತ ಸರಳ ವಿಧಾನ `Ctrl-C` ಒತ್ತುವುದು; ಸಾಮಾನ್ಯವಾಗಿ command ನಿಲ್ಲುತ್ತದೆ.
+ಆದರೆ ಇದು ಒಳಗೆ ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತದೆ? ಕೆಲವೊಮ್ಮೆ ಏಕೆ ನಿಲ್ಲುವುದಿಲ್ಲ?
 
 ```console
 $ sleep 100
@@ -325,21 +332,21 @@ $ sleep 100
 $
 ```
 
-> Note, here `^C` is how `Ctrl` is displayed when typed in the terminal.
+> ಇಲ್ಲಿ `^C` ಅಂದರೆ terminal ನಲ್ಲಿ `Ctrl` ಕೀ ಹೇಗೆ ತೋರಿಸಲಾಗುತ್ತದೆ ಎಂಬುದು.
 
-Under the hood, what happened here is the following:
+ಇದಕ್ಕೆ ಒಳಗಿನ ಕ್ರಮ ಹೀಗಿದೆ:
 
-1. We pressed `Ctrl-C`
-2. The shell identified the special combination of characters
-3. The shell process sent a SIGINT signal to the `sleep` process
-4. The signal interrupted the execution of the `sleep` process
+1. ನಾವು `Ctrl-C` ಒತ್ತುತ್ತೇವೆ
+2. shell ಆ ವಿಶೇಷ key combination ಅನ್ನು ಗುರುತಿಸುತ್ತದೆ
+3. shell process, `sleep` process ಗೆ `SIGINT` signal ಕಳುಹಿಸುತ್ತದೆ
+4. signal, `sleep` process ನ execution ಅನ್ನು interrupt ಮಾಡುತ್ತದೆ
 
-Signals are a special communication mechanism.
-When a process receives a signal it stops its execution, deals with the signal and potentially changes the flow of execution based on the information that the signal delivered. For this reason, signals are _software interrupts_.
+Signals ಒಂದು ವಿಶೇಷ communication mechanism.
+ಒಂದು process signal ಸ್ವೀಕರಿಸಿದಾಗ ಅದು ತನ್ನ execution ನಿಲ್ಲಿಸಿ, signal handle ಮಾಡಿ, ಅದರ ಮಾಹಿತಿಯ ಆಧಾರದ ಮೇಲೆ control flow ಬದಲಿಸಬಹುದು.
+ಈ ಕಾರಣಕ್ಕೆ signals ಅನ್ನು _software interrupts_ ಎಂದು ಕರೆಯುತ್ತಾರೆ.
 
-
-In our case, when typing `Ctrl-C` this prompts the shell to deliver a `SIGINT` signal to the process.
-Here's a minimal example of a Python program that captures `SIGINT` and ignores it, no longer stopping. To kill this program we can now use the `SIGQUIT` signal instead, by typing `Ctrl-\`.
+ನಮ್ಮ ಸಂದರ್ಭದಲ್ಲಿ `Ctrl-C` ಒತ್ತಿದಾಗ shell `SIGINT` ಅನ್ನು process ಗೆ ಕಳುಹಿಸುತ್ತದೆ.
+ಕೆಳಗೆ `SIGINT` ಅನ್ನು ಹಿಡಿದು ignore ಮಾಡುವ Python program ಇದೆ. ಈಗ ಇದನ್ನು ಕೊಲ್ಲಲು `Ctrl-\` ಮೂಲಕ `SIGQUIT` ಕಳುಹಿಸಬೇಕು.
 
 ```python
 #!/usr/bin/env python
@@ -356,7 +363,7 @@ while True:
     i += 1
 ```
 
-Here's what happens if we send `SIGINT` twice to this program, followed by `SIGQUIT`. Note that `^` is how `Ctrl` is displayed when typed in the terminal.
+ಈ program ಗೆ ಎರಡು ಸಲ `SIGINT`, ನಂತರ `SIGQUIT` ಕಳಿಸಿದರೆ ಹೀಗೆ ಕಾಣುತ್ತದೆ. `^` ಎಂದರೆ terminal ನಲ್ಲಿ `Ctrl` ಪ್ರದರ್ಶನ:
 
 ```console
 $ python sigint.py
@@ -367,25 +374,27 @@ I got a SIGINT, but I am not stopping
 30^\[1]    39913 quit       python sigint.py
 ```
 
-While `SIGINT` and `SIGQUIT` are both usually associated with terminal related requests, a more generic signal for asking a process to exit gracefully is the `SIGTERM` signal.
-To send this signal we can use the [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html) command, with the syntax `kill -TERM <PID>`.
+`SIGINT` ಮತ್ತು `SIGQUIT` ಸಾಮಾನ್ಯವಾಗಿ terminal ಸಂಬಂಧಿತವಾದರೂ, process ಅನ್ನು graceful ಆಗಿ ಹೊರಬರಲು ಕೇಳುವ ಸಾಮಾನ್ಯ signal ಎಂದರೆ `SIGTERM`.
+ಇದನ್ನು [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html) command ಮೂಲಕ `kill -TERM <PID>` syntax ನಲ್ಲಿ ಕಳಿಸಬಹುದು.
 
-Signals can do other things beyond killing a process. For instance, `SIGSTOP` pauses a process. In the terminal, typing `Ctrl-Z` will prompt the shell to send a `SIGTSTP` signal, short for Terminal Stop (i.e. the terminal's version of `SIGSTOP`).
+Signals process ಅನ್ನು terminate ಮಾಡುವುದಷ್ಟೇ ಅಲ್ಲ, ಬೇರೆ ಕೆಲಸಗಳೂ ಇವೆ. ಉದಾ: `SIGSTOP` process ಅನ್ನು pause ಮಾಡುತ್ತದೆ.
+terminal ನಲ್ಲಿ `Ctrl-Z` ಒತ್ತಿದರೆ shell `SIGTSTP` (Terminal Stop) signal ಕಳುಹಿಸುತ್ತದೆ.
 
-We can then continue the paused job in the foreground or in the background using [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) or [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), respectively.
+ಅದಾದ ಬಳಿಕ pause ಆದ job ಅನ್ನು foreground ಅಥವಾ background ನಲ್ಲಿ [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) ಅಥವಾ [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html) ಮೂಲಕ ಮುಂದುವರಿಸಬಹುದು.
 
-The [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) command lists the unfinished jobs associated with the current terminal session.
-You can refer to those jobs using their pid (you can use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find that out).
-More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` special parameter.
+[`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) command ಪ್ರಸ್ತುತ terminal session ಗೆ ಸಂಬಂಧಿಸಿದ unfinished jobs ಪಟ್ಟಿಯನ್ನು ತೋರಿಸುತ್ತದೆ.
+ಅವುಗಳನ್ನು pid ಮೂಲಕ (ಅದನ್ನು ಕಂಡುಹಿಡಿಯಲು [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) ಬಳಸಬಹುದು) ಸೂಚಿಸಬಹುದು.
+ಅಥವಾ `jobs` ತೋರಿಸುವ job number ಜೊತೆ `%` ಬಳಸಿ ಸೂಚಿಸಬಹುದು.
+ಕೊನೆಯ background job ಸೂಚಿಸಲು `$!` special parameter ಬಳಸಬಹುದು.
 
-One more thing to know is that the `&` suffix in a command will run the command in the background, giving you the prompt back, although it will still use the shell's STDOUT which can be annoying (use shell redirections in that case). Equivalently, to background an already running program you can do `Ctrl-Z` followed by `bg`.
+ಇನ್ನೊಂದು ವಿಷಯ: command ಕೊನೆಯಲ್ಲಿ `&` ಹಾಕಿದರೆ ಅದು background ನಲ್ಲಿ run ಆಗಿ prompt ತಕ್ಷಣ ಮರಳುತ್ತದೆ. ಆದರೆ ಅದು shell ನ STDOUT ಬಳಸುತ್ತಲೇ ಇರುತ್ತದೆ (ಅಗತ್ಯವಿದ್ದರೆ redirection ಬಳಸಿ).
+ಇದಕ್ಕೆ ಸಮನಾಗಿ ಈಗಾಗಲೇ run ಆಗಿರುವ program ಅನ್ನು `Ctrl-Z` ನಂತರ `bg` ಮೂಲಕ background ಗೆ ಕಳುಹಿಸಬಹುದು.
 
+background processes ಕೂಡ ನಿಮ್ಮ terminal ನ child processes ಆಗಿರುವುದರಿಂದ terminal ಮುಚ್ಚಿದರೆ ಅವು ಸತ್ತುಹೋಗುತ್ತವೆ (`SIGHUP` signal).
+ಅದನ್ನು ತಪ್ಪಿಸಲು [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) ಬಳಸಿ run ಮಾಡಬಹುದು, ಅಥವಾ ಈಗಾಗಲೇ ಶುರುವಾದ process ಗೆ `disown` ಮಾಡಬಹುದು.
+ಇಲ್ಲದಿದ್ದರೆ ಮುಂದಿನ ಭಾಗದಲ್ಲಿ ನೋಡುವ terminal multiplexer ಬಳಸಬಹುದು.
 
-Note that backgrounded processes are still children processes of your terminal and will die if you close the terminal (this will send yet another signal, `SIGHUP`).
-To prevent that from happening you can run the program with [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (a wrapper to ignore `SIGHUP`), or use `disown` if the process has already been started.
-Alternatively, you can use a terminal multiplexer as we will see in the next section.
-
-Below is a sample session to showcase some of these concepts.
+ಕೆಳಗಿನ sample session ಈ ಕಲ್ಪನೆಗಳಲ್ಲಿ ಕೆಲವು ತೋರಿಸುತ್ತದೆ.
 
 ```
 $ sleep 1000
@@ -412,11 +421,12 @@ $ kill %2
 [2]  + 18745 terminated  nohup sleep 2000
 ```
 
-A special signal is `SIGKILL` since it cannot be captured by the process and it will always terminate it immediately. However, it can have bad side effects such as leaving orphaned children processes.
+`SIGKILL` ಒಂದು ವಿಶೇಷ signal - process ಇದನ್ನು ಹಿಡಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ ಮತ್ತು ಅದು ತಕ್ಷಣ terminate ಆಗುತ್ತದೆ.
+ಆದರೆ ಇದರಿಂದ orphaned child processes ಹಾಗು ಇತರೆ side effects ಉಂಟಾಗುವ ಸಾಧ್ಯತೆ ಇದೆ.
 
-You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -l`.
+Signals ಬಗ್ಗೆ ಇನ್ನಷ್ಟು ತಿಳಿಯಲು [ಈ ಲಿಂಕ್](https://en.wikipedia.org/wiki/Signal_(IPC)) ಅಥವಾ [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html), `kill -l` ನೋಡಿ.
 
-Within shell scripts, you can use the `trap` built-in to execute commands when signals are received. This is useful for cleanup operations:
+Shell scripts ಒಳಗೆ signals ಬಂದಾಗ commands ನಡೆಸಲು `trap` built-in ಬಳಸಬಹುದು. Cleanup operations ಗೆ ಇದು ಉಪಯುಕ್ತ.
 
 ```shell
 #!/usr/bin/env bash
@@ -490,17 +500,20 @@ So far we've focused on your local machine, but many of these skills become even
 
 {% endcomment %}
 
-# Remote Machines
+# ರಿಮೋಟ್ ಯಂತ್ರಗಳು
 
-It has become more and more common for programmers to work with remote servers in their everyday work. The most common tool for the job here is SSH (Secure Shell) which will help us connect to a remote server and provide the now familiar shell interface. We connect to a server with a command like:
+ಇಂದು ಬಹುತೇಕ programmers ತಮ್ಮ ದೈನಂದಿನ ಕೆಲಸದಲ್ಲಿ remote servers ಜೊತೆ ಕೆಲಸ ಮಾಡುತ್ತಾರೆ.
+ಇದಕ್ಕಾಗಿ ಸಾಮಾನ್ಯ tool ಎಂದರೆ SSH (Secure Shell). ಇದು remote server ಗೆ connect ಆಗಲು ಮತ್ತು ಈಗಾಗಲೇ ಪರಿಚಿತ shell interface ಬಳಕೆ ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
+ಉದಾಹರಣೆಗೆ server ಗೆ ಹೀಗೆ ಸಂಪರ್ಕಿಸಬಹುದು:
 
 ```bash
 ssh alice@server.mit.edu
 ```
 
-Here we are trying to ssh as user `alice` in server `server.mit.edu`.
+ಇಲ್ಲಿ `server.mit.edu` ನಲ್ಲಿ `alice` user ಆಗಿ ssh ಮಾಡಲು ಪ್ರಯತ್ನಿಸುತ್ತಿದ್ದೇವೆ.
 
-An often overlooked feature of `ssh` is the ability to run commands non-interactively. `ssh` correctly handles sending the stdin and receiving the stdout of the command, so we can combine it with other commands
+`ssh` ನ ಪ್ರಮುಖ ಆದರೆ ಕಡಿಮೆ ಗಮನಕ್ಕೆ ಬರುವ feature ಎಂದರೆ non-interactive command execution.
+`ssh` command ನ stdin ಕಳುಹಿಸುವುದು ಮತ್ತು stdout ಸ್ವೀಕರಿಸುವುದನ್ನು ಸರಿಯಾಗಿ ನಿರ್ವಹಿಸುತ್ತದೆ, ಆದ್ದರಿಂದ ಇತರೆ commands ಜೊತೆ ಇದನ್ನು ಸೇರಿಸಬಹುದು:
 
 ```shell
 # here ls runs in the remote, and wc runs locally
@@ -511,22 +524,25 @@ ssh alice@server 'ls | wc -l'
 
 ```
 
-> Try installing [Mosh](https://mosh.org/) as a SSH replacement that can handle disconnections, entering/exiting sleep, changing networks and dealing with high latency links.
+> disconnection, sleep mode, network ಬದಲಾವಣೆ, high-latency links ಇತ್ಯಾದಿಗಳನ್ನು ಉತ್ತಮವಾಗಿ ನಿಭಾಯಿಸುವ SSH ಪರ್ಯಾಯವಾಗಿ [Mosh](https://mosh.org/) ಅನ್ನು ಪ್ರಯತ್ನಿಸಿ.
 
-For `ssh` to let us run commands in the remote server we need to prove that we are authorized to do so.
-We can do this via passwords or ssh keys.
-Key-based authentication utilizes public-key cryptography to prove to the server that the client owns the secret private key without revealing the key.
-Key based authentication is both more convenient and more secure, so you should prefer it.
-Note that the private key (often `~/.ssh/id_rsa` and more recently `~/.ssh/id_ed25519`) is effectively your password, so treat it like so and never share its contents.
+remote server ನಲ್ಲಿ commands run ಮಾಡಲು `ssh` ನಿಮಗೆ authorization ಇದೆ ಎಂದು ದೃಢೀಕರಿಸಬೇಕು.
+ಇದನ್ನು passwords ಅಥವಾ ssh keys ಮೂಲಕ ಮಾಡಬಹುದು.
+Key-based authentication public-key cryptography ಬಳಸಿಕೊಂಡು client ಬಳಿ secret private key ಇದೆ ಎಂದು ಸರ್ವರ್‌ಗೆ ಸಾಬೀತುಪಡಿಸುತ್ತದೆ - key ನ್ನೇ ಬಹಿರಂಗಪಡಿಸದೆ.
+Key-based authentication ಹೆಚ್ಚು ಸುಲಭ ಮತ್ತು ಹೆಚ್ಚು ಸುರಕ್ಷಿತ; ಆದ್ದರಿಂದ ಅದನ್ನೇ ಆದ್ಯತೆಯಿಂದ ಬಳಸಿ.
+Private key (ಸಾಮಾನ್ಯವಾಗಿ `~/.ssh/id_rsa`, ಇತ್ತೀಚೆಗೆ `~/.ssh/id_ed25519`) ಪ್ರಾಯೋಗಿಕವಾಗಿ password ಸಮಾನ; ಆದ್ದರಿಂದ ಅದನ್ನು ಎಂದಿಗೂ ಹಂಚಿಕೊಳ್ಳಬೇಡಿ.
 
-To generate a pair you can run [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
+Key pair ರಚಿಸಲು [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html) ಬಳಸಬಹುದು.
+
 ```bash
 ssh-keygen -a 100 -t ed25519 -f ~/.ssh/id_ed25519
 ```
 
-If you have ever configured pushing to GitHub using SSH keys, then you have probably done the steps outlined [here](https://help.github.com/articles/connecting-to-github-with-ssh/) and have a valid key pair already. To check if you have a passphrase and validate it you can run `ssh-keygen -y -f /path/to/key`.
+GitHub ಗೆ SSH keys ಮೂಲಕ push ಮಾಡಲು ನೀವು ಹಿಂದೆ configure ಮಾಡಿದ್ದರೆ, [ಈ ಹಂತಗಳು](https://help.github.com/articles/connecting-to-github-with-ssh/) ಬಹುಶಃ ನೀವು ಮಾಡಿರಬಹುದು ಮತ್ತು ಮಾನ್ಯ key pair ಇರಬಹುದು.
+passphrase ಇದೆವೋ, ಸರಿಯೇ ಎಂದು ಪರಿಶೀಲಿಸಲು `ssh-keygen -y -f /path/to/key` ಬಳಸಬಹುದು.
 
-At the server side `ssh` will look into `.ssh/authorized_keys` to determine which clients it should let in. To copy a public key over you can use:
+server ಭಾಗದಲ್ಲಿ `ssh`, `.ssh/authorized_keys` ನೋಡಿ ಯಾವ clients ಗೆ ಪ್ರವೇಶ ಕೊಡಬೇಕೆಂದು ತೀರ್ಮಾನಿಸುತ್ತದೆ.
+Public key ಕಾಪಿ ಮಾಡಲು:
 
 ```bash
 cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
@@ -536,9 +552,14 @@ cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
 ssh-copy-id -i .ssh/id_ed25519 alice@remote
 ```
 
-Beyond running commands, the connection that ssh establishes can be used to transfer files from and to the server securely. [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) is the most traditional tool and the syntax is `scp path/to/local_file remote_host:path/to/remote_file`. [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) improves upon `scp` by detecting identical files in local and remote, and preventing copying them again. It also provides more fine grained control over symlinks, permissions and has extra features like the `--partial` flag that can resume from a previously interrupted copy. `rsync` has a similar syntax to `scp`.
+commands ಮಾತ್ರವಲ್ಲ, ssh connection ಬಳಸಿ files ಅನ್ನು secure ಆಗಿ transfer ಕೂಡ ಮಾಡಬಹುದು.
+[`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) ಪರಂಪರೆಯ tool; syntax: `scp path/to/local_file remote_host:path/to/remote_file`.
+[`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html), `scp` ಗಿಂತ ಉತ್ತಮ - local ಮತ್ತು remote ನಲ್ಲಿ ಸಮಾನ files ಮರು-copy ಆಗದಂತೆ ತಡೆಯುತ್ತದೆ.
+ಇದಲ್ಲದೆ symlinks, permissions ಮೇಲೆ ಹೆಚ್ಚುವರಿ ನಿಯಂತ್ರಣ ಮತ್ತು interrupted copy ಮರುಪ್ರಾರಂಭಿಸುವ `--partial` ಹೀಗೆ features ಒದಗಿಸುತ್ತದೆ.
+`rsync` syntax, `scp` ಗೆ ಹೋಲುತ್ತದೆ.
 
-SSH client configuration is located at `~/.ssh/config` and it lets us declare hosts and set default settings for them. This configuration file is not just read by `ssh` but also other programs like `scp`, `rsync`, `mosh`, &c.
+SSH client configuration `~/.ssh/config` ನಲ್ಲಿ ಇರುತ್ತದೆ. ಇಲ್ಲಿ hosts ಮತ್ತು default settings ಘೋಷಿಸಬಹುದು.
+ಈ config file ಅನ್ನು `ssh` ಮಾತ್ರವಲ್ಲ `scp`, `rsync`, `mosh` ಮುಂತಾದ programs ಕೂಡ ಓದುತ್ತವೆ.
 
 ```bash
 Host vm
@@ -552,83 +573,86 @@ Host *.mit.edu
     User alice
 ```
 
+# ಟರ್ಮಿನಲ್ ಮಲ್ಟಿಪ್ಲೆಕ್ಸರ್ಸ್
 
+command line interface ಬಳಸುವಾಗ ನೀವು ಹಲವಾರು ಕೆಲಸಗಳನ್ನು ಒಂದೇ ಸಮಯದಲ್ಲಿ ನಡೆಸಲು ಬಯಸುತ್ತೀರಿ.
+ಉದಾಹರಣೆಗೆ editor ಮತ್ತು program ಅನ್ನು side-by-side ಓಡಿಸುವ ಅಗತ್ಯ ಬರುತ್ತದೆ.
+ಹೊಸ terminal windows ತೆರೆದು ಇದನ್ನು ಮಾಡಬಹುದು, ಆದರೆ terminal multiplexer ಹೆಚ್ಚು ಬಲವಾದ ಪರಿಹಾರ.
 
+[`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) ಮುಂತಾದ terminal multiplexers panes ಮತ್ತು tabs ಬಳಸಿ terminal windows ಅನ್ನು multiplex ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ.
+ಇದರಿಂದ ಅನೇಕ shell sessions ಅನ್ನು ಪರಿಣಾಮಕಾರಿಯಾಗಿ ನಿರ್ವಹಿಸಬಹುದು.
+ಇದಲ್ಲದೆ ಪ್ರಸ್ತುತ terminal session ಅನ್ನು detach ಮಾಡಿ ನಂತರ ಮರು-attach ಮಾಡಬಹುದು.
+ಅದರ ಕಾರಣ remote machines ಜೊತೆ ಕೆಲಸಿಸುವಾಗ terminal multiplexers ಬಹಳ ಉಪಯುಕ್ತ - `nohup` ಮುಂತಾದ workaroundಗಳ ಅವಶ್ಯಕತೆ ಕಡಿಮೆ.
 
-# Terminal Multiplexers
+ಈ ದಿನಗಳಲ್ಲಿ ಅತಿ ಜನಪ್ರಿಯ terminal multiplexer ಎಂದರೆ [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html).
+`tmux` ಬಹಳ configurable; keybindings ಗಳನ್ನು ಬಳಸಿ tabs ಮತ್ತು panes ಸೃಷ್ಟಿಸಿ ವೇಗವಾಗಿ navigate ಮಾಡಬಹುದು.
 
-When using the command line interface you will often want to run more than one thing at once.
-For instance, you might want to run your editor and your program side by side.
-Although this can be achieved by opening new terminal windows, using a terminal multiplexer is a more versatile solution.
+`tmux` keybindings ತಿಳಿದಿರಬೇಕು; ಅವೆಲ್ಲವೂ `<C-b> x` ರೂಪದಲ್ಲಿರುತ್ತವೆ: (1) `Ctrl+b` ಒತ್ತಿ, (2) ಬಿಡಿ, (3) `x` ಒತ್ತಿ.
+`tmux` ನಲ್ಲಿ objects hierarchy ಹೀಗಿದೆ:
 
-Terminal multiplexers like [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) allow you to multiplex terminal windows using panes and tabs so you can interact with multiple shell sessions in an efficient manner.
-Moreover, terminal multiplexers let you detach a current terminal session and reattach at some point later in time.
-Because of this, terminal multiplexers are really convenient when working with remote machines, as it avoids the need to use `nohup` and similar tricks.
+- **Sessions** - ಒಂದು session ಎಂದರೆ ಒಂದು ಅಥವಾ ಹೆಚ್ಚು windows ಇರುವ ಸ್ವತಂತ್ರ workspace
+    + `tmux` ಹೊಸ session ಆರಂಭಿಸುತ್ತದೆ.
+    + `tmux new -s NAME` ಕೊಟ್ಟರೆ ಆ ಹೆಸರಿನ session ಆರಂಭಿಸುತ್ತದೆ.
+    + `tmux ls` ಪ್ರಸ್ತುತ sessions ಪಟ್ಟಿ ತೋರಿಸುತ್ತದೆ.
+    + `tmux` ಒಳಗೆ `<C-b> d` current session detach ಮಾಡುತ್ತದೆ.
+    + `tmux a` ಕೊನೆಯ session attach ಮಾಡುತ್ತದೆ. `-t` ಮೂಲಕ ನಿರ್ದಿಷ್ಟ session ಸೂಚಿಸಬಹುದು.
 
-The most popular terminal multiplexer these days is [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` is highly configurable and by using the associated keybindings you can create multiple tabs and panes and quickly navigate through them.
+- **Windows** - editors/browsers ನ tabs ಗೆ ಸಮಾನ; session ಒಳಗಿನ ಪ್ರತ್ಯೇಕ ದೃಶ್ಯ ಭಾಗಗಳು
+    + `<C-b> c` ಹೊಸ window ರಚಿಸುತ್ತದೆ. ಮುಚ್ಚಲು `<C-d>` ಬಳಸಿ shells terminate ಮಾಡಿ.
+    + `<C-b> N` _N_ ನೇ window ಗೆ ಹೋಗುತ್ತದೆ.
+    + `<C-b> p` ಹಿಂದಿನ window ಗೆ ಹೋಗುತ್ತದೆ.
+    + `<C-b> n` ಮುಂದಿನ window ಗೆ ಹೋಗುತ್ತದೆ.
+    + `<C-b> ,` current window rename ಮಾಡುತ್ತದೆ.
+    + `<C-b> w` current windows ಪಟ್ಟಿ ತೋರಿಸುತ್ತದೆ.
 
-`tmux` expects you to know its keybindings, and they all have the form `<C-b> x` where that means (1) press `Ctrl+b`, (2) release `Ctrl+b`, and then (3) press `x`. `tmux` has the following hierarchy of objects:
-- **Sessions** - a session is an independent workspace with one or more windows
-    + `tmux` starts a new session.
-    + `tmux new -s NAME` starts it with that name.
-    + `tmux ls` lists the current sessions
-    + Within `tmux` typing `<C-b> d`  detaches the current session
-    + `tmux a` attaches the last session. You can use `-t` flag to specify which
+- **Panes** - vim splits ಹಾಗೆ, ಒಂದೇ ದೃಶ್ಯದಲ್ಲಿ ಅನೇಕ shells
+    + `<C-b> "` current pane ಅನ್ನು horizontally split ಮಾಡುತ್ತದೆ.
+    + `<C-b> %` current pane ಅನ್ನು vertically split ಮಾಡುತ್ತದೆ.
+    + `<C-b> <direction>` ನೀಡಿದ ದಿಕ್ಕಿನ pane ಗೆ ಹೋಗುತ್ತದೆ (arrow keys).
+    + `<C-b> z` current pane zoom toggle ಮಾಡುತ್ತದೆ.
+    + `<C-b> [` scrollback mode ಆರಂಭಿಸುತ್ತದೆ. ನಂತರ `<space>` selection, `<enter>` copy.
+    + `<C-b> <space>` pane arrangements cycle ಮಾಡುತ್ತದೆ.
 
-- **Windows** - Equivalent to tabs in editors or browsers, they are visually separate parts of the same session
-    + `<C-b> c` Creates a new window. To close it you can just terminate the shells doing `<C-d>`
-    + `<C-b> N` Go to the _N_ th window. Note they are numbered
-    + `<C-b> p` Goes to the previous window
-    + `<C-b> n` Goes to the next window
-    + `<C-b> ,` Rename the current window
-    + `<C-b> w` List current windows
+> `tmux` ಬಗ್ಗೆ ಇನ್ನಷ್ಟು ತಿಳಿಯಲು [ಈ quick tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) ಮತ್ತು [ಈ ವಿವರವಾದ ಲೇಖನ](https://linuxcommand.org/lc3_adv_termmux.php) ಓದಿ.
 
-- **Panes** - Like vim splits, panes let you have multiple shells in the same visual display.
-    + `<C-b> "` Split the current pane horizontally
-    + `<C-b> %` Split the current pane vertically
-    + `<C-b> <direction>` Move to the pane in the specified _direction_. Direction here means arrow keys.
-    + `<C-b> z` Toggle zoom for the current pane
-    + `<C-b> [` Start scrollback. You can then press `<space>` to start a selection and `<enter>` to copy that selection.
-    + `<C-b> <space>` Cycle through pane arrangements.
+tmux ಮತ್ತು SSH ನಿಮ್ಮ toolkit ನಲ್ಲಿ ಸೇರಿದ ಮೇಲೆ, ಯಾವ ಯಂತ್ರದಲ್ಲಾದರೂ ನಿಮ್ಮ ಪರಿಸರ ಮನೆಯಂತಿರಬೇಕು ಎಂಬ ಆಸೆ ಬರುತ್ತದೆ. ಅಲ್ಲಿ shell customization ಬರುತ್ತದೆ.
 
-> To learn more about tmux, consider reading [this](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) quick tutorial and [this](https://linuxcommand.org/lc3_adv_termmux.php) more detailed explanation.
+# ಶೆಲ್ ಕಸ್ಟಮೈಸಿಂಗ್
 
-With tmux and SSH in your toolkit, you'll want to make your environment feel like home on any machine. That's where shell customization comes in.
+ಹಲವಾರು command line programs _dotfiles_ ಎಂದು ಕರೆಯುವ plain-text files ಮೂಲಕ configure ಆಗುತ್ತವೆ
+(ಯಾಕೆಂದರೆ ಫೈಲ್ ಹೆಸರು `.` ಇಂದ ಆರಂಭವಾಗುತ್ತದೆ - ಉದಾ. `~/.vimrc`; ಆದ್ದರಿಂದ `ls` ನಲ್ಲಿ default ಆಗಿ hidden ಆಗಿರುತ್ತವೆ).
 
-# Customizing the Shell
+> Dotfiles ಕೂಡ shell convention. ಮುಂದೆ ಇರುವ dot ಅವುಗಳನ್ನು listing ನಲ್ಲಿ ಮರೆಮಾಡಲು ಬಳಸಲಾಗುತ್ತದೆ (ಹೌದು, ಇದೂ ಒಂದು convention).
 
-A wide array of command line programs are configured using plain-text files known as _dotfiles_
-(because the file names begin with a `.`, e.g. `~/.vimrc`, so that they are
-hidden in the directory listing `ls` by default).
+shell ಗಳು dotfiles ಬಳಸುವ programs ಗಳ ಉದಾಹರಣೆ.
+startup ಸಮಯದಲ್ಲಿ shell ತನ್ನ configuration ಲೋಡ್ ಮಾಡಲು ಹಲವಾರು files ಓದುತ್ತದೆ.
+shell ಪ್ರಕಾರ, login/interactive session ಪ್ರಕಾರ ಈ ಪ್ರಕ್ರಿಯೆ ಸಂಕೀರ್ಣವಾಗಬಹುದು.
+[ಈ ಸಂಪನ್ಮೂಲ](https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) ಅತ್ಯುತ್ತಮ ವಿವರ ನೀಡುತ್ತದೆ.
 
-> Dotfiles are yet another shell convention. The dot in the front is to "hide" them when listing (yes, another convention).
-
-Shells are one example of programs configured with such files. On startup, your shell will read many files to load its configuration.
-Depending on the shell and whether you are starting a login and/or interactive session, the entire process can be quite complex.
-[Here](https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) is an excellent resource on the topic.
-
-For `bash`, editing your `.bashrc` or `.bash_profile` will work in most systems.
-Some other examples of tools that can be configured through dotfiles are:
+`bash` ಗಾಗಿ ಹೆಚ್ಚಿನ systems ನಲ್ಲಿ `.bashrc` ಅಥವಾ `.bash_profile` edit ಮಾಡಿದರೆ ಸಾಕಾಗುತ್ತದೆ.
+ಇದೇ ರೀತಿ dotfiles ಮೂಲಕ configure ಆಗುವ tools ಕೆಲವು:
 
 - `bash` - `~/.bashrc`, `~/.bash_profile`
 - `git` - `~/.gitconfig`
-- `vim` - `~/.vimrc` and the `~/.vim` folder
+- `vim` - `~/.vimrc` ಮತ್ತು `~/.vim` folder
 - `ssh` - `~/.ssh/config`
 - `tmux` - `~/.tmux.conf`
 
-A common configuration change is adding new locations for the shell to find programs. You will encounter this pattern when installing software:
+ಸಾಮಾನ್ಯ customization ಒಂದು: shell programs ಹುಡುಕುವ ಸ್ಥಳಗಳಿಗೆ ಹೊಸ paths ಸೇರಿಸುವುದು. software install ಮಾಡುವಾಗ ಇದು ನಿಮಗೆ ಕಾಣುತ್ತದೆ:
 
 ```shell
 export PATH="$PATH:path/to/append"
 ```
 
-Here, we are telling the shell to set the value of the $PATH variable to its current value plus a new path, and have all children processes inherit this new value for PATH.
-This will allow children processes to find programs located under `path/to/append`.
+ಇಲ್ಲಿ `$PATH` ನ current value ಗೆ ಹೊಸ path ಸೇರಿಸಿ, child processes ಗೆ inherit ಆಗುವಂತೆ ಮಾಡುತ್ತಿದ್ದೇವೆ.
+ಇದರಿಂದ `path/to/append` ಅಡಿಯಲ್ಲಿ ಇರುವ programs ಪತ್ತೆಯಾಗುತ್ತವೆ.
 
+shell customization ನಲ್ಲಿ ಸಾಮಾನ್ಯವಾಗಿ ಹೊಸ command-line tools install ಮಾಡುವುದೂ ಸೇರಿದೆ.
+Package managers ಇದನ್ನು ಸುಲಭಗೊಳಿಸುತ್ತವೆ - download, install, update ಎಲ್ಲವನ್ನೂ ನಿರ್ವಹಿಸುತ್ತವೆ.
+Operating system ಪ್ರಕಾರ package managers ಬದಲಾಗುತ್ತವೆ: macOS ನಲ್ಲಿ [Homebrew](https://brew.sh/), Ubuntu/Debian ನಲ್ಲಿ `apt`, Fedora ನಲ್ಲಿ `dnf`, Arch ನಲ್ಲಿ `pacman`.
+Package managers ಬಗ್ಗೆ shipping code ಉಪನ್ಯಾಸದಲ್ಲಿ ಇನ್ನಷ್ಟು ನೋಡೋಣ.
 
-Customizing your shell often means installing new command-line tools. Package managers make this easy. They handle downloading, installing, and updating software. Different operating systems have different package managers: macOS uses [Homebrew](https://brew.sh/), Ubuntu/Debian use `apt`, Fedora uses `dnf`, and Arch uses `pacman`. We'll cover package managers in more depth in the shipping code lecture.
-
-Here's how to install two useful tools using Homebrew on macOS:
+macOS ನಲ್ಲಿ Homebrew ಬಳಸಿ ಉಪಯುಕ್ತವಾದ ಎರಡು tools install ಮಾಡುವ ವಿಧಾನ:
 
 ```shell
 # ripgrep: a faster grep with better defaults
@@ -638,19 +662,22 @@ brew install ripgrep
 brew install fd
 ```
 
-With these installed, you can use `rg` instead of `grep` and `fd` instead of `find`.
+ಇವು install ಆದ ನಂತರ `grep` ಬದಲು `rg`, `find` ಬದಲು `fd` ಬಳಸಬಹುದು.
 
-> **Warning about `curl | bash`**: You'll often see installation instructions like `curl -fsSL https://example.com/install.sh | bash`. This pattern downloads a script and immediately executes it, which is convenient but risky; you're running code you haven't inspected. A safer approach is to download first, review, then execute:
+> **`curl | bash` ಬಗ್ಗೆ ಎಚ್ಚರಿಕೆ**: install ಸೂಚನೆಗಳಲ್ಲಿ `curl -fsSL https://example.com/install.sh | bash` ಆಗಾಗ ಕಾಣಬಹುದು. ಇದು script download ಆಗುತ್ತಿದ್ದಂತೆಯೇ execute ಮಾಡುವ pattern - ಸೌಲಭ್ಯಕರ ಆದರೆ ಅಪಾಯಕಾರಿ, ಏಕೆಂದರೆ ನೀವು ಪರಿಶೀಲಿಸದ code ಅನ್ನು ತಕ್ಷಣ ಓಡಿಸುತ್ತೀರಿ.
+> ಹೆಚ್ಚು ಸುರಕ್ಷಿತ ವಿಧಾನ: ಮೊದಲು download ಮಾಡಿ, ಪರಿಶೀಲಿಸಿ, ನಂತರ execute ಮಾಡಿ.
 > ```shell
 > curl -fsSL https://example.com/install.sh -o install.sh
 > less install.sh  # review the script
 > bash install.sh
 > ```
-> Some installers use a slightly safer variant: `/bin/bash -c "$(curl -fsSL https://url)"` which at least ensures bash interprets the script rather than your current shell.
+> ಕೆಲವು installers `/bin/bash -c "$(curl -fsSL https://url)"` ಎಂಬ ಸ್ವಲ್ಪ ಸುರಕ್ಷಿತ ರೂಪ ಬಳಸುತ್ತವೆ - ಕನಿಷ್ಠ script ಅನ್ನು bash interpret ಮಾಡುತ್ತದೆ.
 
-When you try to run a command that isn't installed, your shell will show `command not found`. The website [command-not-found.com](https://command-not-found.com) is a helpful resource you can use to search for any command to find out how to install it across different package managers and distributions.
+install ಆಗದ command ಓಡಿಸಿದರೆ shell `command not found` ತೋರಿಸುತ್ತದೆ.
+[command-not-found.com](https://command-not-found.com) ವೆಬ್‌ಸೈಟ್ ಯಾವುದೇ command ಹೇಗೆ install ಮಾಡುವುದು ಎಂಬುದನ್ನು ವಿವಿಧ package managers/distributions ಮೇಲೆ ಹುಡುಕಲು ಉಪಯುಕ್ತ.
 
-Another useful tool is [`tldr`](https://tldr.sh/), which provides simplified, example-focused man pages. Instead of reading through lengthy documentation, you can quickly see common usage patterns:
+ಮತ್ತೊಂದು ಉಪಯುಕ್ತ ಸಾಧನ [`tldr`](https://tldr.sh/) - ಸರಳ, example-ಕೇಂದ್ರಿತ man pages ಒದಗಿಸುತ್ತದೆ.
+ದೀರ್ಘ documentation ಓದುವ ಬದಲು ಸಾಮಾನ್ಯ ಬಳಕೆ patterns ವೇಗವಾಗಿ ನೋಡಬಹುದು:
 
 ```console
 $ tldr fd
@@ -667,19 +694,19 @@ $ tldr fd
       fd --extension txt
 ```
 
-Sometimes you don't need a whole new program, but rather just a shortcut for an existing command with specific flags. That's where aliases come in.
+ಕೆಲವೊಮ್ಮೆ ಹೊಸ program ಬೇಡ - ನಿರ್ದಿಷ್ಟ flags ಜೊತೆಗೆ ಇರುವ command ಗೆ shorthand ಸಾಕು. ಅಲ್ಲಿ aliases ಉಪಯೋಗಕ್ಕೆ ಬರುತ್ತವೆ.
 
-We can also create our own command aliases using the `alias` shell built-in.
-A shell alias is a short form for another command that your shell will replace automatically before evaluating the expression.
-For instance, an alias in bash has the following structure:
+ನಮ್ಮದೇ command aliases ಅನ್ನು `alias` built-in ಮೂಲಕ ರಚಿಸಬಹುದು.
+Shell alias ಅಂದರೆ ಬೇರೆ command ಗೆ short form; shell expression evaluate ಮಾಡುವ ಮೊದಲು ಅದನ್ನು substitute ಮಾಡುತ್ತದೆ.
+ಉದಾಹರಣೆಗೆ bash ನಲ್ಲಿ alias ರಚನೆ:
 
 ```bash
 alias alias_name="command_to_alias arg1 arg2"
 ```
 
-> Note that there is no space around the equal sign `=`, because [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) is a shell command that takes a single argument.
+> `=` ಸುತ್ತ space ಇರಬಾರದು; [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) ಒಂದು single argument ತೆಗೆದುಕೊಳ್ಳುವ shell command.
 
-Aliases have many convenient features:
+Aliases ಗಳ ಕೆಲವು ಉಪಯುಕ್ತ ಬಳಕೆಗಳು:
 
 ```bash
 # Make shorthands for common flags
@@ -711,65 +738,61 @@ alias ll
 # Will print ll='ls -lh'
 ```
 
-Aliases have limitations: they cannot take arguments in the middle of a command. For more complex behavior, you should use shell functions instead.
+Aliases ಗೆ ಮಿತಿಗಳೂ ಇವೆ: command ಮಧ್ಯದಲ್ಲಿ arguments ತೆಗೆದುಕೊಳ್ಳುವ ಸಂಕೀರ್ಣ behavior ಗಳಿಗೆ aliases ಸಾಕಾಗುವುದಿಲ್ಲ. ಅಲ್ಲಿ shell functions ಬಳಸಿ.
 
-Most shells support `Ctrl-R` for reverse history search. Type `Ctrl-R` and start typing to search through previous commands. Earlier we introduced `fzf` as a fuzzy finder; with fzf's shell integration configured, `Ctrl-R` becomes an interactive fuzzy search through your entire history, far more powerful than the default.
+ಬಹುತೇಕ shells ನಲ್ಲಿ `Ctrl-R` reverse history search ಕೊಡುತ್ತದೆ.
+`Ctrl-R` ಒತ್ತಿ typing ಶುರು ಮಾಡಿದರೆ ಹಿಂದಿನ commands ಹುಡುಕಬಹುದು.
+ಹಿಂದೆ ಪರಿಚಯಿಸಿದ `fzf` integration configure ಮಾಡಿದರೆ `Ctrl-R` ಇನ್ನಷ್ಟು ಶಕ್ತಿಶಾಲಿ interactive fuzzy history search ಆಗುತ್ತದೆ.
 
-How should you organize your dotfiles? They should be in their own folder,
-under version control, and **symlinked** into place using a script. This has
-the benefits of:
+Dotfiles ಅನ್ನು ಹೇಗೆ ಸಂಘಟಿಸಬೇಕು?
+ಅವುಗಳನ್ನು ಪ್ರತ್ಯೇಕ folder ನಲ್ಲಿ ಇಟ್ಟು, version control ನಲ್ಲಿ ಇಟ್ಟು, script ಮೂಲಕ **symlink** ಮಾಡಿ ಬಳಸಿ.
+ಇದರಿಂದ ಲಾಭಗಳು:
 
-- **Easy installation**: if you log in to a new machine, applying your
-customizations will only take a minute.
-- **Portability**: your tools will work the same way everywhere.
-- **Synchronization**: you can update your dotfiles anywhere and keep them all
-in sync.
-- **Change tracking**: you're probably going to be maintaining your dotfiles
-for your entire programming career, and version history is nice to have for
-long-lived projects.
+- **ಸುಲಭ ಸ್ಥಾಪನೆ** - ಹೊಸ ಯಂತ್ರದಲ್ಲಿ login ಆದಾಗ ನಿಮ್ಮ customizations ಅನ್ನು ಕ್ಷಣಗಳಲ್ಲಿ ಅನ್ವಯಿಸಬಹುದು.
+- **Portability** - ನಿಮ್ಮ tools ಎಲ್ಲೆಡೆ ಒಂದೇ ರೀತಿಯಲ್ಲಿ ಕೆಲಸ ಮಾಡುತ್ತವೆ.
+- **Synchronization** - ಎಲ್ಲೆಡೆ dotfiles update ಮಾಡಿ sync ಇಡಬಹುದು.
+- **Change tracking** - programming career മുഴುವರಿಗೂ dotfiles ಇರುತ್ತವೆ; version history ಬಹಳ ಉಪಯುಕ್ತ.
 
-What should you put in your dotfiles?
-You can learn about your tool's settings by reading online documentation or
-[man pages](https://en.wikipedia.org/wiki/Man_page). Another great way is to
-search the internet for blog posts about specific programs, where authors will
-tell you about their preferred customizations. Yet another way to learn about
-customizations is to look through other people's dotfiles: you can find tons of
-[dotfiles
-repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on GitHub --- see the most popular one
-[here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
-copy configurations though).
-[Here](https://dotfiles.github.io/) is another good resource on the topic.
+Dotfiles ನಲ್ಲಿ ಏನು ಹಾಕಬೇಕು?
+Tool settings ತಿಳಿಯಲು online docs ಅಥವಾ [man pages](https://en.wikipedia.org/wiki/Man_page) ಓದಿ.
+ನಿರ್ದಿಷ್ಟ programs ಕುರಿತು blog posts ಕೂಡ ಉತ್ತಮ ಮಾರ್ಗ.
+ಇನ್ನೊಂದು ಮಾರ್ಗ - ಇತರರ dotfiles ನೋಡುವುದು.
+GitHub ನಲ್ಲಿ ಅನೇಕ [dotfiles repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories) ಲಭ್ಯ - ಜನಪ್ರಿಯದೊಂದು [ಇಲ್ಲಿ](https://github.com/mathiasbynens/dotfiles).
+ಆದರೆ configurations ಅನ್ನು ಪರಿಶೀಲನೆ ಇಲ್ಲದೆ copy ಮಾಡಬೇಡಿ.
+[ಈ ಸಂಪನ್ಮೂಲ](https://dotfiles.github.io/) ಕೂಡ ಒಳ್ಳೆಯದು.
 
-All of the class instructors have their dotfiles publicly accessible on GitHub: [Anish](https://github.com/anishathalye/dotfiles),
+ಈ ತರಗತಿಯ instructors ಅವರ dotfiles GitHub ನಲ್ಲಿ ಸಾರ್ವಜನಿಕವಾಗಿ ಲಭ್ಯ:
+[Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
 [Jose](https://github.com/jjgo/dotfiles).
 
-**Frameworks and plugins** can improve your shell as well. Some popular general frameworks are [prezto](https://github.com/sorin-ionescu/prezto) or [oh-my-zsh](https://ohmyz.sh/), and smaller plugins that focus on specific features:
+**Frameworks ಮತ್ತು plugins** ಕೂಡ shell ಅನುಭವವನ್ನು ಉತ್ತಮಗೊಳಿಸುತ್ತವೆ.
+ಜನಪ್ರಿಯ frameworks: [prezto](https://github.com/sorin-ionescu/prezto), [oh-my-zsh](https://ohmyz.sh/).
+ನಿರ್ದಿಷ್ಟ features ಗಾಗಿ plugins:
 
-- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - colors valid/invalid commands as you type
-- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - suggests commands from history as you type
-- [zsh-completions](https://github.com/zsh-users/zsh-completions) - additional completion definitions
-- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - fish-like history search
-- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - fast, customizable prompt theme
+- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - typing ಸಮಯದಲ್ಲಿ valid/invalid commands ಗೆ ಬಣ್ಣ
+- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - history ನಿಂದ command suggestions
+- [zsh-completions](https://github.com/zsh-users/zsh-completions) - ಹೆಚ್ಚುವರಿ completion definitions
+- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - fish-ಶೈಲಿ history search
+- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - ವೇಗವಾದ, customizable prompt theme
 
-Shells like [fish](https://fishshell.com/) include many of these features by default.
+[fish](https://fishshell.com/) ಮೊದಲಾದ shells ಈ features ಗಳಲ್ಲಿ ಅನೇಕವನ್ನು default ಆಗಿಯೇ ಕೊಡುತ್ತವೆ.
 
-> You don't need a massive framework like oh-my-zsh to get these features. Installing individual plugins is often faster and gives you more control. Large frameworks can significantly slow down shell startup time, so consider installing only what you actually use.
+> oh-my-zsh ಹೀಗೆ ದೊಡ್ಡ frameworks ಕಡ್ಡಾಯವಲ್ಲ. ಪ್ರತ್ಯೇಕ plugins install ಮಾಡಿದರೆ ಸಾಮಾನ್ಯವಾಗಿ ವೇಗವಾಗಿ ಹಾಗೂ ಹೆಚ್ಚಿನ ನಿಯಂತ್ರಣದೊಂದಿಗೆ ಇದೇ features ಪಡೆಯಬಹುದು. ದೊಡ್ಡ frameworks shell startup ಸಮಯವನ್ನು ಗಮನಾರ್ಹವಾಗಿ ನಿಧಾನಗೊಳಿಸಬಹುದು.
 
+# ಶೆಲ್‌ನಲ್ಲಿನ AI
 
-# AI in the Shell
+Shell ನಲ್ಲಿ AI tooling ಸೇರಿಸುವ ಹಲವು ಮಾರ್ಗಗಳಿವೆ. integration ಮಟ್ಟದ ಪ್ರಕಾರ ಕೆಲವು ಉದಾಹರಣೆಗಳು ಇಲ್ಲಿವೆ:
 
-There are many ways to incorporate AI tooling in the shell. Here are a few examples at different levels of integration:
-
-**Command generation**: Tools like [`simonw/llm`](https://github.com/simonw/llm) can help generate shell commands from natural language descriptions:
+**Command generation**: [`simonw/llm`](https://github.com/simonw/llm) ಹಾಗೆಯ tools, natural language ವಿವರಣೆಯಿಂದ shell commands ರಚಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ.
 
 ```console
 $ llm cmd "find all python files modified in the last week"
 find . -name "*.py" -mtime -7
 ```
 
-**Pipeline integration**: LLMs can be integrated into shell pipelines to process and transform data. They're particularly useful when you need to extract information from inconsistent formats where regex would be painful:
+**Pipeline integration**: data process/transform ಮಾಡಲು LLMs ಅನ್ನು shell pipelines ಗೆ ಸೇರಿಸಬಹುದು.
+formats ಅಸಂಗತವಾಗಿರುವ data ಯಿಂದ ಮಾಹಿತಿ ತೆಗೆಯುವಲ್ಲಿ regex ಕಷ್ಟವಾದಾಗ ಇದು ವಿಶೇಷವಾಗಿ ಉಪಯುಕ್ತ.
 
 ```console
 $ cat users.txt
@@ -789,40 +812,40 @@ mike_wilson
 sarah.connor
 ```
 
-Note how we use `"$INSTRUCTIONS"` (quoted) because the variable contains spaces, and `< users.txt` to redirect the file's content to stdin.
+ಇಲ್ಲಿ `"$INSTRUCTIONS"` quoted ಆಗಿದೆ, ಏಕೆಂದರೆ variable ನಲ್ಲಿ spaces ಇವೆ.
+`< users.txt` file content ಅನ್ನು stdin ಗೆ redirect ಮಾಡುತ್ತದೆ.
 
-**AI shells**: Tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) act as a meta-shell that accepts English commands and translates them into shell operations, file edits, and more complex multi-step tasks.
+**AI shells**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ಹಾಗೆಯ tools meta-shell ಆಗಿ ಕೆಲಸ ಮಾಡಿ English commands ಅನ್ನು shell operations, file edits, ಮತ್ತು ಸಂಕೀರ್ಣ multi-step tasks ಗಳಿಗೆ ಅನುವಾದಿಸುತ್ತವೆ.
 
-# Terminal Emulators
+# ಟರ್ಮಿನಲ್ ಎಮ್ಯುಲೇಟರ್ಸ್
 
-Along with customizing your shell, it is worth spending some time figuring out your choice of **terminal emulator** and its settings.
-A terminal emulator is a GUI program that provides the text-based interface where your shell runs.
-There are many terminal emulators out there.
+shell customization ಜೊತೆಗೆ **terminal emulator** ಆಯ್ಕೆ ಮತ್ತು settings ಗೂ ಸಮಯ ಹೂಡುವುದು ಸೂಕ್ತ.
+Terminal emulator ಅಂದರೆ ನಿಮ್ಮ shell ಓಡುವ text-based interface ನೀಡುವ GUI program.
+ಇಂತಹ terminal emulators ಹಲವಾರು ಲಭ್ಯ.
 
-Since you might be spending hundreds to thousands of hours in your terminal it pays off to look into its settings. Some of the aspects that you may want to modify in your terminal include:
+terminal ನಲ್ಲಿ ನೀವು ನೂರಾರು ರಿಂದ ಸಾವಿರಾರು ಗಂಟೆಗಳವರೆಗೆ ಕಳೆಯುವ ಸಾಧ್ಯತೆ ಇರುವುದರಿಂದ ಅದರ settings ಮೇಲೆ ಗಮನ ಕೊಡುವುದು ಪ್ರಯೋಜನಕಾರಿ.
+ಬದಲಾಯಿಸಲು ಪರಿಗಣಿಸಬಹುದಾದ ಅಂಶಗಳು:
 
-- Font choice
-- Color Scheme
+- Font ಆಯ್ಕೆ
+- Color scheme
 - Keyboard shortcuts
 - Tab/Pane support
 - Scrollback configuration
-- Performance (some newer terminals like [Alacritty](https://github.com/alacritty/alacritty) or [Ghostty](https://ghostty.org/) offer GPU acceleration).
+- Performance (ಉದಾ. [Alacritty](https://github.com/alacritty/alacritty), [Ghostty](https://ghostty.org/) ಇತ್ಯಾದಿ terminals GPU acceleration ಒದಗಿಸುತ್ತವೆ)
 
+# ವ್ಯಾಯಾಮಗಳು
 
+## Arguments ಮತ್ತು Globs
 
-# Exercises
+1. `cmd --flag -- --notaflag` ಹೀಗೆ commands ಕಾಣಬಹುದು. ಇಲ್ಲಿ `--` ಒಂದು ವಿಶೇಷ argument: ಇದರ ನಂತರ flags parsing ನಿಲ್ಲಿಸಬೇಕು ಎಂದು program ಗೆ ಸೂಚಿಸುತ್ತದೆ. `--` ನಂತರ ಇರುವ ಎಲ್ಲವೂ positional arguments ಆಗಿ ಪರಿಗಣಿಸಬೇಕು. ಇದು ಯಾಕೆ ಉಪಯುಕ್ತ? `touch -- -myfile` ಪ್ರಯತ್ನಿಸಿ, ನಂತರ `--` ಬಳಸದೆ ಅದನ್ನು remove ಮಾಡಿ ನೋಡಿ.
 
-## Arguments and Globs
+1. [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) ಓದಿ ಮತ್ತು ಈ ರೀತಿಯಲ್ಲಿ files ಪಟ್ಟಿ ಮಾಡುವ `ls` command ಬರೆಯಿರಿ:
+    - hidden files ಸೇರಿ ಎಲ್ಲಾ files ಕಾಣಬೇಕು
+    - size human-readable ರೂಪದಲ್ಲಿ ತೋರಬೇಕು (ಉದಾ. 454279954 ಬದಲು 454M)
+    - files recency ಆಧಾರದ ಮೇಲೆ ಕ್ರಮದಲ್ಲಿರಬೇಕು
+    - output colorized ಆಗಿರಬೇಕು
 
-1. You might see commands like `cmd --flag -- --notaflag`. The `--` is a special argument that tells the program to stop parsing flags. Everything after `--` is treated as a positional argument. Why might this be useful? Try running `touch -- -myfile` and then removing it without `--`.
-
-1. Read [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) and write an `ls` command that lists files in the following manner:
-    - Includes all files, including hidden files
-    - Sizes are listed in human readable format (e.g. 454M instead of 454279954)
-    - Files are ordered by recency
-    - Output is colorized
-
-    A sample output would look like this:
+    sample output:
 
     ```
     -rw-r--r--   1 user group 1.1M Jan 14 09:53 baz
@@ -836,11 +859,14 @@ Since you might be spending hundreds to thousands of hours in your terminal it p
 ls -lath --color=auto
 {% endcomment %}
 
-1. Process substitution `<(command)` lets you use a command's output as if it were a file. Use `diff` with process substitution to compare the output of `printenv` and `export`. Why are they different? (Hint: try `diff <(printenv | sort) <(export | sort)`).
+1. Process substitution `<(command)` command output ಅನ್ನು file ಆಗಿ ಬಳಸಲು ಅನುಮತಿಸುತ್ತದೆ. `printenv` ಮತ್ತು `export` output ಹೋಲಿಸಲು `diff` ಬಳಸಿರಿ. ಅವು ಏಕೆ ಬೇರೆ? (Hint: `diff <(printenv | sort) <(export | sort)` ಪ್ರಯತ್ನಿಸಿ).
 
 ## Environment Variables
 
-1. Write bash functions `marco` and `polo` that do the following: whenever you execute `marco` the current working directory should be saved in some manner, then when you execute `polo`, no matter what directory you are in, `polo` should `cd` you back to the directory where you executed `marco`. For ease of debugging you can write the code in a file `marco.sh` and (re)load the definitions to your shell by executing `source marco.sh`.
+1. `marco` ಮತ್ತು `polo` ಎಂಬ bash functions ಬರೆಯಿರಿ:
+   - `marco` execute ಮಾಡಿದಾಗ current working directory ಯಾವುದಾದರೂ ರೀತಿಯಲ್ಲಿ save ಆಗಬೇಕು.
+   - ನಂತರ ನೀವು ಯಾವ directory ಯಲ್ಲಿದ್ದರೂ `polo` execute ಮಾಡಿದರೆ, `marco` execute ಮಾಡಿದ directory ಗೆ `cd` ಆಗಬೇಕು.
+   Debug ಮಾಡಲು `marco.sh` ಫೈಲ್‌ನಲ್ಲಿ code ಬರೆಯಿರಿ ಮತ್ತು `source marco.sh` ಮೂಲಕ shell ಗೆ (re)load ಮಾಡಿ.
 
 {% comment %}
 marco() {
@@ -854,7 +880,7 @@ polo() {
 
 ## Return Codes
 
-1. Say you have a command that fails rarely. In order to debug it you need to capture its output but it can be time consuming to get a failure run. Write a bash script that runs the following script until it fails and captures its standard output and error streams to files and prints everything at the end. Bonus points if you can also report how many runs it took for the script to fail.
+1. ಅಪರೂಪವಾಗಿ ವಿಫಲವಾಗುವ command ಇದೆ ಎಂದು ಊಹಿಸಿರಿ. Debug ಮಾಡಲು ಅದರ output ಹಿಡಿಯಬೇಕು, ಆದರೆ failure run ಸಿಗಲು ಸಮಯ ಹಿಡಿಯುತ್ತದೆ. ಕೆಳಗಿನ script fail ಆಗುವವರೆಗೆ ಅದನ್ನು ಓಡಿಸಿ, stdout ಮತ್ತು stderr ಅನ್ನು files ಗೆ capture ಮಾಡಿ, ಕೊನೆಯಲ್ಲಿ ಎಲ್ಲವನ್ನೂ print ಮಾಡುವ bash script ಬರೆಯಿರಿ. Bonus: fail ಆಗಲು ಎಷ್ಟು runs ಬೇಕಾಯಿತು ಎಂದು report ಮಾಡಿ.
 
     ```bash
     #!/usr/bin/env bash
@@ -884,47 +910,51 @@ echo "found error after $count runs"
 cat out.txt
 {% endcomment %}
 
-## Signals and Job Control
+## Signals ಮತ್ತು Job Control
 
-1. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-af` flags).
+1. terminal ನಲ್ಲಿ `sleep 10000` job ಆರಂಭಿಸಿ, `Ctrl-Z` ಮೂಲಕ background ಗೆ ಕಳುಹಿಸಿ, `bg` ಬಳಸಿ ಮುಂದುವರಿಸಿ. ನಂತರ [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) ಬಳಸಿ ಅದರ pid ಕಂಡುಹಿಡಿದು, pid ಅನ್ನು ನೇರವಾಗಿ type ಮಾಡದೆ [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) ಬಳಸಿ kill ಮಾಡಿ. (Hint: `-af` flags ಬಳಸಿ).
 
-1. Say you don't want to start a process until another completes. How would you go about it? In this exercise, our limiting process will always be `sleep 60 &`. One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command. Try launching the sleep command and having an `ls` wait until the background process finishes.
+1. ಒಂದು process ಮುಗಿಯುವವರೆಗೆ ಇನ್ನೊಂದು process ಪ್ರಾರಂಭಿಸಬಾರದು ಎಂದು ಹೇಳೋಣ. ಈ exercise ನಲ್ಲಿ limiting process ಎಂದರೆ `sleep 60 &`. ಇದನ್ನು ಸಾಧಿಸಲು [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command ಬಳಸಬಹುದು. `sleep` launch ಮಾಡಿ, `ls` command ಅನ್ನು background process ಮುಗಿಯುವವರೆಗೆ ಕಾಯುವಂತೆ ಮಾಡಿ ನೋಡಿ.
 
-    However, this strategy will fail if we start in a different bash session, since `wait` only works for child processes. One feature we did not discuss in the notes is that the `kill` command's exit status will be zero on success and nonzero otherwise. `kill -0` does not send a signal but will give a nonzero exit status if the process does not exist. Write a bash function called `pidwait` that takes a pid and waits until the given process completes. You should use `sleep` to avoid wasting CPU unnecessarily.
+   ಆದರೆ ಬೇರೆ bash session ನಲ್ಲಿ ಇದ್ದರೆ ಇದು ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ, ಏಕೆಂದರೆ `wait` child processes ಮೇಲಷ್ಟೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ.
+   ನಾವು notes ನಲ್ಲಿ ಚರ್ಚಿಸದ ಒಂದು ವಿಷಯ: `kill` command ಯಶಸ್ವಿಯಾದರೆ exit status zero, ಇಲ್ಲದಿದ್ದರೆ nonzero.
+   `kill -0` signal ಕಳುಹಿಸುವುದಿಲ್ಲ; process ಇಲ್ಲದಿದ್ದರೆ nonzero return ಕೊಡುತ್ತದೆ.
+   ಕೊಟ್ಟ pid ಮುಗಿಯುವವರೆಗೆ ಕಾಯುವ `pidwait` ಎಂಬ bash function ಬರೆಯಿರಿ. CPU ವ್ಯರ್ಥವಾಗದಂತೆ `sleep` ಬಳಸಬೇಕು.
 
-## Files and Permissions
+## Files ಮತ್ತು Permissions
 
-1. (Advanced) Write a command or script to recursively find the most recently modified file in a directory. More generally, can you list all files by recency?
+1. (Advanced) ಒಂದು directory ಯಲ್ಲಿರುವ ಅತ್ಯಂತ ಇತ್ತೀಚೆಗೆ modified ಆದ file ಅನ್ನು recursive ಆಗಿ ಕಂಡುಹಿಡಿಯುವ command/script ಬರೆಯಿರಿ. ಹೆಚ್ಚಿನವಾಗಿ, recency ಪ್ರಕಾರ ಎಲ್ಲಾ files ಪಟ್ಟಿ ಮಾಡಬಹುದೇ?
 
 ## Terminal Multiplexers
 
-1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
+1. ಈ `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) ಅನುಸರಿಸಿ, ನಂತರ [ಈ ಹಂತಗಳು](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/) ಬಳಸಿ ಕೆಲವು ಮೂಲಭೂತ customizations ಕಲಿಯಿರಿ.
 
-## Aliases and Dotfiles
+## Aliases ಮತ್ತು Dotfiles
 
-1. Create an alias `dc` that resolves to `cd` for when you type it wrong.
+1. ತಪ್ಪಾಗಿ type ಮಾಡಿದಾಗ ಉಪಯೋಗವಾಗುವಂತೆ `cd` ಗೆ `dc` alias ರಚಿಸಿ.
 
-1. Run `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` to get your top 10 most used commands and consider writing shorter aliases for them. Note: this works for Bash; if you're using ZSH, use `history 1` instead of just `history`.
+1. `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` command ಓಡಿಸಿ top 10 ಹೆಚ್ಚು ಬಳಸುವ commands ನೋಡಿ, ಅವಕ್ಕೆ ಚಿಕ್ಕ aliases ಬರೆಯುವ ಬಗ್ಗೆ ಯೋಚಿಸಿ. Note: ಇದು Bash ಗೆ. ZSH ಬಳಿಸಿದರೆ `history` ಬದಲು `history 1` ಬಳಸಿ.
 
-1. Create a folder for your dotfiles and set up version control.
+1. dotfiles ಗಾಗಿ folder ರಚಿಸಿ, version control ಹೊಂದಿಸಿ.
 
-1. Add a configuration for at least one program, e.g. your shell, with some customization (to start off, it can be something as simple as customizing your shell prompt by setting `$PS1`).
+1. ಕನಿಷ್ಠ ಒಂದು program (ಉದಾ: shell) ಗೆ configuration ಸೇರಿಸಿ. ಆರಂಭಕ್ಕೆ `$PS1` ಬದಲಿಸಿ prompt customize ಮಾಡುವಷ್ಟು ಸರಳವಾಗಿರಬಹುದು.
 
-1. Set up a method to install your dotfiles quickly (and without manual effort) on a new machine. This can be as simple as a shell script that calls `ln -s` for each file, or you could use a [specialized utility](https://dotfiles.github.io/utilities/).
+1. ಹೊಸ machine ನಲ್ಲಿ manual effort ಇಲ್ಲದೆ dotfiles ತ್ವರಿತವಾಗಿ install ಆಗುವ ವಿಧಾನ ಸಿದ್ಧಪಡಿಸಿ. ಸರಳ `ln -s` script ಸಾಕು, ಅಥವಾ [specialized utility](https://dotfiles.github.io/utilities/) ಬಳಸಿ.
 
-1. Test your installation script on a fresh virtual machine.
+1. ನಿಮ್ಮ install script ಅನ್ನು fresh virtual machine ನಲ್ಲಿ ಪರೀಕ್ಷಿಸಿ.
 
-1. Migrate all of your current tool configurations to your dotfiles repository.
+1. ನಿಮ್ಮ ಪ್ರಸ್ತುತ tool configurations ಎಲ್ಲವನ್ನೂ dotfiles repository ಗೆ ಸ್ಥಳಾಂತರಿಸಿ.
 
-1. Publish your dotfiles on GitHub.
+1. ನಿಮ್ಮ dotfiles ಅನ್ನು GitHub ನಲ್ಲಿ ಪ್ರಕಟಿಸಿ.
 
 ## Remote Machines (SSH)
 
-Install a Linux virtual machine (or use an already existing one) for these exercises. If you are not familiar with virtual machines check out [this](https://hibbard.eu/install-ubuntu-virtual-box/) tutorial for installing one.
+ಈ exercises ಗಾಗಿ Linux virtual machine install ಮಾಡಿ (ಅಥವಾ ಈಗಾಗಲೇ ಇರುವುದನ್ನು ಬಳಸಿ).
+Virtual machines ಪರಿಚಯವಿಲ್ಲದಿದ್ದರೆ [ಈ tutorial](https://hibbard.eu/install-ubuntu-virtual-box/) ನೋಡಿ.
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent`, more info [here](https://www.ssh.com/ssh/agent).
+1. `~/.ssh/` ಗೆ ಹೋಗಿ SSH key pair ಇದೆಯೇ ನೋಡಿ. ಇಲ್ಲದಿದ್ದರೆ `ssh-keygen -a 100 -t ed25519` ಬಳಸಿ generate ಮಾಡಿ. passphrase ಬಳಸುವುದು ಮತ್ತು `ssh-agent` ಬಳಸುವುದು ಶಿಫಾರಸು - ಹೆಚ್ಚಿನ ಮಾಹಿತಿ [ಇಲ್ಲಿ](https://www.ssh.com/ssh/agent).
 
-1. Edit `.ssh/config` to have an entry as follows:
+1. `.ssh/config` ನಲ್ಲಿ ಈ ರೀತಿಯ entry ಸೇರಿಸಿ:
 
     ```bash
     Host vm
@@ -934,12 +964,12 @@ Install a Linux virtual machine (or use an already existing one) for these exerc
         LocalForward 9999 localhost:8888
     ```
 
-1. Use `ssh-copy-id vm` to copy your ssh key to the server.
+1. `ssh-copy-id vm` ಬಳಸಿ ನಿಮ್ಮ ssh key server ಗೆ copy ಮಾಡಿ.
 
-1. Start a webserver in your VM by executing `python -m http.server 8888`. Access the VM webserver by navigating to `http://localhost:9999` in your machine.
+1. VM ನಲ್ಲಿ `python -m http.server 8888` execute ಮಾಡಿ webserver ಶುರುಮಾಡಿ. ನಿಮ್ಮ machine ನಲ್ಲಿ `http://localhost:9999` ತೆರೆಯಿರಿ.
 
-1. Edit your SSH server config by doing `sudo vim /etc/ssh/sshd_config` and disable password authentication by editing the value of `PasswordAuthentication`. Disable root login by editing the value of `PermitRootLogin`. Restart the `ssh` service with `sudo service sshd restart`. Try sshing in again.
+1. `sudo vim /etc/ssh/sshd_config` ಮೂಲಕ SSH server config edit ಮಾಡಿ. `PasswordAuthentication` value ಬದಲಿಸಿ password authentication disable ಮಾಡಿ. `PermitRootLogin` value ಬದಲಿಸಿ root login disable ಮಾಡಿ. `sudo service sshd restart` ಮೂಲಕ `ssh` service restart ಮಾಡಿ. ಮತ್ತೆ ssh ಮಾಡಿ ಪರೀಕ್ಷಿಸಿ.
 
-1. (Challenge) Install [`mosh`](https://mosh.org/) in the VM and establish a connection. Then disconnect the network adapter of the server/VM. Can mosh properly recover from it?
+1. (Challenge) VM ನಲ್ಲಿ [`mosh`](https://mosh.org/) install ಮಾಡಿ connection ಸ್ಥಾಪಿಸಿ. ನಂತರ server/VM network adapter disconnect ಮಾಡಿ. mosh ಸರಿಯಾಗಿ recover ಆಗುತ್ತದೆಯೇ ನೋಡಿ.
 
-1. (Challenge) Look into what the `-N` and `-f` flags do in `ssh` and figure out a command to achieve background port forwarding.
+1. (Challenge) `ssh` command ನಲ್ಲಿ `-N` ಮತ್ತು `-f` flags ಏನು ಮಾಡುತ್ತವೆ ನೋಡಿ. background port forwarding ಮಾಡಲು ಸರಿಯಾದ command ಕಂಡುಹಿಡಿಯಿರಿ.

--- a/_2026/course-shell.md
+++ b/_2026/course-shell.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Course Overview + Introduction to the Shell"
+title: "ಪಠ್ಯದ ಅವಲೋಕನ + ಶೆಲ್‌ಗೆ ಪರಿಚಯ"
 description: >
-  Learn about the motivation for this class, and get started with the shell.
+  ಈ ತರಗತಿಯ ಉದ್ದೇಶವನ್ನು ತಿಳಿದುಕೊಳ್ಳಿ, ಮತ್ತು ಶೆಲ್ ಅನ್ನು ಬಳಸಲು ಆರಂಭಿಸಿ.
 thumbnail: /static/assets/thumbnails/2026/lec1.png
 date: 2026-01-12
 ready: true
@@ -11,156 +11,128 @@ video:
   id: MSgoeuMqUmU
 ---
 
-# Who are we?
+# ನಾವು ಯಾರು?
 
-This class is co-taught by [Anish](https://anish.io/),
-[Jon](https://thesquareplanet.com/), and [Jose](http://josejg.com/). We
-are all ex-MIT students who started this MIT IAP class back when we were
-students. You can reach us collectively at
-[missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+ಈ ತರಗತಿಯನ್ನು [Anish](https://anish.io/),
+[Jon](https://thesquareplanet.com/), ಮತ್ತು [Jose](http://josejg.com/) ಸಹ-ಬೋಧಿಸುತ್ತಾರೆ.
+ನಾವು ಎಲ್ಲರೂ ಮಾಜಿ MIT ವಿದ್ಯಾರ್ಥಿಗಳು; ನಾವು ವಿದ್ಯಾರ್ಥಿಗಳಾಗಿದ್ದಾಗಲೇ ಈ MIT IAP ತರಗತಿಯನ್ನು
+ಆರಂಭಿಸಿದ್ದೇವೆ. ನಮ್ಮನ್ನು ಒಟ್ಟಾಗಿ ಸಂಪರ್ಕಿಸಲು
+[missing-semester@mit.edu](mailto:missing-semester@mit.edu) ಬಳಸಿ.
 
-We are not paid to teach this class, and do not monetize the class in
-any way. We make all the [course
-materials](https://missing.csail.mit.edu/) and [recordings of the
-lectures](https://www.youtube.com/@MissingSemester) freely available
-online. If you want to support our work, the best way to do so is to
-simply spread the word about the class. If you're a company, university,
-or other organization that runs this content past larger cohorts, please
-send us experience reports/testimonials by email so we get to hear about
-it :)
+ಈ ತರಗತಿಯನ್ನು ಬೋಧಿಸಲು ನಮಗೆ ವೇತನ ಸಿಗುವುದಿಲ್ಲ, ಮತ್ತು ಈ ತರಗತಿಯಿಂದ ನಾವು ಯಾವುದೇ ರೀತಿಯಲ್ಲಿ ಆದಾಯ ಗಳಿಸುವುದಿಲ್ಲ.
+ನಾವು ಎಲ್ಲಾ [ಪಠ್ಯ ಸಾಮಗ್ರಿಗಳನ್ನು](https://missing.csail.mit.edu/) ಮತ್ತು
+[ಉಪನ್ಯಾಸಗಳ ದಾಖಲೆಗಳನ್ನು](https://www.youtube.com/@MissingSemester)
+ಉಚಿತವಾಗಿ ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡಿದ್ದೇವೆ. ನೀವು ನಮ್ಮ ಕೆಲಸವನ್ನು ಬೆಂಬಲಿಸಲು ಬಯಸಿದರೆ,
+ಅತ್ಯುತ್ತಮ ಮಾರ್ಗವೆಂದರೆ ಈ ತರಗತಿಯ ಬಗ್ಗೆ ಇತರರಿಗೆ ತಿಳಿಸುವುದು. ನೀವು ಕಂಪನಿ, ವಿಶ್ವವಿದ್ಯಾಲಯ,
+ಅಥವಾ ದೊಡ್ಡ ಗುಂಪುಗಳಿಗೆ ಈ ವಿಷಯವನ್ನು ಕಲಿಸುವ ಬೇರೆ ಸಂಸ್ಥೆಯಾಗಿದ್ದರೆ, ದಯವಿಟ್ಟು ನಿಮ್ಮ ಅನುಭವ ವರದಿ/ಪ್ರಶಂಸಾಪತ್ರಗಳನ್ನು
+ಇಮೇಲ್ ಮೂಲಕ ಕಳುಹಿಸಿ - ನಮಗೆ ಅದರ ಬಗ್ಗೆ ಕೇಳಲು ಸಂತೋಷವಾಗುತ್ತದೆ :)
 
-# Motivation
+# ಉದ್ದೇಶ
 
-As computer scientists, we know that computers are great at aiding in
-repetitive tasks. However, far too often, we forget that this applies
-just as much to our _use_ of the computer as it does to the computations
-we want our programs to perform. We have a vast range of tools available
-at our fingertips that enable us to be more productive and solve more
-complex problems when working on any computer-related problem. Yet many
-of us utilize only a small fraction of those tools; we only know enough
-magical incantations by rote to get by, and blindly copy-paste commands
-from the internet when we get stuck.
+ಕಂಪ್ಯೂಟರ್ ವಿಜ್ಞಾನಿಗಳಾದ ನಾವು, ಪುನರಾವರ್ತಿತ ಕೆಲಸಗಳಲ್ಲಿ ಕಂಪ್ಯೂಟರ್‌ಗಳು ಬಹಳ ಸಹಾಯಕವೆಂದು ತಿಳಿದಿದ್ದೇವೆ.
+ಆದರೆ, ತುಂಬಾ ಬಾರಿ ನಾವು ಮರೆತುಬಿಡುವುದು ಏನೆಂದರೆ - ಇದು ನಮ್ಮ ಪ್ರೋಗ್ರಾಂಗಳು ಮಾಡುವ ಗಣನೆಗಳಿಗೆಷ್ಟೇ ಅಲ್ಲ,
+ನಮ್ಮ _ಕಂಪ್ಯೂಟರ್ ಬಳಕೆ_ಗೂ ಸಮಾನವಾಗಿ ಅನ್ವಯಿಸುತ್ತದೆ. ಕಂಪ್ಯೂಟರ್ ಸಂಬಂಧಿತ ಯಾವುದೇ ಸಮಸ್ಯೆಯಲ್ಲಿ
+ಹೆಚ್ಚು ಉತ್ಪಾದಕವಾಗಲು ಹಾಗೂ ಇನ್ನಷ್ಟು ಜಟಿಲ ಸಮಸ್ಯೆಗಳನ್ನು ಪರಿಹರಿಸಲು ಸಹಾಯ ಮಾಡುವ ಬಹಳಷ್ಟು ಸಾಧನಗಳು
+ನಮ್ಮ ಕೈಬೆರಳ ತುದಿಯಲ್ಲೇ ಇವೆ. ಆದರೂ ನಾವು ಹಲವರು ಅವುಗಳಲ್ಲಿ ಅಲ್ಪ ಭಾಗವನ್ನೇ ಬಳಸುತ್ತೇವೆ;
+ಬಾಳಿಗೆ ಸಾಕಾಗುವಷ್ಟು ಕೆಲವು ಮಾಂತ್ರಿಕ ಆಜ್ಞೆಗಳನ್ನು ಕಂಠಪಾಠ ಮಾಡಿಕೊಂಡು, ಸಿಕ್ಕಿಬಿದ್ದಾಗ
+ಇಂಟರ್ನೆಟ್‌ನಿಂದ ಆಜ್ಞೆಗಳನ್ನು ಅಂಧವಾಗಿ copy-paste ಮಾಡುತ್ತೇವೆ.
 
-This class is an attempt to [address this](/about/).
+ಈ ತರಗತಿ ಅದನ್ನು [ಸರಿಪಡಿಸುವ](/about/) ಪ್ರಯತ್ನವಾಗಿದೆ.
 
-We want to teach you how to make the most of the tools you know, show
-you new tools to add to your toolbox, and hopefully instill in you some
-excitement for exploring (and perhaps building) more tools on your own.
-This is what we believe to be the missing semester from most Computer
-Science curricula.
+ನೀವು ಈಗಾಗಲೇ ತಿಳಿದಿರುವ ಸಾಧನಗಳನ್ನು ಉತ್ತಮವಾಗಿ ಬಳಸುವುದನ್ನು ಕಲಿಸುವುದು, ನಿಮ್ಮ ಉಪಕರಣ ಪೆಟ್ಟಿಗೆಯಲ್ಲಿ ಸೇರಿಸಬಹುದಾದ
+ಹೊಸ ಸಾಧನಗಳನ್ನು ತೋರಿಸುವುದು, ಮತ್ತು ಸ್ವತಃ ಇನ್ನಷ್ಟು ಸಾಧನಗಳನ್ನು ಅನ್ವೇಷಿಸುವ (ಬಹುಶಃ ನಿರ್ಮಿಸುವ) ಆಸಕ್ತಿಯನ್ನು
+ಹುಟ್ಟಿಸುವುದು ನಮ್ಮ ಉದ್ದೇಶ. ಇದು ಕಂಪ್ಯೂಟರ್ ಸೈನ್ಸ್ ಪಠ್ಯಕ್ರಮಗಳಲ್ಲಿ ಇಲ್ಲದಿರುವ ಸೆಮಿಸ್ಟರ್ ಎಂದು ನಾವು ನಂಬುತ್ತೇವೆ.
 
-# Class structure
+# ತರಗತಿಯ ರಚನೆ
 
-The not-for-credit class consists of nine 1-hour lectures, each one
-centering on a [particular topic](/2026/). The lectures are largely
-independent, though as the semester goes on we will presume that you are
-familiar with the content from the earlier lectures. We have lecture
-notes online, but there may be content covered in class (e.g. in the
-form of demos) that may not be in the notes. As for past years, we will
-be recording lectures and posting the recordings
-[online](https://www.youtube.com/@MissingSemester).
+ಈ non-credit ತರಗತಿಯಲ್ಲಿ ಒಟ್ಟು ಒಂಬತ್ತು 1-ಗಂಟೆಯ ಉಪನ್ಯಾಸಗಳಿವೆ, ಮತ್ತು ಪ್ರತಿಯೊಂದು
+[ವಿಶಿಷ್ಟ ವಿಷಯ](/2026/)ವನ್ನು ಕೇಂದ್ರೀಕರಿಸಿದೆ. ಉಪನ್ಯಾಸಗಳು ಬಹುತೇಕ ಸ್ವತಂತ್ರವಾಗಿದ್ದರೂ,
+ಸೆಮಿಸ್ಟರ್ ಮುಂದುವರಿದಂತೆ ಹಿಂದಿನ ಉಪನ್ಯಾಸಗಳ ವಿಷಯವನ್ನು ನೀವು ತಿಳಿದಿರುವಿರಿ ಎಂಬುದನ್ನು ನಾವು ಊಹಿಸುತ್ತೇವೆ.
+ಉಪನ್ಯಾಸ ಟಿಪ್ಪಣಿಗಳು ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಇವೆ, ಆದರೆ ತರಗತಿಯಲ್ಲಿ ಒಳಗೊಂಡಿರುವ ಕೆಲವು ವಿಷಯಗಳು
+(ಉದಾ. ಡೆಮೊಗಳು) ಟಿಪ್ಪಣಿಗಳಲ್ಲಿಲ್ಲದಿರಬಹುದು. ಹಿಂದಿನ ವರ್ಷಗಳಂತೆ, ನಾವು ಉಪನ್ಯಾಸಗಳನ್ನು ದಾಖಲಿಸಿ
+[ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ](https://www.youtube.com/@MissingSemester) ಪ್ರಕಟಿಸುತ್ತೇವೆ.
 
-We are trying to cover a lot of ground over the course of just a few
-1-hour lectures, so the lectures are fairly dense. To allow you some
-time to get familiar with the content at your own pace, each lecture
-includes a set of exercises that guide you through the lecture's key
-points. We will not be running dedicated office hours, but we encourage
-you to ask questions on the [OSSU Discord](https://ossu.dev/#community),
-in `#missing-semester-forum`, or email us at
-[missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+ಕೆಲವೇ 1-ಗಂಟೆಯ ಉಪನ್ಯಾಸಗಳಲ್ಲಿ ಬಹಳ ವಿಷಯವನ್ನು ಒಳಗೊಳ್ಳಲು ಪ್ರಯತ್ನಿಸುತ್ತಿರುವುದರಿಂದ, ಉಪನ್ಯಾಸಗಳು ದಟ್ಟವಾಗಿರುತ್ತವೆ.
+ನೀವು ನಿಮ್ಮ ವೇಗದಲ್ಲಿ ವಿಷಯವನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಸಮಯ ಸಿಗುವಂತೆ, ಪ್ರತಿ ಉಪನ್ಯಾಸದಲ್ಲೂ ಅದರ ಪ್ರಮುಖ ಅಂಶಗಳನ್ನು
+ಮಾರ್ಗದರ್ಶಿಸುವ ವ್ಯಾಯಾಮಗಳ ಒಂದು ಸೆಟ್ ಇರುತ್ತದೆ. ನಾವು ವಿಶೇಷ office hours ನಡೆಸುವುದಿಲ್ಲ,
+ಆದರೆ [OSSU Discord](https://ossu.dev/#community)-ನಲ್ಲಿ,
+`#missing-semester-forum` ನಲ್ಲಿ ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳಲು, ಅಥವಾ
+[missing-semester@mit.edu](mailto:missing-semester@mit.edu) ಗೆ ಇಮೇಲ್ ಮಾಡಲು ಪ್ರೋತ್ಸಾಹಿಸುತ್ತೇವೆ.
 
-Due to the limited time we have, we won't be able to cover all the tools
-in the same level of detail a full-scale class might. Where possible, we
-will try to point you towards resources for digging further into a tool
-or topic, but if something particularly strikes your fancy, don't
-hesitate to reach out to us and ask for pointers!
+ನಮ್ಮ ಸಮಯ ಸೀಮಿತವಾಗಿರುವುದರಿಂದ, ಪೂರ್ಣ ಪ್ರಮಾಣದ ಕೋರ್ಸ್ ಒದಗಿಸುವಷ್ಟು ವಿವರದಲ್ಲಿ ಎಲ್ಲಾ ಸಾಧನಗಳನ್ನು ಚರ್ಚಿಸಲು
+ನಮಗೆ ಸಾಧ್ಯವಾಗುವುದಿಲ್ಲ. ಸಾಧ್ಯವಾದಲ್ಲಿ, ಯಾವುದಾದರೂ ಸಾಧನ ಅಥವಾ ವಿಷಯವನ್ನು ಇನ್ನಷ್ಟು ಆಳವಾಗಿ ಕಲಿಯಲು
+ಬಳಕೆಯಾಗುವ ಸಂಪನ್ಮೂಲಗಳತ್ತ ನಾವು ನಿಮ್ಮನ್ನು ಮುನ್ನಡೆಸುತ್ತೇವೆ. ಆದರೆ ಯಾವದಾದರೂ ವಿಷಯ ನಿಮ್ಮ ಆಸಕ್ತಿಯನ್ನು
+ವಿಶೇಷವಾಗಿ ಸೆಳೆದರೆ, ದಯವಿಟ್ಟು ನಮ್ಮನ್ನು ಸಂಪರ್ಕಿಸಿ ಸಲಹೆ ಕೇಳುವುದರಲ್ಲಿ ಹಿಂಜರಿಯಬೇಡಿ!
 
-Finally, if you have feedback about the class, please send it to us by
-email at [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+ಕೊನೆಗೆ, ತರಗತಿಯ ಬಗ್ಗೆ ನಿಮ್ಮ ಪ್ರತಿಕ್ರಿಯೆಯನ್ನು [missing-semester@mit.edu](mailto:missing-semester@mit.edu)
+ಗೆ ಇಮೇಲ್ ಮೂಲಕ ಕಳುಹಿಸಿ.
 
-# Topic 1: The Shell
+# ವಿಷಯ 1: ಶೆಲ್
 
 {% comment %}
 lecturer: Jon
 {% endcomment %}
 
-## What is the shell?
+## ಶೆಲ್ ಎಂದರೆ ಏನು?
 
-Computers these days have a variety of interfaces for giving them
-commands; fanciful graphical user interfaces, voice interfaces, AR/VR,
-and more recently: LLMs. These are great for 80% of use-cases, but they
-are often fundamentally restricted in what they allow you to do — you
-cannot press a button that isn't there or give a voice command that
-hasn't been programmed. To take full advantage of the tools your
-computer provides, we have to go old-school and drop down to a textual
-interface: The Shell.
+ಇಂದಿನ ಕಂಪ್ಯೂಟರ್‌ಗಳಲ್ಲಿ ಆಜ್ಞೆಗಳನ್ನು ನೀಡಲು ಹಲವು ರೀತಿಯ ಇಂಟರ್ಫೇಸ್‌ಗಳು ಇವೆ - ಆಕರ್ಷಕ GUI,
+ಧ್ವನಿ ಇಂಟರ್ಫೇಸ್‌ಗಳು, AR/VR, ಮತ್ತು ಇತ್ತೀಚೆಗೆ: LLMs. ಇವು 80% ಬಳಕೆ ಸಂದರ್ಭಗಳಿಗೆ ಅದ್ಭುತವಾಗಿವೆ,
+ಆದರೆ ಬಹಳ ಬಾರಿ ನೀವು ಏನು ಮಾಡಬಹುದು ಎಂಬುದರಲ್ಲಿ ಮೂಲಭೂತ ಮಿತಿಗಳಿರುತ್ತವೆ - ಇರುವುದಿಲ್ಲದ ಬಟನ್ ಒತ್ತಲು
+ಅಥವಾ ಪ್ರೋಗ್ರಾಂ ಮಾಡದ voice command ನೀಡಲು ಸಾಧ್ಯವಿಲ್ಲ. ನಿಮ್ಮ ಕಂಪ್ಯೂಟರ್ ಒದಗಿಸುವ ಸಾಧನಗಳನ್ನು ಸಂಪೂರ್ಣವಾಗಿ
+ಬಳಸಲು, ನಮಗೆ ಹಳೆಯ ಶೈಲಿಗೆ ಹಿಂತಿರುಗಿ ಪಠ್ಯ ಆಧಾರಿತ ಇಂಟರ್ಫೇಸ್‌ಗೆ ಇಳಿಯಬೇಕು: The Shell.
 
-Nearly all platforms you can get your hands on have a shell in one form
-or another, and many of them have several shells for you to choose from.
-While they may vary in the details, at their core they are all roughly
-the same: they allow you to run programs, give them input, and inspect
-their output in a semi-structured way.
+ನಿಮ್ಮ ಕೈಗೆ ಸಿಗುವ ಬಹುತೇಕ ಎಲ್ಲಾ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ಗಳಲ್ಲಿ ಒಂದು ರೂಪದಲ್ಲಿ ಶೆಲ್ ಇರುತ್ತದೆ, ಮತ್ತು ಅವುಗಳಲ್ಲಿ ಹಲವೆಡೆ
+ನಿಮಗೆ ಆಯ್ಕೆಗೆ ಅನೇಕ ಶೆಲ್‌ಗಳಿರುತ್ತವೆ. ವಿವರಗಳಲ್ಲಿ ವ್ಯತ್ಯಾಸ ಇದ್ದರೂ, ಅವುಗಳ ಮೂಲಭೂತ ಸ್ವರೂಪ ಒಂದೇ:
+ಅವು ನಿಮಗೆ ಪ್ರೋಗ್ರಾಂಗಳನ್ನು ಓಡಿಸಲು, ಅವುಗಳಿಗೆ ಇನ್‌ಪುಟ್ ನೀಡಲು, ಮತ್ತು ಅವುಗಳ ಔಟ್‌ಪುಟ್ ಪರಿಶೀಲಿಸಲು
+ಅರ್ಧ-ಸಂರಚಿತ ವಿಧಾನ ಒದಗಿಸುತ್ತವೆ.
 
-To open a shell _prompt_ (where you can type commands), you first need a
-_terminal_, which is the visual interface to a shell. Your device
-probably shipped with one installed, or you can install one fairly
-easily:
+ಶೆಲ್ _prompt_ ತೆರೆಯಲು (ಅಲ್ಲಿ ನೀವು ಆಜ್ಞೆಗಳನ್ನು ಟೈಪ್ ಮಾಡಬಹುದು), ಮೊದಲು _terminal_ ಬೇಕು;
+ಇದು ಶೆಲ್‌ಗೆ ದೃಶ್ಯ ಇಂಟರ್ಫೇಸ್. ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಸಾಮಾನ್ಯವಾಗಿ ಇದು ಮೊದಲೇ ಇರುತ್ತದೆ,
+ಅಥವಾ ಸುಲಭವಾಗಿ ಸ್ಥಾಪಿಸಬಹುದು:
 
 - **Linux:**
-  Press `Ctrl + Alt + T` (works on most distributions). Or search for
-  "Terminal" in your applications menu.
+  `Ctrl + Alt + T` ಒತ್ತಿರಿ (ಹೆಚ್ಚಿನ distributionsಗಳಲ್ಲಿ ಕೆಲಸ ಮಾಡುತ್ತದೆ). ಅಥವಾ ನಿಮ್ಮ applications menuದಲ್ಲಿ
+  "Terminal" ಹುಡುಕಿ.
 - **Windows:**
-  Press `Win + R`, type `cmd` or `powershell`, and press Enter.
-  Alternatively, search "Terminal" or "Command Prompt" in the Start menu.
+  `Win + R` ಒತ್ತಿ, `cmd` ಅಥವಾ `powershell` ಟೈಪ್ ಮಾಡಿ, Enter ಒತ್ತಿರಿ.
+  ಪರ್ಯಾಯವಾಗಿ Start menuದಲ್ಲಿ "Terminal" ಅಥವಾ "Command Prompt" ಹುಡುಕಿ.
 - **macOS:**
-  Press `Cmd + Space` to open Spotlight, type "Terminal", and press Enter.
-  Or find it in Applications → Utilities → Terminal.
+  Spotlight ತೆರೆಯಲು `Cmd + Space` ಒತ್ತಿ, "Terminal" ಟೈಪ್ ಮಾಡಿ, Enter ಒತ್ತಿರಿ.
+  ಅಥವಾ Applications → Utilities → Terminal ನಲ್ಲಿ ನೋಡಿ.
 
-On Linux and macOS, this will usually open the Bourne Again SHell, or
-"bash" for short. This is one of the most widely used shells, and its
-syntax is similar to what you will see in many other shells. On Windows,
-you'll be greeted by the "batch" or "powershell" shells, depending on
-which command you ran. These are Windows-specific, and not what we'll be
-focusing on in this class, although it has analogues for most of what
-we'll be teaching. You'll instead want the [Windows Subsystem for
-Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-machine.
+Linux ಮತ್ತು macOS ನಲ್ಲಿ, ಇದು ಸಾಮಾನ್ಯವಾಗಿ Bourne Again SHell ಅಥವಾ ಸಂಕ್ಷಿಪ್ತವಾಗಿ "bash" ಅನ್ನು ತೆರೆಯುತ್ತದೆ.
+ಇದು ಹೆಚ್ಚು ವ್ಯಾಪಕವಾಗಿ ಬಳಸುವ ಶೆಲ್‌ಗಳಲ್ಲಿ ಒಂದು, ಮತ್ತು ಇದರ syntax ಇತರೆ ಅನೇಕ ಶೆಲ್‌ಗಳಲ್ಲಿ ನೀವು ನೋಡುವುದಕ್ಕೆ ಹೋಲುತ್ತದೆ.
+Windows ನಲ್ಲಿ, ನೀವು ಓಡಿಸಿದ ಆಜ್ಞೆಯ ಆಧಾರದ ಮೇಲೆ "batch" ಅಥವಾ "powershell" ಶೆಲ್‌ಗಳು ತೆರೆದುಕೊಳ್ಳುತ್ತವೆ.
+ಇವು Windows-ನಿಗದಿತವಾಗಿವೆ; ಈ ತರಗತಿಯಲ್ಲಿ ನಾವು ಅವುಗಳ ಮೇಲೆ ಕೇಂದ್ರೀಕರಿಸುವುದಿಲ್ಲ, ಆದರೂ ನಾವು ಕಲಿಸುವ ವಿಷಯಗಳ ಬಹುಪಾಲಿಗೆ
+ಇವುಗಳಲ್ಲಿ ಸಮಾನಾಂಶಗಳಿವೆ. ಆದ್ದರಿಂದ ನೀವು [Windows Subsystem for
+Linux](https://docs.microsoft.com/en-us/windows/wsl/) ಅಥವಾ Linux virtual machine ಬಳಸುವುದು ಉತ್ತಮ.
 
-Other shells exist, often with many ergonomic improvements over bash
-(fish and zsh are among the most common). While these are very popular
-(all the instructors use one), they're nowhere near as ubiquitous as
-bash, and lean on many of the same concepts, so we won't be focusing on
-those in this lecture.
+bashಕ್ಕಿಂತ ಬಳಕೆ ಸೌಕರ್ಯದಲ್ಲಿ ಸುಧಾರಣೆಗಳನ್ನು ಹೊಂದಿರುವ ಇತರೆ ಶೆಲ್‌ಗಳೂ ಇವೆ (fish ಮತ್ತು zsh ಸಾಮಾನ್ಯ).
+ಇವು ಬಹಳ ಜನಪ್ರಿಯ (ಎಲ್ಲಾ ಶಿಕ್ಷಕರೂ ಒಂದನ್ನಾದರೂ ಬಳಸುತ್ತಾರೆ), ಆದರೆ bashಷ್ಟು ಎಲ್ಲೆಡೆ ಸಾಮಾನ್ಯವಲ್ಲ,
+ಮತ್ತು ಅನೇಕ ಮೂಲಭೂತ ಆಲೋಚನೆಗಳು ಒಂದೇ ಇರುವುದರಿಂದ ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ಅವುಗಳ ಮೇಲೆ ನಾವು ಕೇಂದ್ರೀಕರಿಸುವುದಿಲ್ಲ.
 
-## Why should you care about it?
+## ಇದನ್ನು ಏಕೆ ಕಾಳಜಿ ವಹಿಸಬೇಕು?
 
-The shell is not just (usually) much faster than "clicking around", it
-also comes with expressive power you can't easily find in any one
-graphical program. As we'll see, the shell gives you the ability to
-_combine_ programs in creative ways to automate nearly any task.
+ಶೆಲ್ "clicking around" ಗಿಂತ (ಸಾಮಾನ್ಯವಾಗಿ) ಬಹಳ ವೇಗವಾಗಿರುವುದಷ್ಟೇ ಅಲ್ಲ,
+ಒಂದು ಗ್ರಾಫಿಕಲ್ ಪ್ರೋಗ್ರಾಂನಲ್ಲಿ ಸುಲಭವಾಗಿ ಸಿಗದ ಅಭಿವ್ಯಕ್ತಿ ಶಕ್ತಿಯನ್ನೂ ಒದಗಿಸುತ್ತದೆ.
+ನಾವು ನೋಡುವಂತೆ, ಶೆಲ್ ನಿಮಗೆ ಪ್ರೋಗ್ರಾಂಗಳನ್ನು ಸೃಜನಾತ್ಮಕವಾಗಿ _ಒಗ್ಗೂಡಿಸಿ_ ಬಹುತೇಕ ಯಾವುದೇ ಕಾರ್ಯವನ್ನು automate ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಸುತ್ತದೆ.
 
-Knowing your way around a shell is also very useful to navigate the
-world of open-source software (which often come with install
-instructions that require the shell), building continuous integration
-for your software projects (as described in the [Code Quality
-lecture](/2026/code-quality/)), and debugging errors when other programs
-fail.
+ಶೆಲ್‌ನಲ್ಲಿ ದಿಟ್ಟತನ ಹೊಂದಿರುವುದು open-source software ಜಗತ್ತಿನಲ್ಲಿ ಸಾಗಲು ಸಹ ಬಹಳ ಉಪಯುಕ್ತ
+(ಸ್ಥಾಪನಾ ಸೂಚನೆಗಳಲ್ಲಿ ಶೆಲ್ ಅಗತ್ಯವಾಗುವುದು ಸಾಮಾನ್ಯ), ನಿಮ್ಮ software projectsಗಳಿಗೆ continuous integration ನಿರ್ಮಿಸಲು
+([Code Quality ಉಪನ್ಯಾಸ](/2026/code-quality/)ದಲ್ಲಿ ತಿಳಿಸಿದಂತೆ), ಮತ್ತು ಇತರೆ ಪ್ರೋಗ್ರಾಂಗಳು ವಿಫಲವಾದಾಗ ದೋಷಗಳನ್ನು debug ಮಾಡಲು.
 
-## Navigating in the shell
+## ಶೆಲ್‌ನಲ್ಲಿ ಸಂಚರಿಸುವುದು
 
-When you launch your terminal, you will see a _prompt_ that often looks
-a little like this:
+ನೀವು terminal ಪ್ರಾರಂಭಿಸಿದಾಗ, ಸಾಮಾನ್ಯವಾಗಿ ಈ ರೀತಿಯಾಗಿ ಕಾಣುವ ಒಂದು _prompt_ ಕಾಣುತ್ತದೆ:
 
 ```console
 missing:~$
 ```
 
-This is the main textual interface to the shell. It tells you that you
-are on the machine `missing` and that your "current working directory",
-or where you currently are, is `~` (short for "home"). The `$` tells you
-that you are not the root user (more on that later). At this prompt you
-can type a _command_, which will then be interpreted by the shell. The
-most basic command is to execute a program:
+ಇದು ಶೆಲ್‌ಗೆ ಮುಖ್ಯ ಪಠ್ಯ ಇಂಟರ್ಫೇಸ್. ಇದು ನೀವು `missing` ಯಂತ್ರದಲ್ಲಿದ್ದೀರಿ ಮತ್ತು ನಿಮ್ಮ
+"current working directory" - ಅಂದರೆ ಈಗಿರುವ ಸ್ಥಳ - `~` ("home"ಗೆ ಸಂಕ್ಷಿಪ್ತ) ಎಂದು ಹೇಳುತ್ತದೆ.
+`$` ಎಂದರೆ ನೀವು root user ಅಲ್ಲ (ಅದಕ್ಕೆ ನಂತರ ಬರುವೆವು). ಈ promptನಲ್ಲಿ ನೀವು _command_ ಟೈಪ್ ಮಾಡಬಹುದು;
+ಅದನ್ನು ಶೆಲ್ ಅರ್ಥೈಸುತ್ತದೆ. ಅತಿ ಮೂಲಭೂತ ಆಜ್ಞೆ ಎಂದರೆ program ಅನ್ನು execute ಮಾಡುವುದು:
 
 ```console
 missing:~$ date
@@ -168,43 +140,35 @@ Fri 10 Jan 2020 11:49:31 AM EST
 missing:~$
 ```
 
-Here, we executed the `date` program, which (perhaps unsurprisingly)
-prints the current date and time. The shell then asks us for another
-command to execute. We can also execute a command with _arguments_:
+ಇಲ್ಲಿ ನಾವು `date` program ಓಡಿಸಿದ್ದೇವೆ; ಅದು (ಅಪೇಕ್ಷಿತವಾಗಿಯೇ) ಪ್ರಸ್ತುತ ದಿನಾಂಕ ಮತ್ತು ಸಮಯ ಮುದ್ರಿಸುತ್ತದೆ.
+ನಂತರ ಶೆಲ್ ಮುಂದಿನ ಆಜ್ಞೆಯನ್ನು ಕೇಳುತ್ತದೆ. ನಾವು _arguments_ ಜೊತೆಗೆ ಆಜ್ಞೆಯನ್ನು ಓಡಿಸಬಹುದು:
 
 ```console
 missing:~$ echo hello
 hello
 ```
 
-In this case, we told the shell to execute the program `echo` with the
-argument `hello`. The `echo` program simply prints out its arguments.
-The shell parses the command by splitting it by whitespace, and then
-runs the program indicated by the first word, supplying each subsequent
-word as an argument that the program can access. If you want to provide
-an argument that contains spaces or other special characters (e.g., a
-directory named "My Photos"), you can either quote the argument with `'`
-or `"` (`"My Photos"`), or escape just the relevant characters with `\`
-(`My\ Photos`).
+ಈ ಸಂದರ್ಭದಲ್ಲಿ, `echo` program ಅನ್ನು `hello` argument ಜೊತೆ ಓಡಿಸಲು ಶೆಲ್‌ಗೆ ತಿಳಿಸಿದ್ದೇವೆ.
+`echo` program ತನ್ನ arguments ಅನ್ನು ಮುದ್ರಿಸುತ್ತದೆ. ಶೆಲ್ ಆಜ್ಞೆಯನ್ನು whitespace ಆಧರಿಸಿ ವಿಭಜಿಸಿ,
+ಮೊದಲ ಪದ ಸೂಚಿಸುವ program ಅನ್ನು ಓಡಿಸಿ, ನಂತರದ ಪ್ರತಿಯೊಂದು ಪದವನ್ನು program ಪ್ರವೇಶಿಸಬಹುದಾದ argument ಆಗಿ ನೀಡುತ್ತದೆ.
+ನೀವು spaces ಅಥವಾ ಇತರೆ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿರುವ argument ನೀಡಬೇಕಾದರೆ (ಉದಾ., "My Photos" ಎಂಬ directory),
+argument ಅನ್ನು `'` ಅಥವಾ `"` ("My Photos") ಮೂಲಕ quote ಮಾಡಬಹುದು, ಅಥವಾ ಅಗತ್ಯ ಅಕ್ಷರಗಳನ್ನು ಮಾತ್ರ `\`
+(`My\ Photos`) ಮೂಲಕ escape ಮಾಡಬಹುದು.
 
-Perhaps the most important command when you're starting out is `man`,
-short for "manual". The `man` program, among other things, lets you look
-up more information about any command on your system. For example, if
-you run `man date`, it'll explain what `date` is, and all of the various
-arguments you can pass it to alter its behavior. You can also usually
-get a short version of the help by passing `--help` as an argument to
-most commands.
+ಆರಂಭಿಕ ಹಂತದಲ್ಲಿ ಅತ್ಯಂತ ಪ್ರಮುಖ ಆಜ್ಞೆಗಳಲ್ಲಿ ಒಂದು `man` - "manual"ಗೆ ಸಂಕ್ಷಿಪ್ತ.
+`man` program, ಇತರೆ ಅನೇಕ ವಿಷಯಗಳ ಜೊತೆ, ನಿಮ್ಮ systemನಲ್ಲಿರುವ ಯಾವುದೇ command ಬಗ್ಗೆ ಹೆಚ್ಚಿನ ಮಾಹಿತಿ ನೀಡುತ್ತದೆ.
+ಉದಾಹರಣೆಗೆ, `man date` ಓಡಿಸಿದರೆ, `date` ಏನು ಮತ್ತು ಅದರ ವರ್ತನೆ ಬದಲಿಸಲು ಯಾವ ಯಾವ arguments ಬಳಸಬಹುದು ಎಂಬುದನ್ನು ವಿವರಿಸುತ್ತದೆ.
+ಹೆಚ್ಚಿನ commandsಗಳಿಗೆ `--help` argument ಕೊಟ್ಟರೂ ಸಂಕ್ಷಿಪ್ತ ಸಹಾಯ ಸಿಗುತ್ತದೆ.
 
-> Consider installing and using [`tldr`](https://tldr.sh/) in addition
-> to `man`, as it shows you common usage examples right there in the
-> terminal. LLMs are also usually very good at explaining how commands
-> work and how you can call them to achieve what you want to accomplish.
+> `man` ಜೊತೆಗೆ [`tldr`](https://tldr.sh/) ಅನ್ನು ಸ್ಥಾಪಿಸಿ ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ,
+> ಏಕೆಂದರೆ ಅದು terminalನಲ್ಲೇ ಸಾಮಾನ್ಯ ಬಳಕೆ ಉದಾಹರಣೆಗಳನ್ನು ತೋರಿಸುತ್ತದೆ.
+> commands ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ ಮತ್ತು ನಿಮ್ಮ ಗುರಿ ಸಾಧಿಸಲು ಅವನ್ನು ಹೇಗೆ ಬಳಸುವುದು ಎಂಬುದನ್ನು ವಿವರಿಸುವಲ್ಲಿ
+> LLMs ಸಹ ಸಾಮಾನ್ಯವಾಗಿ ತುಂಬಾ ಉತ್ತಮವಾಗಿರುತ್ತವೆ.
 
-After `man`, the most important command to learn is `cd`, or "change
-directory". This command is actually built into the shell, and isn't a
-separate program (i.e., `which cd` will say "no cd found"). You pass it
-a path, and that path becomes your current working directory. You'll
-also see the working directory reflected in the shell prompt:
+`man` ನಂತರ ಕಲಿಯಬೇಕಾದ ಅತ್ಯಂತ ಪ್ರಮುಖ command ಎಂದರೆ `cd` - "change directory".
+ಈ command ಶೆಲ್‌ನಲ್ಲೇ built-in ಆಗಿದೆ; ಬೇರೆ program ಅಲ್ಲ (ಅಂದರೆ `which cd` ನೀಡಿದರೆ "no cd found" ಎಂದು ಹೇಳುತ್ತದೆ).
+ಇದಕ್ಕೆ ನೀವು path ನೀಡಿದರೆ, ಆ path ನಿಮ್ಮ current working directory ಆಗುತ್ತದೆ.
+working directory ಬದಲಾವಣೆ promptಲ್ಲೂ ಕಾಣಿಸುತ್ತದೆ:
 
 ```console
 missing:~$ cd /bin
@@ -213,23 +177,18 @@ missing:/$ cd ~
 missing:~$
 ```
 
-> Note that the shell comes with auto-completion, so you can often
-> complete paths faster by pressing `<TAB>`!
+> ಶೆಲ್‌ನಲ್ಲಿ auto-completion ಇದೆ - `<TAB>` ಒತ್ತುವುದರಿಂದ pathಗಳನ್ನು ಬೇಗ ಪೂರ್ಣಗೊಳಿಸಬಹುದು!
 
-A lot of commands operate on the current working directory if nothing
-else is specified. If you're ever unsure where you are, you can run
-`pwd` or print the `$PWD` environment variable (with `echo $PWD`), both
-of which produce the current working directory.
+ಬಹಳ commandsನಲ್ಲಿ ಬೇರೆದೇನೂ ಸೂಚಿಸದಿದ್ದರೆ current working directory ಮೇಲೇ ಕಾರ್ಯ ನಡೆಯುತ್ತದೆ.
+ನೀವು ಎಲ್ಲಿದ್ದೀರಿ ಎಂಬುದು ಗೊಂದಲವಾಗಿದೆಯಾದರೆ, `pwd` ಓಡಿಸಿ ಅಥವಾ `$PWD` environment variable ಅನ್ನು
+(`echo $PWD`) ಮುದ್ರಿಸಿ - ಎರಡೂ current working directory ನೀಡುತ್ತವೆ.
 
-The current working directory also comes in handy in that it allows us to
-use _relative_ paths. All the paths we've seen so far have been
-_absolute_ --- they start with `/` and give the full set of directories
-needed to navigate to some location from the root of the file system
-(`/`). In practice, you'll more commonly work with relative paths; so
-called because they are relative to the current working directory. In a
-relative path (anything _not_ starting with `/`), the first path
-component is looked up in the current working directory, and subsequent
-components traverse as usual. For example:
+current working directory ಮತ್ತೊಂದು ರೀತಿಯಲ್ಲೂ ಉಪಯುಕ್ತ - ಇದರಿಂದ _relative_ paths ಬಳಸಬಹುದು.
+ಇಲ್ಲಿವರೆಗೂ ಕಂಡ pathsಗಳು _absolute_ - ಅವು `/` ಮೂಲಕ ಪ್ರಾರಂಭವಾಗಿ file system root (`/`)ದಿಂದ
+ಒಂದು ಸ್ಥಳಕ್ಕೆ ತಲುಪಲು ಬೇಕಾದ ಸಂಪೂರ್ಣ directories ಸರಣಿಯನ್ನು ನೀಡುತ್ತವೆ. ಪ್ರಾಯೋಗಿಕವಾಗಿ,
+ನೀವು ಹೆಚ್ಚಾಗಿ relative paths ಬಳಸುತ್ತೀರಿ; ಹೆಸರೇ ಸೂಚಿಸುವಂತೆ ಅವು current working directoryಗೆ ಸಂಬಂಧಿತ.
+relative pathನಲ್ಲಿ (`/` ರಿಂದ ಪ್ರಾರಂಭವಾಗದ ಯಾವುದಾದರೂ), ಮೊದಲ path ಘಟಕವನ್ನು current working directoryಯಲ್ಲಿ ಹುಡುಕಲಾಗುತ್ತದೆ,
+ಮತ್ತಿನ ಘಟಕಗಳು ಸಾಮಾನ್ಯವಾಗಿ ಸಾಗುತ್ತವೆ. ಉದಾಹರಣೆ:
 
 ```console
 missing:~$ cd /
@@ -237,9 +196,9 @@ missing:/$ cd bin
 missing:/bin$
 ```
 
-There are also two "special" components that exist in every directory:
-`.` and `..`. `.` is "this directory", and `..` is "the parent
-directory". So:
+ಪ್ರತಿ directoryಯಲ್ಲೂ ಎರಡು "special" ಘಟಕಗಳಿವೆ: `.` ಮತ್ತು `..`.
+`.` ಎಂದರೆ "ಈ directory", ಮತ್ತು `..` ಎಂದರೆ "parent directory".
+ಹೀಗಾಗಿ:
 
 ```console
 missing:~$ cd /
@@ -247,21 +206,18 @@ missing:/$ cd bin/../bin/../bin/././../bin/..
 missing:/$
 ```
 
-You can usually use absolute and relative paths interchangeably for any
-command argument, just keep in mind what your current working directory
-is when using a relative one!
+ಯಾವುದೇ command argumentಗೆ absolute ಮತ್ತು relative paths ಎರಡನ್ನೂ ಸಾಮಾನ್ಯವಾಗಿ ಪರಸ್ಪರ ಬದಲಾಗಿ ಬಳಸಬಹುದು;
+relative path ಬಳಸುವಾಗ ನಿಮ್ಮ current working directory ಏನು ಎಂಬುದನ್ನು ಮಾತ್ರ ಗಮನದಲ್ಲಿಡಿ!
 
-> Consider installing and using
-> [`zoxide`](https://github.com/ajeetdsouza/zoxide) to speed up your
-> `cd`ing --- `z` will remember the paths you frequently visit and let
-> you access with less typing.
+> ನಿಮ್ಮ `cd` ಬಳಕೆಯನ್ನು ವೇಗಗೊಳಿಸಲು
+> [`zoxide`](https://github.com/ajeetdsouza/zoxide) ಅನ್ನು ಸ್ಥಾಪಿಸಿ ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ - `z`
+> ನೀವು ಹೆಚ್ಚಾಗಿ ಹೋಗುವ pathsಗಳನ್ನು ನೆನಪಿಡುತ್ತದೆ ಮತ್ತು ಕಡಿಮೆ typing ಮೂಲಕ ಅಲ್ಲಿ ಕೊಂಡೊಯ್ಯುತ್ತದೆ.
 
-## What is available in the shell?
+## ಶೆಲ್‌ನಲ್ಲಿ ಏನು ಲಭ್ಯವಿದೆ?
 
-But how does the shell know how to find programs like `date` or `echo`?
-If the shell is asked to execute a command, it consults an _environment
-variable_ called `$PATH` that lists which directories the shell should
-search for programs when it is given a command:
+ಆದರೆ ಶೆಲ್ `date` ಅಥವಾ `echo` ಮಾದರಿಯ ಪ್ರೋಗ್ರಾಂಗಳನ್ನು ಹೇಗೆ ಕಂಡುಹಿಡಿಯುತ್ತದೆ?
+ಶೆಲ್‌ಗೆ command execute ಮಾಡಲು ಹೇಳಿದಾಗ, ಅದು `$PATH` ಎನ್ನುವ _environment variable_ ನೋಡುತ್ತದೆ,
+ಅದರಲ್ಲೇ command ನೀಡಿದಾಗ programs ಹುಡುಕಬೇಕಾದ directories ಪಟ್ಟಿ ಇರುತ್ತದೆ:
 
 ```console
 missing:~$ echo $PATH
@@ -272,122 +228,103 @@ missing:~$ /bin/echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
-When we run the `echo` command, the shell sees that it should execute
-the program `echo`, and then searches through the `:`-separated list of
-directories in `$PATH` for a file by that name. When it finds it, it
-runs it (assuming the file is _executable_; more on that later). We can
-find out which file is executed for a given program name using the
-`which` program. We can also bypass `$PATH` entirely by giving the
-_path_ to the file we want to execute.
+ನಾವು `echo` command ಓಡಿಸಿದಾಗ, ಶೆಲ್ `echo` program ಓಡಿಸಬೇಕು ಎಂದು ಕಂಡು,
+`$PATH`ನಲ್ಲಿರುವ `:`-ವಿಭಜಿತ directory ಪಟ್ಟಿಯಲ್ಲಿ ಆ ಹೆಸರಿನ file ಹುಡುಕುತ್ತದೆ.
+ಕಂಡುಬಂದ ನಂತರ ಅದನ್ನು ಓಡಿಸುತ್ತದೆ (file _executable_ ಆಗಿದೆ ಎಂದು ಊಹಿಸಿ - ಅದಕ್ಕೆ ನಂತರ ಬರುತ್ತೇವೆ).
+ಯಾವ program ಹೆಸರು ಯಾವ file ಅನ್ನು execute ಮಾಡುತ್ತಿದೆ ಎಂದು ತಿಳಿಯಲು `which` ಬಳಸಬಹುದು.
+ನಾವು execute ಮಾಡಬೇಕಾದ fileಗೆ _path_ ನೇರವಾಗಿ ನೀಡಿ `$PATH` ಅನ್ನು ಸಂಪೂರ್ಣವಾಗಿ ಕಡೆಗಣಿಸಬಹುದು.
 
-This also gives a clue for how we can determine _all_ the programs we're
-able to execute in the shell: by listing the contents of all the
-directories on `$PATH`. We can do this by passing a given directory path
-to the `ls` program, which lists files:
+ಇದರಿಂದ ಶೆಲ್‌ನಲ್ಲಿ ನಾವು execute ಮಾಡಬಹುದಾದ _ಎಲ್ಲಾ_ programs ಕಂಡುಹಿಡಿಯುವ ಸುಳಿವು ಸಹ ಸಿಗುತ್ತದೆ:
+`$PATH`ನಲ್ಲಿರುವ ಎಲ್ಲಾ directories ಒಳಗಿನ ವಿಷಯವನ್ನು ಪಟ್ಟಿ ಮಾಡುವುದು. ಅದನ್ನು `ls` programಗೆ
+directory path ನೀಡಿ ಮಾಡಬಹುದು; `ls` files ಪಟ್ಟಿ ಮಾಡುತ್ತದೆ:
 
 ```console
 missing:~$ ls /bin
 ```
 
-> Consider installing and using [`eza`](https://eza.rocks/) for a more
-> human-friendly `ls`.
+> ಹೆಚ್ಚು ಮಾನವ ಸ್ನೇಹಿ `ls` ಅನುಭವಕ್ಕಾಗಿ [`eza`](https://eza.rocks/) ಅನ್ನು ಸ್ಥಾಪಿಸಿ ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
 
-This will, on most computers, print a _lot_ of programs, but we'll only
-focus on some of the most important ones here. First, some simple ones:
+ಇದು ಹೆಚ್ಚಿನ ಕಂಪ್ಯೂಟರ್‌ಗಳಲ್ಲಿ _ಬಹಳ_ programs ಮುದ್ರಿಸುತ್ತದೆ, ಆದರೆ ಇಲ್ಲಿ ಕೆಲವು ಪ್ರಮುಖಗಳನ್ನು ಮಾತ್ರ ನೋಡೋಣ.
+ಮೊದಲು ಕೆಲವು ಸರಳವಾದವುಗಳು:
 
-- `cat file`, which prints the contents of `file`.
-- `sort file`, which prints out the lines of `file` in sorted order.
-- `uniq file`, which eliminates consecutive duplicate lines from `file`.
-- `head file` and `tail file`, which respectively print the first and
-  last few lines of `file`.
+- `cat file` - `file`ನ ವಿಷಯವನ್ನು ಮುದ್ರಿಸುತ್ತದೆ.
+- `sort file` - `file`ನ ಸಾಲುಗಳನ್ನು sorted ಕ್ರಮದಲ್ಲಿ ಮುದ್ರಿಸುತ್ತದೆ.
+- `uniq file` - `file`ನಲ್ಲಿನ ಪಕ್ಕಪಕ್ಕದ ಪುನರಾವರ್ತಿತ ಸಾಲುಗಳನ್ನು ತೆಗೆದುಹಾಕುತ್ತದೆ.
+- `head file` ಮತ್ತು `tail file` - ಕ್ರಮವಾಗಿ `file`ನ ಮೊದಲ ಮತ್ತು ಕೊನೆಯ ಕೆಲವು ಸಾಲುಗಳನ್ನು ಮುದ್ರಿಸುತ್ತವೆ.
 
-> Consider installing and using [`bat`](https://github.com/sharkdp/bat)
-> over `cat` for syntax highlighting and scrolling.
+> syntax highlighting ಮತ್ತು scrollingಗಾಗಿ `cat` ಬದಲು [`bat`](https://github.com/sharkdp/bat)
+> ಅನ್ನು ಸ್ಥಾಪಿಸಿ ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
 
-There's also `grep pattern file`, which finds lines matching `pattern`
-in `file`. This one deserves slightly more attention as it's both _very_
-useful and sports a wider array of features than one may expect.
-`pattern` is actually a _regular expression_ which can express very
-complex patterns --- we'll [cover
-those](/2026/code-quality/#regular-expressions)
-in the code quality lecture. You can also specify a directory instead of a
-file (or leave it off for `.`) and pass `-r` to recursively search all
-the files in a directory.
+`grep pattern file` ಎಂಬ command ಸಹ ಇದೆ; ಇದು `file`ನಲ್ಲಿ `pattern` ಗೆ ಹೊಂದುವ ಸಾಲುಗಳನ್ನು ಕಂಡುಹಿಡಿಯುತ್ತದೆ.
+ಇದಕ್ಕೆ ಸ್ವಲ್ಪ ಹೆಚ್ಚುವರಿ ಗಮನ ಬೇಕು - ಇದು _ತುಂಬಾ_ ಉಪಯುಕ್ತವಾಗಿದ್ದು ನಿರೀಕ್ಷೆಗಿಂತ ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನೂ ಹೊಂದಿದೆ.
+`pattern` ವಾಸ್ತವವಾಗಿ _regular expression_; ಇದು ಬಹಳ ಜಟಿಲ ಮಾದರಿಗಳನ್ನು ವ್ಯಕ್ತಪಡಿಸಬಲ್ಲದು -
+ಅವುಗಳನ್ನು [Code Quality ಉಪನ್ಯಾಸದಲ್ಲಿ](/2026/code-quality/#regular-expressions) ನೋಡುತ್ತೇವೆ.
+ನೀವು file ಬದಲು directory ನೀಡಬಹುದು (ಅಥವಾ ನೀಡದೆ `.` ಬಳಸಬಹುದು) ಮತ್ತು `-r` ಕೊಟ್ಟರೆ
+directoryಯಲ್ಲಿನ ಎಲ್ಲಾ filesಗಳನ್ನು recursive ಆಗಿ ಹುಡುಕಬಹುದು.
 
-> Consider installing and using
-> [`ripgrep`](https://github.com/BurntSushi/ripgrep) over `grep` for a
-> faster and more human-friendly (but less portable) alternative.
-> `ripgrep` will also recursively search the current working directory
-> by default!
+> ಹೆಚ್ಚು ವೇಗದ ಮತ್ತು ಮಾನವ ಸ್ನೇಹಿ (ಆದರೆ ಕಡಿಮೆ portable) ಪರ್ಯಾಯಕ್ಕಾಗಿ
+> `grep` ಬದಲು [`ripgrep`](https://github.com/BurntSushi/ripgrep) ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
+> `ripgrep` ಡೀಫಾಲ್ಟ್ ಆಗಿಯೇ current working directoryಯನ್ನು recursive ಆಗಿ ಹುಡುಕುತ್ತದೆ!
 
-There are also some very useful tools with a slightly more complicated
-interface. First among those is `sed`, which is a programmatic file
-editor. It has its own programming language for making automated edits
-to files, but the most common use of it is:
+ಇನ್ನೂ ಸ್ವಲ್ಪ ಜಟಿಲ ಇಂಟರ್ಫೇಸ್ ಹೊಂದಿದ, ಆದರೆ ಬಹಳ ಉಪಯುಕ್ತ ಸಾಧನಗಳೂ ಇವೆ.
+ಮೊದಲದು `sed`, ಇದು ಪ್ರೋಗ್ರಾಮ್ಯಾಟಿಕ್ file editor. filesಗಳಿಗೆ automated edits ಮಾಡಲು ಇದಕ್ಕೇ ತನ್ನದೇ programming language ಇದೆ,
+ಆದರೆ ಅತ್ಯಂತ ಸಾಮಾನ್ಯ ಬಳಕೆ ಹೀಗಿದೆ:
 
 ```console
 missing:~$ sed -i 's/pattern/replacement/g' file
 ```
 
-This replaces all instances of `pattern` with `replacement` in `file`.
-The `-i` indicates that we want the substitutions to happen inline (as
-opposed to leaving `file` unmodified and printing the substituted
-contents). The `s/` is the way to express in the sed programming
-language that we want to do a substitution. The `/` separates the
-pattern from the replacement. And the trailing `/g` indicates that we
-want to replace _all_ occurrences on each line rather than just the
-first. As with `grep`, `pattern` here is a regular expression, which
-gives you significant expressive power. Regular expression substitutions
-also allow `replacement` to refer back to parts of the matched pattern;
-we'll see an example of that in a second.
+ಇದು `file`ನಲ್ಲಿನ `pattern` ಎಲ್ಲ occurrenceಗಳನ್ನು `replacement` ನಿಂದ ಬದಲಿಸುತ್ತದೆ.
+`-i` ಎಂದರೆ substitutions inline ಆಗಿಯೇ ನಡೆಯಬೇಕು (ಅಂದರೆ `file` ಬದಲಿಸದೆ substituted output ಮುದ್ರಿಸುವುದಲ್ಲ).
+`s/` ಎಂದರೆ substitution ಮಾಡಲು sed ಭಾಷೆಯ ಸೂಚನೆ. `/` pattern ಮತ್ತು replacement ಅನ್ನು ಬೇರ್ಪಡಿಸುತ್ತದೆ.
+ಕೊನೆಯ `/g` ಪ್ರತಿ ಸಾಲಿನಲ್ಲಿ ಮೊದಲ occurrence ಮಾತ್ರವಲ್ಲ, _ಎಲ್ಲ_ occurrences ಬದಲಿಸಬೇಕು ಎಂದು ಸೂಚಿಸುತ್ತದೆ.
+`grep`ನಲ್ಲಿ ಇದ್ದಂತೆ, ಇಲ್ಲಿ `pattern` regular expression ಆಗಿದೆ, ಅದು ನಿಮ್ಮಿಗೆ ಹೆಚ್ಚಿನ ಅಭಿವ್ಯಕ್ತಿ ಶಕ್ತಿ ನೀಡುತ್ತದೆ.
+regular expression substitutionsನಲ್ಲಿ `replacement` matched patternನ ಭಾಗಗಳನ್ನು ಮರುಉಲ್ಲೇಖಿಸಬಹುದೂ ಇದೆ;
+ಸ್ವಲ್ಪದಲ್ಲೇ ಅದರ ಉದಾಹರಣೆ ನೋಡುತ್ತೇವೆ.
 
-Next, we have `find`, which lets you find files (recursively) that match
-certain conditions. For example:
+ಮುಂದೆ `find` ಇದೆ; ಇದು ನಿರ್ದಿಷ್ಟ ಷರತ್ತುಗಳಿಗೆ ಹೊಂದುವ filesಗಳನ್ನು (recursive ಆಗಿ) ಕಂಡುಹಿಡಿಯಲು ಸಹಾಯಮಾಡುತ್ತದೆ.
+ಉದಾಹರಣೆ:
 
 ```console
 missing:~$ find ~/Downloads -type f -name "*.zip" -mtime +30
 ```
 
-Finds ZIP files in the download directory that are older than 30 days.
+ಇದು download directoryಯಲ್ಲಿ 30 ದಿನಗಳಿಗಿಂತ ಹಳೆಯ ZIP filesಗಳನ್ನು ಹುಡುಕುತ್ತದೆ.
 
 ```console
 missing:~$ find ~ -type f -size +100M -exec ls -lh {} \;
 ```
 
-Finds files larger than 100M in your home directory and lists them. Note
-that `-exec` takes a _command_ terminated with a stand-alone `;` (which
-we need to escape much like a space) where `{}` is replaced with each
-matching file path by `find`.
+ಇದು ನಿಮ್ಮ home directoryಯಲ್ಲಿನ 100Mಕ್ಕಿಂತ ದೊಡ್ಡ filesಗಳನ್ನು ಹುಡುಕಿ ಪಟ್ಟಿ ಮಾಡುತ್ತದೆ.
+`-exec` ಒಂದು _command_ ಅನ್ನು ಸ್ವತಂತ್ರ `;` ಮೂಲಕ ಅಂತ್ಯಗೊಳಿಸಿ ಪಡೆಯುತ್ತದೆ (space ಹಾಗೆ ಇದನ್ನೂ escape ಮಾಡಬೇಕು),
+ಮತ್ತು `{}` ಸ್ಥಾನದಲ್ಲಿ `find` ಪ್ರತಿ matching file path ಇಡುತ್ತದೆ ಎಂಬುದನ್ನು ಗಮನಿಸಿ.
 
 ```console
 missing:~$ find . -name "*.py" -exec grep -l "TODO" {} \;
 ```
 
-Finds any `.py` files with TODO items in them.
+ಇದು TODO items ಹೊಂದಿರುವ `.py` filesಗಳನ್ನು ಕಂಡುಹಿಡಿಯುತ್ತದೆ.
 
-The syntax of `find` can be a little daunting, but hopefully this gives
-you a sense of how useful it can be!
+`find` syntax ಸ್ವಲ್ಪ ಭಯ ಹುಟ್ಟಿಸುವಂತೆ ತೋರುವ ಸಾಧ್ಯತೆ ಇದೆ, ಆದರೆ ಇದು ಎಷ್ಟು ಉಪಯುಕ್ತವೋ ಎಂಬ ಭಾವನೆಯನ್ನು ಇದರಿಂದ ಪಡೆಯಬಹುದು!
 
-> Consider installing and using [`fd`](https://github.com/sharkdp/fd)
-> instead of `find` for a more human-friendly (but less portable!)
-> experience.
+> ಹೆಚ್ಚು ಮಾನವ ಸ್ನೇಹಿ (ಆದರೆ ಕಡಿಮೆ portable!) ಅನುಭವಕ್ಕಾಗಿ
+> `find` ಬದಲು [`fd`](https://github.com/sharkdp/fd) ಅನ್ನು ಸ್ಥಾಪಿಸಿ ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
 
-Next on the docket is `awk`, which, like `sed`, has its own programming
-language. Where `sed` is built for editing files, `awk` is built for
-parsing them. By far the most common use of `awk` is for data files with
-a regular syntax (like CSV files) where you want to extract only certain
-parts of every record (i.e., line):
+ಮುಂದಿನದು `awk`; `sed`ನಂತೆ ಇದಕ್ಕೂ ತನ್ನದೇ programming language ಇದೆ.
+`sed` filesಗಳನ್ನು edit ಮಾಡಲು ನಿರ್ಮಿತವಾದರೆ, `awk` ಅವನ್ನು parse ಮಾಡಲು ನಿರ್ಮಿತವಾಗಿದೆ.
+`awk`ಯ ಅತ್ಯಂತ ಸಾಮಾನ್ಯ ಬಳಕೆ ಎಂದರೆ ನಿಯಮಿತ syntax ಇರುವ data files (ಉದಾ., CSV)ಗಳಲ್ಲಿ,
+ಪ್ರತಿ record (ಅಂದರೆ ಸಾಲು)ಯ ಕೆಲವು ನಿರ್ದಿಷ್ಟ ಭಾಗಗಳನ್ನು ಮಾತ್ರ ತೆಗೆದುಹಾಕುವುದು:
 
 ```console
 missing:~$ awk '{print $2}' file
 ```
 
-Prints the second whitespace-separated column of every line of `file`.
-If you add `-F,`, it'll print the second comma-separated column of every
-line. `awk` can do much more --- filtering rows, computing aggregates,
-and more --- see the exercises for a taste.
+ಇದು `file`ನ ಪ್ರತಿಯೊಂದು ಸಾಲಿನ whitespace-separated ಎರಡನೇ column ಮುದ್ರಿಸುತ್ತದೆ.
+`-F,` ಸೇರಿಸಿದರೆ ಪ್ರತಿಯೊಂದು ಸಾಲಿನ comma-separated ಎರಡನೇ column ಮುದ್ರಿಸುತ್ತದೆ.
+`awk` ಇದಕ್ಕಿಂತ ತುಂಬಾ ಹೆಚ್ಚನ್ನು ಮಾಡಬಲ್ಲದು - ಸಾಲುಗಳನ್ನು filter ಮಾಡುವುದು, aggregates ಲೆಕ್ಕಿಸುವುದು,
+ಮತ್ತಷ್ಟು - ಸ್ವಲ್ಪ ಅನುಭವಕ್ಕೆ ವ್ಯಾಯಾಮಗಳನ್ನು ನೋಡಿ.
 
-Putting these tools together, we can do fancy things like:
+ಈ ಸಾಧನಗಳನ್ನು ಒಟ್ಟುಗೂಡಿಸಿದಾಗ, ನಾವು ಹೀಗೆ ಚೆನ್ನಾದ ಕೆಲಸಗಳನ್ನು ಮಾಡಬಹುದು:
 
 ```console
 missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
@@ -398,76 +335,60 @@ missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
 postgres,mysql,oracle,dell,ubuntu,inspur,test,admin,user,root
 ```
 
-This grabs SSH logs from a remote server (we'll talk more about `ssh` in
-the next lecture), searches for disconnect messages, extracts the
-username from each such message, and prints the top 10 usernames
-comma-separated. All in one command! We'll leave dissecting each step as
-an exercise.
+ಇದು remote serverನ SSH logs ತೆಗೆದು (ಮುಂದಿನ ಉಪನ್ಯಾಸದಲ್ಲಿ `ssh` ಬಗ್ಗೆ ಹೆಚ್ಚು ನೋಡುತ್ತೇವೆ),
+disconnect messages ಹುಡುಕಿ, ಪ್ರತಿಯೊಂದು messageನಿಂದ username ತೆಗೆಯುತ್ತದೆ, ಮತ್ತು top 10 usernames ಅನ್ನು
+comma-separated ರೂಪದಲ್ಲಿ ಮುದ್ರಿಸುತ್ತದೆ. ಒಂದೇ commandನಲ್ಲಿ! ಪ್ರತಿ ಹಂತವನ್ನು ವಿಶ್ಲೇಷಿಸುವುದನ್ನು ವ್ಯಾಯಾಮವಾಗಿ ಬಿಡುತ್ತೇವೆ.
 
-## The shell language (bash)
+## ಶೆಲ್ ಭಾಷೆ (bash)
 
-The previous example introduced a new concept: pipes (`|`). These let
-you string together the output of one program with the input of another.
-This works because most command-line programs will operate on their
-"standard input" (where your keystrokes normally go) if no `file`
-argument is given. `|` takes the "standard output" (what normally gets
-printed to your terminal) of the program before the `|` and makes it be
-the standard input of the program after the `|`. This allows you to
-_compose_ shell programs, and it's part of what makes the shell such a
-productive environment to work in!
+ಹಿಂದಿನ ಉದಾಹರಣೆಯಲ್ಲಿ ಹೊಸ ಪರಿಕಲ್ಪನೆ ಬಂತು: pipes (`|`). ಇವು ಒಂದು programನ output ಅನ್ನು
+ಮತ್ತೊಂದು programನ input ಜೊತೆ ಜೋಡಿಸುತ್ತವೆ. ಇದು ಕೆಲಸ ಮಾಡುವುದು ಏಕೆಂದರೆ command-line programsನ ಬಹುಪಾಲು,
+`file` argument ಕೊಡದಿದ್ದರೆ ಅವು "standard input" (ಸಾಮಾನ್ಯವಾಗಿ ನಿಮ್ಮ keystrokes ಹೋಗುವ ಸ್ಥಳ) ಮೇಲೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತವೆ.
+`|` ಅಚ್ಚುಕಟ್ಟಾಗಿ `|` ಮುಂಚಿನ programನ "standard output" (ಸಾಮಾನ್ಯವಾಗಿ terminalಗೆ ಮುದ್ರವಾಗುವುದು)
+ತೆಗೆದು `|` ನಂತರದ programಗೆ standard input ಆಗಿ ನೀಡುತ್ತದೆ. ಇದರಿಂದ ನೀವು shell programs ಅನ್ನು _compose_
+ಮಾಡಬಹುದು - ಮತ್ತು ಇದು ಶೆಲ್ ಅನ್ನು ಅತ್ಯಂತ ಉತ್ಪಾದಕ ಪರಿಸರವಾಗಿಸುವ ಪ್ರಮುಖ ಕಾರಣಗಳಲ್ಲಿ ಒಂದು!
 
-In fact, most shells implement a full programming language (like bash),
-just like Python or Ruby. It has variables, conditionals, loops, and
-functions. When you run commands in your shell, you are really writing a
-small bit of code that your shell interprets. We won't teach you all of
-bash today, but there are some bits you'll find particularly useful:
+ವಾಸ್ತವವಾಗಿ, ಬಹುತೇಕ ಶೆಲ್‌ಗಳು bashನಂತೆ ಸಂಪೂರ್ಣ programming language ಅನ್ನು ಜಾರಿಗೊಳಿಸುತ್ತವೆ,
+Python ಅಥವಾ Rubyಯಂತೆಯೇ. ಇದರಲ್ಲಿ variables, conditionals, loops, ಮತ್ತು functions ಇವೆ.
+ನೀವು ಶೆಲ್‌ನಲ್ಲಿ commands ಓಡಿಸುವಾಗ, ಶೆಲ್ ಅರ್ಥೈಸುವ ಸಣ್ಣ ಕೋಡ್ ತುಣುಕನ್ನೇ ಬರೆಯುತ್ತಿದ್ದೀರಿ.
+ಇಂದು ಸಂಪೂರ್ಣ bash ಕಲಿಸುವುದಿಲ್ಲ, ಆದರೆ ಕೆಲವು ಉಪಯುಕ್ತ ಅಂಶಗಳು ಇಲ್ಲಿವೆ:
 
-First, redirects: `>file` lets you take the standard output of a program
-and write it to `file` instead of to your terminal. This makes it easier
-to analyze after the fact. `>>file` will append to `file` rather than
-overwrite it. There's also `<file` which tells the shell to read from
-`file` instead of from your keyboard as the standard input to a program.
+ಮೊದಲು redirects: `>file` programನ standard output ಅನ್ನು terminalಗೆ ಬದಲಾಗಿ `file`ಗೆ ಬರೆಯಲು ಅನುಮತಿಸುತ್ತದೆ.
+ಇದರಿಂದ ನಂತರ ವಿಶ್ಲೇಷಿಸಲು ಸುಲಭವಾಗುತ್ತದೆ. `>>file` ಬಳಸಿದರೆ overwrite ಮಾಡುವ ಬದಲು `file`ಗೆ append ಮಾಡುತ್ತದೆ.
+`<file` ಸಹ ಇದೆ; ಇದು programಗೆ standard input ನಿಮ್ಮ keyboardನಿಂದ ಅಲ್ಲ, `file`ನಿಂದ ಓದಲು ಶೆಲ್‌ಗೆ ಸೂಚಿಸುತ್ತದೆ.
 
-> This is a good time to mention the `tee` program. `tee` will print
-> standard input to standard output (just like `cat`!), but will _also_
-> write it to a file. So `verbose cmd | tee verbose.log | grep CRITICAL`
-> will preserve the full verbose log to a file while keeping your
-> terminal clean!
+> ಇಲ್ಲಿ `tee` program ಉಲ್ಲೇಖಿಸಲು ಒಳ್ಳೆಯ ಸಮಯ. `tee` standard input ಅನ್ನು standard outputಗೆ ಮುದ್ರಿಸುತ್ತದೆ
+> (`cat` ಹಾಗೆ), ಆದರೆ _ಹಾಗೆಯೇ_ ಅದನ್ನು fileಗೂ ಬರೆಯುತ್ತದೆ. ಹೀಗಾಗಿ
+> `verbose cmd | tee verbose.log | grep CRITICAL`
+> ಸಂಪೂರ್ಣ verbose log ಅನ್ನು fileನಲ್ಲಿ ಉಳಿಸಿಕೊಂಡೇ ನಿಮ್ಮ terminal ಸ್ವಚ್ಛವಾಗಿರಲು ಸಹಾಯಮಾಡುತ್ತದೆ!
 
-Next, conditionals: `if command1; then command2; command3; fi` will
-execute `command1`, and if it doesn't result in an error, will run
-`command2` and `command3`. You can also have an `else` branch if you
-wish. The most common command to use as `command1` is the `test`
-command, often abbreviated simply as `[`, which lets you evaluate
-conditions like "does a file exist" (`test -f file` / `[ -f file ]`) or
-"does a string equal another" (`[ "$var" = "string" ]`). In bash,
-there's also `[[ ]]`, which is a "safer" built-in version of `test` that
-has fewer odd behaviours around quoting.
+ಮುಂದೆ conditionals: `if command1; then command2; command3; fi` ಮೊದಲು `command1` execute ಮಾಡುತ್ತದೆ,
+ಮತ್ತು ಅದು error ಕೊಟ್ಟಿಲ್ಲದಿದ್ದರೆ `command2` ಮತ್ತು `command3` ಓಡಿಸುತ್ತದೆ.
+ಬೇಕಾದರೆ `else` branch ಕೂಡ ಇರಿಸಬಹುದು. `command1` ಆಗಿ ಅತ್ಯಂತ ಸಾಮಾನ್ಯವಾಗಿ ಬಳಸುವ command ಎಂದರೆ `test`;
+ಇದನ್ನು ಸಾಮಾನ್ಯವಾಗಿ `[ ` ರೂಪಕ್ಕೂ ಸಂಕ್ಷಿಪ್ತಗೊಳಿಸುತ್ತಾರೆ. ಇದು "file ಅಸ್ತಿತ್ವದಲ್ಲಿದೆಯೇ" (`test -f file` / `[ -f file ]`)
+ಅಥವಾ "string ಮತ್ತೊಂದು stringಗೆ ಸಮಾನವೇ" (`[ "$var" = "string" ]`) ಮುಂತಾದ ಷರತ್ತುಗಳನ್ನು ಪರೀಕ್ಷಿಸಲು ನೆರವಾಗುತ್ತದೆ.
+bashನಲ್ಲಿ `[[ ]]` ಕೂಡ ಇದೆ; ಇದು quoting ಸಂಬಂಧಿತ ವಿಚಿತ್ರ ವರ್ತನೆಗಳು ಕಡಿಮೆ ಇರುವ, `test`ನ "safer" built-in ರೂಪ.
 
-Bash also has two forms of loops, `while` and `for`. `while command1; do
-command2; command3; done` functions just like the equivalent `if`
-command, except that it will re-execute the whole thing over and over
-for as long as `command1` does not error. `for varname in a b c d; do
-command; done` executes `command` four times, each time with `$varname`
-set to one of `a`, `b`, `c`, and `d`. Instead of listing the items
-explicitly, you'll often use "command substitution", such as:
+bashನಲ್ಲಿ ಎರಡು ವಿಧದ loops ಇವೆ: `while` ಮತ್ತು `for`.
+`while command1; do command2; command3; done` ಸಮಾನ `if` ರೂಪದಂತೆಯೇ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತದೆ,
+ಆದರೆ `command1` error ಕೊಡದವರೆಗೆ ಇದನ್ನು ಪುನಃ ಪುನಃ ಚಲಾಯಿಸುತ್ತದೆ.
+`for varname in a b c d; do command; done` `command` ಅನ್ನು ನಾಲ್ಕು ಬಾರಿ execute ಮಾಡುತ್ತದೆ,
+ಪ್ರತಿ ಬಾರಿ `$varname`ಗೆ `a`, `b`, `c`, `d` ಮೌಲ್ಯಗಳನ್ನು ಕ್ರಮವಾಗಿ ನೇಮಿಸಿ.
+items ಅನ್ನು ಸ್ಪಷ್ಟವಾಗಿ ಪಟ್ಟಿ ಮಾಡುವ ಬದಲು, ನೀವು ಹೆಚ್ಚಾಗಿ "command substitution" ಬಳಸುತ್ತೀರಿ, ಉದಾಹರಣೆಗೆ:
 
 ```bash
 for i in $(seq 1 10); do
 ```
 
-This executes the command `seq 1 10` (which prints the numbers from 1 to
-10 inclusive) and then replaces the whole `$()` with that command's
-output, giving you a 10-iteration for loop. In older code you'll
-sometimes see literal backticks (like ``for i in `seq 1 10`; do``)
-instead of `$()`, but you should strongly prefer the `$()` form as it
-can be nested.
+ಇದು `seq 1 10` command execute ಮಾಡುತ್ತದೆ (1ರಿಂದ 10ವರೆಗೆ ಸಂಖ್ಯೆಗಳನ್ನು ಮುದ್ರಿಸುವುದು),
+ನಂತರ ಸಂಪೂರ್ಣ `$()` ಅನ್ನು ಆ commandನ output ನಿಂದ ಬದಲಿಸುತ್ತದೆ. ಹೀಗೆ ನಿಮಗೆ 10-iteration for loop ಸಿಗುತ್ತದೆ.
+ಹಳೆಯ codeನಲ್ಲಿ ಕೆಲವೊಮ್ಮೆ literal backticks ಕಾಣಬಹುದು (``for i in `seq 1 10`; do``)
+`$()` ಬದಲು, ಆದರೆ `$()` nested ಆಗುವ ಕಾರಣ ನೀವು ಅದನ್ನೇ ಬಲವಾಗಿ ಆಯ್ಕೆಮಾಡಬೇಕು.
 
-While you _can_ write long shell scripts directly in your prompt, you'll
-usually want to write them into a `.sh` file instead. For example,
-here's a script that will run a program in a loop until it fails,
-printing the output only of the failed run, while stressing your CPU in
-the background (useful to reproduce flaky tests for example):
+ನೀವು promptಲ್ಲೇ ಉದ್ದವಾದ shell scripts ಬರೆಯಬಹುದಾದರೂ, ಸಾಮಾನ್ಯವಾಗಿ ಅವನ್ನು `.sh` fileನಲ್ಲಿ ಬರೆಯುವುದು ಉತ್ತಮ.
+ಉದಾಹರಣೆಗೆ, ಕೆಳಗಿನ script program ವಿಫಲವಾಗುವವರೆಗೆ loopನಲ್ಲಿ ಓಡಿಸುತ್ತದೆ,
+ವಿಫಲವಾದ runನ output ಮಾತ್ರ ತೋರಿಸಿ, backgroundನಲ್ಲಿ CPUಗೆ ಒತ್ತಡ ಕೊಡುತ್ತದೆ
+(ಉದಾ. flaky tests ಮರುಉತ್ಪಾದಿಸಲು ಉಪಯುಕ್ತ):
 
 ```bash
 #!/bin/bash
@@ -496,161 +417,134 @@ tail -n 20 "$LOGFILE"
 echo "Full log: $LOGFILE"
 ```
 
-This has a number of new things in it that I recommend you spend some
-time diving into, as they're very useful in crafting useful shell
-invocations like background jobs (`&`) to run programs concurrently,
-trickier [shell
+ಇದರಲ್ಲಿ ಹಲವಾರು ಹೊಸ ಅಂಶಗಳಿವೆ; ಅವುಗಳನ್ನು ಅನ್ವೇಷಿಸಲು ನಿಮಗೆ ಸ್ವಲ್ಪ ಸಮಯ ಕಳೆಯಲು ಶಿಫಾರಸು ಮಾಡುತ್ತೇನೆ,
+ಏಕೆಂದರೆ ಉಪಯುಕ್ತ shell invocations ರೂಪಿಸಲು ಅವು ತುಂಬಾ ನೆರವಾಗುತ್ತವೆ - ಉದಾ. programsಗಳನ್ನು ಸಮಕಾಲಿಕವಾಗಿ ಓಡಿಸುವ
+background jobs (`&`), ಸ್ವಲ್ಪ ಜಟಿಲ [shell
 redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html),
-and [arithmetic
+ಮತ್ತು [arithmetic
 expansion](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html).
 
-It's worth spending a second on the first two lines of the program
-though. The first is the "shebang" -- you'll see this at the top of
-other files than shell scripts too. When a file that starts with the
-magic incantation `#!/path` is executed, the shell will start the
-program at `/path`, and pass it the contents of the file as input. In
-the case of a shell script, this means passing the contents of the shell
-script to `/bin/bash`, but you can also write Python scripts with a
-shebang line of `/usr/bin/python`!
+ಆದರೂ programನ ಮೊದಲ ಎರಡು ಸಾಲುಗಳ ಬಗ್ಗೆ ಒಂದು ಕ್ಷಣ ಗಮನಿಸುವುದು ಸೂಕ್ತ.
+ಮೊದಲದು "shebang" - ಶೆಲ್ scripts ಮಾತ್ರವಲ್ಲದೆ ಇತರೆ files ಮೇಲೆಯೂ ಇದನ್ನು ನೋಡುತ್ತೀರಿ.
+`#!/path` ಎಂಬ magic incantation ನಿಂದ ಆರಂಭವಾಗುವ file execute ಆದಾಗ,
+ಶೆಲ್ `/path` ನಲ್ಲಿ ಇರುವ program ಆರಂಭಿಸಿ, file ವಿಷಯವನ್ನು input ಆಗಿ ಅದಕ್ಕೆ ಒದಗಿಸುತ್ತದೆ.
+shell script ಸಂದರ್ಭದಲ್ಲಿ, script ವಿಷಯವನ್ನು `/bin/bash` ಗೆ ಒದಗಿಸುವುದೇ ಇದರ ಅರ್ಥ.
+ಆದರೆ `/usr/bin/python` shebang line ಹೊಂದಿರುವ Python scripts ಕೂಡ ಬರೆಯಬಹುದು!
 
-The second line is a way to make bash "stricter", and mitigate a number
-of footguns when writing shell scripts. `set` can take a whole lot of
-arguments, but briefly: `-e` makes it so that if any command fails, the
-script exits early; `-u` makes it so that use of undefined variables
-crashes the script rather than just using an empty string; and `-o
-pipefail` makes it so that if programs in a `|` sequence fail, the
-shell script as a whole also exits early.
+ಎರಡನೇ ಸಾಲು bash ಅನ್ನು "stricter" ಮಾಡಲು, shell scripts ಬರೆಯುವಾಗ ಕಾಣುವ ಕೆಲವು footguns ಕಡಿಮೆ ಮಾಡಲು ಬಳಸಲಾಗುತ್ತದೆ.
+`set` ಬಹಳ arguments ಪಡೆಯುತ್ತದೆ; ಸಂಕ್ಷಿಪ್ತವಾಗಿ - `-e` ಯಾವುದಾದರೂ command ವಿಫಲವಾದರೆ script ಬೇಗನೆ ಹೊರಬರುವಂತೆ ಮಾಡುತ್ತದೆ;
+`-u` undefined variables ಬಳಕೆಯಾದರೆ ಖಾಲಿ string ಬಳಸುವುದಕ್ಕಿಂತ script crash ಆಗುವಂತೆ ಮಾಡುತ್ತದೆ;
+`-o pipefail` `|` ಸರಣಿಯಲ್ಲಿನ programs ವಿಫಲವಾದರೆ ಸಂಪೂರ್ಣ shell script ಕೂಡ ಬೇಗನೆ ಹೊರಬರುವಂತೆ ಮಾಡುತ್ತದೆ.
 
-> Shell programming is a deep topic, just as any programming language
-> is, but be warned: bash has an unusual number of gotchas, to the point
-> that there are [multiple](https://tldp.org/LDP/abs/html/gotchas.html)
-> websites dedicated to [listing them](https://mywiki.wooledge.org/BashPitfalls).
-> I highly recommend making heavy use of
-> [shellcheck](https://www.shellcheck.net/) when writing them. LLMs are
-> also great at writing and debugging shell scripts, as well as
-> translating them to a "real" programming language (like Python) when
-> they've grown too unwieldy for bash (100+ lines).
+> Shell programming ಯಾವ programming language ಹಾಗೆಯೇ ಆಳವಾದ ವಿಷಯ.
+> ಆದರೆ ಎಚ್ಚರಿಕೆ: bashನಲ್ಲಿ gotchas ಅಸಾಮಾನ್ಯವಾಗಿ ಹೆಚ್ಚು ಇವೆ -
+> ಅವುಗಳನ್ನು ಪಟ್ಟಿ ಮಾಡಲು [ಬಹು](https://tldp.org/LDP/abs/html/gotchas.html)
+> [ವೆಬ್‌ಸೈಟ್‌ಗಳು](https://mywiki.wooledge.org/BashPitfalls) ಕೂಡ ಇವೆ.
+> scripts ಬರೆಯುವಾಗ [shellcheck](https://www.shellcheck.net/) ಅನ್ನು ಹೆಚ್ಚು ಬಳಸಲು ನಾನು ಬಲವಾಗಿ ಶಿಫಾರಸು ಮಾಡುತ್ತೇನೆ.
+> shell scripts ಬರೆಯಲು ಮತ್ತು debug ಮಾಡಲು LLMs ಸಹ ಅದ್ಭುತವಾಗಿವೆ; ಜೊತೆಗೆ bashಗೆ ತುಂಬಾ ದೊಡ್ಡದಾದಾಗ
+> (100+ ಸಾಲುಗಳು) ಅವನ್ನು Python ಮಾದರಿಯ "real" programming language ಗೆ ಅನುವಾದಿಸುವುದಕ್ಕೂ ನೆರವಾಗುತ್ತವೆ.
 
-# Next steps
+# ಮುಂದಿನ ಹಂತಗಳು
 
-At this point you know your way around a shell enough to accomplish
-basic tasks. You should be able to navigate around to find files of
-interest and use the basic functionality of most programs. In the next
-lecture, we will talk about how to perform and automate more complex
-tasks using the shell and the many handy command-line programs out
-there.
+ಈ ಹಂತದಲ್ಲಿ, ಮೂಲಭೂತ ಕೆಲಸಗಳನ್ನು ಮಾಡಲು ಬೇಕಾಗುವಷ್ಟು ಶೆಲ್ ಪರಿಚಯ ನಿಮಗಿದೆ.
+ನೀವು ಆಸಕ್ತಿ ಇರುವ filesಗಳನ್ನು ಹುಡುಕಲು ಸಂಚರಿಸಬಲ್ಲಿರಿ ಮತ್ತು ಹೆಚ್ಚು programsಗಳ ಮೂಲ ಕಾರ್ಯಗಳನ್ನು ಬಳಸಬಲ್ಲಿರಿ.
+ಮುಂದಿನ ಉಪನ್ಯಾಸದಲ್ಲಿ, ಶೆಲ್ ಮತ್ತು ಅನೇಕ ಉಪಯುಕ್ತ command-line programs ಬಳಸಿ ಹೆಚ್ಚು ಜಟಿಲ ಕಾರ್ಯಗಳನ್ನು
+ಹೇಗೆ ಮಾಡುವುದು ಮತ್ತು automate ಮಾಡುವುದು ಎಂಬುದನ್ನು ನೋಡುತ್ತೇವೆ.
 
-# Exercises
+# ವ್ಯಾಯಾಮಗಳು
 
-All classes in this course are accompanied by a series of exercises.
-Some give you a specific task to do, while others are open-ended, like
-"try using X and Y programs". We highly encourage you to try them out.
+ಈ ಕೋರ್ಸ್‌ನ ಪ್ರತಿಯೊಂದು ತರಗತಿಯ ಜೊತೆ ಒಂದು ವ್ಯಾಯಾಮಗಳ ಸರಣಿ ಇರುತ್ತದೆ.
+ಕೆಲವು ನಿರ್ದಿಷ್ಟ ಕಾರ್ಯಗಳನ್ನು ಕೇಳುತ್ತವೆ, ಇತರವು "X ಮತ್ತು Y programs ಪ್ರಯತ್ನಿಸಿ" ಎಂಬ ರೀತಿಯ open-ended ಆಗಿರುತ್ತವೆ.
+ಅವನ್ನು ಪ್ರಯತ್ನಿಸಲು ನಾವು ನಿಮಗೆ ಬಲವಾಗಿ ಪ್ರೋತ್ಸಾಹಿಸುತ್ತೇವೆ.
 
-We have not written solutions for the exercises. If you are stuck on
-anything in particular, feel free to post in `#missing-semester-forum`
-on [Discord](https://ossu.dev/#community) or send us an email describing
-what you've tried so far, and we will try to help you out. These
-exercises will also likely work well as initial prompts in a
-conversation with an LLM where you can interactively dive into the
-topic. The real value in these exercises is the journey of discovering
-the answers, not the answer itself. We encourage you to follow tangents
-and ask "why" as you work through them, rather than just looking for the
-shortest path to the solution.
+ಈ ವ್ಯಾಯಾಮಗಳಿಗೆ ನಾವು ಪರಿಹಾರಗಳನ್ನು ಬರೆಯಿಲ್ಲ. ನೀವು ಯಾವುದಾದರೂ ವಿಷಯದಲ್ಲಿ ಸಿಲುಕಿದರೆ,
+[Discord](https://ossu.dev/#community) ನ `#missing-semester-forum` ನಲ್ಲಿ ಪೋಸ್ಟ್ ಮಾಡಿ,
+ಅಥವಾ ಇದುವರೆಗೆ ನೀವು ಪ್ರಯತ್ನಿಸಿದುದನ್ನು ವಿವರಿಸಿ ನಮಗೆ ಇಮೇಲ್ ಕಳುಹಿಸಿ - ನಾವು ಸಹಾಯ ಮಾಡಲು ಪ್ರಯತ್ನಿಸುತ್ತೇವೆ.
+ಈ ವ್ಯಾಯಾಮಗಳು LLM ಜೊತೆ ಸಂವಾದ ಆರಂಭಿಸಲು ಪ್ರಾರಂಭಿಕ prompts ಆಗಿಯೂ ಚೆನ್ನಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತವೆ,
+ಅಲ್ಲಿ ನೀವು ವಿಷಯವನ್ನು ಸಂವಹನಾತ್ಮಕವಾಗಿ ಆಳಕ್ಕೆ ಅನ್ವೇಷಿಸಬಹುದು. ಈ ವ್ಯಾಯಾಮಗಳ ನಿಜವಾದ ಮೌಲ್ಯ ಉತ್ತರದಲ್ಲಲ್ಲ,
+ಉತ್ತರವನ್ನು ಹುಡುಕುವ ಪ್ರಯಾಣದಲ್ಲಿದೆ. ಪರಿಹಾರಕ್ಕೆ ಅತಿ ಚಿಕ್ಕ ದಾರಿಗೆ ಮಾತ್ರ ಹೋಗುವುದಕ್ಕಿಂತ,
+ವಿಷಯದ ಪಕ್ಕದ ದಾರಿಗಳನ್ನೂ ಅನುಸರಿಸಿ, ಕೆಲಸ ಮಾಡುವಾಗ "ಏಕೆ" ಎಂದು ಕೇಳುತ್ತಾ ಹೋಗುವಂತೆ ನಾವು ಪ್ರೋತ್ಸಾಹಿಸುತ್ತೇವೆ.
 
-1. For this course, you need to be using a Unix shell like Bash or ZSH. If
-   you are on Linux or macOS, you don't have to do anything special. If you
-   are on Windows, you need to make sure you are not running cmd.exe or
-   PowerShell; you can use [Windows Subsystem for
-   Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-   machine to use Unix-style command-line tools. To make sure you're running
-   an appropriate shell, you can try the command `echo $SHELL`. If it says
-   something like `/bin/bash` or `/usr/bin/zsh`, that means you're running
-   the right program.
+1. ಈ ಕೋರ್ಸ್‌ಗೆ, ನೀವು Bash ಅಥವಾ ZSH ಹೋಲುವ Unix shell ಬಳಸಬೇಕು. ನೀವು Linux ಅಥವಾ macOSನಲ್ಲಿ ಇದ್ದರೆ,
+   ವಿಶೇಷವಾಗಿ ಏನೂ ಮಾಡಬೇಕಾಗಿಲ್ಲ. ನೀವು Windowsನಲ್ಲಿ ಇದ್ದರೆ, cmd.exe ಅಥವಾ PowerShell ಬಳಸುತ್ತಿಲ್ಲವೆಂದು ಖಚಿತಪಡಿಸಬೇಕು;
+   Unix ಶೈಲಿಯ command-line tools ಬಳಸಲು [Windows Subsystem for
+   Linux](https://docs.microsoft.com/en-us/windows/wsl/) ಅಥವಾ Linux virtual machine ಬಳಸಿ.
+   ನೀವು ಸರಿಯಾದ shell ಬಳಸುತ್ತಿದ್ದೀರಿ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಲು `echo $SHELL` command ಪ್ರಯತ್ನಿಸಿ.
+   ಅದು `/bin/bash` ಅಥವಾ `/usr/bin/zsh` ಮಾದರಿಯದನ್ನು ತೋರಿಸಿದರೆ, ನೀವು ಸರಿಯಾದ program ಬಳಸುತ್ತಿದ್ದೀರಿ ಎಂದರ್ಥ.
 
-1. What does the `-l` flag to `ls` do? Run `ls -l /` and examine the output.
-   What do the first 10 characters of each line mean? (Hint: `man ls`)
+1. `ls` ಗೆ ಇರುವ `-l` flag ಏನು ಮಾಡುತ್ತದೆ? `ls -l /` ಓಡಿಸಿ output ಪರಿಶೀಲಿಸಿ.
+   ಪ್ರತಿ ಸಾಲಿನ ಮೊದಲ 10 ಅಕ್ಷರಗಳು ಏನನ್ನು ಸೂಚಿಸುತ್ತವೆ? (Hint: `man ls`)
 
-1. In the command `find ~/Downloads -type f -name "*.zip" -mtime +30`, the
-   `*.zip` is a "glob". What is a glob? Create a test directory with some
-   files and experiment with patterns like `ls *.txt`, `ls file?.txt`, and
-   `ls {a,b,c}.txt`. See [Pattern
-   Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)
-   in the Bash manual.
+1. `find ~/Downloads -type f -name "*.zip" -mtime +30` command ನಲ್ಲಿ `*.zip` ಒಂದು "glob" ಆಗಿದೆ.
+   glob ಎಂದರೆ ಏನು? ಕೆಲವು files ಇರುವ ಪರೀಕ್ಷಾ directory ರಚಿಸಿ, `ls *.txt`, `ls file?.txt`,
+   ಮತ್ತು `ls {a,b,c}.txt` ಮಾದರಿಗಳೊಂದಿಗೆ ಪ್ರಯೋಗ ಮಾಡಿ. Bash manualನ [Pattern
+   Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html) ನೋಡಿ.
 
-1. What's the difference between `'single quotes'`, `"double quotes"`, and
-   `$'ANSI quotes'`? Write a command that echoes a string containing a
-   literal `$`, a `!`, and a newline character. See
-   [Quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html).
+1. `'single quotes'`, `"double quotes"`, ಮತ್ತು `$'ANSI quotes'` ಮಧ್ಯೆ ಏನು ವ್ಯತ್ಯಾಸ?
+   literal `$`, ಒಂದು `!`, ಮತ್ತು newline character ಹೊಂದಿರುವ string ಅನ್ನು echo ಮಾಡುವ command ಬರೆಯಿರಿ.
+   [Quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html) ನೋಡಿ.
 
-1. The shell has three standard streams: stdin (0), stdout (1), and stderr
-   (2). Run `ls /nonexistent /tmp` and redirect stdout to one file and
-   stderr to another. How would you redirect both to the same file? See
-   [Redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html).
+1. ಶೆಲ್‌ಗೆ ಮೂರು standard streams ಇವೆ: stdin (0), stdout (1), ಮತ್ತು stderr (2).
+   `ls /nonexistent /tmp` ಓಡಿಸಿ stdout ಅನ್ನು ಒಂದು fileಗೆ ಮತ್ತು stderr ಅನ್ನು ಮತ್ತೊಂದು fileಗೆ redirect ಮಾಡಿ.
+   ಎರಡನ್ನೂ ಒಂದೇ fileಗೆ ಹೇಗೆ redirect ಮಾಡಬಹುದು? [Redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html) ನೋಡಿ.
 
-1. `$?` holds the exit status of the last command (0 = success). `&&` runs
-   the next command only if the previous succeeded; `||` runs it only if
-   the previous failed. Write a one-liner that creates `/tmp/mydir` only if
-   it doesn't already exist. See [Exit
-   Status](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html).
+1. `$?` ಕೊನೆಯ commandನ exit status ಹಿಡಿದಿರುತ್ತದೆ (0 = success).
+   `&&` ಹಿಂದಿನ command ಯಶಸ್ವಿಯಾದಾಗ ಮಾತ್ರ ಮುಂದಿನ command ಓಡಿಸುತ್ತದೆ; `||` ಹಿಂದಿನದು ವಿಫಲವಾದಾಗ ಮಾತ್ರ ಮುಂದಿನದು ಓಡಿಸುತ್ತದೆ.
+   `/tmp/mydir` ಈಗಾಗಲೇ ಇಲ್ಲದಿದ್ದರೆ ಮಾತ್ರ create ಮಾಡುವ one-liner ಬರೆಯಿರಿ.
+   [Exit Status](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html) ನೋಡಿ.
 
-1. Why does `cd` have to be built into the shell itself rather than a
-   standalone program? (Hint: think about what a child process can and
-   cannot affect in its parent.)
+1. `cd` ಏಕೆ ಶೆಲ್‌ನಲ್ಲೇ built-in ಆಗಿರಬೇಕು, standalone program ಆಗಿರಬಾರದು?
+   (Hint: child process ತನ್ನ parent ಮೇಲೆ ಏನು ಪರಿಣಾಮ ಬೀರುವುದು ಮತ್ತು ಏನು ಸಾಧ್ಯವಿಲ್ಲ ಎಂಬುದನ್ನು ಯೋಚಿಸಿ.)
 
-1. Write a script that takes a filename as an argument (`$1`) and checks
-   whether the file exists using `test -f` or `[ -f ... ]`. It should print
-   different messages depending on whether the file exists. See [Bash
-   Conditional
-   Expressions](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html).
+1. filename ಅನ್ನು argument (`$1`) ಆಗಿ ಸ್ವೀಕರಿಸುವ script ಬರೆಯಿರಿ ಮತ್ತು `test -f` ಅಥವಾ `[ -f ... ]`
+   ಬಳಸಿ file ಅಸ್ತಿತ್ವದಲ್ಲಿದೆಯೇ ಎಂದು ಪರಿಶೀಲಿಸಿ. file ಇದ್ದರೂ ಇಲ್ಲದಿದ್ದರೂ ಬೇರೆ ಬೇರೆ ಸಂದೇಶ ಮುದ್ರಿಸಬೇಕು.
+   [Bash Conditional
+   Expressions](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html) ನೋಡಿ.
 
-1. Save the script from the previous exercise to a file (e.g., `check.sh`).
-   Try running it with `./check.sh somefile`. What happens? Now run
-   `chmod +x check.sh` and try again. Why is this step necessary? (Hint:
-   look at `ls -l check.sh` before and after the `chmod`.)
+1. ಹಿಂದಿನ ವ್ಯಾಯಾಮದ script ಅನ್ನು fileಗೆ ಉಳಿಸಿ (ಉದಾ., `check.sh`).
+   `./check.sh somefile` ಮೂಲಕ ಓಡಿಸಿ. ಏನಾಗುತ್ತದೆ? ಈಗ `chmod +x check.sh` ಓಡಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.
+   ಈ ಹಂತ ಏಕೆ ಅಗತ್ಯ? (Hint: `chmod` ಮೊದಲು ಮತ್ತು ನಂತರ `ls -l check.sh` ನೋಡಿ.)
 
-1. What happens if you add `-x` to the `set` flags in a script? Try it with
-    a simple script and observe the output. See [The Set
-    Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
+1. scriptನಲ್ಲಿ `set` flagsಗೆ `-x` ಸೇರಿಸಿದರೆ ಏನಾಗುತ್ತದೆ?
+   ಒಂದು ಸರಳ scriptನಲ್ಲಿ ಪ್ರಯತ್ನಿಸಿ output ಗಮನಿಸಿ.
+   [The Set
+   Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) ನೋಡಿ.
 
-1. Write a command that copies a file to a backup with today's date in the
-    filename (e.g., `notes.txt` → `notes_2026-01-12.txt`). (Hint: `$(date
-    +%Y-%m-%d)`). See [Command
-    Substitution](https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html).
+1. ಇಂದಿನ ದಿನಾಂಕವನ್ನು filenameನಲ್ಲಿ ಸೇರಿಸಿ file ಅನ್ನು backupಗೆ ನಕಲಿಸುವ command ಬರೆಯಿರಿ
+   (ಉದಾ., `notes.txt` → `notes_2026-01-12.txt`). (Hint: `$(date
+   +%Y-%m-%d)`). [Command
+   Substitution](https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html) ನೋಡಿ.
 
-1. Modify the flaky test script from the lecture to accept the test command
-    as an argument instead of hardcoding `cargo test my_test`. (Hint: `$1`
-    or `$@`). See [Special
-    Parameters](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html).
+1. ಉಪನ್ಯಾಸದಲ್ಲಿನ flaky test script ಅನ್ನು `cargo test my_test` ಅನ್ನು hardcode ಮಾಡುವ ಬದಲು,
+   test command ಅನ್ನು argument ಆಗಿ ಸ್ವೀಕರಿಸುವಂತೆ ಬದಲಿಸಿ. (Hint: `$1` ಅಥವಾ `$@`).
+   [Special
+   Parameters](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html) ನೋಡಿ.
 
-1. Use pipes to find the 5 most common file extensions in your home
-    directory. (Hint: combine `find`, `grep` or `sed` or `awk`, `sort`,
-    `uniq -c`, and `head`.)
+1. ನಿಮ್ಮ home directoryಯಲ್ಲಿ ಅತ್ಯಂತ ಸಾಮಾನ್ಯ 5 file extensions ಕಂಡುಹಿಡಿಯಲು pipes ಬಳಸಿ.
+   (Hint: `find`, `grep` ಅಥವಾ `sed` ಅಥವಾ `awk`, `sort`, `uniq -c`, ಮತ್ತು `head` ಒಟ್ಟುಗೂಡಿಸಿ.)
 
-1. `xargs` converts lines from stdin into command arguments. Use `find` and
-    `xargs` together (not `find -exec`) to find all `.sh` files in a
-    directory and count the lines in each with `wc -l`. Bonus: make it
-    handle filenames with spaces. (Hint: `-print0` and `-0`). See `man
-    xargs`.
+1. `xargs` stdinನ ಸಾಲುಗಳನ್ನು command arguments ಆಗಿ ಪರಿವರ್ತಿಸುತ್ತದೆ.
+   `find` ಮತ್ತು `xargs` ಅನ್ನು (`find -exec` ಅಲ್ಲ) ಒಟ್ಟಿಗೆ ಬಳಸಿ, directoryಯಲ್ಲಿನ ಎಲ್ಲಾ `.sh` files ಕಂಡುಹಿಡಿದು,
+   ಪ್ರತಿಯೊಂದರ ಸಾಲುಗಳನ್ನು `wc -l` ಮೂಲಕ ಎಣಿಸಿ. Bonus: spaces ಇರುವ filenames ಸಹ handle ಆಗುವಂತೆ ಮಾಡಿ.
+   (Hint: `-print0` ಮತ್ತು `-0`). `man
+   xargs` ನೋಡಿ.
 
-1. Use `curl` to fetch the HTML of the course website
-    (`https://missing.csail.mit.edu/`) and pipe it to `grep` to count how
-    many lectures are listed. (Hint: look for a pattern that appears once
-    per lecture; use `curl -s` to silence the progress output.)
+1. `curl` ಬಳಸಿ course websiteನ HTML ಅನ್ನು
+   (`https://missing.csail.mit.edu/`) ಪಡೆದು, ಅದನ್ನು `grep` ಗೆ pipe ಮಾಡಿ ಎಷ್ಟು ಉಪನ್ಯಾಸಗಳು ಪಟ್ಟಿ ಆಗಿವೆ ಎಂದು ಎಣಿಸಿ.
+   (Hint: ಪ್ರತಿ ಉಪನ್ಯಾಸಕ್ಕೆ ಒಂದೇ ಬಾರಿ ಕಾಣುವ pattern ಹುಡುಕಿ; progress output ಮೌನಗೊಳಿಸಲು `curl -s` ಬಳಸಿ.)
 
-1. [`jq`](https://jqlang.github.io/jq/) is a powerful tool for processing
-    JSON data. Fetch the sample data at
-    `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` with
-    `curl` and use `jq` to extract just the names of people whose version
-    is greater than 6. (Hint: pipe to `jq .` first to see the structure;
-    then try `jq '.[] | select(...) | .name'`)
+1. [`jq`](https://jqlang.github.io/jq/) JSON data ಸಂಸ್ಕರಣೆಗೆ ಶಕ್ತಿಯುತ ಸಾಧನ.
+   `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` ನ sample data ಅನ್ನು `curl` ಮೂಲಕ ಪಡೆಯಿರಿ,
+   ಮತ್ತು version 6ಕ್ಕಿಂತ ಹೆಚ್ಚಿರುವ ಜನರ ಹೆಸರುಗಳನ್ನು ಮಾತ್ರ ತೆಗೆಯಲು `jq` ಬಳಸಿ.
+   (Hint: ರಚನೆ ನೋಡಲು ಮೊದಲು `jq .` ಗೆ pipe ಮಾಡಿ;
+   ನಂತರ `jq '.[] | select(...) | .name'` ಪ್ರಯತ್ನಿಸಿ)
 
-1. `awk` can filter lines based on column values and manipulate output.
-    For example, `awk '$3 ~ /pattern/ {$4=""; print}'` prints only lines
-    where the third column matches `pattern`, while omitting the fourth
-    column. Write an `awk` command that prints only lines where the second
-    column is greater than 100, and swaps the first and third columns. Test
-    with: `printf 'a 50 x\nb 150 y\nc 200 z\n'`
+1. `awk` column ಮೌಲ್ಯಗಳ ಆಧಾರದ ಮೇಲೆ ಸಾಲುಗಳನ್ನು filter ಮಾಡಬಹುದು ಮತ್ತು output ಅನ್ನು ರೂಪಿಸಬಹುದು.
+   ಉದಾಹರಣೆಗೆ, `awk '$3 ~ /pattern/ {$4=""; print}'` ಮೂರನೇ column `pattern` ಗೆ ಹೊಂದುವ ಸಾಲುಗಳನ್ನು ಮಾತ್ರ ಮುದ್ರಿಸುತ್ತದೆ,
+   ಮತ್ತು ನಾಲ್ಕನೇ column ಅನ್ನು ಬಿಡುತ್ತದೆ. ಎರಡನೇ column 100ಕ್ಕಿಂತ ಹೆಚ್ಚಿನಾಗಿರುವ ಸಾಲುಗಳನ್ನು ಮಾತ್ರ ಮುದ್ರಿಸಿ,
+   ಮೊದಲ ಮತ್ತು ಮೂರನೇ columns ಪರಸ್ಪರ ಬದಲಿಸುವ `awk` command ಬರೆಯಿರಿ.
+   ಪರೀಕ್ಷೆಗೆ: `printf 'a 50 x\nb 150 y\nc 200 z\n'`
 
-1. Dissect the SSH log pipeline from the lecture: what does each step do?
-    Then build something similar to find your most-used shell commands from
-    `~/.bash_history` (or `~/.zsh_history`).
+1. ಉಪನ್ಯಾಸದ SSH log pipeline ಅನ್ನು ವಿಶ್ಲೇಷಿಸಿ: ಪ್ರತಿ ಹಂತ ಏನು ಮಾಡುತ್ತದೆ?
+   ನಂತರ ನಿಮ್ಮ ಹೆಚ್ಚು ಬಳಸುವ shell commands ಕಂಡುಹಿಡಿಯಲು ಅದಕ್ಕೆ ಸಮಾನದ್ದನ್ನು ನಿರ್ಮಿಸಿ
+   `~/.bash_history` (ಅಥವಾ `~/.zsh_history`) ನಿಂದ.

--- a/_2026/debugging-profiling.md
+++ b/_2026/debugging-profiling.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Debugging and Profiling"
+title: "ಡಿಬಗ್ಗಿಂಗ್ ಮತ್ತು ಪ್ರೊಫೈಲಿಂಗ್"
 description: >
-  Learn how to debug programs using logging and debuggers, and how to profile code for performance.
+  ಲಾಗಿಂಗ್ ಮತ್ತು ಡಿಬಗ್ಗರ್‌ಗಳನ್ನು ಬಳಸಿ ಪ್ರೋಗ್ರಾಂಗಳನ್ನು ಹೇಗೆ ಡಿಬಗ್ ಮಾಡುವುದು, ಮತ್ತು ಕಾರ್ಯಕ್ಷಮತಿಗಾಗಿ ಕೋಡ್ ಅನ್ನು ಹೇಗೆ ಪ್ರೊಫೈಲ್ ಮಾಡುವುದು ಎಂಬುದನ್ನು ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec4.png
 date: 2026-01-15
 ready: true
@@ -12,69 +12,66 @@ video:
   id: 8VYT9TcUmKs
 ---
 
-A golden rule in programming is that code does not do what you expect it to do, but what you tell it to do. Bridging that gap can sometimes be a quite difficult feat. In this lecture we are going to cover useful techniques for dealing with buggy and resource hungry code: debugging and profiling.
+ಪ್ರೋಗ್ರಾಮಿಂಗ್‌ನಲ್ಲಿನ ಒಂದು ಸುವರ್ಣ ನಿಯಮವೆಂದರೆ: ಕೋಡ್ ನೀವು ನಿರೀಕ್ಷಿಸುವುದನ್ನು ಮಾಡುವುದಿಲ್ಲ, ನೀವು ಅದಕ್ಕೆ ಹೇಳಿದುದನ್ನೇ ಮಾಡುತ್ತದೆ. ಈ ಅಂತರವನ್ನು ಭರ್ತಿಮಾಡುವುದು ಕೆಲವೊಮ್ಮೆ ಬಹಳ ಕಷ್ಟಕರವಾಗಿರಬಹುದು. ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ದೋಷಯುಕ್ತ ಮತ್ತು ಸಂಪನ್ಮೂಲ-ಆಹಾರಿ ಕೋಡ್‌ನೊಂದಿಗೆ ಕೆಲಸ ಮಾಡಲು ಉಪಯುಕ್ತ ತಂತ್ರಗಳನ್ನು ನೋಡೋಣ: ಡಿಬಗ್ಗಿಂಗ್ ಮತ್ತು ಪ್ರೊಫೈಲಿಂಗ್.
 
-# Debugging
+# ಡಿಬಗ್ಗಿಂಗ್
 
-## Printf Debugging and Logging
+## Printf ಡಿಬಗ್ಗಿಂಗ್ ಮತ್ತು ಲಾಗಿಂಗ್
 
-> "The most effective debugging tool is still careful thought, coupled with judiciously placed print statements" — Brian Kernighan, _Unix for Beginners_.
+> "The most effective debugging tool is still careful thought, coupled with judiciously placed print statements" - Brian Kernighan, _Unix for Beginners_.
 
-A first approach to debug a program is to add print statements around where you have detected the problem, and keep iterating until you have extracted enough information to understand what is responsible for the issue.
+ಒಂದು ಪ್ರೋಗ್ರಾಂ ಅನ್ನು ಡಿಬಗ್ ಮಾಡಲು ಮೊದಲ ವಿಧಾನವೆಂದರೆ, ಸಮಸ್ಯೆಯನ್ನು ಕಂಡುಹಿಡಿದ ಸ್ಥಳದ ಸುತ್ತಲೂ print statements ಸೇರಿಸಿ, ಸಮಸ್ಯೆಗೆ ಕಾರಣವೇನು ಎಂಬುದನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಸಾಕಷ್ಟು ಮಾಹಿತಿ ದೊರೆಯುವವರೆಗೆ ಅದನ್ನು ಮರುಮರು ಪ್ರಯತ್ನಿಸುವುದು.
 
-A second approach is to use logging in your program, instead of ad hoc print statements. Logging is essentially "printing with more care", and is usually done through a logging framework that includes built-in support for things like:
+ಎರಡನೇ ವಿಧಾನವೆಂದರೆ ad hoc print statements ಬದಲು ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂನಲ್ಲಿ logging ಬಳಸುವುದು. Logging ಎಂದರೆ ಮೂಲತಃ "ಹೆಚ್ಚು ಜಾಗ್ರತೆಯಿಂದ print ಮಾಡುವುದು", ಮತ್ತು ಸಾಮಾನ್ಯವಾಗಿ ಇದನ್ನು logging framework ಮೂಲಕ ಮಾಡಲಾಗುತ್ತದೆ. ಇವು ಸಾಮಾನ್ಯವಾಗಿ ಕೆಳಗಿನಂತಿರುವ built-in ಬೆಂಬಲವನ್ನು ಒಳಗೊಂಡಿರುತ್ತವೆ:
 
-- the ability to direct the logs (or subsets of the logs) to other output locations;
-- setting severity levels (such as INFO, DEBUG, WARN, ERROR, etc.) and allow you to filter the output according to those; and
-- support for structured logging of data related to the log entries, which can then be extracted more easily after the fact.
+- ಲಾಗ್‌ಗಳನ್ನು (ಅಥವಾ ಲಾಗ್‌ಗಳ ಉಪಸಮೂಹಗಳನ್ನು) ಬೇರೆ output ಸ್ಥಳಗಳಿಗೆ ಕಳುಹಿಸುವ ಸಾಮರ್ಥ್ಯ;
+- ತೀವ್ರತಾ ಮಟ್ಟಗಳನ್ನು (INFO, DEBUG, WARN, ERROR ಮುಂತಾದವು) ಹೊಂದಿಸಿ, ಅವುಗಳ ಆಧಾರದ ಮೇಲೆ output ಅನ್ನು ಫಿಲ್ಟರ್ ಮಾಡುವ ಸಾಮರ್ಥ್ಯ; ಮತ್ತು
+- log entries ಗೆ ಸಂಬಂಧಿಸಿದ ಡೇಟಾವನ್ನು structured logging ರೂಪದಲ್ಲಿ ಉಳಿಸುವ ಬೆಂಬಲ, ಇದರಿಂದ ನಂತರ ಅವನ್ನು ಸುಲಭವಾಗಿ ಹೊರತೆಗೆಯಬಹುದು.
 
-Logging statements you'll also usually proactively put in while
-programming so that the data you need to debug may already be there!
-And indeed, once you've found and fixed a problem using print
-statements, it's often worthwhile to convert those prints into proper
-log statements before removing them. This way, if similar bugs occur
-in the future, you'll already have the diagnostic information you need
-without modifying the code.
+ಸಾಮಾನ್ಯವಾಗಿ, ಡಿಬಗ್ಗಿಂಗ್‌ಗೆ ಬೇಕಾದ ಮಾಹಿತಿ ಮುಂಚೆಯೇ ಲಭ್ಯವಾಗಲೆಂದು ನೀವು ಪ್ರೋಗ್ರಾಮಿಂಗ್ ಮಾಡುವಾಗಲೇ logging statements ಅನ್ನು ಪ್ರೋಆಕ್ಟಿವ್ ಆಗಿ ಸೇರಿಸುತ್ತೀರಿ.
+ಮತ್ತು ನಿಜಕ್ಕೂ, print statements ಬಳಸಿ ಸಮಸ್ಯೆಯನ್ನು ಕಂಡು ಸರಿಪಡಿಸಿದ ನಂತರ, ಅವನ್ನು ತೆಗೆದುಹಾಕುವ ಮೊದಲು ಸರಿಯಾದ log statements ಆಗಿ ಪರಿವರ್ತಿಸುವುದು ಬಹಳ ಉಪಯುಕ್ತ.
+ಈ ವಿಧಾನದಿಂದ ಮುಂದೆಯೂ ಹೋಲುವ ದೋಷಗಳು ಕಂಡುಬಂದರೆ,
+ಕೋಡ್ ಅನ್ನು ತಿದ್ದುಪಡಿ ಮಾಡದೇ ನಿಮಗೆ ಬೇಕಾದ diagnostic ಮಾಹಿತಿ ಈಗಾಗಲೇ ಲಭ್ಯವಾಗಿರುತ್ತದೆ.
 
-> **Third-party logs**: Many programs support the `-v` or `--verbose` flag to print more information when they run. This can be useful for discovering why a given command fails. Some even allow repeating the flag for more details. When debugging issues with services (databases, web servers, etc.), check their logs—often in `/var/log/` on Linux. Use `journalctl -u <service>` to view logs for systemd services. For third-party libraries, check if they support debug logging via environment variables or configuration.
+> **Third-party logs**: ಅನೇಕ ಪ್ರೋಗ್ರಾಂಗಳು ಚಾಲನೆಯಲ್ಲಿರುವಾಗ ಹೆಚ್ಚಿನ ಮಾಹಿತಿಯನ್ನು ಮುದ್ರಿಸಲು `-v` ಅಥವಾ `--verbose` flag ಅನ್ನು ಬೆಂಬಲಿಸುತ್ತವೆ. ನಿರ್ದಿಷ್ಟ command ಏಕೆ ವಿಫಲವಾಗುತ್ತಿದೆ ಎಂಬುದನ್ನು ತಿಳಿಯಲು ಇದು ಉಪಯುಕ್ತವಾಗಬಹುದು. ಕೆಲವು ಪ್ರೋಗ್ರಾಂಗಳು ಹೆಚ್ಚಿನ ವಿವರಗಳಿಗೆ flag ಅನ್ನು ಮರುಮರು ನೀಡಲು ಸಹ ಅವಕಾಶ ಕೊಡುತ್ತವೆ. services (databases, web servers, ಇತ್ಯಾದಿ) ಗೆ ಸಂಬಂಧಿಸಿದ ಸಮಸ್ಯೆಗಳನ್ನು ಡಿಬಗ್ ಮಾಡುವಾಗ, ಅವುಗಳ logs ಪರಿಶೀಲಿಸಿ - Linux ನಲ್ಲಿ ಸಾಮಾನ್ಯವಾಗಿ `/var/log/` ನಲ್ಲಿ ಇರುತ್ತವೆ. systemd services ಗಳ log ವೀಕ್ಷಿಸಲು `journalctl -u <service>` ಬಳಸಿ. third-party libraries ಗಾಗಿ, environment variables ಅಥವಾ configuration ಮೂಲಕ debug logging ಬೆಂಬಲವಿದೆಯೇ ಎಂದು ನೋಡಿ.
 
-## Debuggers
+## ಡಿಬಗ್ಗರ್‌ಗಳು
 
-Print debugging works well when you know what to print and can easily modify and re-run your code. Debuggers become valuable when you're not sure what information you need, when the bug only manifests in hard-to-reproduce conditions, or when modifying and restarting the program is expensive (long startup times, complex state to recreate, etc.).
+ನೀವು ಏನು print ಮಾಡಬೇಕು ಎಂದು ತಿಳಿದಿದ್ದಾಗ ಮತ್ತು ಕೋಡ್ ಅನ್ನು ಸುಲಭವಾಗಿ ತಿದ್ದುಪಡಿ ಮಾಡಿ ಮರುಚಾಲನೆ ಮಾಡಬಹುದಾಗಿದ್ದಾಗ print debugging ಉತ್ತಮವಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತದೆ. ಆದರೆ ಯಾವ ಮಾಹಿತಿ ಬೇಕು ಎಂಬುದು ಸ್ಪಷ್ಟವಿಲ್ಲದಾಗ, ದೋಷವು ಪುನರುತ್ಪಾದಿಸಲು ಕಷ್ಟವಾದ ಸಂದರ್ಭಗಳಲ್ಲಿ ಮಾತ್ರ ಕಾಣಿಸಿಕೊಂಡಾಗ, ಅಥವಾ ಪ್ರೋಗ್ರಾಂ ತಿದ್ದುಪಡಿ ಮಾಡಿ ಮರುಪ್ರಾರಂಭಿಸುವುದು ದುಬಾರಿಯಾದಾಗ (ಉದಾ: ದೀರ್ಘ startup ಸಮಯ, ಮರುಸೃಷ್ಟಿಸಲು ಕಷ್ಟವಾದ ಸ್ಥಿತಿ) debuggers ಬಹಳ ಮೌಲ್ಯಮಯವಾಗುತ್ತವೆ.
 
-Debuggers are programs that let you interact with the execution of a program as it happens, allowing you to:
+ಡಿಬಗ್ಗರ್‌ಗಳು ಪ್ರೋಗ್ರಾಂ ಕಾರ್ಯಗತಗೊಳ್ಳುವ ಸಂದರ್ಭದಲ್ಲಿ ಅದರೊಂದಿಗೆ ಸಂವಹನ ಮಾಡಲು ಅವಕಾಶ ನೀಡುವ ಸಾಧನಗಳು. ಇವುಗಳ ಮೂಲಕ ನೀವು:
 
-- Halt execution when it reaches a certain line.
-- Step through one instruction at a time.
-- Inspect values of variables after a crash.
-- Conditionally halt execution when a given condition is met.
-- And many more advanced features.
+- ನಿರ್ದಿಷ್ಟ ಸಾಲಿಗೆ ತಲುಪಿದಾಗ ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು ನಿಲ್ಲಿಸಬಹುದು.
+- ಒಂದೊಂದು instruction ಅನ್ನು ಹಂತ ಹಂತವಾಗಿ ನಡೆಸಬಹುದು.
+- crash ನಂತರ variable ಮೌಲ್ಯಗಳನ್ನು ಪರಿಶೀಲಿಸಬಹುದು.
+- ನಿರ್ದಿಷ್ಟ condition ಸತ್ಯವಾದಾಗ ಮಾತ್ರ ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು ನಿಲ್ಲಿಸಬಹುದು.
+- ಮತ್ತು ಇನ್ನೂ ಅನೇಕ ಸುಧಾರಿತ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಬಳಸಬಹುದು.
 
-Most programming languages support (or come with) some form of debugger. The most versatile are **general-purpose debuggers** like [`gdb`](https://www.gnu.org/software/gdb/) (GNU Debugger) and [`lldb`](https://lldb.llvm.org/) (LLVM Debugger), which can debug any native binary. Many languages also have **language-specific debuggers** that integrate more tightly with the runtime (like Python's pdb or Java's jdb).
+ಬಹುತೇಕ programming languages ಗಳು debugger‌ನ ಯಾವುದೋ ರೂಪವನ್ನು ಬೆಂಬಲಿಸುತ್ತವೆ (ಅಥವಾ ಅದೊಂದಿಗೇ ಬರುತ್ತವೆ). ಅತ್ಯಂತ ಬಹುಮುಖವಾದವು **general-purpose debuggers** ಆಗಿರುವ [`gdb`](https://www.gnu.org/software/gdb/) (GNU Debugger) ಮತ್ತು [`lldb`](https://lldb.llvm.org/) (LLVM Debugger), ಇವು ಯಾವುದೇ native binary ಅನ್ನು ಡಿಬಗ್ ಮಾಡಬಲ್ಲವು. ಅನೇಕ ಭಾಷೆಗಳಿಗೆ runtime ಜೊತೆಗೆ ಹೆಚ್ಚು ಒಗ್ಗೂಡುವ **language-specific debuggers** ಕೂಡ ಇವೆ (ಉದಾ: Python‌ನ pdb, Java‌ನ jdb).
 
-`gdb` is the de-facto standard debugger for C, C++, Rust, and other compiled languages. It lets you probe pretty much any process and get its current machine state: registers, stack, program counter, and more.
+`gdb` C, C++, Rust ಮತ್ತು ಇತರೆ compiled languages ಗಾಗಿ de-facto standard debugger ಆಗಿದೆ. ಇದು ಯಾವುದಾದರೂ process ಅನ್ನು ಪರಿಶೀಲಿಸಲು ಮತ್ತು ಅದರ ಪ್ರಸ್ತುತ machine state - registers, stack, program counter ಮುಂತಾದವುಗಳನ್ನು - ತಿಳಿಯಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
 
-Some useful GDB commands:
+ಕೆಲವು ಉಪಯುಕ್ತ GDB commands:
 
-- `run` - Start the program
-- `b {function}` or `b {file}:{line}` - Set a breakpoint
-- `c` - Continue execution
-- `step` / `next` / `finish` - Step in / step over / step out
-- `p {variable}` - Print value of variable
-- `bt` - Show backtrace (call stack)
-- `watch {expression}` - Break when the value changes
+- `run` - ಪ್ರೋಗ್ರಾಂ ಪ್ರಾರಂಭಿಸು
+- `b {function}` ಅಥವಾ `b {file}:{line}` - breakpoint ಹೊಂದಿಸು
+- `c` - ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆ ಮುಂದುವರಿಸು
+- `step` / `next` / `finish` - ಒಳಗೆ ಹೋಗು / ಮೇಲಿಂದ ಮುಂದುವರಿಸು / ಹೊರಗೆ ಬಾ
+- `p {variable}` - variable ಮೌಲ್ಯ ಮುದ್ರಿಸು
+- `bt` - backtrace (call stack) ತೋರಿಸು
+- `watch {expression}` - ಮೌಲ್ಯ ಬದಲಾಗುವಾಗ break ಆಗು
 
-> Consider using GDB's TUI mode (`gdb -tui` or press `Ctrl-x a` inside GDB) for a split-screen view showing source code alongside the command prompt.
+> source code ಮತ್ತು command prompt ಅನ್ನು split-screen ನಲ್ಲಿ ನೋಡಲು GDBಯ TUI mode (`gdb -tui` ಅಥವಾ GDB ಒಳಗೆ `Ctrl-x a`) ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
 
-### Record-Replay Debugging
+### Record-Replay ಡಿಬಗ್ಗಿಂಗ್
 
-Some of the most frustrating bugs are _Heisenbugs_: bugs that seem to disappear or change behavior when you try to observe them. Race conditions, timing-dependent bugs, and issues that only appear under certain system conditions fall into this category. Traditional debugging is often useless here because running the program again produces different behavior (e.g., print statements may slow down the code sufficiently that the race no longer happens).
+ಕೆಲವು ಅತ್ಯಂತ ಕಿರಿಕಿರಿ ಉಂಟುಮಾಡುವ ದೋಷಗಳು _Heisenbugs_ ಆಗಿರುತ್ತವೆ: ಅವನ್ನು ಗಮನಿಸಲು ಪ್ರಯತ್ನಿಸಿದಾಗ ಅವು ಕಾಣೆಯಾಗುವುದು ಅಥವಾ ವರ್ತನೆ ಬದಲಾಗುವುದು. race conditions, timing-dependent bugs, ಮತ್ತು ನಿರ್ದಿಷ್ಟ system ಪರಿಸ್ಥಿತಿಗಳಲ್ಲಿ ಮಾತ್ರ ಕಾಣಿಸಿಕೊಳ್ಳುವ ಸಮಸ್ಯೆಗಳು ಈ ವರ್ಗಕ್ಕೆ ಸೇರುತ್ತವೆ. ಇಂತಹ ಸಂದರ್ಭಗಳಲ್ಲಿ ಪರಂಪರागत ಡಿಬಗ್ಗಿಂಗ್ ಹೆಚ್ಚಾಗಿ ಫಲಕಾರಿಯಾಗುವುದಿಲ್ಲ, ಏಕೆಂದರೆ ಪ್ರೋಗ್ರಾಂ ಅನ್ನು ಮತ್ತೆ ಓಡಿಸಿದಾಗ ವರ್ತನೆ ಬದಲಾಗಿರುತ್ತದೆ (ಉದಾ: print statements ಕಾರಣದಿಂದ code ನಿಧಾನವಾಗಿ ಓಡಿ race ನಡೆಯದೇ ಇರಬಹುದು).
 
-**Record-replay debugging** solves this by recording a program's execution and allowing you to replay it deterministically as many times as you need. Even better, you can _reverse_ through the execution to find exactly where things went wrong.
+**Record-replay debugging** ಈ ಸಮಸ್ಯೆಗೆ ಪರಿಹಾರ ನೀಡುತ್ತದೆ: ಪ್ರೋಗ್ರಾಂ ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು ದಾಖಲಿಸಿ, ಅದನ್ನು deterministic ರೀತಿಯಲ್ಲಿ ಬೇಕಾದಷ್ಟು ಬಾರಿ replay ಮಾಡಲು ಅವಕಾಶ ನೀಡುತ್ತದೆ. ಇನ್ನೂ ಉತ್ತಮವೆಂದರೆ, ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯಲ್ಲಿ _ಹಿಂದಕ್ಕೆ_ ಹೋಗಿ ದೋಷ ಎಲ್ಲಿ ಸಂಭವಿಸಿತು ಎಂಬುದನ್ನು ಖಚಿತವಾಗಿ ಕಂಡುಹಿಡಿಯಬಹುದು.
 
-[rr](https://rr-project.org/) is a powerful tool for Linux that records program execution and allows deterministic replay with full debugging capabilities. It works with GDB, so you already know the interface.
+[rr](https://rr-project.org/) Linux ಗಾಗಿ ಶಕ್ತಿಶಾಲಿ ಸಾಧನವಾಗಿದೆ. ಇದು ಪ್ರೋಗ್ರಾಂ ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು ದಾಖಲಿಸಿ, ಸಂಪೂರ್ಣ debugging ಸಾಮರ್ಥ್ಯಗಳೊಂದಿಗೆ deterministic replay ಮಾಡಲು ಅವಕಾಶ ನೀಡುತ್ತದೆ. ಇದು GDB ಜೊತೆ ಕೆಲಸ ಮಾಡುವುದರಿಂದ, interface ಈಗಾಗಲೇ ಪರಿಚಿತವಾಗಿರುತ್ತದೆ.
 
-Basic usage:
+ಮೂಲ ಬಳಕೆ:
 
 ```bash
 # Record a program execution
@@ -84,37 +81,37 @@ rr record ./my_program
 rr replay
 ```
 
-The magic happens during replay. Because the execution is deterministic, you can use **reverse debugging** commands:
+ನಿಜವಾದ ಶಕ್ತಿ replay ವೇಳೆ ಗೋಚರಿಸುತ್ತದೆ. ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆ deterministic ಆಗಿರುವುದರಿಂದ, ನೀವು **reverse debugging** commands ಬಳಸಬಹುದು:
 
-- `reverse-continue` (`rc`) - Run backwards until hitting a breakpoint
-- `reverse-step` (`rs`) - Step backwards one line
-- `reverse-next` (`rn`) - Step backwards, skipping function calls
-- `reverse-finish` - Run backwards until entering the current function
+- `reverse-continue` (`rc`) - breakpoint ತಲುಪುವವರೆಗೆ ಹಿಂದಕ್ಕೆ ಓಡು
+- `reverse-step` (`rs`) - ಒಂದು ಸಾಲು ಹಿಂದಕ್ಕೆ ಹಂತ ಹಾಕು
+- `reverse-next` (`rn`) - function calls ಬಿಟ್ಟು ಹಿಂದಕ್ಕೆ ಹಂತ ಹಾಕು
+- `reverse-finish` - ಪ್ರಸ್ತುತ function ಗೆ ಪ್ರವೇಶಿಸುವವರೆಗೆ ಹಿಂದಕ್ಕೆ ಓಡು
 
-This is incredibly powerful for debugging. Say you have a crash—instead of guessing where the bug is and setting breakpoints, you can:
+ಡಿಬಗ್ಗಿಂಗ್‌ಗಾಗಿ ಇದು ಅತ್ಯಂತ ಶಕ್ತಿಯುತ ವಿಧಾನವಾಗಿದೆ. ಉದಾಹರಣೆಗೆ crash ಆಗಿದೆ ಎಂದ್ಕೊಳ್ಳಿ - ದೋಷ ಎಲ್ಲಿರಬಹುದು ಎಂದು ಊಹಿಸಿ breakpoints ಹಾಕುವುದಕ್ಕೆ ಬದಲು, ನೀವು:
 
-1. Run to the crash
-2. Inspect the corrupted state
-3. Set a watchpoint on the corrupted variable
-4. `reverse-continue` to find exactly where it was corrupted
+1. crash ವರೆಗೆ ಓಡಿಸಿ
+2. corrupted state ಪರಿಶೀಲಿಸಿ
+3. corrupted variable ಮೇಲೆ watchpoint ಹೊಂದಿಸಿ
+4. `reverse-continue` ಬಳಸಿ ಅದು ಎಲ್ಲಿ corrupt ಆಯಿತು ಎಂದು ಖಚಿತವಾಗಿ ಕಂಡುಹಿಡಿಯಿರಿ
 
-**When to use rr:**
-- Flaky tests that fail intermittently
-- Race conditions and threading bugs
-- Crashes that are hard to reproduce
-- Any bug where you wish you could "go back in time"
+**rr ಅನ್ನು ಯಾವಾಗ ಬಳಸಬೇಕು:**
+- ಮಧ್ಯಂತರವಾಗಿ ವಿಫಲವಾಗುವ flaky tests
+- race conditions ಮತ್ತು threading bugs
+- ಪುನರುತ್ಪಾದಿಸಲು ಕಷ್ಟವಾದ crashes
+- "ಸಮಯದಲ್ಲಿ ಹಿಂದೆ ಹೋಗಬಹುದೇ?" ಎಂದು ನೀವು ಬಯಸುವ ಯಾವುದೇ bug
 
-> Note: rr only works on Linux and requires hardware performance counters. It doesn't work in VMs that don't expose these counters, such as on most AWS EC2 instances, and it doesn't support GPU access. For macOS, check out [Warpspeed](https://warpspeed.dev/).
+> ಗಮನಿಸಿ: rr Linux ನಲ್ಲಿ ಮಾತ್ರ ಕೆಲಸ ಮಾಡುತ್ತದೆ ಮತ್ತು hardware performance counters ಅಗತ್ಯವಿರುತ್ತವೆ. ಈ counters ಅನ್ನು expose ಮಾಡದ VMಗಳಲ್ಲಿ (ಉದಾ: ಬಹುತೇಕ AWS EC2 instances) ಇದು ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ, ಮತ್ತು GPU access ಗೆ ಬೆಂಬಲವಿಲ್ಲ. macOSಗಾಗಿ [Warpspeed](https://warpspeed.dev/) ನೋಡಿ.
 
-> **rr and concurrency**: Because rr records execution deterministically, it serializes thread scheduling. This means some race conditions may not manifest under rr if they depend on specific timing. rr is still useful for debugging races—once you capture a failing run, you can replay it reliably—but you may need multiple recording attempts to catch an intermittent bug. For bugs that don't involve concurrency, rr shines brightest: you can always reproduce the exact execution and use reverse debugging to hunt down corruption.
+> **rr ಮತ್ತು concurrency**: rr ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು deterministicವಾಗಿ ದಾಖಲಿಸುವುದರಿಂದ, ಇದು thread scheduling ಅನ್ನು serialize ಮಾಡುತ್ತದೆ. ಅಂದರೆ ನಿರ್ದಿಷ್ಟ timing ಮೇಲೆ ಅವಲಂಬಿತವಾಗಿರುವ ಕೆಲವು race conditions rr ಅಡಿ ಕಾಣಿಸದೇ ಇರಬಹುದು. ಆದರೂ rr race debugging ಗೆ ಉಪಯುಕ್ತವೇ - ಒಮ್ಮೆ failing run ಅನ್ನು capture ಮಾಡಿದರೆ ಅದನ್ನು ವಿಶ್ವಾಸಾರ್ಹವಾಗಿ replay ಮಾಡಬಹುದು - ಆದರೆ intermittent bug ಹಿಡಿಯಲು ಹಲವು recording ಪ್ರಯತ್ನಗಳು ಬೇಕಾಗಬಹುದು. concurrency ಸೇರದ ದೋಷಗಳಿಗೆ rr ಅತ್ಯಂತ ಉತ್ತಮ: ನೀವು ಅದೇ ಕಾರ್ಯಗತಗೊಳಿಸುವಿಕೆಯನ್ನು ಎಂದಿಗೂ ಪುನರುತ್ಪಾದಿಸಿ reverse debugging ಮೂಲಕ corruption ಹಂತವರೆಗೆ ತಲುಪಬಹುದು.
 
-## System Call Tracing
+## System Call ಟ್ರೇಸಿಂಗ್
 
-Sometimes you need to understand how your program interacts with the operating system. Programs make [system calls](https://en.wikipedia.org/wiki/System_call) to request services from the kernel—opening files, allocating memory, creating processes, and more. Tracing these calls can reveal why a program is hanging, what files it's trying to access, or where it's spending time waiting.
+ಕೆಲವೊಮ್ಮೆ ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂ operating system ಜೊತೆ ಹೇಗೆ ಸಂವಹನ ಮಾಡುತ್ತದೆ ಎಂಬುದನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಬೇಕಾಗುತ್ತದೆ. ಪ್ರೋಗ್ರಾಂಗಳು kernel ನಿಂದ ಸೇವೆಗಳನ್ನು ಕೇಳಲು [system calls](https://en.wikipedia.org/wiki/System_call) ಮಾಡುತ್ತವೆ - files ತೆರೆಯುವುದು, memory allocate ಮಾಡುವುದು, processes ರಚಿಸುವುದು ಮುಂತಾದವು. ಈ calls ಅನ್ನು trace ಮಾಡುವುದರಿಂದ ಪ್ರೋಗ್ರಾಂ ಏಕೆ hang ಆಗುತ್ತಿದೆ, ಯಾವ files ಅನ್ನು access ಮಾಡಲು ಪ್ರಯತ್ನಿಸುತ್ತಿದೆ, ಅಥವಾ ಯಾವ ಸ್ಥಳದಲ್ಲಿ ಕಾಯುವಿಕೆಯಲ್ಲಿ ಸಮಯ ಕಳೆಯುತ್ತಿದೆ ಎಂಬುದು ಗೊತ್ತಾಗಬಹುದು.
 
-### strace (Linux) and dtruss (macOS)
+### strace (Linux) ಮತ್ತು dtruss (macOS)
 
-[`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) lets you observe every system call a program makes:
+[`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) ಪ್ರೋಗ್ರಾಂ ಮಾಡುವ ಪ್ರತಿಯೊಂದು system call ಅನ್ನು ಗಮನಿಸಲು ಅವಕಾಶ ನೀಡುತ್ತದೆ:
 
 ```bash
 # Trace all system calls
@@ -133,13 +130,13 @@ strace -p <PID>
 strace -T ./my_program
 ```
 
-> On macOS and BSD, use [`dtruss`](https://www.manpagez.com/man/1/dtruss/) (which wraps `dtrace`) for similar functionality:
+> macOS ಮತ್ತು BSD ಯಲ್ಲಿ, ಸಮಾನ ಕಾರ್ಯಕ್ಷಮತೆಗೆ [`dtruss`](https://www.manpagez.com/man/1/dtruss/) (ಇದು `dtrace` ಅನ್ನು wrap ಮಾಡುತ್ತದೆ) ಬಳಸಿ:
 
-> For deeper dives into `strace`, check out Julia Evans' excellent [strace zine](https://jvns.ca/strace-zine-unfolded.pdf).
+> `strace` ಕುರಿತು ಇನ್ನಷ್ಟು ಆಳವಾಗಿ ತಿಳಿಯಲು Julia Evans ಅವರ ಅತ್ಯುತ್ತಮ [strace zine](https://jvns.ca/strace-zine-unfolded.pdf) ನೋಡಿ.
 
-### bpftrace and eBPF
+### bpftrace ಮತ್ತು eBPF
 
-[eBPF](https://ebpf.io/) (extended Berkeley Packet Filter) is a powerful Linux technology that allows running sandboxed programs in the kernel. [`bpftrace`](https://github.com/iovisor/bpftrace) provides a high-level syntax for writing eBPF programs. These are arbitrary programs running in the kernel, and thus have huge expressive power (though also a somewhat clumsy awk-like syntax). The most common use-case for them is to investigate what system calls are being invoked, including aggregations (like counts or latency statistics) or introspecting (or even filtering on) system call arguments.
+[eBPF](https://ebpf.io/) (extended Berkeley Packet Filter) Linux ನಲ್ಲಿನ ಶಕ್ತಿಶಾಲಿ ತಂತ್ರಜ್ಞಾನವಾಗಿದೆ; ಇದು kernel ಒಳಗೆ sandboxed programs ಓಡಿಸಲು ಅವಕಾಶ ಮಾಡುತ್ತದೆ. [`bpftrace`](https://github.com/iovisor/bpftrace) eBPF programs ಬರೆಯಲು high-level syntax ಒದಗಿಸುತ್ತದೆ. ಇವು kernel ನಲ್ಲಿ ನಡೆಯುವ arbitrary programs ಆಗಿರುವುದರಿಂದ, ಅವುಗಳಿಗೆ ದೊಡ್ಡ ಮಟ್ಟದ expressive power ಇದೆ (ಆದರೆ ಸ್ವಲ್ಪ awk-like ಅಸೌಕರ್ಯಕರ syntax ಸಹ ಇದೆ). ಇವುಗಳ ಸಾಮಾನ್ಯ ಬಳಕೆ ಪ್ರಕರಣವೆಂದರೆ ಯಾವ system calls invoke ಆಗುತ್ತಿವೆ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸುವುದು - aggregations (ಉದಾ: counts ಅಥವಾ latency statistics) ಸೇರಿದಂತೆ - ಅಥವಾ system call arguments ಅನ್ನು introspect (ಅಥವಾ filter) ಮಾಡುವುದು.
 
 ```bash
 # Trace file opens system-wide (prints immediately)
@@ -149,9 +146,9 @@ sudo bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm,
 sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* { @[probe] = count(); }'
 ```
 
-However, you can also write eBPF programs directly in C using a toolchain like [`bcc`](https://github.com/iovisor/bcc), which also ships with [many handy tools](https://www.brendangregg.com/blog/2015-09-22/bcc-linux-4.3-tracing.html) like `biosnoop` for printing latency distributions for disk operations or `opensnoop` for printing all open files.
+ಆದರೆ, [`bcc`](https://github.com/iovisor/bcc) போன்ற toolchain ಬಳಸಿ eBPF programs ಅನ್ನು ನೇರವಾಗಿ C ಯಲ್ಲಿ ಬರೆಯಬಹುದು. ಇದರಲ್ಲಿ `biosnoop` (disk operations ಗೆ latency distributions ಮುದ್ರಿಸಲು) ಅಥವಾ `opensnoop` (open files ಎಲ್ಲವನ್ನೂ ಮುದ್ರಿಸಲು) ಮುಂತಾದ [ಬಹಳ ಉಪಯುಕ್ತ ಸಾಧನಗಳು](https://www.brendangregg.com/blog/2015-09-22/bcc-linux-4.3-tracing.html) ಕೂಡ ದೊರಕುತ್ತವೆ.
 
-Where `strace` is useful because it's easy to "just get up and running", `bpftrace` is what you should reach for when you need lower overhead, want to trace through kernel functions, need to do any kind of aggregation, etc. Note that `bpftrace` has to run as `root` though, and that it generally monitors the entire kernel, not just a particular process. To target a specific program, you can filter by command name or PID:
+`strace` ನ ಲಾಭವೆಂದರೆ ಅದನ್ನು ತಕ್ಷಣವೇ ಸುಲಭವಾಗಿ ಪ್ರಾರಂಭಿಸಬಹುದು. ಆದರೆ ಕಡಿಮೆ overhead ಬೇಕಾದಾಗ, kernel functions ಮೂಲಕ trace ಮಾಡಬೇಕಾದಾಗ, ಅಥವಾ ಯಾವುದಾದರೂ aggregation ಬೇಕಾದಾಗ `bpftrace` ಅನ್ನು ಬಳಸುವುದು ಸೂಕ್ತ. ಆದರೆ `bpftrace` ಅನ್ನು `root` ಆಗಿ ಓಡಿಸಬೇಕು, ಹಾಗೂ ಇದು ಸಾಮಾನ್ಯವಾಗಿ ನಿರ್ದಿಷ್ಟ process ಮಾತ್ರವಲ್ಲದೆ ಸಂಪೂರ್ಣ kernel ಅನ್ನು monitor ಮಾಡುತ್ತದೆ ಎಂಬುದನ್ನು ಗಮನಿಸಿ. ನಿರ್ದಿಷ್ಟ program ಗುರಿಯಾಗಬೇಕಾದರೆ command name ಅಥವಾ PID ಆಧಾರವಾಗಿ filter ಮಾಡಬಹುದು:
 
 ```bash
 # Filter by command name (prints summary on Ctrl-C)
@@ -161,11 +158,11 @@ sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* /comm == "bash"/ { @[probe] = 
 sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* /pid == cpid/ { @[probe] = count(); }' -c 'ls -la'
 ```
 
-The `-c` flag runs the specified command and sets `cpid` to its PID, which is useful for tracing a program from the moment it starts. When the traced command exits, bpftrace prints the aggregated results.
+`-c` flag ನಿರ್ದಿಷ್ಟ command ಅನ್ನು ಓಡಿಸಿ ಅದರ PID ಅನ್ನು `cpid` ಗೆ ಹೊಂದಿಸುತ್ತದೆ. ಪ್ರೋಗ್ರಾಂ ಪ್ರಾರಂಭವಾದ ಕ್ಷಣದಿಂದ trace ಮಾಡಲು ಇದು ಉಪಯುಕ್ತ. trace ಆಗುತ್ತಿರುವ command ಮುಗಿದ ನಂತರ bpftrace aggregated ಫಲಿತಾಂಶಗಳನ್ನು ಮುದ್ರಿಸುತ್ತದೆ.
 
-### Network Debugging
+### ನೆಟ್ವರ್ಕ್ ಡಿಬಗ್ಗಿಂಗ್
 
-For network issues, [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) and [Wireshark](https://www.wireshark.org/) let you capture and analyze network packets:
+ನೆಟ್ವರ್ಕ್ ಸಮಸ್ಯೆಗಳಿಗಾಗಿ [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) ಮತ್ತು [Wireshark](https://www.wireshark.org/) ಬಳಸಿ network packets capture ಮಾಡಿ ವಿಶ್ಲೇಷಿಸಬಹುದು:
 
 ```bash
 # Capture packets on port 80
@@ -175,16 +172,16 @@ sudo tcpdump -i any port 80
 sudo tcpdump -i any -w capture.pcap
 ```
 
-For HTTPS traffic, the encryption makes tcpdump less useful. Tools like [mitmproxy](https://mitmproxy.org/) can act as an intercepting proxy to inspect encrypted traffic. Browser developer tools (Network tab) are often the easiest way to debug HTTPS requests from web applications—they show decrypted request/response data, headers, and timing.
+HTTPS traffic ಗಾಗಿ encryption ಇರುವುದರಿಂದ tcpdump ಕಡಿಮೆ ಉಪಯುಕ್ತವಾಗಬಹುದು. [mitmproxy](https://mitmproxy.org/) போன்ற tools intercepting proxy ಆಗಿ ಕೆಲಸಮಾಡಿ encrypted traffic ಪರಿಶೀಲಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ. web applications ನ HTTPS requests ಡಿಬಗ್ ಮಾಡಲು browser developer tools (Network tab) ಸಾಮಾನ್ಯವಾಗಿ ಸುಲಭ ವಿಧಾನವಾಗಿದೆ - ಇವು decrypted request/response data, headers, ಮತ್ತು timing ತೋರಿಸುತ್ತವೆ.
 
-## Memory Debugging
+## ಮೆಮೊರಿ ಡಿಬಗ್ಗಿಂಗ್
 
-Memory bugs—buffer overflows, use-after-free, memory leaks—are among the most dangerous and difficult to debug. They often don't crash immediately but corrupt memory in ways that cause problems much later.
+buffer overflows, use-after-free, memory leaks ಮುಂತಾದ memory bugs ಅತ್ಯಂತ ಅಪಾಯಕಾರಿ ಮತ್ತು ಡಿಬಗ್ ಮಾಡಲು ಕಷ್ಟವಾದವುಗಳಾಗಿವೆ. ಇವು ತಕ್ಷಣ crash ಆಗದೇ, ನಂತರದ ಹಂತಗಳಲ್ಲಿ ಸಮಸ್ಯೆ ಉಂಟುಮಾಡುವ ರೀತಿಯಲ್ಲಿ memory ಅನ್ನು ಹಾಳುಮಾಡಬಹುದು.
 
 ### Sanitizers
 
-One approach to finding memory bugs is to use **sanitizers**, which are compiler features that instrument your code to detect errors at runtime. For example, the widely used **AddressSanitizer (ASan)** detects:
-- Buffer overflows (stack, heap, and global)
+memory bugs ಹುಡುಕುವ ಒಂದು ವಿಧಾನವೆಂದರೆ **sanitizers** ಬಳಸುವುದು. ಇವು compiler ವೈಶಿಷ್ಟ್ಯಗಳು; runtime ನಲ್ಲಿ errors ಪತ್ತೆಹಚ್ಚಲು ನಿಮ್ಮ code ಅನ್ನು instrument ಮಾಡುತ್ತವೆ. ಉದಾಹರಣೆಗೆ ವ್ಯಾಪಕವಾಗಿ ಬಳಕೆಯಲ್ಲಿರುವ **AddressSanitizer (ASan)** ಕೆಳಗಿನ ದೋಷಗಳನ್ನು ಪತ್ತೆಹಚ್ಚುತ್ತದೆ:
+- Buffer overflows (stack, heap, ಮತ್ತು global)
 - Use-after-free
 - Use-after-return
 - Memory leaks
@@ -195,66 +192,66 @@ gcc -fsanitize=address -g program.c -o program
 ./program
 ```
 
-There are a variety of useful sanitizers:
+ಉಪಯುಕ್ತವಾದ ಹಲವು sanitizers ಲಭ್ಯವಿವೆ:
 
-- **ThreadSanitizer (TSan)**: Detects data races in multithreaded code (`-fsanitize=thread`)
-- **MemorySanitizer (MSan)**: Detects reads of uninitialized memory (`-fsanitize=memory`)
-- **UndefinedBehaviorSanitizer (UBSan)**: Detects undefined behavior like integer overflow (`-fsanitize=undefined`)
+- **ThreadSanitizer (TSan)**: multithreaded code ನಲ್ಲಿ data races ಪತ್ತೆಹಚ್ಚುತ್ತದೆ (`-fsanitize=thread`)
+- **MemorySanitizer (MSan)**: uninitialized memory ಓದುಗಳನ್ನು ಪತ್ತೆಹಚ್ಚುತ್ತದೆ (`-fsanitize=memory`)
+- **UndefinedBehaviorSanitizer (UBSan)**: integer overflow ಮುಂತಾದ undefined behavior ಪತ್ತೆಹಚ್ಚುತ್ತದೆ (`-fsanitize=undefined`)
 
-Sanitizers require recompilation but are fast enough to use in CI pipelines and during regular development.
+sanitizers ಬಳಸಲು recompilation ಅಗತ್ಯ, ಆದರೆ CI pipelines ಮತ್ತು ದೈನಂದಿನ development ನಲ್ಲಿ ಬಳಕೆಗೆ ಸಾಕಷ್ಟು ವೇಗವಾಗಿವೆ.
 
-### Valgrind: When You Can't Recompile
+### Valgrind: ಮರುಸಂಕಲನ ಸಾಧ್ಯವಿಲ್ಲದಾಗ
 
-[Valgrind](https://valgrind.org/) instead runs your program in something akin to a virtual machine to detect memory errors. It's slower than sanitizers but doesn't require recompilation:
+[Valgrind](https://valgrind.org/) memory errors ಪತ್ತೆಹಚ್ಚಲು ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂ ಅನ್ನು virtual machine ಗೆ ಸಮಾನವಾದ ನಿಯಂತ್ರಿತ ಪರಿಸರದಲ್ಲಿ ಓಡಿಸುತ್ತದೆ. sanitizers ಗಿಂತ ನಿಧಾನ, ಆದರೆ recompilation ಅಗತ್ಯವಿಲ್ಲ:
 
 ```bash
 valgrind --leak-check=full ./my_program
 ```
 
-Use Valgrind when:
-- You don't have source code
-- You can't recompile (third-party libraries)
-- You need specific tools not available as sanitizers
+ಈ ಸಂದರ್ಭಗಳಲ್ಲಿ Valgrind ಬಳಸಿ:
+- source code ಇಲ್ಲದಿದ್ದಾಗ
+- ಮರುಸಂಕಲನ ಮಾಡಲು ಆಗದಿದ್ದಾಗ (third-party libraries)
+- sanitizers ರೂಪದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲದ ನಿರ್ದಿಷ್ಟ tools ಬೇಕಾದಾಗ
 
-Valgrind is actually a really powerful controlled execution environment, and we'll see more of it later when we get to profiling!
+Valgrind ನಿಜವಾಗಿ ಬಹಳ ಶಕ್ತಿಯುತ ನಿಯಂತ್ರಿತ execution environment ಆಗಿದೆ. profiling ವಿಭಾಗಕ್ಕೆ ಬಂದಾಗ ಇದರ ಬಗ್ಗೆ ಇನ್ನಷ್ಟು ನೋಡುತ್ತೇವೆ.
 
-## AI for Debugging
+## ಡಿಬಗ್ಗಿಂಗ್‌ಗಾಗಿ AI
 
-Large language models have become surprisingly useful debugging assistants. They excel at certain debugging tasks that complement traditional tools.
+Large language models ಪರಂಪರಾಗತ tools ಗೆ ಪೂರಕವಾಗುವ ರೀತಿಯಲ್ಲಿ ಆಶ್ಚರ್ಯಕರವಾಗಿ ಉಪಯುಕ್ತ debugging assistants ಆಗಿವೆ. ನಿರ್ದಿಷ್ಟ ರೀತಿಯ debugging ಕಾರ್ಯಗಳಲ್ಲಿ ಇವು ಹೆಚ್ಚು ಪರಿಣಾಮಕಾರಿ.
 
-**Where LLMs shine:**
+**LLMs ಉತ್ತಮವಾಗಿ ನೆರವಾಗುವ ಸ್ಥಳಗಳು:**
 
-- **Explaining cryptic error messages**: Compiler errors, especially from C++ templates or Rust's borrow checker, can be notoriously cryptic. LLMs can translate them into plain English and suggest fixes.
+- **ಗುಂಗುರುವ error messages ವಿವರಣೆ**: Compiler errors - ವಿಶೇಷವಾಗಿ C++ templates ಅಥವಾ Rust borrow checker ನವು - ಬಹಳ ಗೂಢವಾಗಿರಬಹುದು. LLMs ಅವನ್ನು ಸರಳ ಭಾಷೆಗೆ ಅನುವಾದಿಸಿ ತಿದ್ದುಪಡಿ ಸಲಹೆಗಳನ್ನು ನೀಡಬಹುದು.
 
-- **Traversing language and abstraction boundaries**: If you're debugging a problem that spans multiple languages (say, a bug in a C library that manifests through a Python binding), LLMs can help navigate the different layers. They're particularly good at understanding FFI boundaries, build system issues, and cross-language debugging (e.g., my program errors, but I believe it is because of a bug in one of my dependencies).
+- **ಭಾಷೆ ಮತ್ತು abstraction ಗಡಿಗಳನ್ನು ದಾಟುವುದು**: ಹಲವು ಭಾಷೆಗಳನ್ನು ಅಡ್ಡಬರುವ ದೋಷವನ್ನು (ಉದಾ: Python binding ಮೂಲಕ ಕಾಣಿಸಿಕೊಳ್ಳುವ C library ದೋಷ) ಡಿಬಗ್ ಮಾಡುತ್ತಿರುವಾಗ, LLMs ವಿಭಿನ್ನ ಪದರಗಳನ್ನು ಅನ್ವೇಷಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ. FFI boundaries, build system issues, ಮತ್ತು cross-language debugging ನಲ್ಲಿ ಇವು ವಿಶೇಷವಾಗಿ ಉತ್ತಮ (ಉದಾ: ನನ್ನ ಪ್ರೋಗ್ರಾಂ ದೋಷ ತೋರಿಸುತ್ತದೆ, ಆದರೆ ಅದು dependency ಯ ದೋಷ ಎಂದು ನಾನು ನಂಬುತ್ತೇನೆ).
 
-- **Correlating symptoms with root causes**: "My program works fine but uses 10x more memory than expected" is the kind of vague symptom that LLMs can help investigate, suggesting likely causes and what to look for.
+- **ಲಕ್ಷಣಗಳು ಮತ್ತು ಮೂಲ ಕಾರಣಗಳ ನಡುವೆ ಸಂಬಂಧ ಕಂಡುಹಿಡಿಯುವುದು**: "ನನ್ನ ಪ್ರೋಗ್ರಾಂ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತದೆ ಆದರೆ ನಿರೀಕ್ಷಿತಕ್ಕಿಂತ 10x memory ಹೆಚ್ಚು ಬಳಕೆ ಮಾಡುತ್ತಿದೆ" ಎಂಬಂತ ಅಸ್ಪಷ್ಟ ಲಕ್ಷಣಗಳನ್ನು ಪರಿಶೀಲಿಸಲು LLMs ಸಾಧ್ಯ ಕಾರಣಗಳು ಮತ್ತು ಯಾವ ಅಂಶಗಳನ್ನು ಪರೀಕ್ಷಿಸಬೇಕು ಎಂಬುದರ ಬಗ್ಗೆ ದಿಕ್ಕು ತೋರಿಸುತ್ತವೆ.
 
-- **Analyzing crash dumps and stack traces**: Paste a stack trace and ask what might have caused it.
+- **crash dumps ಮತ್ತು stack traces ವಿಶ್ಲೇಷಣೆ**: stack trace ಅಂಟಿಸಿ, ಅದಕ್ಕೆ ಸಾಧ್ಯ ಕಾರಣಗಳ ಬಗ್ಗೆ ಪ್ರಶ್ನಿಸಬಹುದು.
 
-> **Note on debug symbols**: For meaningful stack traces and debugging, ensure your binaries (and any linked libraries) are compiled with debug symbols (`-g` flag). Debug information is typically stored in DWARF format. Additionally, compiling with frame pointers (`-fno-omit-frame-pointer`) makes stack traces more reliable, especially for profiling tools. Without these, stack traces may show only memory addresses or be incomplete. This matters more for natively compiled programs (C++, Rust) than Python or Java.
+> **debug symbols ಬಗ್ಗೆ ಗಮನಿಸಿ**: ಅರ್ಥಪೂರ್ಣ stack traces ಮತ್ತು debugging ಗಾಗಿ, binaries (ಮತ್ತು link ಆಗಿರುವ libraries) debug symbols (`-g` flag) ಜೊತೆ compile ಆಗಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿ. debug ಮಾಹಿತಿ ಸಾಮಾನ್ಯವಾಗಿ DWARF format ನಲ್ಲಿ ಸಂಗ್ರಹವಾಗಿರುತ್ತದೆ. ಜೊತೆಗೆ frame pointers (`-fno-omit-frame-pointer`) ಜೊತೆ compile ಮಾಡಿದರೆ stack traces ಹೆಚ್ಚು ವಿಶ್ವಾಸಾರ್ಹವಾಗುತ್ತವೆ - ವಿಶೇಷವಾಗಿ profiling tools ಗಾಗಿ. ಇಲ್ಲದಿದ್ದರೆ stack traces ನಲ್ಲಿ memory addresses ಮಾತ್ರ ಕಾಣಿಸಬಹುದು ಅಥವಾ ಅವು ಅಪೂರ್ಣವಾಗಿರಬಹುದು. ಇದು Python ಅಥವಾ Java ಗಿಂತ native compiled programs (C++, Rust) ಗಾಗಿ ಹೆಚ್ಚು ಮಹತ್ವದ್ದಾಗಿದೆ.
 
-**Limitations to keep in mind:**
-- LLMs can hallucinate plausible-sounding but wrong explanations
-- They may suggest fixes that mask the bug rather than fix it
-- Always verify suggestions with actual debugging tools
-- They work best as a complement to, not replacement for, understanding your code
+**ಗಮನದಲ್ಲಿರಬೇಕಾದ ಮಿತಿಗಳು:**
+- LLMs ಯುಕ್ತಿಯುಕ್ತವಾಗಿ ಕೇಳಿಸಬಹುದಾದರೂ ತಪ್ಪಾದ ವಿವರಣೆಗಳನ್ನು (hallucinations) ನೀಡಬಹುದು
+- ಅವು ದೋಷವನ್ನು ಸರಿಪಡಿಸುವ ಬದಲು ಅದನ್ನು ಮಸುಕಾಗಿಸುವ ತಿದ್ದುಪಡಿಗಳನ್ನು ಸೂಚಿಸಬಹುದು
+- ಸಲಹೆಗಳನ್ನು ಯಾವಾಗಲೂ ನೈಜ debugging tools ಬಳಸಿ ಪರಿಶೀಲಿಸಿ
+- ಇವು ನಿಮ್ಮ code ಅರಿವಿಗೆ ಪರ್ಯಾಯವಲ್ಲ; ಪೂರಕ ಮಾತ್ರ
 
-> This is distinct from the [general AI coding capabilities](/2026/development-environment/#ai-powered-development) covered in the Development Environment lecture. Here we're specifically talking about using LLMs as a debugging aid.
+> ಇದು Development Environment ಉಪನ್ಯಾಸದಲ್ಲಿ ಒಳಗೊಂಡಿರುವ [general AI coding capabilities](/2026/development-environment/#ai-powered-development) ಇಂದ ಭಿನ್ನವಾಗಿದೆ. ಇಲ್ಲಿ ನಾವು ವಿಶೇಷವಾಗಿ LLMs ಅನ್ನು debugging ನೆರವಿಗಾಗಿ ಬಳಸುವ ಬಗ್ಗೆ ಮಾತನಾಡುತ್ತಿದ್ದೇವೆ.
 
-# Profiling
+# ಪ್ರೊಫೈಲಿಂಗ್
 
-Even if your code functionally behaves as you would expect, that might not be good enough if it takes all your CPU or memory in the process. Algorithms classes often teach big _O_ notation but not how to find hot spots in your programs. Since [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), you should learn about profilers and monitoring tools. They will help you understand which parts of your program are taking most of the time and/or resources so you can focus on optimizing those parts.
+ನಿಮ್ಮ code ಕಾರ್ಯಾತ್ಮಕವಾಗಿ ಸರಿಯಾಗಿದ್ದರೂ, ಅದೇ ಸಮಯದಲ್ಲಿ ಎಲ್ಲ CPU ಅಥವಾ memory ಸಂಪನ್ಮೂಲಗಳನ್ನು ಉಪಯೋಗಿಸಿದರೆ ಅದು ಸಾಕಾಗುವುದಿಲ್ಲ. algorithms ತರಗತಿಗಳು ಸಾಮಾನ್ಯವಾಗಿ big _O_ notation ಅನ್ನು ಕಲಿಸುತ್ತವೆ, ಆದರೆ ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂಗಳಲ್ಲಿ hot spots ಹೇಗೆ ಕಂಡುಹಿಡಿಯುವುದು ಎಂಬುದನ್ನು ಕಲಿಸುವುದಿಲ್ಲ. [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization) ಎಂಬುದರಿಂದ, profilers ಮತ್ತು monitoring tools ಬಗ್ಗೆ ಕಲಿಯುವುದು ಮುಖ್ಯ. ಇವು ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂನ ಯಾವ ಭಾಗಗಳಲ್ಲಿ ಹೆಚ್ಚು ಸಮಯ ಮತ್ತು/ಅಥವಾ ಸಂಪನ್ಮೂಲ ಬಳಕೆಯಾಗುತ್ತಿದೆ ಎಂಬುದನ್ನು ತಿಳಿಸಿ, ನೀವು ಸುಧಾರಣೆಗೊಳಿಸಬೇಕಾದ ಭಾಗಗಳ ಮೇಲೆ ಕೇಂದ್ರೀಕರಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ.
 
-## Timing
+## ಸಮಯ ಮಾಪನ
 
-The simplest way to measure performance is to time things. In many scenarios it can be enough to just print the time it took your code between two points.
+ಕಾರ್ಯಕ್ಷಮತೆ ಅಳೆಯುವ ಅತ್ಯಂತ ಸರಳ ವಿಧಾನವೆಂದರೆ ಸಮಯ ಮಾಪನ. ಅನೇಕ ಸಂದರ್ಭಗಳಲ್ಲಿ ನಿಮ್ಮ code ನಲ್ಲಿ ಎರಡು ಬಿಂದುಗಳ ನಡುವೆ ತೆಗೆದುಕೊಂಡ ಸಮಯವನ್ನು print ಮಾಡಿದರೆ ಸಾಕಾಗಬಹುದು.
 
-However, wall clock time can be misleading since your computer might be running other processes at the same time or waiting for events to happen. The `time` command distinguishes between _Real_, _User_, and _Sys_ time:
+ಆದರೆ wall clock time ತಪ್ಪುದಾರಿ ತೋರಿಸಬಹುದು, ಏಕೆಂದರೆ ನಿಮ್ಮ ಕಂಪ್ಯೂಟರ್ ಸಮಕಾಲೀನವಾಗಿ ಬೇರೆ processes ಓಡಿಸುತ್ತಿರಬಹುದು ಅಥವಾ ಘಟನೆಗಳಿಗಾಗಿ ಕಾಯುತ್ತಿರಬಹುದು. `time` command _Real_, _User_, ಮತ್ತು _Sys_ ಸಮಯಗಳನ್ನು ಪ್ರತ್ಯೇಕಿಸುತ್ತದೆ:
 
-- **Real** - Wall clock time from start to finish, including time spent waiting
-- **User** - Time spent in the CPU running user code
-- **Sys** - Time spent in the CPU running kernel code
+- **Real** - ಆರಂಭದಿಂದ ಅಂತ್ಯವರೆಗಿನ wall clock ಸಮಯ, ಕಾಯುವ ಸಮಯ ಸಹಿತ
+- **User** - user code ನಡೆಸುವಾಗ CPU ನಲ್ಲಿ ಕಳೆದ ಸಮಯ
+- **Sys** - kernel code ನಡೆಸುವಾಗ CPU ನಲ್ಲಿ ಕಳೆದ ಸಮಯ
 
 ```bash
 $ time curl https://missing.csail.mit.edu &> /dev/null
@@ -263,58 +260,58 @@ user	0m0.079s
 sys	    0m0.028s
 ```
 
-Here the request took nearly 300 milliseconds (real time) but only 107ms of CPU time (user + sys). The rest was waiting for the network.
+ಈ ಉದಾಹರಣೆಯಲ್ಲಿ request ಸುಮಾರು 300 milliseconds (real time) ತೆಗೆದುಕೊಂಡರೂ, CPU ಸಮಯ ಕೇವಲ 107ms (user + sys) ಮಾತ್ರ. ಉಳಿದದ್ದು network ಕಾಯುವಿಕೆಯಲ್ಲಿ ಕಳೆದಿದೆ.
 
-## Resource Monitoring
+## ಸಂಪನ್ಮೂಲ ಮಾನಿಟರಿಂಗ್
 
-Sometimes the first step towards analyzing the performance of your program is to understand what its actual resource consumption is. Programs often run slowly when they are resource constrained.
+ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂನ ಕಾರ್ಯಕ್ಷಮತೆಯನ್ನು ವಿಶ್ಲೇಷಿಸುವ ಮೊದಲ ಹೆಜ್ಜೆಯಾಗಿ ಅದರ ನಿಜವಾದ ಸಂಪನ್ಮೂಲ ಬಳಕೆ ಏನು ಎಂಬುದನ್ನು ತಿಳಿದುಕೊಳ್ಳುವುದು ಅಗತ್ಯವಾಗಿರಬಹುದು. programs ಸಾಮಾನ್ಯವಾಗಿ resource constrained ಆಗಿದ್ದಾಗ ನಿಧಾನವಾಗಿ ಓಡುತ್ತವೆ.
 
-- **General Monitoring**: [`htop`](https://htop.dev/) is an improved version of `top` that presents various statistics for currently running processes. Useful keybinds: `<F6>` to sort processes, `t` to show tree hierarchy, `h` to toggle threads. There's also [`btop`](https://github.com/aristocratos/btop) which monitors _way_ more things.
+- **General Monitoring**: [`htop`](https://htop.dev/) `top` ನ ಸುಧಾರಿತ ರೂಪವಾಗಿದ್ದು, ಪ್ರಸ್ತುತ ಓಡುತ್ತಿರುವ processes ಗಳ ವಿವಿಧ ಅಂಕಿಅಂಶಗಳನ್ನು ತೋರಿಸುತ್ತದೆ. ಉಪಯುಕ್ತ keybinds: processes sort ಮಾಡಲು `<F6>`, tree hierarchy ತೋರಿಸಲು `t`, threads toggle ಮಾಡಲು `h`. ಹೆಚ್ಚುವರಿಯಾಗಿ _ಇನ್ನಷ್ಟು_ ಅಂಶಗಳನ್ನು ಮಾನಿಟರ್ ಮಾಡುವ [`btop`](https://github.com/aristocratos/btop) ಕೂಡ ಇದೆ.
 
-- **I/O Operations**: [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) displays live I/O usage information.
+- **I/O Operations**: [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) live I/O ಬಳಕೆ ಮಾಹಿತಿಯನ್ನು ತೋರಿಸುತ್ತದೆ.
 
-- **Memory Usage**: [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) displays total free and used memory.
+- **Memory Usage**: [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) ಒಟ್ಟು free ಮತ್ತು used memory ತೋರಿಸುತ್ತದೆ.
 
-- **Open Files**: [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) lists file information about files opened by processes. Useful for checking which process has opened a specific file.
+- **Open Files**: [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) processes ತೆರೆಯಿರುವ files ಬಗ್ಗೆ ಮಾಹಿತಿ ಪಟ್ಟಿ ಮಾಡುತ್ತದೆ. ನಿರ್ದಿಷ್ಟ file ಅನ್ನು ಯಾವ process ತೆರೆಯಿದೆ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸಲು ಉಪಯುಕ್ತ.
 
-- **Network Connections**: [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) lets you monitor network connections. A common use case is figuring out what process is using a given port: `ss -tlnp | grep :8080`.
+- **Network Connections**: [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) network connections ಮಾನಿಟರ್ ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ. ಸಾಮಾನ್ಯ ಬಳಕೆ: ನಿರ್ದಿಷ್ಟ port ಅನ್ನು ಯಾವ process ಬಳಸುತ್ತಿದೆ ಎಂದು ಕಂಡುಹಿಡಿಯುವುದು - `ss -tlnp | grep :8080`.
 
-- **Network Usage**: [`nethogs`](https://github.com/raboof/nethogs) and [`iftop`](https://pdw.ex-parrot.com/iftop/) are good interactive CLI tools for monitoring network usage per process.
+- **Network Usage**: [`nethogs`](https://github.com/raboof/nethogs) ಮತ್ತು [`iftop`](https://pdw.ex-parrot.com/iftop/) process ಪ್ರತಿ network ಬಳಕೆಯನ್ನು ಮಾನಿಟರ್ ಮಾಡಲು ಉತ್ತಮ interactive CLI tools.
 
-## Visualizing Performance Data
+## ಕಾರ್ಯಕ್ಷಮತಾ ಡೇಟಾ ದೃಶ್ಯೀಕರಣ
 
-Humans spot patterns in graphs much faster than in tables of numbers. When analyzing performance, plotting your data often reveals trends, spikes, and anomalies that would be invisible in raw numbers.
+ಮಾನವರು ಸಂಖ್ಯೆಗಳ ಪಟ್ಟಿಗಿಂತ ಗ್ರಾಫ್‌ಗಳಲ್ಲಿ ಮಾದರಿಗಳನ್ನು ಬಹಳ ವೇಗವಾಗಿ ಗುರುತಿಸುತ್ತಾರೆ. ಕಾರ್ಯಕ್ಷಮತಾ ವಿಶ್ಲೇಷಣೆಯಲ್ಲಿ ಡೇಟಾವನ್ನು plot ಮಾಡಿದರೆ raw ಸಂಖ್ಯಗಳಲ್ಲಿ ಕಾಣದ trends, spikes, anomalies ಸ್ಪಷ್ಟವಾಗುತ್ತವೆ.
 
-**Making data plottable**: When adding print or log statements for debugging, consider formatting the output so it can be easily graphed later. A simple timestamp and value in CSV format (`1705012345,42.5`) is much easier to plot than a prose sentence. JSON-structured logs can also be parsed and plotted with minimal effort. In other words, log your data [in a tidy way](https://vita.had.co.nz/papers/tidy-data.pdf).
+**ಡೇಟಾವನ್ನು plot ಮಾಡಲು ಸೂಕ್ತಗೊಳಿಸುವುದು**: debugging ಗಾಗಿ print ಅಥವಾ log statements ಸೇರಿಸುವಾಗ, output ಅನ್ನು ನಂತರ ಸುಲಭವಾಗಿ graph ಮಾಡಲು ಸಾಧ್ಯವಾಗುವಂತೆ ವಿನ್ಯಾಸಗೊಳಿಸುವುದನ್ನು ಪರಿಗಣಿಸಿ. ಉದಾ: CSV (`1705012345,42.5`) ರೂಪದಲ್ಲಿ ಸರಳ timestamp ಮತ್ತು value, prose sentence ಗಿಂತ plot ಮಾಡಲು ಬಹಳ ಸುಲಭ. JSON-structured logs ಕೂಡ ಕಡಿಮೆ ಪ್ರಯತ್ನದಲ್ಲಿ parse ಮಾಡಿ plot ಮಾಡಬಹುದು. ಅಂದರೆ, ನಿಮ್ಮ ಡೇಟಾವನ್ನು [tidy ರೀತಿಯಲ್ಲಿ](https://vita.had.co.nz/papers/tidy-data.pdf) log ಮಾಡಿ.
 
-**Quick plotting with gnuplot**: For simple command-line plotting, [`gnuplot`](http://www.gnuplot.info/) can generate graphs directly from data files:
+**gnuplot ಮೂಲಕ ವೇಗವಾದ plotting**: ಸರಳ command-line plotting ಗಾಗಿ [`gnuplot`](http://www.gnuplot.info/) data files ನಿಂದ ನೇರವಾಗಿ graphs ರಚಿಸಬಹುದು:
 
 ```bash
 # Plot a simple CSV with timestamp,value
 gnuplot -e "set datafile separator ','; plot 'latency.csv' using 1:2 with lines"
 ```
 
-**Iterative exploration with matplotlib and ggplot2**: For deeper analysis, Python's [`matplotlib`](https://matplotlib.org/) and R's [`ggplot2`](https://ggplot2.tidyverse.org/) enable iterative exploration. Unlike one-off plotting, these tools let you quickly slice and transform data to investigate hypotheses. ggplot2's facet plots are particularly powerful—you can split a single dataset across multiple subplots by category (e.g., faceting request latency by endpoint or time-of-day) to tease out patterns that would otherwise be hidden.
+**matplotlib ಮತ್ತು ggplot2 ಮೂಲಕ ಪುನರಾವರ್ತಿತ ಅನ್ವೇಷಣೆ**: ಆಳವಾದ ವಿಶ್ಲೇಷಣೆಗೆ Python ನ [`matplotlib`](https://matplotlib.org/) ಮತ್ತು R ನ [`ggplot2`](https://ggplot2.tidyverse.org/) ಉಪಕರಣಗಳು iterative exploration ಗೆ ಅನುಕೂಲಕರ. one-off plotting ಗಿಂತ ಭಿನ್ನವಾಗಿ, ಇವು hypotheses ಪರಿಶೀಲಿಸಲು data ಅನ್ನು ತ್ವರಿತವಾಗಿ slice ಮತ್ತು transform ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ. ggplot2 ನ facet plots ವಿಶೇಷವಾಗಿ ಶಕ್ತಿಶಾಲಿ - category ಆಧಾರದ ಮೇಲೆ ಒಂದೇ dataset ಅನ್ನು ಹಲವಾರು subplots ಗಳಾಗಿ ವಿಭಜಿಸಬಹುದು (ಉದಾ: endpoint ಅಥವಾ time-of-day ಪ್ರಕಾರ request latency faceting), ಇದರಿಂದ ಮರೆಯಾಗಿದ್ದ ಮಾದರಿಗಳು ಗೋಚರಿಸುತ್ತವೆ.
 
-**Example use cases:**
-- Plotting request latency over time reveals periodic slowdowns (garbage collection, cron jobs, traffic patterns) that raw percentiles obscure
-- Visualizing insert times for a growing data structure can expose algorithmic complexity issues—a plot of vector insertions will show characteristic spikes when the backing array doubles in size
-- Faceting metrics by different dimensions (request type, user cohort, server) often reveals that a "system-wide" problem is actually isolated to one category
+**ಉದಾಹರಣೆ ಬಳಕೆ ಪ್ರಕರಣಗಳು:**
+- ಕಾಲಾಂತರದಲ್ಲಿ request latency plot ಮಾಡಿದರೆ periodic slowdowns (garbage collection, cron jobs, traffic patterns) ಗೋಚರಿಸುತ್ತವೆ - raw percentiles ಇದನ್ನು ಮರೆಮಾಚಬಹುದು
+- ಬೆಳೆಯುತ್ತಿರುವ data structure ಗಾಗಿ insert times ದೃಶ್ಯೀಕರಿಸಿದರೆ algorithmic complexity ಸಮಸ್ಯೆಗಳು ಬಯಲಾಗಬಹುದು - vector insertions plot ನಲ್ಲಿ backing array ದ್ವಿಗುಣಗೊಳ್ಳುವಾಗ ಲಕ್ಷಣಾತ್ಮಕ spikes ಕಾಣುತ್ತವೆ
+- ಬೇರೆ dimensions (request type, user cohort, server) ಆಧಾರವಾಗಿ metrics faceting ಮಾಡಿದಾಗ, "system-wide" ಸಮಸ್ಯೆ ವಾಸ್ತವದಲ್ಲಿ ಒಂದೇ category ಗೆ ಸೀಮಿತವಾಗಿರುವುದು ಅನೇಕ ಬಾರಿ ತಿಳಿಯುತ್ತದೆ
 
-## CPU Profilers
+## CPU ಪ್ರೊಫೈಲರ್‌ಗಳು
 
-Most of the time when people refer to _profilers_ they mean _CPU profilers_. There are two main types:
+ಜನರು _profilers_ ಎಂದು ಹೇಳಿದಾಗ ಹೆಚ್ಚಿನ ಸಂದರ್ಭಗಳಲ್ಲಿ _CPU profilers_ ಅನ್ನು ಉದ್ದೇಶಿಸುತ್ತಾರೆ. ಮುಖ್ಯವಾಗಿ ಎರಡು ವಿಧಗಳಿವೆ:
 
-- **Tracing profilers** keep a record of every function call your program makes
-- **Sampling profilers** probe your program periodically (commonly every millisecond) and record the program's stack
+- **Tracing profilers** ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂ ಮಾಡುವ ಪ್ರತಿಯೊಂದು function call ನ ದಾಖಲೆಯನ್ನು ಇಟ್ಟುಕೊಳ್ಳುತ್ತವೆ
+- **Sampling profilers** ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂ ಅನ್ನು ಅವಧಿ ಅವಧಿಗೆ (ಸಾಮಾನ್ಯವಾಗಿ ಪ್ರತಿ millisecond) sample ಮಾಡಿ stack ಅನ್ನು ದಾಖಲಿಸುತ್ತವೆ
 
-Sampling profilers have lower overhead and are generally preferred for production use.
+Sampling profilers ಗಳ overhead ಕಡಿಮೆ ಇರುವುದರಿಂದ, production ಬಳಕೆಗೆ ಸಾಮಾನ್ಯವಾಗಿ ಇವುಗಳನ್ನು ಮೆಚ್ಚಲಾಗುತ್ತದೆ.
 
-### perf: the sampling profiler
+### perf: sampling profiler
 
-[`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) is the standard Linux profiler. It can profile any program without recompilation:
+[`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) Linux ನ ಮಾನದಂಡ profiler ಆಗಿದೆ. ಇದು recompilation ಇಲ್ಲದೇ ಯಾವುದೇ ಪ್ರೋಗ್ರಾಂ ಅನ್ನು profile ಮಾಡಬಹುದು:
 
-`perf stat` gives you a quick overview of where time is spent:
+`perf stat` ಸಮಯ ಎಲ್ಲಿ ವ್ಯಯವಾಗುತ್ತಿದೆ ಎಂಬುದರ ತ್ವರಿತ ಅವಲೋಕನ ನೀಡುತ್ತದೆ:
 
 ```bash
 $ perf stat ./slow_program
@@ -331,13 +328,13 @@ $ perf stat ./slow_program
        12,345,678      branch-misses             #    1.00% of all branches
 ```
 
-Profiler output for real world programs will contain large amounts of information. Humans are visual creatures and are quite terrible at reading large amounts of numbers. [Flame graphs](https://www.brendangregg.com/flamegraphs.html) are a visualization that makes profiling data much easier to understand.
+ನೈಜ ಲೋಕದ programs ಗೆ profiler output ಬಹಳ ದೊಡ್ಡ ಮಾಹಿತಿಯನ್ನು ಒಳಗೊಂಡಿರುತ್ತದೆ. ಮಾನವರು ದೃಶ್ಯಾಧಾರಿತ ಪ್ರಾಣಿಗಳಾಗಿರುವುದರಿಂದ, ದೊಡ್ಡ ಪ್ರಮಾಣದ ಸಂಖ್ಯೆಗಳ ಓದಿನಲ್ಲಿ ಕಡಿಮೆ ಪರಿಣಾಮಕಾರಿಗಳು. [Flame graphs](https://www.brendangregg.com/flamegraphs.html) profiling data ಅರ್ಥಮಾಡಿಕೊಳ್ಳುವುದನ್ನು ಬಹಳ ಸುಲಭಗೊಳಿಸುವ ದೃಶ್ಯೀಕರಣ ವಿಧಾನವಾಗಿದೆ.
 
-A flame graph displays a hierarchy of function calls across the Y axis and time taken proportional to the X axis. They're interactive—you can click to zoom into specific parts of the program.
+flame graph ನಲ್ಲಿ function calls ನ hierarchy Y axis ಮೇಲೆ ಹಾಗೂ ತೆಗೆದುಕೊಳ್ಳುವ ಸಮಯ X axis ಮೇಲೆ ಅನುಪಾತವಾಗಿ ತೋರಿಸಲಾಗುತ್ತದೆ. ಅವು interactive ಆಗಿರುವುದರಿಂದ, ನಿರ್ದಿಷ್ಟ ಭಾಗಗಳಿಗೆ click ಮಾಡಿ zoom ಮಾಡಬಹುದು.
 
 [![FlameGraph](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)
 
-To generate a flame graph from `perf` data:
+`perf` data ನಿಂದ flame graph ರಚಿಸಲು:
 
 ```bash
 # Record profile
@@ -347,11 +344,11 @@ perf record -g ./my_program
 perf script | stackcollapse-perf.pl | flamegraph.pl > flamegraph.svg
 ```
 
-> Consider using [Speedscope](https://www.speedscope.app/) for an interactive web-based flame graph viewer, or [Perfetto](https://perfetto.dev/) for comprehensive system-level analysis.
+> interactive web-based flame graph viewer ಗಾಗಿ [Speedscope](https://www.speedscope.app/) ಅಥವಾ comprehensive system-level analysis ಗಾಗಿ [Perfetto](https://perfetto.dev/) ಬಳಸುವುದನ್ನು ಪರಿಗಣಿಸಿ.
 
-### Valgrind's Callgrind: the tracing profiler
+### Valgrind ನ Callgrind: tracing profiler
 
-[`callgrind`](https://valgrind.org/docs/manual/cl-manual.html) is a profiling tool that records the call history and instruction counts of your program. Unlike sampling profilers, it provides exact call counts and can show the relationship between callers and callees:
+[`callgrind`](https://valgrind.org/docs/manual/cl-manual.html) ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂನ call history ಮತ್ತು instruction counts ದಾಖಲಿಸುವ profiling tool ಆಗಿದೆ. sampling profilers ಗಿಂತ ವಿಭಿನ್ನವಾಗಿ, ಇದು ಖಚಿತ call counts ನೀಡುತ್ತದೆ ಮತ್ತು callers-ಗೆ-callees ಸಂಬಂಧವನ್ನು ತೋರಿಸುತ್ತದೆ:
 
 ```bash
 # Run with callgrind
@@ -362,30 +359,30 @@ callgrind_annotate callgrind.out.<pid>
 kcachegrind callgrind.out.<pid>
 ```
 
-Callgrind is slower than sampling profilers but provides precise call counts and can optionally simulate cache behavior (with `--cache-sim=yes`) if you need that information.
+Callgrind sampling profilers ಗಿಂತ ನಿಧಾನವಾದರೂ, ನಿಖರ call counts ಒದಗಿಸುತ್ತದೆ ಮತ್ತು ಅಗತ್ಯವಿದ್ದರೆ cache behavior ಅನ್ನು (`--cache-sim=yes`) simulate ಮಾಡಬಹುದು.
 
-> If you're using a particular language, there may be more specialized profilers. For example, Python has [`cProfile`](https://docs.python.org/3/library/profile.html) and [`py-spy`](https://github.com/benfred/py-spy), Go has [`go tool pprof`](https://pkg.go.dev/cmd/pprof), and Rust has [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph).
+> ನೀವು ನಿರ್ದಿಷ್ಟ ಭಾಷೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದರೆ, ಇನ್ನಷ್ಟು ವಿಶೇಷ profilers ಲಭ್ಯವಿರಬಹುದು. ಉದಾಹರಣೆಗೆ, Python ನಲ್ಲಿ [`cProfile`](https://docs.python.org/3/library/profile.html) ಮತ್ತು [`py-spy`](https://github.com/benfred/py-spy), Go ನಲ್ಲಿ [`go tool pprof`](https://pkg.go.dev/cmd/pprof), ಮತ್ತು Rust ನಲ್ಲಿ [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph) ಇದೆ.
 
-## Memory Profilers
+## ಮೆಮೊರಿ ಪ್ರೊಫೈಲರ್‌ಗಳು
 
-Memory profilers help you understand how your program uses memory over time and find memory leaks.
+memory profilers ನಿಮ್ಮ ಪ್ರೋಗ್ರಾಂ ಕಾಲಕ್ರಮದಲ್ಲಿ memory ಅನ್ನು ಹೇಗೆ ಬಳಸುತ್ತಿದೆ ಎಂಬುದನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಮತ್ತು memory leaks ಪತ್ತೆಹಚ್ಚಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ.
 
-### Valgrind's Massif
+### Valgrind ನ Massif
 
-[`massif`](https://valgrind.org/docs/manual/ms-manual.html) profiles heap memory usage:
+[`massif`](https://valgrind.org/docs/manual/ms-manual.html) heap memory ಬಳಕೆಯನ್ನು profile ಮಾಡುತ್ತದೆ:
 
 ```bash
 valgrind --tool=massif ./my_program
 ms_print massif.out.<pid>
 ```
 
-This shows you heap usage over time, helping identify memory leaks and excessive allocation.
+ಇದು ಕಾಲಕ್ರಮದಲ್ಲಿ heap usage ತೋರಿಸಿ memory leaks ಮತ್ತು ಅತಿಯಾದ allocation ಗುರುತಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
 
-> For Python, [`memory-profiler`](https://pypi.org/project/memory-profiler/) provides line-by-line memory usage information.
+> Python ಗಾಗಿ [`memory-profiler`](https://pypi.org/project/memory-profiler/) line-by-line memory usage ಮಾಹಿತಿ ಒದಗಿಸುತ್ತದೆ.
 
-## Benchmarking
+## ಬೆಂಚ್ಮಾರ್ಕಿಂಗ್
 
-When you need to compare the performance of different implementations or tools, [`hyperfine`](https://github.com/sharkdp/hyperfine) is excellent for benchmarking command-line programs:
+ಬೇರೆ implementations ಅಥವಾ tools ಗಳ ಕಾರ್ಯಕ್ಷಮತೆಯನ್ನು ಹೋಲಿಸಬೇಕಾದಾಗ, command-line programs ಬೆಂಚ್ಮಾರ್ಕ್ ಮಾಡಲು [`hyperfine`](https://github.com/sharkdp/hyperfine) ಅತ್ಯುತ್ತಮ ಸಾಧನವಾಗಿದೆ:
 
 ```bash
 $ hyperfine --warmup 3 'fd -e jpg' 'find . -iname "*.jpg"'
@@ -402,13 +399,13 @@ Summary
    21.89 ± 2.33 times faster than 'find . -iname "*.jpg"'
 ```
 
-> For web development, browser developer tools include excellent profilers. See the [Firefox Profiler](https://profiler.firefox.com/docs/) and [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/rendering-tools) documentation.
+> web development ಗಾಗಿ browser developer tools ನಲ್ಲಿ ಅತ್ಯುತ್ತಮ profilers ಒಳಗೊಂಡಿವೆ. [Firefox Profiler](https://profiler.firefox.com/docs/) ಮತ್ತು [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/rendering-tools) documentation ನೋಡಿ.
 
-# Exercises
+# ಅಭ್ಯಾಸಗಳು
 
-## Debugging
+## ಡಿಬಗ್ಗಿಂಗ್
 
-1. **Debug a sorting algorithm**: The following pseudocode implements merge sort but contains a bug. Implement it in a language of your choice, then use a debugger (gdb, lldb, pdb, or your IDE's debugger) to find and fix the bug.
+1. **sorting algorithm ಅನ್ನು ಡಿಬಗ್ ಮಾಡಿ**: ಕೆಳಗಿನ pseudocode merge sort ಅನ್ನು ಅನುಷ್ಠಾನಗೊಳಿಸುತ್ತದೆ, ಆದರೆ ಇದರಲ್ಲಿ ಒಂದು bug ಇದೆ. ಇದನ್ನು ನಿಮ್ಮ ಆಯ್ಕೆಯ ಭಾಷೆಯಲ್ಲಿ ಅನುಷ್ಠಾನಗೊಳಿಸಿ, ನಂತರ debugger (gdb, lldb, pdb, ಅಥವಾ ನಿಮ್ಮ IDE ಯ debugger) ಬಳಸಿ bug ಅನ್ನು ಕಂಡುಹಿಡಿದು ಸರಿಪಡಿಸಿ.
 
    ```
    function merge_sort(arr):
@@ -433,9 +430,9 @@ Summary
        return result
    ```
 
-   Test vector: `merge_sort([3, 1, 4, 1, 5, 9, 2, 6])` should return `[1, 1, 2, 3, 4, 5, 6, 9]`. Use breakpoints and step through the merge function to find where the incorrect element is being selected.
+   ಪರೀಕ್ಷಾ vector: `merge_sort([3, 1, 4, 1, 5, 9, 2, 6])` ಫಲಿತಾಂಶವಾಗಿ `[1, 1, 2, 3, 4, 5, 6, 9]` ಮರಳಬೇಕು. ತಪ್ಪಾದ element ಯಾವ ಸ್ಥಳದಲ್ಲಿ ಆಯ್ಕೆಯಾಗುತ್ತಿದೆ ಎಂಬುದನ್ನು ಕಂಡುಹಿಡಿಯಲು breakpoints ಬಳಸಿ merge function ಅನ್ನು ಹಂತ ಹಂತವಾಗಿ ನಡೆಸಿ.
 
-1. Install [`rr`](https://rr-project.org/) and use reverse debugging to find a corruption bug. Save this program as `corruption.c`:
+1. [`rr`](https://rr-project.org/) install ಮಾಡಿ ಮತ್ತು reverse debugging ಬಳಸಿ corruption bug ಅನ್ನು ಕಂಡುಹಿಡಿಯಿರಿ. ಈ program ಅನ್ನು `corruption.c` ಎಂಬ ಹೆಸರಿನಲ್ಲಿ ಉಳಿಸಿ:
 
    ```c
    #include <stdio.h>
@@ -486,9 +483,9 @@ Summary
    }
    ```
 
-   Compile with `gcc -g corruption.c -o corruption` and run it. Student 1's ID gets corrupted, but the corruption happens in a function that only touches student 0. Use `rr record ./corruption` and `rr replay` to find the culprit. Set a watchpoint on `students[1].id` and use `reverse-continue` after the corruption to find exactly which line of code overwrote it.
+   `gcc -g corruption.c -o corruption` ಮೂಲಕ compile ಮಾಡಿ ಮತ್ತು program ಅನ್ನು ಓಡಿಸಿ. Student 1 ರ ID corrupt ಆಗುತ್ತದೆ, ಆದರೆ corruption student 0 ಅನ್ನು ಮಾತ್ರ ತಾಕುವ function ನಲ್ಲಿ ಆಗುತ್ತದೆ. ಕಾರಣವನ್ನು ಕಂಡುಹಿಡಿಯಲು `rr record ./corruption` ಮತ್ತು `rr replay` ಬಳಸಿ. `students[1].id` ಮೇಲೆ watchpoint ಹೊಂದಿಸಿ, corruption ಆದ ನಂತರ `reverse-continue` ಬಳಸಿ ಅದನ್ನು ಯಾವ code ಸಾಲು overwrite ಮಾಡಿತು ಎಂದು ಖಚಿತವಾಗಿ ಪತ್ತೆಹಚ್ಚಿ.
 
-1. Debug a memory error with AddressSanitizer. Save this as `uaf.c`:
+1. AddressSanitizer ಬಳಸಿ memory error ಡಿಬಗ್ ಮಾಡಿ. ಇದನ್ನು `uaf.c` ಎಂದು ಉಳಿಸಿ:
 
    ```c
    #include <stdlib.h>
@@ -509,17 +506,17 @@ Summary
    }
    ```
 
-   First compile and run without sanitizers: `gcc uaf.c -o uaf && ./uaf`. It may appear to work. Now compile with AddressSanitizer: `gcc -fsanitize=address -g uaf.c -o uaf && ./uaf`. Read the error report. What bug does ASan find? Fix the issue it identifies.
+   ಮೊದಲು sanitizers ಇಲ್ಲದೆ compile ಮಾಡಿ ಓಡಿಸಿ: `gcc uaf.c -o uaf && ./uaf`. ಇದು ಕೆಲಸ ಮಾಡಿದಂತೆ ಕಾಣಬಹುದು. ಈಗ AddressSanitizer ಜೊತೆಗೆ compile ಮಾಡಿ: `gcc -fsanitize=address -g uaf.c -o uaf && ./uaf`. error report ಓದಿ. ASan ಯಾವ bug ಪತ್ತೆಹಚ್ಚುತ್ತದೆ? ಅದು ಗುರುತಿಸಿದ ಸಮಸ್ಯೆಯನ್ನು ಸರಿಪಡಿಸಿ.
 
-1. Use `strace` (Linux) or `dtruss` (macOS) to trace the system calls made by a command like `ls -l`. What system calls is it making? Try tracing a more complex program and see what files it opens.
+1. `strace` (Linux) ಅಥವಾ `dtruss` (macOS) ಬಳಸಿ `ls -l` போன்ற command ಮಾಡುವ system calls ಅನ್ನು trace ಮಾಡಿ. ಅದು ಯಾವ system calls ಮಾಡುತ್ತಿದೆ? ಇನ್ನಷ್ಟು ಸಂಕೀರ್ಣ program ಅನ್ನು trace ಮಾಡಿ ಅದು ಯಾವ files ತೆರೆಯುತ್ತದೆ ಎಂಬುದನ್ನೂ ನೋಡಿ.
 
-1. Use an LLM to help debug a cryptic error message. Try copying a compiler error (especially from C++ templates or Rust) and asking for an explanation and fix. Try putting some of the output from `strace` or the address sanitizer into it.
+1. ಗುಂಗುರುವ error message ಅನ್ನು ಡಿಬಗ್ ಮಾಡಲು LLM ಬಳಸಿ. ಒಂದು compiler error (ವಿಶೇಷವಾಗಿ C++ templates ಅಥವಾ Rust ನಿಂದ) ನಕಲಿಸಿ ಅದರ ವಿವರಣೆ ಮತ್ತು ತಿದ್ದುಪಡಿ ಕೇಳಿ. `strace` ಅಥವಾ address sanitizer output ನ ಕೆಲ ಭಾಗಗಳನ್ನು ಕೂಡ ನೀಡಿ ಪ್ರಯತ್ನಿಸಿ.
 
-## Profiling
+## ಪ್ರೊಫೈಲಿಂಗ್
 
-1. Use `perf stat` to get basic performance statistics for a program of your choice. What do the different counters mean?
+1. ನಿಮ್ಮ ಆಯ್ಕೆಯ program ಗೆ `perf stat` ಬಳಸಿ ಮೂಲ ಕಾರ್ಯಕ್ಷಮತಾ ಅಂಕಿಅಂಶಗಳನ್ನು ಪಡೆಯಿರಿ. ವಿಭಿನ್ನ counters ಎಂದರೆ ಏನು?
 
-1. Profile with `perf record`. Save this as `slow.c`:
+1. `perf record` ಬಳಸಿ profile ಮಾಡಿ. ಇದನ್ನು `slow.c` ಎಂದು ಉಳಿಸಿ:
 
    ```c
    #include <math.h>
@@ -545,10 +542,10 @@ Summary
    }
    ```
 
-   Compile with debug symbols: `gcc -g -O2 slow.c -o slow -lm`. Run `perf record -g ./slow`, then `perf report` to see where time is spent. Try generating a flame graph using the flamegraph scripts.
+   debug symbols ಜೊತೆ compile ಮಾಡಿ: `gcc -g -O2 slow.c -o slow -lm`. `perf record -g ./slow` ಓಡಿಸಿ, ನಂತರ `perf report` ಬಳಸಿ ಸಮಯ ಎಲ್ಲಿ ಕಳೆಯುತ್ತಿದೆ ನೋಡಿ. flamegraph scripts ಬಳಸಿ flame graph ರಚಿಸಲು ಪ್ರಯತ್ನಿಸಿ.
 
-1. Use `hyperfine` to benchmark two different implementations of the same task (e.g., `find` vs `fd`, `grep` vs `ripgrep`, or two versions of your own code).
+1. ಒಂದೇ ಕಾರ್ಯದ ಎರಡು ವಿಭಿನ್ನ implementations ಅನ್ನು `hyperfine` ಬಳಸಿ ಬೆಂಚ್ಮಾರ್ಕ್ ಮಾಡಿ (ಉದಾ: `find` vs `fd`, `grep` vs `ripgrep`, ಅಥವಾ ನಿಮ್ಮದೇ code ನ ಎರಡು ಆವೃತ್ತಿಗಳು).
 
-1. Use `htop` to monitor your system while running a resource-intensive program. Try using `taskset` to limit which CPUs a process can use: `taskset --cpu-list 0,2 stress -c 3`. Why doesn't `stress` use three CPUs?
+1. resource-intensive program ಓಡಿಸುತ್ತಿರುವಾಗ ನಿಮ್ಮ system ಅನ್ನು `htop` ಮೂಲಕ ಮಾನಿಟರ್ ಮಾಡಿ. process ಯಾವ CPUs ಬಳಕೆ ಮಾಡಬಹುದು ಎಂಬುದನ್ನು ಮಿತಿಗೊಳಿಸಲು `taskset` ಬಳಸಿ ಪ್ರಯತ್ನಿಸಿ: `taskset --cpu-list 0,2 stress -c 3`. `stress` ಮೂರು CPUs ಬಳಸದೇ ಇರುವುದಕ್ಕೆ ಕಾರಣವೇನು?
 
-1. A common issue is that a port you want to listen on is already taken by another process. Learn how to discover that process: First execute `python -m http.server 4444` to start a minimal web server on port 4444. On a separate terminal run `ss -tlnp | grep 4444` to find the process. Terminate it with `kill <PID>`.
+1. ನೀವು listen ಮಾಡಲು ಬಯಸುವ port ಅನ್ನು ಬೇರೆ process ಈಗಾಗಲೇ ಬಳಸುತ್ತಿರುವುದು ಸಾಮಾನ್ಯ ಸಮಸ್ಯೆ. ಆ process ಅನ್ನು ಹೇಗೆ ಪತ್ತೆಹಚ್ಚುವುದು ಎಂಬುದನ್ನು ಕಲಿಯಿರಿ: ಮೊದಲು port 4444 ಮೇಲೆ ಕನಿಷ್ಠ web server ಆರಂಭಿಸಲು `python -m http.server 4444` ನಡೆಸಿ. ಪ್ರತ್ಯೇಕ terminal ನಲ್ಲಿ `ss -tlnp | grep 4444` ಓಡಿಸಿ process ಪತ್ತೆಮಾಡಿ. ನಂತರ `kill <PID>` ಮೂಲಕ ಅದನ್ನು ಸ್ಥಗಿತಗೊಳಿಸಿ.

--- a/_2026/development-environment.md
+++ b/_2026/development-environment.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Development Environment and Tools"
+title: "Development Environment ಮತ್ತು Tools"
 description: >
-  Learn about IDEs, Vim, language servers, and AI-powered development tools.
+  IDEs, Vim, language servers, ಮತ್ತು AI-powered development tools ಬಗ್ಗೆ ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec3.png
 date: 2026-01-14
 ready: true
@@ -11,121 +11,121 @@ video:
   id: QnM1nVzrkx8
 ---
 
-A _development environment_ is a set of tools for developing software. At the heart of a development environment is text editing functionality, along with accompanying features such as syntax highlighting, type checking, code formatting, and autocomplete. _Integrated development environments_ (IDEs) such as [VS Code][vs-code] bring together all of this functionality into a single application. Terminal-based development workflows combine tools such as [tmux](https://github.com/tmux/tmux) (a terminal multiplexer), [Vim](https://www.vim.org/) (a text editor), [Zsh](https://www.zsh.org/) (a shell), and language-specific command-line tools, such as [Ruff](https://docs.astral.sh/ruff/) (a Python linter and code formatter) and [Mypy](https://mypy-lang.org/) (a Python type checker).
+_development environment_ ಎಂದರೆ software ಅಭಿವೃದ್ಧಿಗೆ ಬಳಸುವ tools ಸಮೂಹ. ಇದರ ಕೇಂದ್ರದಲ್ಲಿ text editing functionality ಇರುತ್ತದೆ; ಜೊತೆಗೆ syntax highlighting, type checking, code formatting, autocomplete ಮೊದಲಾದ ಬೆಂಬಲ ವೈಶಿಷ್ಟ್ಯಗಳು ಇರುತ್ತವೆ. [VS Code][vs-code] ಮೊದಲಾದ _integrated development environments_ (IDEs) ಈ ಎಲ್ಲವನ್ನು ಒಂದೇ application ನಲ್ಲಿ ಒಟ್ಟುಗೂಡಿಸುತ್ತವೆ. Terminal-based development workflows ನಲ್ಲಿ [tmux](https://github.com/tmux/tmux) (terminal multiplexer), [Vim](https://www.vim.org/) (text editor), [Zsh](https://www.zsh.org/) (shell), ಮತ್ತು ಭಾಷೆ-ನಿರ್ದಿಷ್ಟ command-line tools ಬಳಸಲಾಗುತ್ತವೆ - ಉದಾ: [Ruff](https://docs.astral.sh/ruff/) (Python linter ಮತ್ತು formatter), [Mypy](https://mypy-lang.org/) (Python type checker).
 
-IDEs and terminal-based workflows each have their strengths and weaknesses. For example, graphical IDEs can be easier to learn, and today's IDEs generally have better out-of-the-box AI integrations like AI autocomplete; on the other hand, terminal-based workflows are lightweight, and they may be your only option in environments where you don't have a GUI or can't install software. We recommend you develop basic familiarity with both and develop mastery of at least one. If you don't already have a preferred IDE, we recommend starting with [VS Code][vs-code].
+IDEs ಮತ್ತು terminal-based workflows ಎರಡಕ್ಕೂ ತಮ್ಮದೇ ಬಲ-ದೌರ್ಬಲ್ಯಗಳಿವೆ. ಉದಾ: graphical IDEs ಕಲಿಯಲು ಸುಲಭವಾಗಬಹುದು, ಹಾಗೂ ಇಂದಿನ IDE ಗಳಲ್ಲಿ AI autocomplete ಮೊದಲಾದ out-of-the-box AI integrations ಉತ್ತಮವಾಗಿರುತ್ತವೆ. ಮತ್ತೊಂದೆಡೆ terminal-based workflows ಹಗುರವಾಗಿವೆ; GUI ಇಲ್ಲದ ಅಥವಾ software install ಸಾಧ್ಯವಿಲ್ಲದ ಪರಿಸರಗಳಲ್ಲಿ ಕೆಲವೊಮ್ಮೆ ಇದೇ ಏಕೈಕ ಆಯ್ಕೆ. ಎರಡರ ಮೇಲೂ ಮೂಲ ಪರಿಚಯ ಬೆಳೆಸಿಕೊಳ್ಳಿ, ಮತ್ತು ಕನಿಷ್ಠ ಒಂದರಲ್ಲಿ ನೈಪುಣ್ಯ ಗಳಿಸಿ. ಈಗಾಗಲೇ ನಿಮಗೆ ಇಷ್ಟದ IDE ಇಲ್ಲದಿದ್ದರೆ, [VS Code][vs-code] ನಿಂದ ಪ್ರಾರಂಭಿಸಲು ಶಿಫಾರಸು.
 
-In this lecture, we'll cover:
+ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ನಾವು ನೋಡೋವುದು:
 
-- [Text editing and Vim](#text-editing-and-vim)
-- [Code intelligence and language servers](#code-intelligence-and-language-servers)
-- [AI-powered development](#ai-powered-development)
-- [Extensions and other IDE functionality](#extensions-and-other-ide-functionality)
+- [ಪಠ್ಯ ಸಂಪಾದನೆ ಮತ್ತು Vim](#text-editing-and-vim)
+- [ಕೋಡ್ ಇಂಟೆಲಿಜೆನ್ಸ್ ಮತ್ತು language servers](#code-intelligence-and-language-servers)
+- [AI-ಆಧಾರಿತ ಅಭಿವೃದ್ಧಿ](#ai-powered-development)
+- [Extensions ಮತ್ತು ಇತರೆ IDE ವೈಶಿಷ್ಟ್ಯಗಳು](#extensions-and-other-ide-functionality)
 
 [vs-code]: https://code.visualstudio.com/
 
 # Text editing and Vim
 
-When programming, you spend most of your time navigating through code, reading snippets of code, and making edits to code, rather than writing long streams or reading files top-to-bottom. [Vim] is a text editor that is optimized for this distribution of tasks.
+Programming ಮಾಡುವಾಗ ಹೆಚ್ಚು ಸಮಯ code ನಲ್ಲಿ ಸಂಚರಿಸುವುದು, snippets ಓದುವುದು, edits ಮಾಡುವುದು ಇತ್ಯಾದಿಗಳಲ್ಲೇ ಕಳೆಯುತ್ತದೆ - ದೀರ್ಘ ಪಠ್ಯ ನಿರಂತರವಾಗಿ ಬರೆಯುವುದಕ್ಕಿಂತಲೂ, file ಅನ್ನು top-to-bottom ಓದುವುದಕ್ಕಿಂತಲೂ. [Vim] ಈ ಕೆಲಸಗಳ ವಿನ್ಯಾಸಕ್ಕೆ ಹೊಂದಿಕೆಯಾಗುವಂತೆ optimize ಮಾಡಲಾದ text editor.
 
-**The philosophy of Vim.** Vim has a beautiful idea as its foundation: its interface is itself a programming language, designed for navigating and editing text. Keystrokes (with mnemonic names) are commands, and these commands are composable. Vim avoids the use of the mouse, because it's too slow; Vim even avoids use of the arrow keys because it requires too much movement. The result: an editor that feels like a brain-computer interface and matches the speed at which you think.
+**Vim ನ ತತ್ತ್ವ.** Vim ನ ಮೂಲಭೂತ ಕಲ್ಪನೆ ಬಹಳ ಸುಂದರ: Vim interface ತಾನೇ navigation ಮತ್ತು text editing ಗಾಗಿ ವಿನ್ಯಾಸಗೊಂಡ programming language ಆಗಿದೆ. Keystrokes (ಅರ್ಥಪೂರ್ಣ mnemonic ಹೆಸರುಗಳೊಂದಿಗೆ) commands ಆಗಿವೆ; commands composable ಆಗಿವೆ. Vim mouse ಬಳಕೆಯನ್ನು ತಪ್ಪಿಸುತ್ತದೆ - ಅದು ನಿಧಾನ. Vim arrow keys ಬಳಕೆಯನ್ನೂ ಕಡಿಮೆ ಮಾಡುತ್ತದೆ - ಹೆಚ್ಚು ಕೈ ಚಲನೆ ಬೇಕಾಗುತ್ತದೆ. ಫಲಿತಾಂಶ: ನಿಮ್ಮ ಚಿಂತನೆಯ ವೇಗಕ್ಕೆ ಹೊಂದಿಕೊಂಡಂತೆ brain-computer interface ಅನುಭವ ನೀಡುವ editor.
 
-**Vim support in other software.** You don't have to use [Vim] itself to benefit from the ideas at its core. Many programs that involve any kind of text editing support "Vim mode", either as built-in functionality or as a plugin. For example, VS Code has the [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) plugin, Zsh has [built-in support](https://zsh.sourceforge.io/Guide/zshguide04.html) for Vim emulation, and even Claude Code has [built-in support](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) for Vim editor mode. Chances are that any tool you use that involves text editing supports Vim mode in one way or another.
+**ಇತರೆ software ನಲ್ಲಿ Vim ಬೆಂಬಲ.** [Vim] ನ್ನೇ ನೇರವಾಗಿ ಬಳಸದೆ ಅದರ ಮೂಲ ಕಲ್ಪನೆಗಳ ಲಾಭ ಪಡೆಯಬಹುದು. Text editing ಒಳಗೊಂಡ ಅನೇಕ software ಗಳಲ್ಲಿ "Vim mode" ಇದೆ - built-in ಆಗಿರಬಹುದು ಅಥವಾ plugin ಆಗಿರಬಹುದು. ಉದಾ: VS Code ನಲ್ಲಿ [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) plugin ಇದೆ, Zsh ನಲ್ಲಿ Vim emulation ಗೆ [built-in support](https://zsh.sourceforge.io/Guide/zshguide04.html) ಇದೆ, Claude Code ನಲ್ಲೂ [built-in support](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) ಇದೆ. ನೀವು ಬಳಸುವ text-editing tools ಬಹುತೇಕ ಯಾವುದಾದರೂ ರೂಪದಲ್ಲಿ Vim mode ಬೆಂಬಲಿಸುತ್ತವೆ.
 
 ## Modal editing
 
-Vim is a _modal editor_: it has different operating modes for different classes of tasks.
+Vim ಒಂದು _modal editor_: ವಿಭಿನ್ನ ಕಾರ್ಯಗಳಿಗೆ ವಿಭಿನ್ನ modes ಇವೆ.
 
-- **Normal**: for moving around a file and making edits
-- **Insert**: for inserting text
-- **Replace**: for replacing text
-- **Visual** (plain, line, or block): for selecting blocks of text
-- **Command-line**: for running a command
+- **Normal**: file ನಲ್ಲಿ ಸಂಚರಿಸಿ edits ಮಾಡಲು
+- **Insert**: text ಸೇರಿಸಲು
+- **Replace**: text ಬದಲಿಸಲು
+- **Visual** (plain, line, block): text blocks ಆಯ್ಕೆ ಮಾಡಲು
+- **Command-line**: command run ಮಾಡಲು
 
-Keystrokes have different meanings in different operating modes. For example, the letter `x` in Insert mode will just insert a literal character "x", but in Normal mode, it will delete the character under the cursor, and in Visual mode, it will delete the selection.
+Keystrokes ಅರ್ಥ mode ಪ್ರಕಾರ ಬದಲಾಗುತ್ತದೆ. ಉದಾ: Insert mode ನಲ್ಲಿ `x` ಒತ್ತಿದರೆ literal "x" ಸೇರುತ್ತದೆ. ಆದರೆ Normal mode ನಲ್ಲಿ cursor ಕೆಳಗಿನ character delete ಆಗುತ್ತದೆ. Visual mode ನಲ್ಲಿ selection delete ಆಗುತ್ತದೆ.
 
-In its default configuration, Vim shows the current mode in the bottom left. The initial/default mode is Normal mode. You'll generally spend most of your time between Normal mode and Insert mode.
+Default configuration ನಲ್ಲಿ Vim ಕೆಳ ಎಡ ಭಾಗದಲ್ಲಿ current mode ತೋರಿಸುತ್ತದೆ. ಪ್ರಾರಂಭ/ಪೂರ್ವನಿಯೋಜಿತ mode Normal mode. ಸಾಮಾನ್ಯವಾಗಿ ಹೆಚ್ಚು ಸಮಯ Normal ಮತ್ತು Insert mode ನಡುವೆ ಕಳೆಯುತ್ತೀರಿ.
 
-You change modes by pressing `<ESC>` (the escape key) to switch from any mode back to Normal mode. From Normal mode, enter Insert mode with `i`, Replace mode with `R`, Visual mode with `v`, Visual Line mode with `V`, Visual Block mode with `<C-v>` (Ctrl-V, sometimes also written `^V`), and Command-line mode with `:`.
+Modes ಬದಲಿಸಲು `<ESC>` ಕೀ ಬಳಸಿ - ಯಾವುದೇ mode ನಿಂದ Normal mode ಗೆ ಮರಳಬಹುದು. Normal mode ನಿಂದ Insert ಗೆ `i`, Replace ಗೆ `R`, Visual ಗೆ `v`, Visual Line ಗೆ `V`, Visual Block ಗೆ `<C-v>` (Ctrl-V; ಕೆಲವೊಮ್ಮೆ `^V`), Command-line mode ಗೆ `:` ಬಳಸಿ.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to Escape ([macOS instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)) or create an [alternative mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) for `<ESC>` with a simple key sequence.
+Vim ಬಳಸುವಾಗ `<ESC>` ಅನ್ನು ತುಂಬಾ ಬಾರಿ ಬಳಸುತ್ತೀರಿ. ಆದ್ದರಿಂದ Caps Lock ಅನ್ನು Escape ಗೆ remap ಮಾಡುವುದನ್ನು ಪರಿಗಣಿಸಿ ([macOS instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)); ಅಥವಾ ಸರಳ key sequence ಮೂಲಕ `<ESC>` ಗೆ [alternative mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) ರಚಿಸಬಹುದು.
 
 ## Basics: inserting text
 
-From Normal mode, press `i` to enter Insert mode. Now, Vim behaves like any other text editor, until you press `<ESC>` to return to Normal mode. This, along with the basics explained above, are all you need to start editing files using Vim (though not particularly efficiently, if you're spending all your time editing from Insert mode).
+Normal mode ನಿಂದ `i` ಒತ್ತಿ Insert mode ಗೆ ಹೋಗಿ. ಈಗ `<ESC>` ಒತ್ತಿ Normal ಗೆ ಮರಳುವವರೆಗೆ Vim ಇತರೆ ಸಾಮಾನ್ಯ text editor ಹೋಲೆಯೇ ವರ್ತಿಸುತ್ತದೆ. ಮೇಲಿನ ಮೂಲಭೂತಗಳ ಜೊತೆಗೆ ಇದಿಷ್ಟೇ ಸಾಕು - Vim ನಲ್ಲಿ files edit ಮಾಡಲು ಪ್ರಾರಂಭಿಸಬಹುದು (Insert mode ನಲ್ಲೇ ಇಡೀ ಸಮಯ ಕಳೆಯುತ್ತಿದ್ದರೆ ಮಾತ್ರ ದಕ್ಷತೆ ಕಡಿಮೆ).
 
 ## Vim's interface is a programming language
 
-Vim's interface is a programming language. Keystrokes (with mnemonic names) are commands, and these commands _compose_. This enables efficient movement and edits, especially once the commands become muscle memory, just like typing becomes super efficient once you've learned your keyboard layout.
+Vim interface ಒಂದು programming language. Keystrokes (mnemonic ಹೆಸರುಗಳೊಂದಿಗೆ) commands ಆಗಿವೆ; commands _compose_ ಆಗುತ್ತವೆ. ಇದರಿಂದ ಪರಿಣಾಮಕಾರಿ navigation ಮತ್ತು edits ಸಾಧ್ಯವಾಗುತ್ತವೆ, ವಿಶೇಷವಾಗಿ commands muscle memory ಆಗಿದ ಮೇಲೆ - keyboard layout ಕಲಿತ ಮೇಲೆ typing ವೇಗ ಹೆಚ್ಚಿದಂತೆ.
 
 ### Movement
 
-You should spend most of your time in Normal mode, using movement commands to navigate the file. Movements in Vim are also called "nouns", because they refer to chunks of text.
+ಸಮಯದ ಬಹುಪಾಲು Normal mode ನಲ್ಲಿ ಇರಬೇಕು. Movement commands ಬಳಸಿ file ನಲ್ಲಿ ಸಂಚರಿಸಿ. Vim ನಲ್ಲಿ movements ಅನ್ನು "nouns" ಎಂದೂ ಕರೆಯುತ್ತಾರೆ, ಏಕೆಂದರೆ ಅವು text chunks ಸೂಚಿಸುತ್ತವೆ.
 
-- Basic movement: `hjkl` (left, down, up, right)
-- Words: `w` (next word), `b` (beginning of word), `e` (end of word)
-- Lines: `0` (beginning of line), `^` (first non-blank character), `$` (end of line)
-- Screen: `H` (top of screen), `M` (middle of screen), `L` (bottom of screen)
-- Scroll: `Ctrl-u` (up), `Ctrl-d` (down)
-- File: `gg` (beginning of file), `G` (end of file)
-- Line numbers: `:{number}<CR>` or `{number}G` (line {number})
-    - `<CR>` refers to the carriage return / enter key
-- Misc: `%` (matching item, like parenthesis or brace)
-- Find: `f{character}`, `t{character}`, `F{character}`, `T{character}`
-    - find/to forward/backward {character} on the current line
-    - `,` / `;` for navigating matches
-- Search: `/{regex}`, `n` / `N` for navigating matches
+- ಮೂಲ ಚಲನೆ: `hjkl` (ಎಡ, ಕೆಳಗೆ, ಮೇಲೆ, ಬಲ)
+- ಪದಗಳು: `w` (ಮುಂದಿನ ಪದ), `b` (ಪದದ ಆರಂಭ), `e` (ಪದದ ಅಂತ್ಯ)
+- ಸಾಲುಗಳು: `0` (ಸಾಲಿನ ಆರಂಭ), `^` (ಮೊದಲ ಖಾಲಿಯಲ್ಲದ ಅಕ್ಷರ), `$` (ಸಾಲಿನ ಅಂತ್ಯ)
+- ತೆರೆ: `H` (ತೆರೆಯ ಮೇಲ್ಭಾಗ), `M` (ಮಧ್ಯಭಾಗ), `L` (ಕೆಳಭಾಗ)
+- ಸ್ಕ್ರೋಲ್: `Ctrl-u` (ಮೇಲಕ್ಕೆ), `Ctrl-d` (ಕೆಳಕ್ಕೆ)
+- ಫೈಲ್: `gg` (ಫೈಲ್ ಆರಂಭ), `G` (ಫೈಲ್ ಅಂತ್ಯ)
+- ಸಾಲು ಸಂಖ್ಯೆಗಳು: `:{number}<CR>` ಅಥವಾ `{number}G` (ಸಾಲು {number})
+    - `<CR>` ಎಂದರೆ carriage return / enter key
+- ಇತರೆ: `%` (ಹೊಂದುವ ಜೋಡಿ item, ಉದಾ: parenthesis ಅಥವಾ brace)
+- ಹುಡುಕು: `f{character}`, `t{character}`, `F{character}`, `T{character}`
+    - ಪ್ರಸ್ತುತ ಸಾಲಿನಲ್ಲಿ {character} ಅನ್ನು ಮುಂದೆ/ಹಿಂದೆ ಹುಡುಕುತ್ತದೆ
+    - ಹೊಂದಿಕೆಗಳ ನಡುವೆ ಸಂಚರಿಸಲು `,` / `;`
+- ಹುಡುಕಾಟ: `/{regex}`, ಹೊಂದಿಕೆಗಳ ನಡುವೆ ಸಂಚರಿಸಲು `n` / `N`
 
 ### Selection
 
-Visual modes:
+ದೃಶ್ಯ ಮೋಡ್‌ಗಳು:
 
 - Visual: `v`
 - Visual Line: `V`
 - Visual Block: `Ctrl-v`
 
-Can use movement keys to make selection.
+ಆಯ್ಕೆ ಮಾಡಲು movement keys ಬಳಸಬಹುದು.
 
 ### Edits
 
-Everything that you used to do with the mouse, you now do with the keyboard using editing commands that compose with movement commands. Here's where Vim's interface starts to look like a programming language. Vim's editing commands are also called "verbs", because verbs act on nouns.
+ನೀವು mouse ಬಳಸಿ ಮಾಡುತ್ತಿದ್ದ ಹಲವಾರು editing ಕೆಲಸಗಳನ್ನು ಈಗ keyboard ಮೂಲಕ movement commands ಜೊತೆ compose ಆಗುವ editing commands ಮೂಲಕ ಮಾಡುತ್ತೀರಿ. ಇಲ್ಲಿಯೇ Vim interface ಒಂದು programming language ನಂತೆ ಸ್ಪಷ್ಟವಾಗುತ್ತದೆ. Vim editing commands ಅನ್ನು "verbs" ಎಂದು ಕರೆಯುತ್ತಾರೆ, ಏಕೆಂದರೆ verbs nouns ಮೇಲೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತವೆ.
 
-- `i` enter Insert mode
-    - but for manipulating/deleting text, want to use something more than backspace
-- `o` / `O` insert line below / above
+- `i` Insert mode ಗೆ ಹೋಗಲು
+    - ಆದರೆ text manipulate/delete ಮಾಡಲು backspace ಗಿಂತ ಹೆಚ್ಚಿನ commands ಬಳಸುವುದು ಉತ್ತಮ
+- `o` / `O` ಕೆಳಗೆ / ಮೇಲೆ line ಸೇರಿಸಲು
 - `d{motion}` delete {motion}
-    - e.g. `dw` is delete word, `d$` is delete to end of line, `d0` is delete to beginning of line
+    - ಉದಾ: `dw` delete word, `d$` line ಅಂತ್ಯವರೆಗೆ delete, `d0` line ಆರಂಭದವರೆಗೆ delete
 - `c{motion}` change {motion}
-    - e.g. `cw` is change word
-    - like `d{motion}` followed by `i`
-- `x` delete character (equivalent to `dl`)
-- `s` substitute character (equivalent to `cl`)
+    - ಉದಾ: `cw` change word
+    - `d{motion}` ನಂತರ `i` ಹೋಲುತ್ತದೆ
+- `x` character delete (`dl` ಗೆ ಸಮಾನ)
+- `s` substitute character (`cl` ಗೆ ಸಮಾನ)
 - Visual mode + manipulation
-    - select text, `d` to delete it or `c` to change it
-- `u` to undo, `<C-r>` to redo
-- `y` to copy / "yank" (some other commands like `d` also copy)
-- `p` to paste
-- Lots more to learn: for example, `~` flips the case of a character, and `J` joins together lines
+    - text ಆಯ್ಕೆ ಮಾಡಿ, `d` delete ಅಥವಾ `c` change
+- `u` undo, `<C-r>` redo
+- `y` copy / "yank" (`d` ಮೊದಲಾದ ಕೆಲವು commands ಕೂಡ copy ಮಾಡುತ್ತವೆ)
+- `p` paste
+- ಇನ್ನೂ ಬಹಳವು: ಉದಾ `~` character case flip ಮಾಡುತ್ತದೆ, `J` lines join ಮಾಡುತ್ತದೆ
 
 ### Counts
 
-You can combine nouns and verbs with a count, which will perform a given action a number of times.
+Nouns ಮತ್ತು verbs ಗೆ count ಸೇರಿಸಿ action ಅನ್ನು ಹಲವು ಬಾರಿ ನಡೆಸಬಹುದು.
 
-- `3w` move 3 words forward
-- `5j` move 5 lines down
-- `7dw` delete 7 words
+- `3w` 3 words ಮುಂದೆ ಸರಿಯುತ್ತದೆ
+- `5j` 5 lines ಕೆಳಗೆ ಸರಿಯುತ್ತದೆ
+- `7dw` 7 words delete ಮಾಡುತ್ತದೆ
 
 ### Modifiers
 
-You can use modifiers to change the meaning of a noun. Some modifiers are `i`, which means "inner" or "inside", and `a`, which means "around".
+Modifier ಗಳಿಂದ noun ನ ಅರ್ಥ ಬದಲಾಗುತ್ತದೆ. ಸಾಮಾನ್ಯ modifiers: `i` ("inner" ಅಥವಾ "inside"), `a` ("around").
 
-- `ci(` change the contents inside the current pair of parentheses
-- `ci[` change the contents inside the current pair of square brackets
-- `da'` delete a single-quoted string, including the surrounding single quotes
+- `ci(` ಪ್ರಸ್ತುತ parentheses ಜೋಡಿಯ ಒಳಗಿನ ವಿಷಯ ಬದಲಾಯಿಸುತ್ತದೆ
+- `ci[` ಪ್ರಸ್ತುತ square brackets ಜೋಡಿಯ ಒಳಗಿನ ವಿಷಯ ಬದಲಾಯಿಸುತ್ತದೆ
+- `da'` single-quoted string ಪೂರ್ಣವಾಗಿ (quotes ಸಹಿತ) delete ಮಾಡುತ್ತದೆ
 
 ## Putting it all together
 
-Here is a broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) implementation:
+ಇಲ್ಲಿ ಒಂದು broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) implementation ಇದೆ:
 
 ```python
 def fizz_buzz(limit):
@@ -142,73 +142,73 @@ def main():
     fizz_buzz(20)
 ```
 
-We use the following sequence of commands to fix the issues, beginning in Normal mode:
+ಈ ದೋಷಗಳನ್ನು ಸರಿಪಡಿಸಲು, Normal mode ನಿಂದ ಆರಂಭಿಸಿ, ಕೆಳಗಿನ command ಕ್ರಮ ಬಳಸಿ:
 
-- Main is never called
-    - `G` to jump to the end of the file
-    - `o` to **o**pen a new line below
-    - Type in `if __name__ == "__main__": main()`
-        - If your editor has Python language support, it might do some auto-indentation for you in Insert mode
-    - `<ESC>` to go back to Normal mode
-- Starts at 0 instead of 1
-    - `/` followed by `range` and `<CR>` to search for "range"
-    - `ww` to move forward two **w**ords (you could also use `2w`, but in practice, for small counts it's common to repeat the key instead of using the count functionality)
-    - `i` to switch to **i**nsert mode, and add `1,`
-    - `<ESC>` to go back to Normal mode
-    - `e` to jump to the **e**nd of the next word
-    - `a` to start **a**ppending text, and add `+ 1`
-    - `<ESC>` to go back to Normal mode
-- Prints "fizz" for multiples of 5
-    - `:6<CR>` to go to line 6
-    - `ci"` to **c**hange **i**nside the '**"**', change to `"buzz"`
-    - `<ESC>` to go back to Normal mode
+- Main call ಆಗುವುದಿಲ್ಲ
+    - file ಅಂತ್ಯಕ್ಕೆ jump ಮಾಡಲು `G`
+    - ಕೆಳಗೆ ಹೊಸ line **o**pen ಮಾಡಲು `o`
+    - `if __name__ == "__main__": main()` ಎಂದು type ಮಾಡಿ
+        - editor ನಲ್ಲಿ Python language support ಇದ್ದರೆ Insert mode ನಲ್ಲಿ auto-indentation ಆಗಬಹುದು
+    - Normal mode ಗೆ ಮರಳಲು `<ESC>`
+- 1 ಬದಲು 0 ರಿಂದ ಆರಂಭವಾಗುತ್ತದೆ
+    - `range` ಹುಡುಕಲು `/` ನಂತರ `range` ಹಾಗೂ `<CR>`
+    - ಎರಡು **w**ords ಮುಂದೆ ಹೋಗಲು `ww` (`2w` ಕೂಡ ಬಳಸಿ; ಆದರೆ ಸಣ್ಣ counts ನಲ್ಲಿ count ಬರೆವುದಕ್ಕಿಂತ key ಮರುಬಳಕೆ ಸಾಮಾನ್ಯ)
+    - **i**nsert mode ಗೆ `i`, ನಂತರ `1,` ಸೇರಿಸಿ
+    - Normal mode ಗೆ `<ESC>`
+    - ಮುಂದಿನ ಪದದ **e**nd ಗೆ `e`
+    - **a**ppend mode ಗೆ `a`, ನಂತರ `+ 1` ಸೇರಿಸಿ
+    - Normal mode ಗೆ `<ESC>`
+- 5 ರ multiples ಗೆ "fizz" ಮುದ್ರಿಸುತ್ತದೆ
+    - line 6 ಗೆ `:6<CR>`
+    - quotes ಒಳಗಿನ ಭಾಗ **c**hange **i**nside ಮಾಡಲು `ci"`, ನಂತರ `"buzz"` ಹಾಕಿ
+    - Normal mode ಗೆ `<ESC>`
 
 ## Learning Vim
 
-The best way to learn Vim is to learn the fundamentals (what we've covered so far) and then just enable Vim mode in all your software and start using it in practice. Avoid the temptation to use the mouse or the arrow keys; in some editors, you can unbind the arrow keys to force yourself to build good habits.
+Vim ಕಲಿಯಲು ಅತ್ಯುತ್ತಮ ವಿಧಾನ: ಮೂಲಭೂತಗಳನ್ನು (ಇಲ್ಲಿವರೆಗೆ ನೋಡಿದ್ದು) ಕಲಿತು, ನಂತರ ನಿಮ್ಮ software ಎಲ್ಲೆಲ್ಲಿ ಸಾಧ್ಯವೋ ಅಲ್ಲಿ Vim mode ಸಕ್ರಿಯಗೊಳಿಸಿ ನಿಜವಾದ ಕೆಲಸದಲ್ಲಿ ಬಳಸುವುದು. Mouse ಅಥವಾ arrow keys ಗೆ ತಕ್ಷಣ ಮರಳುವ ಅಭ್ಯಾಸ ತಪ್ಪಿಸಿ. ಕೆಲವು editors ನಲ್ಲಿ arrow keys unbind ಮಾಡಿ ಉತ್ತಮ ಅಭ್ಯಾಸ ಬೆಳೆಸಿಕೊಳ್ಳಬಹುದು.
 
 ### Additional resources
 
-- The [Vim lecture](/2020/editors/) from the previous iteration of this class --- we have covered Vim in more depth there
-- `vimtutor` is a tutorial that comes installed with Vim --- if Vim is installed, you should be able to run `vimtutor` from your shell
-- [Vim Adventures](https://vim-adventures.com/) is a game to learn Vim
+- ಈ ತರಗತಿಯ ಹಿಂದಿನ ಆವೃತ್ತಿಯ [Vim lecture](/2020/editors/) - ಅಲ್ಲಿ Vim ಅನ್ನು ಹೆಚ್ಚಿನ ಆಳದಲ್ಲಿ ನೋಡಿದ್ದೇವೆ
+- `vimtutor` Vim ಜೊತೆ ಬರುತ್ತದೆ - Vim install ಇದ್ದರೆ shell ನಿಂದ `vimtutor` run ಮಾಡಬಹುದು
+- [Vim Adventures](https://vim-adventures.com/) - Vim ಕಲಿಯುವ ಆಟ
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2019/) has various Vim tips
-- [VimGolf](https://www.vimgolf.com/) is [code golf](https://en.wikipedia.org/wiki/Code_golf), but where the programming language is Vim's UI
+- [Vim Advent Calendar](https://vimways.org/2019/) - ಹಲವು Vim ಸಲಹೆಗಳು
+- [VimGolf](https://www.vimgolf.com/) - [code golf](https://en.wikipedia.org/wiki/Code_golf), ಆದರೆ programming language Vim UI
 - [Vi/Vim Stack Exchange](https://vi.stackexchange.com/)
 - [Vim Screencasts](http://vimcasts.org/)
-- [Practical Vim](https://pragprog.com/titles/dnvim2/) (book)
+- [Practical Vim](https://pragprog.com/titles/dnvim2/) (ಪುಸ್ತಕ)
 
 [Vim]: https://www.vim.org/
 
 # Code intelligence and language servers
 
-IDEs generally offer language-specific support that requires semantic understanding of the code through IDE extensions that connect to _language servers_ that implement [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). For example, the [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) relies on [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), and the [Go extension for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) relies on the first-party [gopls](https://go.dev/gopls/). By installing the extension and language server for the languages you work with, you can enable many language-specific features in your IDE, such as:
+IDEs ಸಾಮಾನ್ಯವಾಗಿ language-specific support ಕೊಡುತ್ತವೆ. ಇದು code ನ semantic understanding ಆಧರಿಸಿ _language servers_ ಗೆ ಸಂಪರ್ಕಿಸುವ IDE extensions ಮೂಲಕ ನಡೆಯುತ್ತದೆ. Language servers ಗಳು [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) ಅನ್ನು ಜಾರಿಗೊಳಿಸುತ್ತವೆ. ಉದಾ: [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python), [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) ಮೇಲೆ ಅವಲಂಬಿತ. [Go extension for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go), first-party [gopls](https://go.dev/gopls/) ಬಳಕೆ ಮಾಡುತ್ತದೆ. ನೀವು ಕೆಲಸ ಮಾಡುವ ಭಾಷೆಗಳ extension + language server install ಮಾಡಿದರೆ IDE ಯಲ್ಲಿ ಅನೇಕ language-specific ವೈಶಿಷ್ಟ್ಯಗಳು ಸಕ್ರಿಯವಾಗುತ್ತವೆ:
 
-- **Code completion.** Better autocomplete and autosuggest, such as being able to see an object's fields and methods after typing `object.`.
-- **Inline documentation.** Seeing documentation on hover and autosuggest.
-- **Jump-to-definition.** Jumping from a use site to the definition, such as being able to go from a field reference `object.field` to the definition of the field.
-- **Find references.** The inverse of the above, find all sites where a particular item such as a field or type is referenced.
-- **Help with imports.** Organizing imports, removing unused imports, flagging missing imports.
-- **Code quality.** These tools can be used standalone, but this functionality is often provided by language servers as well. Code formatting auto-indents and auto-formats code, and type checkers and linters find errors in your code, as you type. We will cover this class of functionality in greater depth in the [lecture on code quality](/2026/code-quality/).
+- **Code completion.** ಉತ್ತಮ autocomplete/autosuggest - ಉದಾ: `object.` ನಂತರ object's fields/methods ಕಾಣುವುದು.
+- **Inline documentation.** hover/autosuggest ಸಮಯದಲ್ಲಿ documentation ಕಾಣುವುದು.
+- **Jump-to-definition.** ಬಳಕೆ ಸ್ಥಳದಿಂದ definition ಗೆ ಹೋಗುವುದು - ಉದಾ: `object.field` ಇಂದ field definition ಗೆ.
+- **Find references.** ಮೇಲಿನದಕ್ಕೆ ವಿರೋಧ - ನಿರ್ದಿಷ್ಟ field/type ಎಲ್ಲೆಲ್ಲಿ ಬಳಕೆಯಾಗಿದೆ ಎನ್ನುವುದು ಕಂಡುಹಿಡಿಯುವುದು.
+- **Help with imports.** imports ಸಂಘಟಿಸುವುದು, unused imports ತೆಗೆದುಹಾಕುವುದು, missing imports ಸೂಚಿಸುವುದು.
+- **Code quality.** ಈ tools standalone ಆಗಿಯೂ ಬಳಸಬಹುದು; ಆದರೆ language servers ಮುಖಾಂತರವೂ ಈ functionality ಲಭ್ಯ. Code formatting auto-indent/auto-format ಮಾಡುತ್ತದೆ. Type checkers/linters ನೀವು type ಮಾಡುವಾಗಲೇ ದೋಷ ಹಿಡಿಯುತ್ತವೆ. ಈ ವರ್ಗವನ್ನು [code quality](/2026/code-quality/) ಉಪನ್ಯಾಸದಲ್ಲಿ ಆಳವಾಗಿ ನೋಡುತ್ತೇವೆ.
 
 ## Configuring language servers
 
-For some languages, all you need to do is install the extension and language server, and you'll be all set. For others, to get the maximum benefit from the language server, you need to tell the IDE about your environment. For example, pointing VS Code to your [Python environment](https://code.visualstudio.com/docs/python/environments) will enable the language server to see your installed packages. Environments are covered in more depth in our [lecture on packaging and shipping code](/2026/shipping-code/).
+ಕೆಲವು ಭಾಷೆಗಳಲ್ಲಿ extension ಮತ್ತು language server install ಮಾಡಿದರೆ ಸಾಕು. ಇತರ ಭಾಷೆಗಳಲ್ಲಿ language server ನ ಸಂಪೂರ್ಣ ಲಾಭ ಪಡೆಯಲು IDE ಗೆ ನಿಮ್ಮ environment ಬಗ್ಗೆ ತಿಳಿಸಬೇಕು. ಉದಾ: VS Code ನಲ್ಲಿ [Python environment](https://code.visualstudio.com/docs/python/environments) ಸೂಚಿಸಿದರೆ language server ಗೆ installed packages ಗೋಚರಿಸುತ್ತವೆ. Environments ಕುರಿತು ಹೆಚ್ಚಿನ ಮಾಹಿತಿ [packaging and shipping code](/2026/shipping-code/) ಉಪನ್ಯಾಸದಲ್ಲಿ.
 
-Depending on the language, there might be some settings you can configure for your language server. For example, using the Python support in VS Code, you can disable static type checking for projects that don't make use of Python's optional type annotations.
+ಭಾಷೆ ಪ್ರಕಾರ language server ಗೆ configure ಮಾಡಬಹುದಾದ settings ಇರಬಹುದು. ಉದಾ: VS Code ಯ Python support ನಲ್ಲಿ optional type annotations ಬಳಸದೆ ಇರುವ projects ಗಾಗಿ static type checking disable ಮಾಡಬಹುದು.
 
 # AI-powered development
 
-Since the introduction of [GitHub Copilot][github-copilot] using OpenAI's [Codex model](https://openai.com/index/openai-codex/) in mid 2021, [LLMs](https://en.wikipedia.org/wiki/Large_language_model) have become widely adopted in software engineering. There are three main form factors in use right now: autocomplete, inline chat, and coding agents.
+2021 ಮಧ್ಯಭಾಗದಲ್ಲಿ OpenAI ಯ [Codex model](https://openai.com/index/openai-codex/) ಬಳಸಿದ [GitHub Copilot][github-copilot] ಪರಿಚಯವಾದ ನಂತರ, [LLMs](https://en.wikipedia.org/wiki/Large_language_model) software engineering ನಲ್ಲಿ ವ್ಯಾಪಕವಾಗಿ ಅಳವಡಿಸಲ್ಪಟ್ಟಿವೆ. ಈಗ ಮುಖ್ಯವಾಗಿ ಮೂರು form factors ಹೆಚ್ಚು ಬಳಕೆಯಲ್ಲಿವೆ: autocomplete, inline chat, coding agents.
 
 [github-copilot]: https://github.com/features/copilot/ai-code-editor
 
 ## Autocomplete
 
-AI-powered autocomplete has the same form factor as traditional autocomplete in your IDE, suggesting completions at your cursor position as you type. Sometimes, it's used as a passive feature that "just works". Beyond that, AI autocomplete is generally [prompted](https://en.wikipedia.org/wiki/Prompt_engineering) using code comments.
+AI-powered autocomplete, ನಿಮ್ಮ IDE ಯ ಪರಂಪರಾಗತ autocomplete ಹೋಲೆಯೇ ಕಾಣುತ್ತದೆ - ನೀವು type ಮಾಡುವಾಗ cursor ಸ್ಥಾನದಲ್ಲೇ completions ಸೂಚಿಸುತ್ತದೆ. ಕೆಲವೊಮ್ಮೆ ಇದು passive feature ಆಗಿ "ಹಾಗೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ". ಅದಕ್ಕಿಂತ ಮುಂದೆ, AI autocomplete ಸಾಮಾನ್ಯವಾಗಿ code comments ಮೂಲಕ [prompted](https://en.wikipedia.org/wiki/Prompt_engineering) ಆಗುತ್ತದೆ.
 
-For example, let's write a script to download the contents of these lecture notes and extract all the links. We can start with:
+ಉದಾಹರಣೆಗೆ lecture notes content download ಮಾಡಿ links ತೆಗೆಯುವ script ಬರೆಯೋಣ. ಆರಂಭ:
 
 ```python
 import requests
@@ -216,34 +216,34 @@ import requests
 def download_contents(url: str) -> str:
 ```
 
-The model will autocomplete the body of the function:
+Model function body autocomplete ಮಾಡುತ್ತದೆ:
 
 ```python
     response = requests.get(url)
     return response.text
 ```
 
-We can further guide completions using comments. For example, if we start writing a function to extract all Markdown links, but it doesn't have a particularly descriptive name:
+Comments ಮೂಲಕ completion ಅನ್ನು ಇನ್ನಷ್ಟು guide ಮಾಡಬಹುದು. ಉದಾ: Markdown links ತೆಗೆದುಹಾಕುವ function ಬರೆಯಲು ಶುರುಮಾಡಿದಾಗ function name ಸಾಕಷ್ಟು descriptive ಆಗಿರದಿದ್ದರೆ:
 
 ```python
 def extract(contents: str) -> list[str]:
 ```
 
-The model will autocomplete something like this:
+Model ಈ ರೀತಿಯ completion ಕೊಡಬಹುದು:
 
 ```python
     lines = contents.splitlines()
     return [line for line in lines if line.strip()]
 ```
 
-We can guide the completion through code comments:
+Code comments ಮೂಲಕ completion ದಿಕ್ಕು ತೋರಿಸಬಹುದು:
 
 ```python
 def extract(content: str) -> list[str]:
     # extract all Markdown links from the content
 ```
 
-This time, the model gives a better completion:
+ಈ ಬಾರಿ completion ಉತ್ತಮವಾಗಿರುತ್ತದೆ:
 
 ```python
     import re
@@ -251,11 +251,11 @@ This time, the model gives a better completion:
     return re.findall(pattern, content)
 ```
 
-Here, we see one downside of this AI coding tool: it can only provide completions at the cursor. In this case, it would be better practice to put the `import re` at the module level, rather than inside the function.
+ಇಲ್ಲಿ ಈ AI coding tool ನ ಒಂದು ಮಿತಿ ಕಾಣಿಸುತ್ತದೆ: cursor ಇರುವ ಸ್ಥಳಕ್ಕಷ್ಟೇ completion ಕೊಡುತ್ತದೆ. ಈ ಸಂದರ್ಭದಲ್ಲಿ `import re` ಅನ್ನು function ಒಳಗೆ ಬದಲಾಗಿ module ಮಟ್ಟದಲ್ಲಿ ಇಡುವುದು ಉತ್ತಮ ಅಭ್ಯಾಸ.
 
-The example above used a poorly-named function to demonstrate how code completion can be steered using comments; in practice, you'd want to write code with functions named more descriptively, like `extract_links`, and you'd want to write docstrings (and based on this, the model should generate a completion analogous to the one above).
+ಮೇಲಿನ ಉದಾಹರಣೆಯಲ್ಲಿ comments ಮೂಲಕ code completion ಹೇಗೆ steer ಮಾಡಬಹುದು ತೋರಿಸಲು function name ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಸರಳವಾಗಿ ಇಡಲಾಗಿದೆ. ಪ್ರಾಯೋಗಿಕವಾಗಿ `extract_links` ಹೀಗೆ descriptive function names ಬಳಸಿ, docstrings ಬರೆಯುವುದು ಉತ್ತಮ (ಇದರಿಂದ model ಮೇಲಿನಂತೆಯೇ ಸೂಕ್ತ completion ಕೊಡುತ್ತದೆ).
 
-For demonstration purposes, we can complete the script:
+Demo ಗಾಗಿ script ಪೂರ್ಣಗೊಳಿಸಬಹುದು:
 
 ```python
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
@@ -263,15 +263,15 @@ print(extract(download_contents("https://raw.githubusercontent.com/missing-semes
 
 ## Inline chat
 
-Inline chat lets you select a line or block and then directly prompt the AI model to propose an edit. In this interaction mode, the model can make changes to existing code (which differs from autocomplete, which only completes code beyond the cursor).
+Inline chat ನಲ್ಲಿ line/block ಆಯ್ಕೆ ಮಾಡಿ, ನೇರವಾಗಿ AI model ಗೆ edit ಸೂಚಿಸಬಹುದು. ಈ mode ನಲ್ಲಿ model ಇರುವ code ನ್ನೇ ಬದಲಾಯಿಸಬಹುದು (autocomplete ಇಂದ ವ್ಯತ್ಯಾಸ - ಅದು cursor ನಂತರದ code ಮಾತ್ರ ಪೂರ್ಣಗೊಳಿಸುತ್ತದೆ).
 
-Continuing the example from above, suppose we decided not to use the third-party `requests` library. We could select the relevant three lines of code, invoke inline chat, and say something like:
+ಮೇಲಿನ ಉದಾಹರಣೆ ಮುಂದುವರಿಸಿದರೆ, third-party `requests` library ಬಳಸಬಾರದು ಎಂದು ತೀರ್ಮಾನಿಸಿದ್ದೇವೆ ಎಂದು ಊಹಿಸೋಣ. ಸಂಬಂಧಿತ ಮೂರು lines ಆಯ್ಕೆ ಮಾಡಿ inline chat invoke ಮಾಡಿ ಹೀಗೆ ಹೇಳಬಹುದು:
 
 ```
 use built-in libraries instead
 ```
 
-The model proposes:
+Model ನೀಡುವ ಪ್ರಸ್ತಾವನೆ:
 
 ```python
 from urllib.request import urlopen
@@ -283,23 +283,23 @@ def download_contents(url: str) -> str:
 
 ## Coding agents
 
-Coding agents are covered in depth in the [Agentic Coding](/2026/agentic-coding/) lecture.
+Coding agents ಬಗ್ಗೆ [Agentic Coding](/2026/agentic-coding/) ಉಪನ್ಯಾಸದಲ್ಲಿ ಆಳವಾಗಿ ನೋಡುತ್ತೇವೆ.
 
 ## Recommended software
 
-Some popular AI IDEs are [VS Code][vs-code] with the [GitHub Copilot][github-copilot] extension and [Cursor](https://cursor.com/). GitHub Copilot is currently available [for free for students](https://github.com/education/students), teachers, and maintainers of popular open source projects. This is a rapidly evolving space. Many of the leading products have roughly equivalent functionality.
+ಜನಪ್ರಿಯ AI IDEs ಗಳಲ್ಲಿ [GitHub Copilot][github-copilot] extension ಹೊಂದಿರುವ [VS Code][vs-code] ಮತ್ತು [Cursor](https://cursor.com/) ಪ್ರಮುಖ. GitHub Copilot ಇದೀಗ [students](https://github.com/education/students), teachers, ಮತ್ತು ಜನಪ್ರಿಯ open-source project maintainers ಗಾಗಿ ಉಚಿತ ಲಭ್ಯ. ಈ ಕ್ಷೇತ್ರ ವೇಗವಾಗಿ ಬದಲಾಗುತ್ತಿದೆ; ಮುಂಚೂಣಿ ಉತ್ಪನ್ನಗಳಲ್ಲಿ ಅನೇಕವು ಸಮಾನ ಮಟ್ಟದ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಹೊಂದಿವೆ.
 
 # Extensions and other IDE functionality
 
-IDEs are powerful tools, made even more powerful by _extensions_. We can't cover all of these features in a single lecture, but here we provide some pointers to a couple popular extensions. We encourage you to explore this space on your own; there are many lists of popular IDE extensions available online, such as [Vim Awesome](https://vimawesome.com/) for Vim plugins and [VS Code extensions sorted by popularity](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
+IDEs ಶಕ್ತಿಶಾಲಿ tools. _Extensions_ ಅವನ್ನು ಇನ್ನಷ್ಟು ಶಕ್ತಿಶಾಲಿಯಾಗಿಸುತ್ತವೆ. ಒಂದು ಉಪನ್ಯಾಸದಲ್ಲಿ ಎಲ್ಲ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಆವರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ, ಆದ್ದರಿಂದ ಇಲ್ಲಿ ಕೆಲ ಪ್ರಮುಖ extensions ಕಡೆ ಸೂಚನೆಗಳನ್ನು ಕೊಡುತ್ತೇವೆ. ಈ ಕ್ಷೇತ್ರವನ್ನು ನೀವು ಸ್ವತಃ ಅನ್ವೇಷಿಸಲು ಪ್ರೋತ್ಸಾಹಿಸುತ್ತೇವೆ. ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಜನಪ್ರಿಯ IDE extensions ಪಟ್ಟಿಗಳು ಹಲವೆಡೆ ಲಭ್ಯ - ಉದಾ: Vim plugins ಗೆ [Vim Awesome](https://vimawesome.com/), ಮತ್ತು [ಜನಪ್ರಿಯತೆ ಆಧಾರದ ಮೇಲೆ ಸಜ್ಜುಗೊಳಿಸಿದ VS Code extensions](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
 
-- [Development containers](https://containers.dev/): supported by popular IDEs (e.g., [supported by VS Code](https://code.visualstudio.com/docs/devcontainers/containers)), dev containers let you use a container to run development tools. This can be helpful for portability or isolation. The [lecture on packaging and shipping code](/2026/shipping-code/) covers containers in more depth.
-- Remote development: do development on a remote machine using SSH (e.g., with the [Remote SSH plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). This can be handy, for example, if you want to develop and run code on a beefy GPU machine in the cloud.
-- Collaborative editing: edit the same file, Google Docs style (e.g., with the [Live Share plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
+- [Development containers](https://containers.dev/): ಜನಪ್ರಿಯ IDEs ಬೆಂಬಲಿಸುತ್ತವೆ (ಉದಾ: [VS Code support](https://code.visualstudio.com/docs/devcontainers/containers)). Dev containers ಮೂಲಕ development tools ಅನ್ನು container ಒಳಗೆ ನಡೆಸಬಹುದು. ಇದು portability ಮತ್ತು isolation ಗೆ ಸಹಾಯಕ. [packaging and shipping code](/2026/shipping-code/) ಉಪನ್ಯಾಸದಲ್ಲಿ containers ಕುರಿತು ಹೆಚ್ಚಿನ ವಿವರ.
+- Remote development: SSH ಬಳಸಿ remote machine ನಲ್ಲಿ development ಮಾಡಿ (ಉದಾ: [Remote SSH plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). Cloud ನಲ್ಲಿ ಇರುವ ಶಕ್ತಿಶಾಲಿ GPU machine ಮೇಲೆ code ಬರೆಯಲು/ಓಡಿಸಲು ಇದು ಉಪಯುಕ್ತ.
+- Collaborative editing: Google Docs ಶೈಲಿಯಲ್ಲಿ ಅದೇ file ಅನ್ನು ಒಟ್ಟಿಗೆ edit ಮಾಡಿ (ಉದಾ: [Live Share plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
 
 # Exercises
 
-1. Enable Vim mode in all the software you use that supports it, such as your editor and your shell, and use Vim mode for all your text editing for the next month. Whenever something seems inefficient, or when you think "there must be a better way", try Googling it, there probably is a better way.
-1. Complete a challenge from [VimGolf](https://www.vimgolf.com/).
-1. Configure an IDE extension and language server for a project that you're working on. Ensure that all the expected functionality, such as jump-to-definition for library dependencies, works as expected. If you don't have code that you can use for this exercise, you can use some open-source project from GitHub (such as [this one](https://github.com/spf13/cobra)).
-1. Browse a list of IDE extensions and install one that seems useful to you.
+1. ನೀವು ಬಳಸುವ ಎಲ್ಲ Vim-support software ಗಳಲ್ಲಿ (ಉದಾ: editor, shell) Vim mode ಸಕ್ರಿಯಗೊಳಿಸಿ. ಮುಂದಿನ ಒಂದು ತಿಂಗಳು ನಿಮ್ಮ text editing ಕೆಲಸಗಳೆಲ್ಲ Vim mode ನಲ್ಲಿ ಮಾಡಿ. ಯಾವುದಾದರೂ ಅಸಮರ್ಥವಾಗಿ ಕಂಡರೆ, ಅಥವಾ "ಇದಕ್ಕಿಂತ ಉತ್ತಮ ಮಾರ್ಗ ಇರಬೇಕು" ಅನ್ನಿಸಿದರೆ Google ನಲ್ಲಿ ಹುಡುಕಿ - ಬಹುಶಃ ಉತ್ತಮ ಮಾರ್ಗ ಇರುತ್ತದೆ.
+1. [VimGolf](https://www.vimgolf.com/) ನಲ್ಲಿ ಒಂದು challenge ಪೂರ್ಣಗೊಳಿಸಿ.
+1. ನೀವು ಕೆಲಸ ಮಾಡುತ್ತಿರುವ project ಗೆ IDE extension ಮತ್ತು language server configure ಮಾಡಿ. Library dependencies ಗೆ jump-to-definition ಸೇರಿದಂತೆ ನಿರೀಕ್ಷಿತ features ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತಿವೆಯೇ ಪರಿಶೀಲಿಸಿ. ಈ exercise ಗೆ ನಿಮ್ಮ code ಇಲ್ಲದಿದ್ದರೆ GitHub open-source project ಒಂದನ್ನು ಬಳಸಿ (ಉದಾ: [this one](https://github.com/spf13/cobra)).
+1. IDE extensions ಪಟ್ಟಿ ವೀಕ್ಷಿಸಿ, ನಿಮಗೆ ಉಪಯುಕ್ತವೆನಿಸುವ ಒಂದು extension install ಮಾಡಿ.

--- a/_2026/index.md
+++ b/_2026/index.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: "2026 Lectures"
+title: "2026 ಉಪನ್ಯಾಸಗಳು"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2026.
+  Missing Semester, MIT IAP 2026 ಗಾಗಿ ಉಪನ್ಯಾಸ ಟಿಪ್ಪಣಿಗಳು ಮತ್ತು ವೀಡಿಯೊಗಳು.
 permalink: /2026/
 phony: true
 ---
@@ -16,9 +16,9 @@ phony: true
         {% if lecture.ready %}
           <a href="{{ lecture.url }}">{{ lecture.title }}</a>
         {% elsif lecture.noclass %}
-          {{ lecture.title }} [no class]
+          {{ lecture.title }} [ತರಗತಿ ಇಲ್ಲ]
         {% else %}
-          {{ lecture.title }} [coming soon]
+          {{ lecture.title }} [ಶೀಘ್ರದಲ್ಲೇ]
         {% endif %}
         {% if lecture.details %}
           <br>

--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Packaging and Shipping Code"
+title: "ಕೋಡ್ ಪ್ಯಾಕೇಜಿಂಗ್ ಮತ್ತು ಶಿಪ್ಪಿಂಗ್"
 description: >
-  Learn about project packaging, environments, versioning, and deploying libraries, applications, and services.
+  ಪ್ರಾಜೆಕ್ಟ್ ಪ್ಯಾಕೇಜಿಂಗ್, environments, versioning, ಮತ್ತು libraries, applications, ಹಾಗೂ services ಗಳ deployment ಬಗ್ಗೆ ತಿಳಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec6.png
 date: 2026-01-20
 ready: true
@@ -11,32 +11,32 @@ video:
   id: KBMiB-8P4Ns
 ---
 
-Getting code to work as intended is hard; getting that same code to run on a machine different from your own is often harder.
+ಕೋಡ್ ಅನ್ನು ಉದ್ದೇಶಿತ ರೀತಿಯಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುವಂತೆ 만드는ುದು ಕಷ್ಟಕರ - ಅದೇ ಕೋಡ್ ಅನ್ನು ನಿಮ್ಮ ಯಂತ್ರಕ್ಕಿಂತ ಭಿನ್ನವಾದ ಯಂತ್ರದಲ್ಲಿ ಓಡಿಸುವುದು ಬಹುಪಾಲು ಇನ್ನಷ್ಟು ಕಷ್ಟಕರ.
 
-Shipping code means taking the code you wrote and converting it into a usable form that someone else can run without your computer's exact setup.
-Shipping code takes many forms and depends on the choices of programming language, system libraries, and operating system, among many other factors.
-It also depends on what you are building: a software library, a command line tool, and a web service all have different requirements and deployment steps.
-Regardless, there is a common pattern between all these scenarios: we need to define what the deliverable is --- a.k.a. the _artifact_ --- and what assumptions it makes about the environment around it.
+ಕೋಡ್ ಶಿಪ್ಪಿಂಗ್ ಎಂದರೆ ನೀವು ಬರೆದ ಕೋಡ್ ಅನ್ನು, ನಿಮ್ಮ ಕಂಪ್ಯೂಟರ್‌ನ ನಿಖರ setup ಇಲ್ಲದೆ ಮತ್ತೊಬ್ಬರು ನಡೆಸಬಹುದಾದ ಬಳಸಬಹುದಾದ ರೂಪಕ್ಕೆ ಪರಿವರ್ತಿಸುವುದಾಗಿದೆ.
+ಕೋಡ್ ಶಿಪ್ಪಿಂಗ್ ಹಲವು ರೂಪಗಳನ್ನು ಹೊಂದಿದ್ದು, programming language, system libraries, ಮತ್ತು operating system ಸೇರಿದಂತೆ ಅನೇಕ ಅಂಶಗಳ ಆಯ್ಕೆಗಳ ಮೇಲೆ ಅವಲಂಬಿತವಾಗಿರುತ್ತದೆ.
+ಇದು ನೀವು ನಿರ್ಮಿಸುತ್ತಿರುವದನ್ನು ಕೂಡ ಅವಲಂಬಿಸುತ್ತದೆ: software library, command line tool, ಮತ್ತು web service - ಇವು ಪ್ರತಿಯೊಂದಕ್ಕೂ ವಿಭಿನ್ನ ಅವಶ್ಯಕತೆಗಳು ಮತ್ತು deployment ಹಂತಗಳು ಇವೆ.
+ಆದಾಗ್ಯೂ, ಈ ಎಲ್ಲಾ ಸಂದರ್ಭಗಳಲ್ಲಿ ಒಂದು ಸಾಮಾನ್ಯ ಮಾದರಿ ಇದೆ: deliverable ಏನು - ಅಂದರೆ _artifact_ ಏನು - ಮತ್ತು ಅದರ ಸುತ್ತಲಿನ environment ಬಗ್ಗೆ ಅದು ಯಾವ assumptions ಮಾಡುತ್ತದೆ ಎಂಬುದನ್ನು ನಿರ್ದಿಷ್ಟಗೊಳಿಸಬೇಕು.
 
-In this lecture, we'll cover:
+ಈ ಉಪನ್ಯಾಸದಲ್ಲಿ ನಾವು ಈ ಕೆಳಗಿನ ವಿಷಯಗಳನ್ನು ಆವರಿಸುತ್ತೇವೆ:
 
-- [Dependencies & Environments](#dependencies--environments)
-- [Artifacts & Packaging](#artifacts--packaging)
-- [Releases & Versioning](#releases--versioning)
+- [Dependencies ಮತ್ತು Environments](#dependencies--environments)
+- [Artifacts ಮತ್ತು Packaging](#artifacts--packaging)
+- [Releases ಮತ್ತು Versioning](#releases--versioning)
 - [Reproducibility](#reproducibility)
-- [VMs & Containers](#vms--containers)
+- [VMs ಮತ್ತು Containers](#vms--containers)
 - [Configuration](#configuration)
-- [Services & Orchestration](#services--orchestration)
+- [Services ಮತ್ತು Orchestration](#services--orchestration)
 - [Publishing](#publishing)
 
-We'll explain these concepts through examples from the Python ecosystem, as concrete examples are helpful for understanding. While the tools are different for other programming language ecosystems, the concepts will largely be the same.
+ಈ ಪರಿಕಲ್ಪನೆಗಳನ್ನು ನಾವು Python ecosystem ನ ಉದಾಹರಣೆಗಳ ಮೂಲಕ ವಿವರಿಸುತ್ತೇವೆ, ಏಕೆಂದರೆ ಸ್ಪಷ್ಟ ಉದಾಹರಣೆಗಳು ಅರ್ಥಗರ್ಭಿತ ತಿಳುವಳಿಕೆಗೆ ಸಹಾಯಕ. ಇತರೆ programming language ecosystems ಗಳಲ್ಲಿ tools ಬೇರೆಯಾಗಿದ್ದರೂ, ಪರಿಕಲ್ಪನೆಗಳ ಮೂಲಭೂತ ಅಂಶಗಳು ಬಹುತೇಕ ಒಂದೇ ಆಗಿರುತ್ತವೆ.
 
 # Dependencies & Environments
 
-In modern software development, layers of abstraction are ubiquitous.
-Programs naturally offload logic to other libraries or services.
-However, this introduces a _dependency_ relationship between your program and the libraries it requires to function.
-For instance, in Python, to fetch the content of a website we often do:
+ಆಧುನಿಕ software development ನಲ್ಲಿ abstraction ಪದರಗಳು ಎಲ್ಲೆಡೆ ಕಂಡುಬರುತ್ತವೆ.
+ಪ್ರೋಗ್ರಾಂಗಳು ಸ್ವಾಭಾವಿಕವಾಗಿ ಕೆಲವು logic ಅನ್ನು ಇತರೆ libraries ಅಥವಾ services ಗಳಿಗೆ ಒಪ್ಪಿಸುತ್ತವೆ.
+ಆದರೆ ಇದರಿಂದ ನಿಮ್ಮ program ಮತ್ತು ಅದು ಕಾರ್ಯನಿರ್ವಹಿಸಲು ಅಗತ್ಯವಿರುವ libraries ಗಳ ನಡುವೆ _dependency_ ಸಂಬಂಧ ನಿರ್ಮಾಣವಾಗುತ್ತದೆ.
+ಉದಾಹರಣೆಗೆ, Python ನಲ್ಲಿ website ನ content ಪಡೆಯಲು ನಾವು ಸಾಮಾನ್ಯವಾಗಿ ಹೀಗೆ ಮಾಡುತ್ತೇವೆ:
 
 ```python
 import requests
@@ -44,7 +44,7 @@ import requests
 response = requests.get("https://missing.csail.mit.edu")
 ```
 
-Yet the `requests` library does not come bundled with the Python runtime, so if we try to run this code without having `requests` installed, Python will raise an error:
+ಆದರೆ `requests` library Python runtime ಜೊತೆಗೆ bundled ಆಗಿ ಬರುವುದಿಲ್ಲ; ಆದ್ದರಿಂದ `requests` install ಮಾಡದೆ ಈ ಕೋಡ್ ಅನ್ನು ಓಡಿಸಲು ಯತ್ನಿಸಿದರೆ Python error ನೀಡುತ್ತದೆ:
 
 ```console
 $ python fetch.py
@@ -54,14 +54,14 @@ Traceback (most recent call last):
 ModuleNotFoundError: No module named 'requests'
 ```
 
-To make this library available we need to first run `pip install requests` to install it.
-`pip` is the command line tool that the Python programming language provides for installing packages.
-Executing `pip install requests` produces the following sequence of actions:
+ಈ library ಲಭ್ಯವಾಗಲು ಮೊದಲು `pip install requests` ಅನ್ನು ಚಾಲನೆ ಮಾಡಿ install ಮಾಡಬೇಕು.
+`pip` ಎಂದರೆ Python programming language ಒದಗಿಸುವ package install ಮಾಡುವ command line tool ಆಗಿದೆ.
+`pip install requests` ಕಾರ್ಯಗತಗೊಳಿಸಿದಾಗ ಕೆಳಗಿನ ಕ್ರಮದಲ್ಲಿ ಹಂತಗಳು ನಡೆಯುತ್ತವೆ:
 
-1. Search for requests in the Python Package Index ([PyPI](https://pypi.org/))
-1. Search for the appropriate artifact for the platform we are running under
-1. Resolve dependencies --- the `requests` library itself depends on other packages, so the installer must find compatible versions of all transitive dependencies and install them beforehand
-1. Download the artifacts, then unpack and copy the files into the right places in our filesystem
+1. Python Package Index ([PyPI](https://pypi.org/)) ನಲ್ಲಿ requests ಹುಡುಕುವುದು
+1. ನಾವು ಬಳಸುತ್ತಿರುವ platform ಗೆ ಸರಿಯಾದ artifact ಹುಡುಕುವುದು
+1. Dependencies resolve ಮಾಡುವುದು - `requests` library ಗೆ ತಾನೇ ಇತರೆ packages ಮೇಲೂ ಅವಲಂಬನೆ ಇದೆ; ಆದ್ದರಿಂದ installer ಎಲ್ಲಾ transitive dependencies ಗಳಿಗೂ ಹೊಂದಿಕೊಳ್ಳುವ versions ಕಂಡುಹಿಡಿದು ಮೊದಲು install ಮಾಡಬೇಕು
+1. Artifacts download ಮಾಡಿ, ನಂತರ files ಅನ್ನು unpack ಮಾಡಿ filesystem ನಲ್ಲಿ ಸರಿಯಾದ ಸ್ಥಳಗಳಿಗೆ ನಕಲಿಸುವುದು
 
 ```console
 $ pip install requests
@@ -79,8 +79,8 @@ Installing collected packages: urllib3, idna, charset-normalizer, certifi, reque
 Successfully installed certifi-2024.8.30 charset-normalizer-3.4.0 idna-3.10 requests-2.32.3 urllib3-2.2.3
 ```
 
-Here we can see that `requests` has its own dependencies such as `certifi` or `charset-normalizer` and that they have to be installed before `requests` can be installed.
-Once installed, the Python runtime can find this library when importing it.
+ಇಲ್ಲಿ `requests` ಗೆ `certifi` ಅಥವಾ `charset-normalizer` ನಂತಹ ತನ್ನದೇ dependencies ಇರುವುದನ್ನು ನೋಡಬಹುದು; ಹಾಗಾಗಿ `requests` install ಮಾಡುವ ಮೊದಲು ಅವು install ಆಗಬೇಕು.
+ಒಮ್ಮೆ install ಆದ ನಂತರ, import ಮಾಡುವಾಗ Python runtime ಈ library ಅನ್ನು ಹುಡುಕಿ ಬಳಸಲು ಸಾಧ್ಯವಾಗುತ್ತದೆ.
 
 ```console
 $ python -c 'import requests; print(requests.__path__)'
@@ -90,19 +90,19 @@ $ pip list | grep requests
 requests        2.32.3
 ```
 
-Programming languages have different tools, conventions and practices for installing and publishing libraries.
-In some languages like Rust, the toolchain is unified --- `cargo` handles building, testing, dependency management, and publishing.
-In others like Python, the unification happens at a specification level --- rather than a single tool, there are standardized specifications that define how packaging works, allowing multiple competing tools for each task (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
-And in some ecosystems like LaTeX, distributions like TeX Live or MacTeX come bundled with thousands of packages pre-installed.
+Programming languages ಗಳಲ್ಲಿ libraries install ಮತ್ತು publish ಮಾಡಲು ಬೇರೆ ಬೇರೆ tools, conventions ಮತ್ತು practices ಇರುತ್ತವೆ.
+Rust ನಂತಹ ಕೆಲವು languages ಗಳಲ್ಲಿ toolchain ಏಕೀಕೃತವಾಗಿದೆ - `cargo` build, test, dependency management, ಮತ್ತು publishing ಎಲ್ಲವನ್ನೂ ನೋಡಿಕೊಳ್ಳುತ್ತದೆ.
+Python ನಂತಹ ecosystems ಗಳಲ್ಲಿ ಈ ಏಕೀಕರಣವು specification ಮಟ್ಟದಲ್ಲಿ ನಡೆದಿದೆ - ಒಂದೇ tool ಬದಲಾಗಿ packaging ಹೇಗೆ ಕೆಲಸ ಮಾಡಬೇಕು ಎಂಬುದನ್ನು standardized specifications ನಿರ್ಧರಿಸುತ್ತವೆ; ಇದರ ಮೂಲಕ ಪ್ರತಿ ಕಾರ್ಯಕ್ಕೂ ಹಲವಾರು ಸ್ಪರ್ಧಾತ್ಮಕ tools ಇರಲು ಅವಕಾಶವಿದೆ (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
+ಮತ್ತೆ LaTeX ನಂತಹ ಕೆಲ ecosystems ಗಳಲ್ಲಿ TeX Live ಅಥವಾ MacTeX distributions ಗಳೊಂದಿಗೆ ಸಾವಿರಾರು packages ಪೂರ್ವಸ್ಥಾಪಿತವಾಗಿ bundled ಆಗಿ ಬರುತ್ತವೆ.
 
-Introducing dependencies also introduces dependency conflicts.
-Conflicts happen when programs require incompatible versions of the same dependency.
-For example, if `tensorflow==2.3.0` requires `numpy>=1.16.0,<1.19.0` and `pandas==1.2.0`  requires `numpy>=1.16.5`, then any version satisfying `numpy>=1.16.5,<1.19.0` will be valid.
-But if another package in your project requires `numpy>=1.19`, you have a conflict with no valid version that satisfies all constraints.
+Dependencies ಪರಿಚಯಿಸುವುದರಿಂದ dependency conflicts ಕೂಡ ಉಂಟಾಗುತ್ತವೆ.
+ಒಂದೇ dependency ಗೆ programs ಪರಸ್ಪರ ಹೊಂದಿಕೆಯಾಗದ versions ಅಗತ್ಯವಿದ್ದಾಗ conflicts ಉಂಟಾಗುತ್ತವೆ.
+ಉದಾಹರಣೆಗೆ, `tensorflow==2.3.0` ಗೆ `numpy>=1.16.0,<1.19.0` ಅಗತ್ಯವಿದ್ದು, `pandas==1.2.0` ಗೆ `numpy>=1.16.5` ಅಗತ್ಯವಿದ್ದರೆ `numpy>=1.16.5,<1.19.0` ತೃಪ್ತಿಪಡಿಸುವ ಯಾವ version ಆದರೂ ಮಾನ್ಯ.
+ಆದರೆ ನಿಮ್ಮ project ನ ಇನ್ನೊಂದು package ಗೆ `numpy>=1.19` ಅಗತ್ಯವಿದ್ದರೆ, ಎಲ್ಲ constraints ಗಳನ್ನೂ ತೃಪ್ತಿಪಡಿಸುವ ಮಾನ್ಯ version ಇಲ್ಲದ conflict ಉಂಟಾಗುತ್ತದೆ.
 
-This situation --- where multiple packages require mutually incompatible versions of shared dependencies --- is commonly referred to as _dependency hell_.
-One way to deal with conflicts is to isolate the dependencies of each program into their own _environment_.
-In Python we create a virtual environment by running:
+ಈ ಪರಿಸ್ಥಿತಿ - ಹಲವಾರು packages ಗಳು shared dependencies ಗಳಿಗೆ ಪರಸ್ಪರ ಅಸಂಗತ versions ಬೇಡುವುದು - ಸಾಮಾನ್ಯವಾಗಿ _dependency hell_ ಎಂದು ಕರೆಯಲಾಗುತ್ತದೆ.
+ಈ conflicts ನನ್ನು ನಿಭಾಯಿಸುವ ಒಂದು ವಿಧಾನವೆಂದರೆ ಪ್ರತಿ program ನ dependencies ಗಳನ್ನು ಪ್ರತ್ಯೇಕ _environment_ ಗಳಲ್ಲಿ ಪ್ರತ್ಯೇಕಿಸುವುದು.
+Python ನಲ್ಲಿ virtual environment ರಚಿಸಲು ಹೀಗೆ ಮಾಡುತ್ತೇವೆ:
 
 ```console
 $ which python
@@ -124,17 +124,17 @@ Package Version
 pip     24.0
 ```
 
-You can think of an environment as an entire standalone version of the language runtime with its own set of installed packages.
-This virtual environment or venv isolates the installed dependencies from the global Python installation.
-It is a good practice to have a virtual environment for each project, containing the dependencies it requires.
+Environment ಅನ್ನು language runtime ನ ಸಂಪೂರ್ಣ standalone ರೂಪವಾಗಿ, ಅದಕ್ಕೇ ಸೇರಿದ packages ಗಳ ಸಮೂಹದೊಂದಿಗೆ ಕಲ್ಪಿಸಬಹುದು.
+ಈ virtual environment ಅಥವಾ venv, install ಆಗಿರುವ dependencies ಗಳನ್ನು global Python installation ನಿಂದ ಪ್ರತ್ಯೇಕಿಸುತ್ತದೆ.
+ಪ್ರತಿ project ಗೆ ಅದಕ್ಕೆ ಬೇಕಾದ dependencies ಒಳಗೊಂಡ ಪ್ರತ್ಯೇಕ virtual environment ಇರುವುದು ಉತ್ತಮ ಅಭ್ಯಾಸ.
 
-> While many modern operating systems ship with installations of programming language runtimes like Python, it is unwise to modify these installations since the OS might rely on them for its own functionality. Prefer using separate environments instead.
+> ಅನೇಕ ಆಧುನಿಕ operating systems ಗಳು Python ಮುಂತಾದ programming language runtimes ಗಳ installations ಜೊತೆ ಬರುತ್ತವೆ; ಆದರೆ OS ತನ್ನ ಸ್ವಂತ ಕಾರ್ಯಚಟುವಟಿಕೆಗಾಗಿ ಅವುಗಳ ಮೇಲೆ ಅವಲಂಬಿತವಾಗಿರಬಹುದಾದ್ದರಿಂದ ಅವನ್ನು ತಿದ್ದುಪಡಿ ಮಾಡುವುದು ಸಮಂಜಸವಲ್ಲ. ಬದಲಾಗಿ ಪ್ರತ್ಯೇಕ environments ಬಳಸುವುದನ್ನು ಆದ್ಯತೆ ನೀಡಿ.
 
-In some languages, the installation protocol is not defined by a tool but as a specification.
-In Python [PEP 517](https://peps.python.org/pep-0517/) defines the build system interface and [PEP 621](https://peps.python.org/pep-0621/) specifies how project metadata is stored in `pyproject.toml`.
-This has enabled developers to improve upon `pip` and produce more optimized tools like `uv`. To install `uv` it suffices to do `pip install uv`.
+ಕೆಲ languages ಗಳಲ್ಲಿ installation protocol ಒಂದು tool ಮೂಲಕವಲ್ಲ, specification ರೂಪದಲ್ಲೇ ವ್ಯಾಖ್ಯಾನಗೊಂಡಿರುತ್ತದೆ.
+Python ನಲ್ಲಿ [PEP 517](https://peps.python.org/pep-0517/) build system interface ಅನ್ನು ವ್ಯಾಖ್ಯಾನಿಸುತ್ತದೆ ಮತ್ತು [PEP 621](https://peps.python.org/pep-0621/) project metadata ಅನ್ನು `pyproject.toml` ನಲ್ಲಿ ಹೇಗೆ ಸಂಗ್ರಹಿಸಬೇಕು ಎಂದು ಸೂಚಿಸುತ್ತದೆ.
+ಇದರ ಫಲವಾಗಿ ಅಭಿವೃದ್ಧಿಪರರು `pip` ಅನ್ನು ಸುಧಾರಿಸಿ `uv` ನಂತಹ ಹೆಚ್ಚು optimized tools ರೂಪಿಸಿದ್ದಾರೆ. `uv` install ಮಾಡಲು `pip install uv` ಸಾಕಾಗುತ್ತದೆ.
 
-Using `uv` instead of `pip` follows the same interface but is significantly faster:
+`pip` ಬದಲಿಗೆ `uv` ಬಳಸಿದರೂ interface ಅದೇ ಇರುತ್ತದೆ; ಆದರೆ ವೇಗ ಗಣನೀಯವಾಗಿ ಹೆಚ್ಚಿರುತ್ತದೆ:
 
 ```console
 $ uv pip install requests
@@ -148,9 +148,9 @@ Installed 5 packages in 8ms
  + urllib3==2.2.3
 ```
 
-> We strongly recommend using `uv pip` instead of `pip` whenever possible as it dramatically reduces the installation time.
+> ಸಾಧ್ಯವಾದಾಗಲೆಲ್ಲ `pip` ಬದಲು `uv pip` ಬಳಸಿ ಎಂದು ನಾವು ಬಲವಾಗಿ ಶಿಫಾರಸು ಮಾಡುತ್ತೇವೆ, ಏಕೆಂದರೆ ಇದು installation ಸಮಯವನ್ನು ಗಣನೀಯವಾಗಿ ಕಡಿತಗೊಳಿಸುತ್ತದೆ.
 
-Beyond dependency isolation, environments also allow you to have different versions of your programming language runtime.
+Dependency isolation ಗಿಂತಲೂ ಹೊರತು, environments ನಿಮ್ಮ programming language runtime ನ ವಿಭಿನ್ನ versions ಇಟ್ಟುಕೊಳ್ಳಲು ಸಹ ನೆರವಾಗುತ್ತವೆ.
 
 ```console
 $ uv venv --python 3.12 venv312
@@ -168,15 +168,15 @@ $ source venv311/bin/activate && python --version
 Python 3.11.10
 ```
 
-This helps when you need to test your code across multiple Python versions or when a project requires a specific version.
+ಇದು ಹಲವು Python versions ಗಳಲ್ಲಿ ನಿಮ್ಮ code test ಮಾಡಲು ಅಥವಾ project ಒಂದು ನಿರ್ದಿಷ್ಟ version ಬೇಡುವಾಗ ಬಹಳ ಉಪಯುಕ್ತ.
 
-> In some programming languages, each project automatically gets its own environment for its dependencies rather than you creating it manually, but the principle is the same. Most languages these days also have a mechanism for managing multiple versions of the language on a single system, and then specifying which version to use for individual projects.
+> ಕೆಲವು programming languages ಗಳಲ್ಲಿ ಪ್ರತಿ project ಗೆ dependencies ಗಾಗಿ environment ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಿಗುತ್ತದೆ; ನೀವು ಕೈಯಾರೆ ರಚಿಸುವ ಅಗತ್ಯವಿಲ್ಲ. ಆದರೂ ತತ್ವ ಒಂದೇ. ಇಂದಿನ ಬಹುತೇಕ languages ಒಂದೇ system ನಲ್ಲಿ ಭಾಷೆಯ ಹಲವು versions ನಿರ್ವಹಿಸಲು ಹಾಗೂ ಪ್ರತಿ project ಗೆ ಯಾವ version ಬಳಸಬೇಕು ಎಂದು ಸೂಚಿಸಲು ವ್ಯವಸ್ಥೆ ಹೊಂದಿವೆ.
 
 # Artifacts & Packaging
 
-In software development we differentiate between source code and artifacts. Developers write and read source code, while artifacts are the packaged, distributable outputs produced from that source code --- ready to be installed or deployed.
-An artifact can be as simple as a file of code that we run, and as complex as an entire Virtual Machine that contains all the necessary bits and bobs of an application.
-Consider this example where we have a Python file `greet.py` in our current directory:
+Software development ನಲ್ಲಿ source code ಮತ್ತು artifacts ಮಧ್ಯೆ ನಾವು ವ್ಯತ್ಯಾಸ ಮಾಡುತ್ತೇವೆ. ಅಭಿವೃದ್ಧಿಪರರು source code ಓದುತ್ತಾರೆ ಮತ್ತು ಬರೆಯುತ್ತಾರೆ; artifacts ಎಂದರೆ ಆ source code ನಿಂದ ಉತ್ಪತ್ತಿಯಾಗುವ packaged, distributable outputs - install ಅಥವಾ deploy ಮಾಡಲು ಸಿದ್ಧವಾಗಿರುವವು.
+Artifact ಒಂದು ನಾವು ಓಡಿಸುವ ಸರಳ code file ಆಗಿರಬಹುದು; ಅಥವಾ application ನ ಎಲ್ಲಾ ಅಗತ್ಯ ಅಂಶಗಳನ್ನು ಹೊಂದಿರುವ ಸಂಪೂರ್ಣ Virtual Machine ಆಗಿರಬಹುದು.
+ಉದಾಹರಣೆಗೆ, ನಮ್ಮ ಪ್ರಸ್ತುತ directory ಯಲ್ಲಿ `greet.py` ಎಂಬ Python file ಇದೆ ಎಂದು ಪರಿಗಣಿಸಿ:
 
 ```console
 $ cat greet.py
@@ -191,15 +191,15 @@ $ python -c "from greet import greet; print(greet('World'))"
 ModuleNotFoundError: No module named 'greet'
 ```
 
-The import fails once we move to a different directory because Python only searches for modules in specific locations (the current directory, installed packages, and paths in `PYTHONPATH`). Packaging solves this by installing the code into a known location.
+ಬೇರೆ directory ಗೆ ಹೋದ ಕೂಡಲೇ import ವಿಫಲವಾಗುತ್ತದೆ, ಏಕೆಂದರೆ Python modules ಅನ್ನು ನಿರ್ದಿಷ್ಟ ಸ್ಥಳಗಳಲ್ಲಿ ಮಾತ್ರ ಹುಡುಕುತ್ತದೆ (current directory, installed packages, ಮತ್ತು `PYTHONPATH` ನಲ್ಲಿರುವ paths). Packaging ಈ ಸಮಸ್ಯೆಯನ್ನು ಕೋಡ್ ಅನ್ನು ತಿಳಿದಿರುವ ಸ್ಥಳಕ್ಕೆ install ಮಾಡುವ ಮೂಲಕ ಪರಿಹರಿಸುತ್ತದೆ.
 
-In Python, packaging a library involves producing an artifact that package installers like `pip` or `uv` can use to install the relevant files.
-Python artifacts are called _wheels_ and contain all the necessary information to install a package: the code files, metadata about the package (name, version, dependencies), and instructions for where to place files in the environment.
-Building an artifact requires that we write a project file (also often known as manifest) detailing the specifics of the project, the required dependencies, the version of the package, and other information. In Python, we use `pyproject.toml` for this purpose.
+Python ನಲ್ಲಿ library ಪ್ಯಾಕೇಜ್ ಮಾಡುವುದೆಂದರೆ `pip` ಅಥವಾ `uv` ಮುಂತಾದ package installers ಗೆ ಸಂಬಂಧಿತ files install ಮಾಡಲು ಸಾಧ್ಯವಾಗುವ artifact ನಿರ್ಮಿಸುವುದು.
+Python artifacts ಗಳನ್ನು _wheels_ ಎಂದು ಕರೆಯುತ್ತಾರೆ; package install ಮಾಡಲು ಬೇಕಾದ ಎಲ್ಲಾ ಮಾಹಿತಿಯನ್ನು ಅವು ಹೊಂದಿರುತ್ತವೆ: code files, package metadata (name, version, dependencies), ಮತ್ತು files ಅನ್ನು environment ನಲ್ಲಿ ಯಾವ ಸ್ಥಳಕ್ಕೆ ಇಡಬೇಕು ಎಂಬ ಸೂಚನೆಗಳು.
+Artifact ನಿರ್ಮಿಸಲು project file (manifest ಎಂದೂ ಕರೆಯಲಾಗುತ್ತದೆ) ಬರೆಯಬೇಕು; ಅದರಲ್ಲಿ project ವಿವರಗಳು, ಅಗತ್ಯ dependencies, package version, ಮತ್ತು ಇತರ ಮಾಹಿತಿ ಇರಬೇಕು. Python ನಲ್ಲಿ ಈ ಉದ್ದೇಶಕ್ಕಾಗಿ `pyproject.toml` ಬಳಸುತ್ತೇವೆ.
 
-> `pyproject.toml` is the modern and recommended way. While earlier packaging methods like `requirements.txt` or `setup.py` are still supported, you should prefer `pyproject.toml` whenever possible.
+> `pyproject.toml` ಆಧುನಿಕ ಮತ್ತು ಶಿಫಾರಸುಗೊಂಡ ವಿಧಾನವಾಗಿದೆ. `requirements.txt` ಅಥವಾ `setup.py` ನಂತಹ ಹಿಂದಿನ packaging ವಿಧಾನಗಳಿಗೆ ಇನ್ನೂ support ಇದ್ದರೂ, ಸಾಧ್ಯವಾದರೆ `pyproject.toml` ಗೆ ಆದ್ಯತೆ ನೀಡಿ.
 
-Here's a minimal `pyproject.toml` for a library that also provides a command-line tool:
+Command-line tool ಕೂಡ ಒದಗಿಸುವ library ಗಾಗಿ ಕನಿಷ್ಠ `pyproject.toml` ಉದಾಹರಣೆ ಇಲ್ಲಿದೆ:
 
 ```toml
 [project]
@@ -216,9 +216,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 ```
 
-The `typer` library is a popular Python package for creating command-line interfaces with minimal boilerplate.
+`typer` library ಎಂದರೆ ಅತಿ ಕಡಿಮೆ boilerplate ನೊಂದಿಗೆ command-line interfaces ರಚಿಸಲು ಪ್ರಸಿದ್ಧ Python package ಆಗಿದೆ.
 
-And the corresponding `greeting.py`:
+ಇದಕ್ಕೆ ಹೊಂದುವ `greeting.py`:
 
 ```python
 import typer
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     typer.run(main)
 ```
 
-With this file, we can now build the wheel:
+ಈ file ನೊಂದಿಗೆ ಈಗ ನಾವು wheel build ಮಾಡಬಹುದು:
 
 ```console
 $ uv build
@@ -250,9 +250,9 @@ greeting-0.1.0-py3-none-any.whl
 greeting-0.1.0.tar.gz
 ```
 
-The `.whl` file is the wheel (a zip archive with a specific structure), and the `.tar.gz` is a source distribution for systems that need to build from source.
+`.whl` file ಎಂದರೆ wheel (ನಿರ್ದಿಷ್ಟ ರಚನೆಯ zip archive), ಮತ್ತು `.tar.gz` ಎಂದರೆ source ನಿಂದ build ಮಾಡಬೇಕಾದ systems ಗಾಗಿ source distribution.
 
-You can inspect the contents of a wheel to see what gets packaged:
+Package ಆಗುವ ವಿಷಯವನ್ನು ನೋಡಲು wheel ನ ಒಳಗಿನ ವಿಷಯವನ್ನು ಪರಿಶೀಲಿಸಬಹುದು:
 
 ```console
 $ unzip -l dist/greeting-0.1.0-py3-none-any.whl
@@ -268,7 +268,7 @@ Archive:  dist/greeting-0.1.0-py3-none-any.whl
       998                     5 files
 ```
 
-Now if we were to give this wheel to someone else, they could install it by running:
+ಈ wheel ಅನ್ನು ಇನ್ನೊಬ್ಬರಿಗೆ ಕೊಟ್ಟರೆ, ಅವರು ಹೀಗೆ install ಮಾಡಬಹುದು:
 
 ```console
 $ uv pip install ./greeting-0.1.0-py3-none-any.whl
@@ -276,45 +276,45 @@ $ greet Alice
 Hello, Alice!
 ```
 
-This would install the library we built earlier into their environment, including the `greet` cli tool.
+ಇದರಿಂದ ನಾವು ಮೊದಲು build ಮಾಡಿದ್ದ library ಅನ್ನು, `greet` cli tool ಸೇರಿ, ಅವರ environment ನಲ್ಲಿ install ಮಾಡಬಹುದು.
 
-There are limitations to this approach. In particular if our library depends on platform-specific libraries, e.g. CUDA for GPU acceleration, then our artifact only works on systems with those specific libraries installed, and we may need to build separate wheels for different platforms (Linux, macOS, Windows) and architectures (x86, ARM).
+ಈ ವಿಧಾನಕ್ಕೆ ಕೆಲವು ಮಿತಿಗಳಿವೆ. ವಿಶೇಷವಾಗಿ, ನಮ್ಮ library platform-specific libraries ಮೇಲೆ ಅವಲಂಬಿತವಾಗಿದ್ದರೆ (ಉದಾ., GPU acceleration ಗಾಗಿ CUDA), artifact ಆ ವಿಶೇಷ libraries install ಆಗಿರುವ systems ಗಳಲ್ಲಿ ಮಾತ್ರ ಕೆಲಸ ಮಾಡುತ್ತದೆ; ಜೊತೆಗೆ ವಿಭಿನ್ನ platforms (Linux, macOS, Windows) ಮತ್ತು architectures (x86, ARM) ಗಾಗಿ ಬೇರೆ ಬೇರೆ wheels build ಮಾಡಬೇಕಾಗಬಹುದು.
 
 
-When installing software, there's an important distinction between installing from source and installing a prebuilt binary. Installing from source means downloading the original code and compiling it on your machine --- this requires having a compiler and build tools installed, and can take significant time for large projects.
+Software install ಮಾಡುವಾಗ source ನಿಂದ install ಮಾಡುವುದೂ prebuilt binary ನಿಂದ install ಮಾಡುವುದೂ ಬೇರೆ ಎಂಬ ಮುಖ್ಯ ವ್ಯತ್ಯಾಸವಿದೆ. Source ನಿಂದ install ಮಾಡುವುದೆಂದರೆ ಮೂಲ code download ಮಾಡಿ ನಿಮ್ಮ ಯಂತ್ರದಲ್ಲೇ compile ಮಾಡುವುದು - ಇದಕ್ಕಾಗಿ compiler ಮತ್ತು build tools install ಆಗಿರಬೇಕು; ದೊಡ್ಡ projects ಗಳಿಗೆ ಇದು ಹೆಚ್ಚಿನ ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು.
 
-Installing a prebuilt binary means downloading an artifact that was already compiled by someone else --- faster and simpler, but the binary must match your platform and architecture.
-For example, [ripgrep's releases page](https://github.com/BurntSushi/ripgrep/releases) shows prebuilt binaries for Linux (x86_64, ARM), macOS (Intel, Apple Silicon), and Windows.
+Prebuilt binary install ಮಾಡುವುದೆಂದರೆ ಇತರೆ ಯಾರಾದರೂ ಈಗಾಗಲೇ compile ಮಾಡಿದ artifact download ಮಾಡುವುದು - ವೇಗವಾಗಿ ಹಾಗೂ ಸರಳವಾಗಿ ನಡೆಯುತ್ತದೆ; ಆದರೆ binary ನಿಮ್ಮ platform ಮತ್ತು architecture ಗೆ ಹೊಂದಿರಬೇಕು.
+ಉದಾಹರಣೆಗೆ, [ripgrep ನ releases page](https://github.com/BurntSushi/ripgrep/releases) ನಲ್ಲಿ Linux (x86_64, ARM), macOS (Intel, Apple Silicon), ಮತ್ತು Windows ಗಾಗಿ prebuilt binaries ಕಾಣಬಹುದು.
 
 
 # Releases & Versioning
 
-Code is built in a continuous process but is released on a discrete basis.
-In software development there is a clear distinction between development and production environments.
-Code needs to be proven to work in a dev environment before getting _shipped_ to prod.
-The release process involves many steps, including testing, dependency management, versioning, configuration, deployment and publishing.
+ಕೋಡ್ ನಿರಂತರ ಪ್ರಕ್ರಿಯೆಯಲ್ಲಿ ನಿರ್ಮಾಣವಾಗುತ್ತದೆ, ಆದರೆ release ಗಳು discrete ಆಧಾರದ ಮೇಲೆ ನಡೆಯುತ್ತವೆ.
+Software development ನಲ್ಲಿ development ಮತ್ತು production environments ಗಳ ನಡುವೆ ಸ್ಪಷ್ಟ ವ್ಯತ್ಯಾಸವಿದೆ.
+ಕೋಡ್ ಅನ್ನು prod ಗೆ _shipped_ ಮಾಡುವ ಮೊದಲು dev environment ನಲ್ಲಿ ಅದು ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುತ್ತದೆ ಎಂಬುದು ದೃಢವಾಗಬೇಕು.
+Release ಪ್ರಕ್ರಿಯೆಯಲ್ಲಿ testing, dependency management, versioning, configuration, deployment, ಮತ್ತು publishing ಸೇರಿದಂತೆ ಅನೇಕ ಹಂತಗಳು ಸೇರಿರುತ್ತವೆ.
 
 
-Software libraries are not static and evolve over time getting fixes and new features.
-We track this evolution by discrete version identifiers that correspond to the state of the library at a certain point in time.
-Changes in the behavior of a library can range from patches that fix noncritical functionality, new features that extend its functionality, to changes breaking backwards compatibility.
-Changelogs document what changes a version introduces --- these are documents that software developers use to communicate the changes associated with a new release.
+Software libraries ಸ್ಥಿರವಾಗಿರುವುದಿಲ್ಲ; ಅವು ಕಾಲಕ್ರಮದಲ್ಲಿ fixes ಹಾಗೂ ಹೊಸ features ಗಳೊಂದಿಗೆ ವಿಕಸಿಸುತ್ತವೆ.
+ಈ ವಿಕಾಸವನ್ನು ನಾವು discrete version identifiers ಮೂಲಕ ಹತ್ತಿರದಿಂದ ಅನುಸರಿಸುತ್ತೇವೆ; ಅವು ನಿರ್ದಿಷ್ಟ ಸಮಯದ library ಸ್ಥಿತಿಯನ್ನು ಸೂಚಿಸುತ್ತವೆ.
+Library ವರ್ತನೆಯಲ್ಲಿ ಬರುವ ಬದಲಾವಣೆಗಳು noncritical ಕಾರ್ಯಕ್ಷಮತೆಯನ್ನು ಸರಿಪಡಿಸುವ patches ಇಂದ, ಕಾರ್ಯಕ್ಷಮತೆಯನ್ನು ವಿಸ್ತರಿಸುವ ಹೊಸ features ಗಳವರೆಗೆ, ಹಾಗೂ backwards compatibility ಮುರಿಯುವ ಬದಲಾವಣೆಗಳವರೆಗೆ ಇರಬಹುದು.
+Changelogs ಒಂದು version ಪರಿಚಯಿಸುವ ಬದಲಾವಣೆಗಳನ್ನು ದಾಖಲಿಸುತ್ತವೆ - ಹೊಸ release ಗೆ ಸಂಬಂಧಿಸಿದ ಬದಲಾವಣೆಗಳನ್ನು software developers ಪರಸ್ಪರ ಸಂವಹನ ಮಾಡಲು ಬಳಸುವ ದಾಖಲೆಗಳು ಅವು.
 
-However, keeping track of the ongoing changes in each and every dependency is impractical, even more so when we consider the transitive dependencies --- i.e. the dependencies of our dependencies.
+ಆದಾಗ್ಯೂ, ಪ್ರತಿ dependency ಯ ನಡೆಯುತ್ತಿರುವ ಬದಲಾವಣೆಗಳನ್ನು ಎಲ್ಲವನ್ನೂ ಟ್ರ್ಯಾಕ್ ಮಾಡುವುದು ಪ್ರಾಯೋಗಿಕವಲ್ಲ; transitive dependencies - ಅಂದರೆ ನಮ್ಮ dependencies ಗಳ dependencies - ಪರಿಗಣಿಸಿದರೆ ಇದು ಇನ್ನೂ ಕಷ್ಟಕರ.
 
-> You can visualize the entire dependency tree of your project with `uv tree`, which shows all packages and their transitive dependencies in a tree format.
+> ನಿಮ್ಮ project ನ ಸಂಪೂರ್ಣ dependency tree ಅನ್ನು `uv tree` ಮೂಲಕ ದೃಶ್ಯೀಕರಿಸಬಹುದು; ಇದು ಎಲ್ಲಾ packages ಮತ್ತು ಅವುಗಳ transitive dependencies ಅನ್ನು tree ರೂಪದಲ್ಲಿ ತೋರಿಸುತ್ತದೆ.
 
-To simplify this problem there are conventions on how to version software, and one of the most prevalent is [Semantic Versioning](https://semver.org/) or SemVer.
-Under Semantic Versioning a version has an identifier of the form MAJOR.MINOR.PATCH where each one of the values takes an integer value. The short version is that upgrading:
+ಈ ಸಮಸ್ಯೆಯನ್ನು ಸರಳಗೊಳಿಸಲು software versioning ಕುರಿತು conventions ಇವೆ; ಅವುಗಳಲ್ಲಿ ಹೆಚ್ಚು ವ್ಯಾಪಕವಾದುದು [Semantic Versioning](https://semver.org/) ಅಥವಾ SemVer.
+Semantic Versioning ಅಡಿಯಲ್ಲಿ version ರೂಪ MAJOR.MINOR.PATCH ಆಗಿರುತ್ತದೆ; ಪ್ರತಿಯೊಂದು ಮೌಲ್ಯವೂ ಪೂರ್ಣಾಂಕ. ಸಂಕ್ಷಿಪ್ತವಾಗಿ, upgrade ಮಾಡುವಾಗ:
 
-- PATCH (e.g., 1.2.3 → 1.2.4) should only contain bug fixes and be fully backwards compatible
-- MINOR (e.g., 1.2.3 → 1.3.0) adds new functionality in a backwards-compatible way
-- MAJOR (e.g., 1.2.3 → 2.0.0) indicates breaking changes that may require code modifications
+- PATCH (ಉದಾ., 1.2.3 → 1.2.4) ನಲ್ಲಿ bug fixes ಮಾತ್ರ ಇರಬೇಕು ಮತ್ತು ಸಂಪೂರ್ಣ backwards compatible ಆಗಿರಬೇಕು
+- MINOR (ಉದಾ., 1.2.3 → 1.3.0) backwards-compatible ರೀತಿಯಲ್ಲಿ ಹೊಸ functionality ಸೇರಿಸುತ್ತದೆ
+- MAJOR (ಉದಾ., 1.2.3 → 2.0.0) breaking changes ಸೂಚಿಸುತ್ತದೆ; code ಬದಲಾವಣೆಗಳು ಅಗತ್ಯವಾಗಬಹುದು
 
-> This is a simplification and we encourage reading the full SemVer specification to understand for instance why going from 0.1.3 to 0.2.0 might cause breaking changes or what 1.0.0-rc.1 means.
-Python packaging supports semantic versioning natively, so when we specify the versions of our dependencies we can use various specifiers:
+> ಇದು ಸರಳೀಕೃತ ವಿವರಣೆ ಮಾತ್ರ. ಉದಾಹರಣೆಗೆ 0.1.3 ಇಂದ 0.2.0 ಗೆ ಹೋಗುವಾಗ ಏಕೆ breaking changes ಆಗಬಹುದು ಅಥವಾ 1.0.0-rc.1 ಎಂದರೇನು ಎಂಬುದನ್ನು ತಿಳಿಯಲು ಪೂರ್ಣ SemVer specification ಓದಲು ನಾವು ಪ್ರೋತ್ಸಾಹಿಸುತ್ತೇವೆ.
+Python packaging semantic versioning ಗೆ ಸ್ಥಳೀಯ support ನೀಡುತ್ತದೆ; ಆದ್ದರಿಂದ dependencies versions ಸೂಚಿಸುವಾಗ ವಿವಿಧ specifiers ಬಳಸಬಹುದು:
 
-In the `pyproject.toml` we have different ways of constraining the ranges of compatible versions of our dependencies:
+`pyproject.toml` ನಲ್ಲಿ dependencies ಗಳ compatible versions ಶ್ರೇಣಿಯನ್ನು constrain ಮಾಡಲು ಬೇರೆ ಬೇರೆ ವಿಧಾನಗಳಿವೆ:
 
 ```toml
 [project]
@@ -326,22 +326,22 @@ dependencies = [
 ]
 ```
 
-Version specifiers exist across many package managers (npm, cargo, etc.) with varying exact semantics. The `~=` operator is Python's "compatible release" operator --- `~=2.1.0` means "any version that is compatible with 2.1.0", which translates to `>=2.1.0` and `<2.2.0`. This is roughly equivalent to the caret (`^`) operator in npm and cargo, which follows SemVer's notion of compatibility.
+Version specifiers ಅನೇಕ package managers (npm, cargo, ಇತ್ಯಾದಿ) ಗಳಲ್ಲಿ ಕಂಡುಬರುತ್ತವೆ; ಆದರೆ ನಿಖರ semantics ಬೇರೆ ಇರಬಹುದು. `~=` operator Python ನ "compatible release" operator - `~=2.1.0` ಎಂದರೆ "2.1.0 ಗೆ ಹೊಂದಿಕೊಳ್ಳುವ ಯಾವುದೇ version", ಅಂದರೆ `>=2.1.0` ಮತ್ತು `<2.2.0`. ಇದು npm ಮತ್ತು cargo ಯ caret (`^`) operator ಗೆ ಸುಮಾರು ಸಮಾನ, ಅದು SemVer compatibility ಪರಿಕಲ್ಪನೆ ಅನುಸರಿಸುತ್ತದೆ.
 
-Not all software uses semantic versioning. A common alternative is Calendar Versioning (CalVer), where versions are based on release dates rather than semantic meaning. For example, Ubuntu uses versions like `24.04` (April 2024) and `24.10` (October 2024). CalVer makes it easy to see how old a release is, though it doesn't communicate anything about compatibility.  Lastly, semantic versioning is not infallible, and sometimes maintainers inadvertently introduce breaking changes in minor or patch releases.
+ಎಲ್ಲ software ಗಳು semantic versioning ಬಳಸುವುದಿಲ್ಲ. ಸಾಮಾನ್ಯ ಪರ್ಯಾಯವೆಂದರೆ Calendar Versioning (CalVer), ಇದರಲ್ಲಿ versions semantic ಅರ್ಥದ ಬದಲಾಗಿ release ದಿನಾಂಕಗಳ ಆಧಾರವಾಗಿರುತ್ತವೆ. ಉದಾಹರಣೆಗೆ, Ubuntu `24.04` (April 2024) ಮತ್ತು `24.10` (October 2024) ಮಾದರಿಯ versions ಬಳಸುತ್ತದೆ. CalVer release ಎಷ್ಟು ಹಳೆಯದು ಎನ್ನುವುದನ್ನು ಸುಲಭವಾಗಿ ತೋರಿಸುತ್ತದೆ; ಆದರೆ compatibility ಬಗ್ಗೆ ಮಾಹಿತಿ ನೀಡುವುದಿಲ್ಲ. ಕೊನೆಗೆ, semantic versioning ಅಚ್ಯುತವಲ್ಲ; ಕೆಲವೊಮ್ಮೆ maintainers minor ಅಥವಾ patch releases ಗಳಲ್ಲಿಯೂ ಅಜಾಗರೂಕತೆಯಿಂದ breaking changes ಪರಿಚಯಿಸುತ್ತಾರೆ.
 
 
 # Reproducibility
 
-In modern software development the code you write sits atop a significant number of layers of abstraction.
-This includes things like your programming language runtime, third party libraries, the operating system, or even the hardware itself.
-Any difference across any of these layers might change the behavior of your code or even prevent it from working as intended.
-Furthermore, even differences in the underlying hardware impact your ability to ship software.
+ಆಧುನಿಕ software development ನಲ್ಲಿ ನೀವು ಬರೆಯುವ code ಬಹಳ ಪ್ರಮಾಣದ abstraction ಪದರಗಳ ಮೇಲೆ ನಿಂತಿರುತ್ತದೆ.
+ಇದರಲ್ಲಿ ನಿಮ್ಮ programming language runtime, third party libraries, operating system, ಅಥವಾ hardware ಕೂಡ ಸೇರಿರಬಹುದು.
+ಈ ಪದರಗಳಲ್ಲಿ ಯಾವುದಾದರೂ ವ್ಯತ್ಯಾಸವು ನಿಮ್ಮ code ವರ್ತನೆಯನ್ನು ಬದಲಿಸಬಹುದು ಅಥವಾ ಅದು ಉದ್ದೇಶಿತಂತೆ ಕೆಲಸ ಮಾಡುವುದನ್ನೇ ತಡೆಯಬಹುದು.
+ಮತ್ತಷ್ಟು, ಅಡಿಗಟ್ಟಿನ hardware ವ್ಯತ್ಯಾಸಗಳೂ software ship ಮಾಡುವ ನಿಮ್ಮ ಸಾಮರ್ಥ್ಯವನ್ನು ಪ್ರಭಾವಿಸುತ್ತವೆ.
 
-Pinning a library refers to specifying an exact version rather than a range, e.g. `requests==2.32.3` instead of `requests>=2.0`.
+Library pinning ಎಂದರೆ range ಬದಲಿಗೆ exact version ಸೂಚಿಸುವುದು; ಉದಾ., `requests>=2.0` ಬದಲಿಗೆ `requests==2.32.3`.
 
-Part of the job of a package manager is to consider all the constraints provided by the dependencies --- and transitive dependencies --- and then produce a valid list of versions that will satisfy all the constraints.
-The specific list of versions can then be saved to a file for reproducibility purposes; these files are referred to as _lock files_.
+Package manager ನ ಪ್ರಮುಖ ಕೆಲಸಗಳಲ್ಲಿ ಒಂದು ಎಂದರೆ dependencies - ಹಾಗೂ transitive dependencies - ನೀಡುವ ಎಲ್ಲಾ constraints ಗಳನ್ನು ಪರಿಗಣಿಸಿ, ಅವನ್ನೆಲ್ಲ ತೃಪ್ತಿಪಡಿಸುವ ಮಾನ್ಯ versions ಪಟ್ಟಿಯನ್ನು ಉತ್ಪಾದಿಸುವುದು.
+ಆ ನಿರ್ದಿಷ್ಟ versions ಪಟ್ಟಿಯನ್ನು reproducibility ಗಾಗಿ file ಗೆ ಉಳಿಸಬಹುದು; ಇವುಗಳನ್ನು _lock files_ ಎಂದು ಕರೆಯಲಾಗುತ್ತದೆ.
 
 ```console
 $ uv lock
@@ -362,37 +362,37 @@ wheels = [
 ...
 ```
 
-One critical distinction when dealing with dependency versioning and reproducibility is the difference between libraries and applications/services.
-A library is intended to be imported and used by other code which might have its own dependencies, so specifying overly strict version constraints can cause conflicts with the user's other dependencies.
-In contrast, applications or services are final consumers of the software and typically expose their functionality through a user interface or an API, not through a programming interface.
-For libraries, it is good practice to specify version ranges to maximize compatibility with the wider package ecosystem. For applications, pinning exact versions ensures reproducibility --- everyone running the application uses the exact same dependencies.
+Dependency versioning ಮತ್ತು reproducibility ನೋಡಿಕೊಳ್ಳುವಾಗ ಒಂದು ಪ್ರಮುಖ ವ್ಯತ್ಯಾಸವೆಂದರೆ libraries ಮತ್ತು applications/services ನಡುವಿನ ಭೇದ.
+Library ಅನ್ನು ಇತರೆ code import ಮಾಡಿ ಬಳಸಲು ಉದ್ದೇಶಿಸಿರುವುದರಿಂದ, ಆ ಇತರೆ code ಗೆ ತನ್ನದೇ dependencies ಇರಬಹುದು; ಆದ್ದರಿಂದ ಅತಿಯಾಗಿ ಕಠಿಣ version constraints ನೀಡುವುದು ಬಳಕೆದಾರರ ಇತರೆ dependencies ಗಳೊಂದಿಗೆ conflicts ಉಂಟುಮಾಡಬಹುದು.
+ಇದಕ್ಕೆ ವಿರುದ್ಧವಾಗಿ, applications ಅಥವಾ services software ನ ಅಂತಿಮ ಗ್ರಾಹಕರು; ಅವು ಸಾಮಾನ್ಯವಾಗಿ programming interface ಮೂಲಕವಲ್ಲ, user interface ಅಥವಾ API ಮೂಲಕ ತಮ್ಮ functionality ಒದಗಿಸುತ್ತವೆ.
+Libraries ಗಾಗಿ, package ecosystem ನಲ್ಲಿ ಹೆಚ್ಚಿನ compatibility ಪಡೆಯಲು version ranges ಸೂಚಿಸುವುದು ಉತ್ತಮ ಅಭ್ಯಾಸ. Applications ಗಾಗಿ, exact versions pin ಮಾಡುವುದರಿಂದ reproducibility ಖಚಿತವಾಗುತ್ತದೆ - application ಓಡಿಸುವ ಎಲ್ಲರೂ ಅದೇ dependencies ಬಳಸುತ್ತಾರೆ.
 
 
-For projects requiring maximum reproducibility, tools like [Nix](https://nixos.org/) and [Bazel](https://bazel.build/) provide _hermetic_ builds --- where every input including compilers, system libraries, and even the build environment itself is pinned and content-addressed. This guarantees bit-for-bit identical outputs regardless of when or where the build runs.
+ಗರಿಷ್ಠ reproducibility ಅಗತ್ಯವಿರುವ projects ಗಾಗಿ [Nix](https://nixos.org/) ಮತ್ತು [Bazel](https://bazel.build/) ನಂತಹ tools _hermetic_ builds ಒದಗಿಸುತ್ತವೆ - ಇಲ್ಲಿ compilers, system libraries, ಹಾಗೂ build environment ಕೂಡ ಸೇರಿ ಪ್ರತಿಯೊಂದು input pin ಆಗಿ content-addressed ಆಗಿರುತ್ತದೆ. ಇದರಿಂದ build ಯಾವಾಗ, ಎಲ್ಲಲ್ಲಿ ನಡೆದರೂ bit-for-bit ಒಂದೇ output ದೊರೆಯುತ್ತದೆ.
 
-> You can even use NixOS to manage your entire computer install so that you can trivially spin up new copies of your computer setup and manage their complete configuration through version-controlled configuration files.
+> ನೀವು NixOS ಬಳಸಿ ಸಂಪೂರ್ಣ ಕಂಪ್ಯೂಟರ್ install ನ್ನೇ ನಿರ್ವಹಿಸಬಹುದು; ಹೀಗಾಗಿ ನಿಮ್ಮ setup ನ ಹೊಸ ಪ್ರತಿಗಳನ್ನು ಸುಲಭವಾಗಿ ನಿರ್ಮಿಸಿ, ಅವುಗಳ ಸಂಪೂರ್ಣ configuration ಅನ್ನು version-controlled configuration files ಮೂಲಕ ನಿರ್ವಹಿಸಬಹುದು.
 
-A neverending tension in software development is that new software versions introduce breakage either intentionally or unintentionally, while on the other hand, old software versions become compromised with security vulnerabilities over time.
-We can address this by using continuous integration pipelines (we'll see more in the [Code Quality and CI](/2026/code-quality/) lecture) that test our application against new software versions and having automation in place for detecting when new versions of our dependencies are released, such as [Dependabot](https://github.com/dependabot).
+Software development ನಲ್ಲಿ ಅಂತ್ಯವಿಲ್ಲದ ಒತ್ತಡವೊಂದಿದೆ: ಹೊಸ software versions ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿಯೂ ಅಥವಾ ಅನಾಯಾಸವಾಗಿಯೂ breakage ತರಬಹುದು; ಮತ್ತೊಂದೆಡೆ ಹಳೆಯ software versions ಕಾಲಕ್ರಮದಲ್ಲಿ security vulnerabilities ಗೆ ಒಳಗಾಗುತ್ತವೆ.
+ಇದನ್ನು continuous integration pipelines (ಇದರ ಬಗ್ಗೆ [Code Quality and CI](/2026/code-quality/) ಉಪನ್ಯಾಸದಲ್ಲಿ ಇನ್ನಷ್ಟು ನೋಡುತ್ತೇವೆ) ಬಳಸಿ, ಹೊಸ software versions ವಿರುದ್ಧ application ಅನ್ನು test ಮಾಡುವ ಮೂಲಕ ಮತ್ತು dependencies ಗಳ ಹೊಸ versions ಬಿಡುಗಡೆಯಾಗುವಾಗ ಪತ್ತೆಹಚ್ಚುವ automation (ಉದಾ., [Dependabot](https://github.com/dependabot)) ಇಟ್ಟುಕೊಳ್ಳುವ ಮೂಲಕ ಎದುರಿಸಬಹುದು.
 
-Even with CI testing in place, issues still occur when upgrading software versions, often because of the inevitable mismatch between dev and prod environments.
-In those circumstances the best course of action is to have a _rollback_ plan, where the version upgrade is reverted and a known good version is redeployed instead.
+CI testing ಇದ್ದರೂ software versions upgrade ಮಾಡುವಾಗ ಸಮಸ್ಯೆಗಳು ಉಂಟಾಗುತ್ತವೆ; ಬಹುಪಾಲು dev ಮತ್ತು prod environments ನಡುವಿನ ಅನಿವಾರ್ಯ ವ್ಯತ್ಯಾಸ ಇದಕ್ಕೆ ಕಾರಣ.
+ಅಂತಹ ಸಂದರ್ಭಗಳಲ್ಲಿ ಉತ್ತಮ ವಿಧಾನವೆಂದರೆ _rollback_ ಯೋಜನೆ ಹೊಂದಿರುವುದು - version upgrade ಹಿಂತೆಗೆದು, ಹಿಂದಿನ known-good version ಮರು-deploy ಮಾಡುವುದು.
 
 # VMs & Containers
 
-As you start relying on more complex dependencies, it is likely that the dependencies of your code will span beyond the boundaries of what the package manager can handle.
-One common reason is having to interface with specific system libraries or hardware drivers.
-For example, in scientific computing and AI, programs often need specialized libraries and drivers to utilize GPU hardware.
-Many system-level dependencies (GPU drivers, specific compiler versions, shared libraries like OpenSSL) still require system-wide installation.
+ನೀವು ಹೆಚ್ಚು ಸಂಕೀರ್ಣ dependencies ಗಳ ಮೇಲೆ ಅವಲಂಬಿಸತೊಡಗಿದಂತೆ, ನಿಮ್ಮ code dependencies package manager ನ ವ್ಯಾಪ್ತಿಯನ್ನು ಮೀರಿ ಹೋಗುವ ಸಾಧ್ಯತೆ ಹೆಚ್ಚಾಗುತ್ತದೆ.
+ಇದಕ್ಕೆ ಸಾಮಾನ್ಯ ಕಾರಣಗಳಲ್ಲಿ ಒಂದು ನಿರ್ದಿಷ್ಟ system libraries ಅಥವಾ hardware drivers ಜೊತೆ ಸಂವಹನ ಮಾಡುವ ಅಗತ್ಯ.
+ಉದಾಹರಣೆಗೆ, scientific computing ಮತ್ತು AI ನಲ್ಲಿ programs ಗಳು GPU hardware ಬಳಸಲು ವಿಶೇಷ libraries ಮತ್ತು drivers ಅಗತ್ಯಪಡುತ್ತವೆ.
+ಅನೇಕ system-level dependencies (GPU drivers, ನಿರ್ದಿಷ್ಟ compiler versions, OpenSSL ನಂತಹ shared libraries) ಇನ್ನೂ system-wide installation ಅಗತ್ಯಪಡಿಸುತ್ತವೆ.
 
-Traditionally this wider dependency problem was solved with Virtual Machines (VMs).
-VMs abstract the entire computer and provide a completely isolated environment with its own dedicated operating system.
-A more modern approach is containers, which package an application along with its dependencies, libraries, and filesystem, but share the host's operating system kernel rather than virtualizing an entire computer.
-Containers are lighter weight than VMs because they share the kernel, making them faster to start and more efficient to run.
+ಪಾರಂಪರಿಕವಾಗಿ ಈ ವಿಶಾಲ dependency ಸಮಸ್ಯೆಯನ್ನು Virtual Machines (VMs) ಮೂಲಕ ಪರಿಹರಿಸಲಾಗುತ್ತಿತ್ತು.
+VM ಗಳು ಸಂಪೂರ್ಣ ಕಂಪ್ಯೂಟರ್ ಅನ್ನು abstract ಮಾಡಿ, ತನ್ನದೇ dedicated operating system ಹೊಂದಿರುವ ಸಂಪೂರ್ಣ isolated environment ಒದಗಿಸುತ್ತವೆ.
+ಹೆಚ್ಚು ಆಧುನಿಕ ವಿಧಾನವೆಂದರೆ containers, ಇವು application ಜೊತೆಗೆ ಅದರ dependencies, libraries, ಮತ್ತು filesystem ಅನ್ನು package ಮಾಡುತ್ತವೆ; ಆದರೆ ಸಂಪೂರ್ಣ ಕಂಪ್ಯೂಟರ್ virtualize ಮಾಡುವ ಬದಲು host ನ operating system kernel ಹಂಚಿಕೊಳ್ಳುತ್ತವೆ.
+Containers, kernel ಹಂಚಿಕೊಳ್ಳುವುದರಿಂದ, VMs ಗಿಂತ lightweight ಆಗಿದ್ದು ಆರಂಭಿಸಲು ವೇಗವಾಗಿಯೂ ಚಲಾಯಿಸಲು ಪರಿಣಾಮಕಾರಿಯಾಗಿಯೂ ಇರುತ್ತವೆ.
 
-The most popular container platform is [Docker](https://www.docker.com/). Docker introduced a standardized way to build, distribute, and run containers. Under the hood, Docker uses containerd as its container runtime --- an industry standard that other tools like Kubernetes also use.
+ಅತ್ಯಂತ ಜನಪ್ರಿಯ container platform ಎಂದರೆ [Docker](https://www.docker.com/). Docker containers build, distribute, ಮತ್ತು run ಮಾಡಲು standardized ವಿಧಾನವನ್ನು ಪರಿಚಯಿಸಿತು. ಒಳಭಾಗದಲ್ಲಿ Docker ತನ್ನ container runtime ಆಗಿ containerd ಬಳಸುತ್ತದೆ - Kubernetes ನಂತಹ ಇತರೆ tools ಕೂಡ ಬಳಸುವ industry standard ಇದು.
 
-Running a container is straightforward. For example, to run a Python interpreter inside a container we use `docker run` (The `-it` flags make the container interactive with a terminal. When you exit, the container stops.).
+Container ಓಡಿಸುವುದು ಸರಳ. ಉದಾಹರಣೆಗೆ container ಒಳಗೆ Python interpreter ಓಡಿಸಲು `docker run` ಬಳಸುತ್ತೇವೆ (ಇಲ್ಲಿನ `-it` flags container ಅನ್ನು terminal ಜೊತೆ interactive ಆಗಿ ಮಾಡುತ್ತವೆ. ನೀವು ಹೊರಬಂದಾಗ container ನಿಲ್ಲುತ್ತದೆ.).
 
 ```console
 $ docker run -it python:3.12 python
@@ -401,9 +401,9 @@ Python 3.12.7 (main, Nov  5 2024, 02:53:25) [GCC 12.2.0] on linux
 Hello from inside a container!
 ```
 
-In practice your program might depend on the entire filesystem.
-To overcome this, we can use container images that ship the entire filesystem of the application as the artifact.
-The container images are created programmatically. With docker we specify exactly the dependencies, system libraries, and configuration of the image using a Dockerfile syntax:
+ಪ್ರಾಯೋಗಿಕವಾಗಿ ನಿಮ್ಮ program ಸಂಪೂರ್ಣ filesystem ಮೇಲೇ ಅವಲಂಬಿತವಾಗಿರಬಹುದು.
+ಇದನ್ನು ನಿಭಾಯಿಸಲು, application ನ ಸಂಪೂರ್ಣ filesystem ಅನ್ನು artifact ಆಗಿ ಶಿಪ್ ಮಾಡುವ container images ಬಳಸಬಹುದು.
+Container images ಅನ್ನು programmatically ರಚಿಸಲಾಗುತ್ತದೆ. Docker ನಲ್ಲಿ image ಗೆ ಬೇಕಾದ dependencies, system libraries, ಮತ್ತು configuration ಅನ್ನು Dockerfile syntax ಮೂಲಕ ನಿಖರವಾಗಿ ಸೂಚಿಸುತ್ತೇವೆ:
 
 ```dockerfile
 FROM python:3.12
@@ -417,11 +417,11 @@ WORKDIR /app
 RUN pip install .
 ```
 
-An important distinction: a Docker **image** is the packaged artifact (like a template), while a **container** is a running instance of that image. You can run multiple containers from the same image. Images are built in layers, where each instruction (`FROM`, `RUN`, `COPY`, etc) in a Dockerfile creates a new layer. Docker caches these layers, so if you change a line in your Dockerfile, only that layer and subsequent layers need to be rebuilt.
+ಒಂದು ಪ್ರಮುಖ ವ್ಯತ್ಯಾಸ: Docker **image** packaged artifact (template ನಂತಹುದು), ಆದರೆ **container** ಆ image ನ running instance. ಒಂದೇ image ನಿಂದ ಅನೇಕ containers ಓಡಿಸಬಹುದು. Images ಪದರಗಳಲ್ಲಿ build ಆಗುತ್ತವೆ; Dockerfile ನ ಪ್ರತಿಯೊಂದು instruction (`FROM`, `RUN`, `COPY`, ಇತ್ಯಾದಿ) ಹೊಸ layer ರಚಿಸುತ್ತದೆ. Docker ಈ layers ಅನ್ನು cache ಮಾಡುತ್ತದೆ; ಆದ್ದರಿಂದ Dockerfile ನಲ್ಲಿ ಒಂದು line ಬದಲಾದರೆ, ಆ layer ಮತ್ತು ಅದರ ನಂತರದ layers ಮಾತ್ರ rebuild ಆಗಬೇಕು.
 
-The previous Dockerfile has several issues: it uses the full Python image instead of a slim variant, runs separate `RUN` commands creating unnecessary layers, versions are not pinned, and it doesn't clean up package manager caches, shipping unnecessary files. Other frequent mistakes include insecurely running containers as root and accidentally embedding secrets in layers.
+ಹಿಂದಿನ Dockerfile ನಲ್ಲಿ ಹಲವು ದೋಷಗಳಿವೆ: ಇದು slim variant ಬದಲಿಗೆ full Python image ಬಳಸುತ್ತದೆ, ಅನಗತ್ಯ layers ಉಂಟುಮಾಡುವಂತೆ ಪ್ರತ್ಯೇಕ `RUN` commands ಬಳಸುತ್ತದೆ, versions pin ಆಗಿಲ್ಲ, package manager caches ಶುದ್ಧೀಕರಿಸಲಾಗಿಲ್ಲ, ಹೀಗಾಗಿ ಅನಗತ್ಯ files ship ಆಗುತ್ತವೆ. ಸಾಮಾನ್ಯವಾಗಿ ಕಾಣುವ ಇತರೆ ತಪ್ಪುಗಳಲ್ಲಿ containers ಅನ್ನು ಅಸುರಕ್ಷಿತವಾಗಿ root ಆಗಿ ಓಡಿಸುವುದು ಮತ್ತು layers ನಲ್ಲಿ ಅನಾಹುತವಾಗಿ secrets ಸೇರಿಸುವುದೂ ಸೇರಿವೆ.
 
-Here's an improved version
+ಇಲ್ಲಿ ಸುಧಾರಿತ version ಇದೆ
 
 ```dockerfile
 FROM python:3.12-slim
@@ -434,19 +434,19 @@ RUN uv pip install --system -r uv.lock
 COPY . /app
 ```
 
-In the previous example we see that instead of installing `uv` from source, we are copying the prebuilt binary from the `ghcr.io/astral-sh/uv:latest` image. This is known as the _builder_ pattern. With this pattern we do not need to ship all the tools needed to compile our code, just the final binary that is needed to run the application (`uv` in this case).
+ಹಿಂದಿನ ಉದಾಹರಣೆಯಲ್ಲಿ `uv` ಅನ್ನು source ನಿಂದ install ಮಾಡುವ ಬದಲಾಗಿ `ghcr.io/astral-sh/uv:latest` image ನಿಂದ prebuilt binary ನಕಲಿಸುತ್ತಿದ್ದೇವೆ. ಇದನ್ನು _builder_ pattern ಎನ್ನುತ್ತಾರೆ. ಈ pattern ಮೂಲಕ code compile ಮಾಡಲು ಬೇಕಾದ tools ಎಲ್ಲವನ್ನೂ ship ಮಾಡುವ ಅಗತ್ಯವಿಲ್ಲ; application ಓಡಿಸಲು ಬೇಕಾದ ಅಂತಿಮ binary (`uv` ಈ ಸಂದರ್ಭದಲ್ಲ) ಮಾತ್ರ ಸಾಕಾಗುತ್ತದೆ.
 
-Docker has important limitations to be aware of. First, container images are often platform-specific --- an image built for `linux/amd64` won't run natively on `linux/arm64` (Apple Silicon Macs) without emulation, which is slow. Second, Docker containers require a Linux kernel, so on macOS and Windows, Docker actually runs a lightweight Linux VM under the hood, adding overhead. Third, Docker's isolation is weaker than VMs --- containers share the host kernel, which is a security concern in multi-tenant environments.
+Docker ಗೆ ಗಮನಿಸಬೇಕಾದ ಕೆಲವು ಮುಖ್ಯ ಮಿತಿಗಳು ಇವೆ. ಮೊದಲನೆಯದಾಗಿ, container images ಬಹಳ ಬಾರಿ platform-specific ಆಗಿರುತ್ತವೆ - `linux/amd64` ಗಾಗಿ build ಮಾಡಿದ image, emulation ಇಲ್ಲದೆ `linux/arm64` (Apple Silicon Macs) ನಲ್ಲಿ native ಆಗಿ ಓಡುವುದಿಲ್ಲ; emulation ನಿಧಾನ. ಎರಡನೆಯದಾಗಿ, Docker containers ಗೆ Linux kernel ಅಗತ್ಯವಿರುವುದರಿಂದ macOS ಮತ್ತು Windows ನಲ್ಲಿ Docker ವಾಸ್ತವವಾಗಿ ಒಳಗೆ lightweight Linux VM ಓಡಿಸುತ್ತದೆ, ಇದರಿಂದ overhead ಸೇರುತ್ತದೆ. ಮೂರನೆಯದಾಗಿ, Docker isolation VMs ಗಿಂತ ದುರ್ಬಲ - containers host kernel ಹಂಚಿಕೊಳ್ಳುತ್ತವೆ; multi-tenant environments ಗಳಲ್ಲಿ ಇದು security ಚಿಂತೆ.
 
-> These days, more projects are also making use of nix to manage even "system-wide" libraries and applications per project through [nix flakes](https://serokell.io/blog/practical-nix-flakes).
+> ಇತ್ತೀಚೆಗೆ, ಇನ್ನೂ ಹೆಚ್ಚು projects [nix flakes](https://serokell.io/blog/practical-nix-flakes) ಮೂಲಕ project-ಪ್ರತಿ "system-wide" libraries ಮತ್ತು applications ಗಳನ್ನೂ ನಿರ್ವಹಿಸಲು nix ಬಳಸುತ್ತಿವೆ.
 
 # Configuration
 
-Software is inherently configurable. In the [command line environment](/2026/command-line-environment/) lecture we saw programs receiving options via flags, environment variables or even configuration files a.k.a. dotfiles. This holds true even for more complex applications, and there are established patterns for managing configuration at scale.
-Software configuration should not be embedded in the code but be provided at runtime.
-A couple of common ones being environment variables and config files.
+Software ಸ್ವಭಾವತಃ configurable ಆಗಿದೆ. [command line environment](/2026/command-line-environment/) ಉಪನ್ಯಾಸದಲ್ಲಿ flags, environment variables ಅಥವಾ configuration files (a.k.a. dotfiles) ಮೂಲಕ programs options ಸ್ವೀಕರಿಸುವುದನ್ನು ನೋಡಿದ್ದೇವೆ. ಇದೇ ತತ್ವ ಹೆಚ್ಚು ಸಂಕೀರ್ಣ applications ಗಳಿಗೂ ಅನ್ವಯಿಸುತ್ತದೆ, ಮತ್ತು scale ನಲ್ಲಿ configuration ನಿರ್ವಹಣೆಗೆ ಸ್ಥಿರವಾದ patterns ಇವೆ.
+Software configuration code ನಲ್ಲಿ hardcode ಆಗಿರಬಾರದು; runtime ನಲ್ಲಿ ಒದಗಿಸಬೇಕು.
+ಸಾಮಾನ್ಯ ವಿಧಾನಗಳಲ್ಲಿ environment variables ಮತ್ತು config files ಪ್ರಮುಖ.
 
-Here's an example of an application that is configured via environment variables:
+Environment variables ಮೂಲಕ configure ಆಗುವ application ಉದಾಹರಣೆ ಇಲ್ಲಿದೆ:
 
 ```python
 import os
@@ -456,7 +456,7 @@ DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
 API_KEY = os.environ["API_KEY"]  # Required - will raise if not set
 ```
 
-An application could also be configured via a configuration file (e.g., a Python program that loads a config via `yaml.load`), `config.yaml`:
+Configuration file ಮೂಲಕವೂ application configure ಮಾಡಬಹುದು (ಉದಾ., `yaml.load` ಮೂಲಕ config load ಮಾಡುವ Python program), `config.yaml`:
 
 ```yaml
 database:
@@ -468,22 +468,22 @@ server:
   debug: false
 ```
 
-A good right-hand rule for thinking about configuration is that the same codebase should be deployable to different environments (development, staging, production) with only configuration changes, never code changes.
+Configuration ಬಗ್ಗೆ ಯೋಚಿಸಲು ಉತ್ತಮ right-hand rule ಎಂದರೆ: ಒಂದೇ codebase ಅನ್ನು ವಿಭಿನ್ನ environments (development, staging, production) ಗೆ deploy ಮಾಡಬಹುದಾಗಿರಬೇಕು; ಬದಲಾಗುವುದು configuration ಮಾತ್ರ, code ಎಂದಿಗೂ ಅಲ್ಲ.
 
-Among the many configuration options there is often sensitive data such as API keys.
-Secrets need to be handled with care to avoid exposing them accidentally, and must not be included in version control.
+ಬಹು configuration ಆಯ್ಕೆಗಳಲ್ಲಿ API keys ಮುಂತಾದ sensitive data ಸಾಮಾನ್ಯವಾಗಿ ಇರುತ್ತವೆ.
+Secrets ಅನ್ನು ಅಪರಾಧಪ್ರಾಯವಾಗಿ ಬಯಲಾಗದಂತೆ ಜಾಗ್ರತೆಯಿಂದ ನಿರ್ವಹಿಸಬೇಕು; ಮತ್ತು ಅವನ್ನು version control ನಲ್ಲಿ ಎಂದಿಗೂ ಸೇರಿಸಬಾರದು.
 
 
 # Services & Orchestration
 
-Modern applications rarely exist in isolation. A typical web application might need a database for persistent storage, a cache for performance, a message queue for background tasks, and various other supporting services. Rather than bundling everything into a single monolithic application, modern architectures often decompose functionality into separate services that can be developed, deployed, and scaled independently.
+ಆಧುನಿಕ applications ಅಪರೂಪವಾಗಿ ಒಂಟಿಯಾಗಿಯೇ ಇರುತ್ತವೆ. ಒಂದು ಸಾಮಾನ್ಯ web application ಗೆ persistent storage ಗಾಗಿ database, performance ಗಾಗಿ cache, background tasks ಗಾಗಿ message queue, ಮತ್ತು ಇತರ supporting services ಅಗತ್ಯವಿರಬಹುದು. ಎಲ್ಲವನ್ನೂ ಒಂದೇ monolithic application ನಲ್ಲಿ ಬಂಧಿಸುವ ಬದಲು, ಆಧುನಿಕ architectures ಸಾಮಾನ್ಯವಾಗಿ functionality ಅನ್ನು ಪ್ರತ್ಯೇಕ services ಗಳಾಗಿ ವಿಭಜಿಸುತ್ತವೆ; ಇವುಗಳನ್ನು ಪ್ರತ್ಯೇಕವಾಗಿ ಅಭಿವೃದ್ಧಿಪಡಿಸಿ, deploy ಮಾಡಿ, scale ಮಾಡಬಹುದು.
 
-As an example, if we determine our application might benefit from using a cache, instead of rolling our own we can leverage existing battle tested solutions like [Redis](https://redis.io/) or [Memcached](https://memcached.org/).
-We could embed Redis in our application dependencies by building it as part of the container, but that means harmonizing all the dependencies between Redis and our application which could be challenging or even unfeasible.
-Instead what we can do is deploy each application separately in its own container.
-This is commonly referred to as a microservice architecture where each component runs as an independent service that communicates over the network, typically via HTTP APIs.
+ಉದಾಹರಣೆಗೆ, ನಮ್ಮ application ಗೆ cache ಉಪಯುಕ್ತ ಎಂದು ನಿರ್ಧರಿಸಿದರೆ, ನಮ್ಮದೇ ಪರಿಹಾರ ನಿರ್ಮಿಸುವ ಬದಲು [Redis](https://redis.io/) ಅಥವಾ [Memcached](https://memcached.org/) ನಂತಹ battle tested ಪರಿಹಾರಗಳನ್ನು ಬಳಸಬಹುದು.
+Redis ಅನ್ನು container ಭಾಗವಾಗಿ build ಮಾಡಿ ನಮ್ಮ application dependencies ಒಳಗೆ ಸೇರಿಸಬಹುದಾದರೂ, Redis ಮತ್ತು application ನಡುವಿನ ಎಲ್ಲಾ dependencies harmonize ಮಾಡಬೇಕಾಗುತ್ತದೆ; ಅದು ಸವಾಲಾಗಬಹುದು ಅಥವಾ ಅಸಾಧ್ಯವೂ ಆಗಬಹುದು.
+ಬದಲಾಗಿ, ಪ್ರತಿ application ಅನ್ನು ಅದರದೇ container ನಲ್ಲಿ ಪ್ರತ್ಯೇಕವಾಗಿ deploy ಮಾಡಬಹುದು.
+ಇದನ್ನು ಸಾಮಾನ್ಯವಾಗಿ microservice architecture ಎಂದು ಕರೆಯುತ್ತಾರೆ; ಇಲ್ಲಿ ಪ್ರತಿ component ಒಂದು ಸ್ವತಂತ್ರ service ಆಗಿ ಓಡಿ, ಸಾಮಾನ್ಯವಾಗಿ HTTP APIs ಮೂಲಕ network ಮೇಲೆ ಸಂವಹನ ಮಾಡುತ್ತದೆ.
 
-[Docker Compose](https://docs.docker.com/compose/) is a tool for defining and running multi-container applications. Rather than managing containers individually, you declare all services in a single YAML file and orchestrate them together. Now our full application encompasses more than one container:
+[Docker Compose](https://docs.docker.com/compose/) multi-container applications ನಿರ್ಧರಿಸಿ ಓಡಿಸಲು ಉಪಯುಕ್ತ tool ಆಗಿದೆ. Containers ಅನ್ನು ಪ್ರತ್ಯೇಕವಾಗಿ ನಿರ್ವಹಿಸುವ ಬದಲಾಗಿ, ನೀವು ಎಲ್ಲ services ಗಳನ್ನು ಒಂದೇ YAML file ನಲ್ಲಿ ಘೋಷಿಸಿ ಅವನ್ನು ಒಟ್ಟಿಗೆ orchestrate ಮಾಡುತ್ತೀರಿ. ಈಗ ನಮ್ಮ ಸಂಪೂರ್ಣ application ಒಂದಕ್ಕಿಂತ ಹೆಚ್ಚು container ಒಳಗೊಂಡಿದೆ:
 
 ```yaml
 # docker-compose.yml
@@ -506,10 +506,10 @@ volumes:
   redis_data:
 ```
 
-With `docker compose up`, both services start together, and the web application can connect to Redis using the hostname `cache` (Docker's internal DNS resolves service names automatically).
-Docker Compose lets us declare how we want to deploy one or more services, and handles the orchestration of starting them together, setting up networking between them, and managing shared volumes for data persistence.
+`docker compose up` ಮೂಲಕ ಎರಡೂ services ಒಟ್ಟಿಗೆ ಪ್ರಾರಂಭಗೊಳ್ಳುತ್ತವೆ; web application `cache` hostname ಬಳಸಿ Redis ಗೆ ಸಂಪರ್ಕಿಸಬಹುದು (Docker ನ internal DNS service names ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ resolve ಮಾಡುತ್ತದೆ).
+Docker Compose ಮೂಲಕ ಒಂದು ಅಥವಾ ಹೆಚ್ಚು services ಅನ್ನು ಹೇಗೆ deploy ಮಾಡಬೇಕು ಎಂದು ಘೋಷಿಸಬಹುದು; ಜೊತೆಗೆ ಅವನ್ನು ಒಟ್ಟಿಗೆ ಆರಂಭಿಸುವುದು, networking ಹೊಂದಿಸುವುದು, ಮತ್ತು data persistence ಗಾಗಿ shared volumes ನಿರ್ವಹಿಸುವ orchestration ನ್ನೂ ಇದು ನೋಡಿಕೊಳ್ಳುತ್ತದೆ.
 
-For production deployments, you often want your docker compose services to start automatically on boot and restart on failure. A common approach is to use systemd to manage the docker compose deployment:
+Production deployments ಗಾಗಿ, docker compose services boot ಸಮಯದಲ್ಲೇ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆರಂಭವಾಗಿ failure ಆಗಿದರೆ ಮರುಪ್ರಾರಂಭಗೊಳ್ಳಬೇಕು ಎಂದು ನೀವು ಬಯಸಬಹುದು. ಸಾಮಾನ್ಯ ವಿಧಾನವೆಂದರೆ docker compose deployment ಅನ್ನು systemd ಮೂಲಕ ನಿರ್ವಹಿಸುವುದು:
 
 ```ini
 # /etc/systemd/system/myapp.service
@@ -529,11 +529,11 @@ ExecStop=/usr/bin/docker compose down
 WantedBy=multi-user.target
 ```
 
-This systemd unit file ensures your application starts when the system boots (after Docker is ready), and provides standard controls like `systemctl start myapp`, `systemctl stop myapp`, and `systemctl status myapp`.
+ಈ systemd unit file ನಿಮ್ಮ application ಅನ್ನು system boot ಆಗುವಾಗ (Docker ಸಿದ್ಧವಾದ ನಂತರ) ಪ್ರಾರಂಭವಾಗುವಂತೆ ಖಚಿತಪಡಿಸುತ್ತದೆ; ಜೊತೆಗೆ `systemctl start myapp`, `systemctl stop myapp`, ಮತ್ತು `systemctl status myapp` ನಂತಹ standard controls ಒದಗಿಸುತ್ತದೆ.
 
-As deployment requirements grow more complex --- needing scalability across multiple machines, fault tolerance when services crash, and high availability guarantees --- organizations turn to sophisticated container orchestration platforms like Kubernetes (k8s), which can manage thousands of containers across clusters of machines. That said, Kubernetes has a steep learning curve and significant operational overhead, so it's often overkill for smaller projects.
+Deployment ಅಗತ್ಯಗಳು ಇನ್ನಷ್ಟು ಸಂಕೀರ್ಣವಾದಂತೆ - ಅನೇಕ ಯಂತ್ರಗಳಾಚೆ scalability, services crash ಆದಾಗ fault tolerance, ಮತ್ತು high availability guarantees ಅಗತ್ಯವಿರುವ ಸಂದರ್ಭಗಳಲ್ಲಿ - ಸಂಸ್ಥೆಗಳು Kubernetes (k8s) ನಂತಹ ಉನ್ನತ ಮಟ್ಟದ container orchestration platforms ಕಡೆ ತಿರುಗುತ್ತವೆ; ಇವು machines ಗಳ clusters ಅಳೆಯಲ್ಲೂ ಸಾವಿರಾರು containers ನಿರ್ವಹಿಸಬಲ್ಲವು. ಆದಾಗ್ಯೂ Kubernetes ಗೆ ಕಲಿಕೆಯ ತೀವ್ರ ವಕ್ರತೆ ಹಾಗೂ ಗಮನಾರ್ಹ operational overhead ಇರುವುದರಿಂದ, ಸಣ್ಣ projects ಗಾಗಿ ಇದು ಅನೇಕ ಬಾರಿ ಅತಿಯಾಗುತ್ತದೆ.
 
-This multi-container setup is partly feasible because modern services communicate with each other via standardized APIs, with HTTP REST APIs. For example, whenever a program interacts with an LLM provider like OpenAI or Anthropic, under the hood it is sending an HTTP request to their servers and parsing the response:
+ಈ multi-container setup ಭಾಗಶಃ ಸಾಧ್ಯವಾಗಿರುವುದು, ಆಧುನಿಕ services ಪರಸ್ಪರ standardized APIs ಮೂಲಕ - ಮುಖ್ಯವಾಗಿ HTTP REST APIs ಮೂಲಕ - ಸಂವಹನ ಮಾಡುವುದರಿಂದ. ಉದಾಹರಣೆಗೆ, program ಒಂದು OpenAI ಅಥವಾ Anthropic ನಂತಹ LLM provider ಜೊತೆ ಸಂವಹನಿಸಿದಾಗ, ಒಳಗೆ ಅದು ಅವರ servers ಗೆ HTTP request ಕಳುಹಿಸಿ response parse ಮಾಡುತ್ತದೆ:
 
 ```console
 $ curl https://api.anthropic.com/v1/messages \
@@ -546,17 +546,17 @@ $ curl https://api.anthropic.com/v1/messages \
 
 # Publishing
 
-Once you have shown your code to work, you might be interested in distributing it for others to download and install.
-Distribution takes many forms and is intrinsically tied to the programming language and environments that you operate with.
+ನಿಮ್ಮ code ಸರಿಯಾಗಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತದೆ ಎಂದು ತೋರಿಸಿದ ನಂತರ, ಅದನ್ನು ಇತರರು download ಮಾಡಿ install ಮಾಡಲು ಹಂಚಬೇಕೆಂಬ ಆಸಕ್ತಿ ಮೂಡಬಹುದು.
+Distribution ಹಲವು ರೂಪಗಳನ್ನು ಹೊಂದಿದ್ದು, ಅದು ನಿಮ್ಮ programming language ಹಾಗೂ ನೀವು ಕಾರ್ಯನಿರ್ವಹಿಸುವ environments ಜೊತೆಗೆ ಆಂತರಿಕವಾಗಿ ಸಂಬಂಧಿಸಿದೆ.
 
-The simplest form of distribution is uploading artifacts for people to download and install locally.
-This is still common and you can find it in places like [Ubuntu's package archive](http://archive.ubuntu.com/ubuntu/pool/main/), which is essentially an HTTP directory listing of `.deb` files.
+Distribution ನ ಸರಳ ರೂಪವೆಂದರೆ ಜನರು download ಮಾಡಿ ಸ್ಥಳೀಯವಾಗಿ install ಮಾಡಲು artifacts ಅಪ್‌ಲೋಡ್ ಮಾಡುವುದು.
+ಇದು ಇನ್ನೂ ಸಾಮಾನ್ಯವಾಗಿದೆ; ಉದಾಹರಣೆಗೆ [Ubuntu's package archive](http://archive.ubuntu.com/ubuntu/pool/main/) ನಲ್ಲಿ ಕಾಣಬಹುದು, ಅದು ಮೂಲತಃ `.deb` files ಗಳ HTTP directory listing ಆಗಿದೆ.
 
-These days, GitHub has become the de facto platform for publishing source code and artifacts.
-While the source code is often publicly available, GitHub Releases allow maintainers to attach prebuilt binaries and other artifacts to tagged versions.
+ಇತ್ತೀಚಿನ ದಿನಗಳಲ್ಲಿ source code ಮತ್ತು artifacts publish ಮಾಡಲು GitHub de facto platform ಆಗಿದೆ.
+Source code ಬಹುಶಃ ಸಾರ್ವಜನಿಕವಾಗಿದ್ದರೂ, GitHub Releases maintainers ಗೆ tagged versions ಗೆ prebuilt binaries ಮತ್ತು ಇತರೆ artifacts ಸೇರಿಸಲು ಅವಕಾಶ ನೀಡುತ್ತದೆ.
 
 
-Package managers sometimes support installing directly from GitHub, either from source or from a pre-built wheel:
+Package managers ಕೆಲವೊಮ್ಮೆ GitHub ನಿಂದ ನೇರವಾಗಿ install ಮಾಡಲು support ಮಾಡುತ್ತವೆ - source ನಿಂದಲೂ, pre-built wheel ನಿಂದಲೂ:
 
 ```console
 # Install from source (will clone and build)
@@ -569,8 +569,8 @@ $ pip install git+https://github.com/psf/requests.git@v2.32.3
 $ pip install https://github.com/user/repo/releases/download/v1.0/package-1.0-py3-none-any.whl
 ```
 
-In fact, some languages like Go use a decentralized distribution model --- rather than a central package repository, Go modules are distributed directly from their source code repositories.
-Module paths like `github.com/gorilla/mux` indicate where the code lives, and `go get` fetches directly from there. However, most package managers like `pip`, `cargo`, or `brew` have central indexes of pre-packaged projects for ease of distribution and installation. If we run
+ವಾಸ್ತವವಾಗಿ Go ನಂತಹ ಕೆಲವು languages decentralized distribution model ಬಳಸುತ್ತವೆ - central package repository ಬದಲಿಗೆ, Go modules ನೇರವಾಗಿ source code repositories ಗಳಿಂದ ಹಂಚಲಾಗುತ್ತವೆ.
+`github.com/gorilla/mux` ನಂತಹ module paths code ಎಲ್ಲಿದೆ ಎಂಬುದನ್ನು ಸೂಚಿಸುತ್ತವೆ; `go get` ಅಲ್ಲಿಂದಲೇ fetch ಮಾಡುತ್ತದೆ. ಆದರೆ `pip`, `cargo`, ಅಥವಾ `brew` ಮುಂತಾದ ಬಹುತೇಕ package managers distribution ಮತ್ತು installation ಸುಗಮಗೊಳಿಸಲು pre-packaged projects ಗಳ central indexes ಹೊಂದಿವೆ. ನಾವು ಹೀಗೆ ಚಾಲನೆ ಮಾಡಿದರೆ
 
 ```console
 $ uv pip install requests --verbose --no-cache 2>&1 | grep -F '.whl'
@@ -579,18 +579,18 @@ DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3ea
 DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
 ```
 
-we see where we are fetching the `requests` wheel from. Notice the `py3-none-any` in the filename --- this means the wheel works with any Python 3 version, on any OS, on any architecture. For packages with compiled code, the wheel is platform-specific:
+`requests` wheel ಅನ್ನು ನಾವು ಎಲ್ಲಿಂದ fetch ಮಾಡುತ್ತಿದ್ದೇವೆ ಎಂಬುದು ಗೋಚರಿಸುತ್ತದೆ. filename ನಲ್ಲಿರುವ `py3-none-any` ಗಮನಿಸಿ - ಇದರ ಅರ್ಥ ಆ wheel ಯಾವುದೇ Python 3 version, ಯಾವುದೇ OS, ಯಾವುದೇ architecture ನಲ್ಲಿ ಕೆಲಸ ಮಾಡುತ್ತದೆ. Compiled code ಇರುವ packages ಗಾಗಿ wheel platform-specific ಆಗಿರುತ್ತದೆ:
 
 ```console
 $ uv pip install numpy --verbose --no-cache 2>&1 | grep -F '.whl'
 DEBUG Selecting: numpy==2.2.1 [compatible] (numpy-2.2.1-cp312-cp312-macosx_14_0_arm64.whl)
 ```
 
-Here `cp312-cp312-macosx_14_0_arm64` indicates this wheel is specifically for CPython 3.12 on macOS 14+ for ARM64 (Apple Silicon). If you're on a different platform, `pip` will download a different wheel or build from source.
+ಇಲ್ಲಿ `cp312-cp312-macosx_14_0_arm64` ಎಂದರೆ ಈ wheel CPython 3.12, macOS 14+, ARM64 (Apple Silicon) ಗಾಗಿ ವಿಶೇಷವಾಗಿ ಸಿದ್ಧಪಡಿಸಲಾಗಿದೆ. ನೀವು ಬೇರೆ platform ನಲ್ಲಿ ಇದ್ದರೆ `pip` ಬೇರೆ wheel download ಮಾಡುತ್ತದೆ ಅಥವಾ source ನಿಂದ build ಮಾಡುತ್ತದೆ.
 
-Conversely, for people to be able to find a package we've created, we need to publish it to one of these registries.
-In Python, the main registry is the [Python Package Index (PyPI)](https://pypi.org).
-Like with installing, there are multiple ways of publishing packages. The `uv publish` command provides a modern interface for uploading packages to PyPI:
+ಇನ್ನೊಂದೆಡೆ, ನಾವು ಸೃಷ್ಟಿಸಿದ package ಇತರರಿಗೆ ದೊರೆಯಲು ಅದನ್ನು ಈ registries ಗಳಲ್ಲಿ ಒಂದಕ್ಕೆ publish ಮಾಡಬೇಕು.
+Python ನಲ್ಲಿ ಮುಖ್ಯ registry [Python Package Index (PyPI)](https://pypi.org) ಆಗಿದೆ.
+Install ಮಾಡುವಂತೆಯೇ, packages publish ಮಾಡಲು ಅನೇಕ ವಿಧಾನಗಳಿವೆ. `uv publish` command, packages ಅನ್ನು PyPI ಗೆ upload ಮಾಡಲು ಆಧುನಿಕ interface ಒದಗಿಸುತ್ತದೆ:
 
 ```console
 $ uv publish --publish-url https://test.pypi.org/legacy/
@@ -598,33 +598,33 @@ Publishing greeting-0.1.0.tar.gz
 Publishing greeting-0.1.0-py3-none-any.whl
 ```
 
-Here we are using [TestPyPI](https://test.pypi.org) --- a separate package registry intended for testing your publishing workflow without polluting the real PyPI. Once uploaded, you can install from TestPyPI:
+ಇಲ್ಲಿ ನಾವು [TestPyPI](https://test.pypi.org) ಬಳಸುತ್ತಿದ್ದೇವೆ - ಇದು ನಿಜವಾದ PyPI ಯನ್ನು ಅಶುದ್ಧಗೊಳಿಸದೆ ನಿಮ್ಮ publishing workflow ಪರೀಕ್ಷಿಸಲು ಉದ್ದೇಶಿತ ಪ್ರತ್ಯೇಕ package registry. Upload ಆದ ನಂತರ, ನೀವು TestPyPI ಯಿಂದ install ಮಾಡಬಹುದು:
 
 ```console
 $ uv pip install --index-url https://test.pypi.org/simple/ greeting
 ```
 
-A key consideration when publishing software is trust. How do users verify that the package they download actually comes from you and hasn't been tampered with? Package registries use checksums to verify integrity, and some ecosystems support package signing to provide cryptographic proof of authorship.
+Software publish ಮಾಡುವಾಗ trust ಪ್ರಮುಖ ಪ್ರಶ್ನೆಯಾಗುತ್ತದೆ. ಬಳಕೆದಾರರು download ಮಾಡುವ package ನಿಜವಾಗಿ ನಿಮ್ಮಿಂದ ಬಂದಿದೆಯೇ ಮತ್ತು tamper ಆಗಿಲ್ಲವೇ ಎಂಬುದನ್ನು ಹೇಗೆ ಖಚಿತಪಡಿಸಿಕೊಳ್ಳುವುದು? Package registries integrity ಪರಿಶೀಲಿಸಲು checksums ಬಳಸುತ್ತವೆ; ಕೆಲವು ecosystems authorship ಗೆ cryptographic proof ಒದಗಿಸಲು package signing support ಮಾಡುತ್ತವೆ.
 
-Different languages have their own package registries: [crates.io](https://crates.io) for Rust, [npm](https://www.npmjs.com) for JavaScript, [RubyGems](https://rubygems.org) for Ruby, and [Docker Hub](https://hub.docker.com) for container images. Meanwhile, for private or internal packages, organizations often deploy their own package repositories (such as a private PyPI server or a private Docker registry) or use managed solutions from cloud providers.
+ವಿಭಿನ್ನ languages ಗಳಿಗೆ ಸ್ವಂತ package registries ಇವೆ: Rust ಗಾಗಿ [crates.io](https://crates.io), JavaScript ಗಾಗಿ [npm](https://www.npmjs.com), Ruby ಗಾಗಿ [RubyGems](https://rubygems.org), ಮತ್ತು container images ಗಾಗಿ [Docker Hub](https://hub.docker.com). ಮತ್ತೊಂದೆಡೆ private ಅಥವಾ internal packages ಗಾಗಿ ಸಂಸ್ಥೆಗಳು ತಮ್ಮದೇ package repositories (ಉದಾ., private PyPI server ಅಥವಾ private Docker registry) deploy ಮಾಡಬಹುದು, ಅಥವಾ cloud providers ನ managed solutions ಬಳಸಬಹುದು.
 
-Deploying a web service to the internet involves additional infrastructure: domain name registration, DNS configuration to point your domain to your server, and often a reverse proxy like nginx to handle HTTPS and route traffic. For simpler use cases like documentation or static sites, [GitHub Pages](https://pages.github.com/) provides free hosting directly from a repository.
+Web service ಅನ್ನು internet ಗೆ deploy ಮಾಡಲು ಹೆಚ್ಚುವರಿ infrastructure ಅಗತ್ಯ: domain name registration, ನಿಮ್ಮ domain ಅನ್ನು server ಕಡೆ point ಮಾಡಲು DNS configuration, ಮತ್ತು ಬಹಳ ಬಾರಿ HTTPS ನಿರ್ವಹಿಸಿ traffic route ಮಾಡಲು nginx ನಂತಹ reverse proxy. documentation ಅಥವಾ static sites ನಂತಹ ಸರಳ ಬಳಕೆ ಸಂದರ್ಭಗಳಿಗೆ [GitHub Pages](https://pages.github.com/) repository ನಿಂದ ನೇರವಾಗಿ ಉಚಿತ hosting ಒದಗಿಸುತ್ತದೆ.
 
 <!--
 ## Documentation
 
-So far we have emphasized the deliverable _artifact_ as the main output of packaging and shipping code.
-In addition to the artifact, we need to document for users the code's functionality, installation instructions, and usage examples.
+ಇಲ್ಲಿಯವರೆಗೆ ನಾವು packaging ಮತ್ತು shipping code ನ ಮುಖ್ಯ output ಆಗಿ deliverable _artifact_ ಮೇಲೆ ಒತ್ತಡ ನೀಡಿದ್ದೇವೆ.
+Artifact ಜೊತೆಗೆ, code ನ functionality, installation ಸೂಚನೆಗಳು, ಮತ್ತು usage ಉದಾಹರಣೆಗಳನ್ನು ಬಳಕೆದಾರರಿಗೆ documentation ರೂಪದಲ್ಲಿ ನೀಡಬೇಕಾಗುತ್ತದೆ.
 
-Tools like [Sphinx](https://www.sphinx-doc.org/) (Python) and [MkDocs](https://www.mkdocs.org/) can automatically generate browsable documentation from docstrings and markdown files, often hosted on services like [Read the Docs](https://readthedocs.org/).
-For HTTP-based APIs, the [OpenAPI specification](https://www.openapis.org/) (formerly Swagger) provides a standard format for describing API endpoints, which tools can use to generate interactive documentation and client libraries automatically. -->
+[Sphinx](https://www.sphinx-doc.org/) (Python) ಮತ್ತು [MkDocs](https://www.mkdocs.org/) ನಂತಹ tools docstrings ಮತ್ತು markdown files ನಿಂದ browsable documentation ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ರಚಿಸಬಹುದು; ಇದನ್ನು ಸಾಮಾನ್ಯವಾಗಿ [Read the Docs](https://readthedocs.org/) ನಂತಹ ಸೇವೆಗಳಲ್ಲಿ host ಮಾಡಲಾಗುತ್ತದೆ.
+HTTP ಆಧಾರಿತ APIs ಗಾಗಿ [OpenAPI specification](https://www.openapis.org/) (ಹಿಂದೆ Swagger) API endpoints ವಿವರಿಸಲು ಒಂದು ಮಾನದಂಡಿತ ರೂಪ ಒದಗಿಸುತ್ತದೆ; ಇದನ್ನು tools ಬಳಸಿ interactive documentation ಮತ್ತು client libraries ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ರಚಿಸಬಹುದು. -->
 
 
 # Exercises
 
-1. Save your environment with `printenv` to a file, create a venv, activate it, `printenv` to another file and `diff before.txt after.txt`. What changed in the environment? Why does the shell prefer the venv? (Hint: look at `$PATH` before and after activation.) Run `which deactivate` and reason about what the deactivate bash function is doing.
-1. Create a Python package with a `pyproject.toml` and install it in a virtual environment. Create a lockfile and inspect it.
-1. Install Docker and use it to build the Missing Semester class website locally using docker compose.
-1. Write a Dockerfile for a simple Python application. Then write a `docker-compose.yml` that runs your application alongside a Redis cache.
-1. Publish a Python package to TestPyPI (don't publish to the real PyPI unless it's worth sharing!). Then build a Docker image with said package and push it to `ghcr.io`.
-1. Make a website using [GitHub Pages](https://docs.github.com/en/pages/quickstart). Extra (non-)credit: configure it with a custom domain.
+1. `printenv` ಬಳಸಿ ನಿಮ್ಮ environment ಅನ್ನು file ಗೆ ಉಳಿಸಿ, venv ರಚಿಸಿ, activate ಮಾಡಿ, ಮತ್ತೊಂದು file ಗೆ `printenv` ಉಳಿಸಿ, ಮತ್ತು `diff before.txt after.txt` ಚಾಲನೆ ಮಾಡಿ. Environment ನಲ್ಲಿ ಏನು ಬದಲಾಯಿತು? shell ಯಾಕೆ venv ಗೆ ಆದ್ಯತೆ ನೀಡುತ್ತದೆ? (ಸುಳಿವು: activation ಮೊದಲು ಮತ್ತು ನಂತರ `$PATH` ನೋಡಿ.) `which deactivate` ಚಾಲನೆ ಮಾಡಿ, deactivate bash function ಏನು ಮಾಡುತ್ತಿದೆ ಎಂದು ವಿಶ್ಲೇಷಿಸಿ.
+1. `pyproject.toml` ಹೊಂದಿರುವ Python package ರಚಿಸಿ, ಅದನ್ನು virtual environment ನಲ್ಲಿ install ಮಾಡಿ. lockfile ರಚಿಸಿ ಮತ್ತು ಅದನ್ನು ಪರಿಶೀಲಿಸಿ.
+1. Docker install ಮಾಡಿ ಮತ್ತು docker compose ಬಳಸಿ Missing Semester class website ಅನ್ನು ಸ್ಥಳೀಯವಾಗಿ build ಮಾಡಿ.
+1. ಸರಳ Python application ಗಾಗಿ Dockerfile ಬರೆಯಿರಿ. ನಂತರ ನಿಮ್ಮ application ಜೊತೆಗೆ Redis cache ಓಡಿಸುವ `docker-compose.yml` ಬರೆಯಿರಿ.
+1. Python package ಅನ್ನು TestPyPI ಗೆ publish ಮಾಡಿ (ಹಂಚಿಕೊಳ್ಳುವ ಮೌಲ್ಯವಿದ್ದಾಗ ಮಾತ್ರ ನಿಜವಾದ PyPI ಗೆ publish ಮಾಡಿ). ನಂತರ ಆ package ಒಳಗೊಂಡ Docker image build ಮಾಡಿ ಮತ್ತು ಅದನ್ನು `ghcr.io` ಗೆ push ಮಾಡಿ.
+1. [GitHub Pages](https://docs.github.com/en/pages/quickstart) ಬಳಸಿ website ನಿರ್ಮಿಸಿ. Extra (non-)credit: ಅದನ್ನು custom domain ಜೊತೆಗೆ configure ಮಾಡಿ.

--- a/_2026/version-control.md
+++ b/_2026/version-control.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Version Control and Git"
+title: "ಆವೃತ್ತಿ ನಿಯಂತ್ರಣ ಮತ್ತು Git"
 description: >
-  Learn Git's data model and how to use Git for version control and collaboration.
+  Git ನ data model ಅನ್ನು ತಿಳಿದುಕೊಂಡು, version control ಮತ್ತು collaboration ಗಾಗಿ Git ಅನ್ನು ಬಳಸುವ ವಿಧಾನವನ್ನು ಕಲಿಯಿರಿ.
 thumbnail: /static/assets/thumbnails/2026/lec5.png
 date: 2026-01-16
 ready: true
@@ -11,61 +11,46 @@ video:
   id: 9K8lB61dl3Y
 ---
 
-Version control systems (VCSs) are tools used to track changes to source code
-(or other collections of files and folders). As the name implies, these tools
-help maintain a history of changes; furthermore, they facilitate collaboration.
-Logically, VCSs track changes to a folder and its contents in a series of
-_snapshots_, where each snapshot encapsulates the entire state of files/folders
-within a top-level directory. VCSs also maintain metadata like who created each
-snapshot, messages associated with each snapshot, and so on.
+Version control systems (VCSs) ಎಂದರೆ source code
+(ಅಥವಾ files ಮತ್ತು folders ಗಳ ಇತರ ಸಂಗ್ರಹಗಳು) ಗಳಲ್ಲಿನ ಬದಲಾವಣೆಗಳನ್ನು ಹಾದುಹೋಗುವಂತೆ ಟ್ರ್ಯಾಕ್ ಮಾಡಲು ಬಳಸುವ ಉಪಕರಣಗಳು. ಹೆಸರೇ ಸೂಚಿಸುವಂತೆ, ಈ ಉಪಕರಣಗಳು
+ಬದಲಾವಣೆಗಳ ಇತಿಹಾಸವನ್ನು ನಿರ್ವಹಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತವೆ; ಇನ್ನೂ ಮುಂದೆ, ಅವು collaboration ನ್ನೂ ಸುಗಮಗೊಳಿಸುತ್ತವೆ.
+ತಾರ್ಕಿಕವಾಗಿ ನೋಡಿದರೆ, VCSs ಒಂದು folder ಹಾಗೂ ಅದರ ಒಳಪರಿವಿಡಿಯನ್ನು
+_snapshots_ ಗಳ ಸರಣಿಯಾಗಿ ಟ್ರ್ಯಾಕ್ ಮಾಡುತ್ತವೆ; ಇಲ್ಲಿ ಪ್ರತಿಯೊಂದು snapshot, top-level directory ಒಳಗಿನ files/folders ಗಳ ಸಂಪೂರ್ಣ ಸ್ಥಿತಿಯನ್ನು ಒಳಗೊಂಡಿರುತ್ತದೆ. VCSs ಪ್ರತಿಯೊಂದು
+snapshot ಅನ್ನು ಯಾರು ಸೃಷ್ಟಿಸಿದರು, snapshot ಗೆ ಸಂಬಂಧಿಸಿದ ಸಂದೇಶಗಳು, ಇತ್ಯಾದಿ metadata ಯನ್ನೂ ನಿರ್ವಹಿಸುತ್ತವೆ.
 
-Why is version control useful? Even when you're working by yourself, it can let
-you look at old snapshots of a project, keep a log of why certain changes were
-made, work on parallel branches of development, and much more. When working
-with others, it's an invaluable tool for seeing what other people have changed,
-as well as resolving conflicts in concurrent development.
+Version control ಯಾಕೆ ಉಪಯುಕ್ತ? ನೀವು ಒಬ್ಬರೇ ಕೆಲಸ ಮಾಡುತ್ತಿದ್ದರೂ ಸಹ, ಇದು ಯೋಜನೆಯ ಹಳೆಯ snapshots ಗಳನ್ನು ನೋಡಲು, ನಿರ್ದಿಷ್ಟ ಬದಲಾವಣೆಗಳನ್ನು ಏಕೆ ಮಾಡಲಾಯಿತು ಎಂಬ ಲಾಗ್ ಅನ್ನು ಉಳಿಸಲು,
+ಅಭಿವೃದ್ಧಿಯ ಸಮಾಂತರ branches ಗಳಲ್ಲಿ ಕೆಲಸ ಮಾಡಲು ಮತ್ತು ಇನ್ನೂ ಅನೇಕ ಕಾರ್ಯಗಳಿಗೆ ನೆರವಾಗುತ್ತದೆ. ಇತರರೊಂದಿಗೆ ಕೆಲಸ ಮಾಡುವಾಗ, ಇದು ಇತರರು ಏನು ಬದಲಾಯಿಸಿದ್ದಾರೆ ಎಂಬುದನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು,
+ಹಾಗೂ concurrent development ನಲ್ಲಿ ಉಂಟಾಗುವ conflicts ಗಳನ್ನು ಪರಿಹರಿಸಲು ಅಮೂಲ್ಯವಾದ ಸಾಧನವಾಗುತ್ತದೆ.
 
-Modern VCSs also let you easily (and often automatically) answer questions
-like:
+ಆಧುನಿಕ VCSsಗಳು ಈ ರೀತಿಯ ಪ್ರಶ್ನೆಗಳಿಗೆ ಸುಲಭವಾಗಿ (ಮತ್ತು ಬಹುಶಃ ಸ್ವಯಂಚಾಲಿತವಾಗಿ) ಉತ್ತರಿಸಲು ಸಹ ಅವಕಾಶ ಮಾಡಿಕೊಡುತ್ತವೆ:
 
-- Who wrote this module?
-- When was this particular line of this particular file edited? By whom? Why
-  was it edited?
-- Over the last 1000 revisions, when/why did a particular unit test stop
-working?
+- ಈ module ಅನ್ನು ಯಾರು ಬರೆದರು?
+- ಈ ನಿರ್ದಿಷ್ಟ file ನ ಈ ನಿರ್ದಿಷ್ಟ line ಅನ್ನು ಯಾವಾಗ ಸಂಪಾದಿಸಲಾಯಿತು? ಯಾರೆಂದರು? ಏಕೆ
+  ಸಂಪಾದಿಸಲಾಯಿತು?
+- ಕಳೆದ 1000 revisions ಗಳಲ್ಲಿ, ನಿರ್ದಿಷ್ಟ unit test ಯಾವಾಗ/ಏಕೆ ಕೆಲಸ ಮಾಡುವುದು ನಿಂತಿತು?
 
-While other VCSs exist, **Git** is the de facto standard for version control.
-This [XKCD comic](https://xkcd.com/1597/) captures Git's reputation:
+ಇತರೆ VCSs ಇದ್ದರೂ ಸಹ, version control ಗಾಗಿ **Git** de facto standard ಆಗಿದೆ.
+ಈ [XKCD comic](https://xkcd.com/1597/) Git ನ ಖ್ಯಾತಿಯನ್ನು ಚೆನ್ನಾಗಿ ಹಿಡಿದಿಡುತ್ತದೆ:
 
 ![xkcd 1597](https://imgs.xkcd.com/comics/git.png)
 
-Because Git's interface is a leaky abstraction, learning Git top-down (starting
-with its interface / command-line interface) can lead to a lot of confusion.
-It's possible to memorize a handful of commands and think of them as magic
-incantations, and follow the approach in the comic above whenever anything goes
-wrong.
+Git ನ interface ಒಂದು leaky abstraction ಆಗಿರುವುದರಿಂದ, Git ಅನ್ನು top-down ರೀತಿಯಲ್ಲಿ ಕಲಿಯುವುದು (ಅಂದರೆ ಅದರ interface / command-line interface ರಿಂದ ಪ್ರಾರಂಭಿಸುವುದು)
+ಸಾಕಷ್ಟು ಗೊಂದಲಕ್ಕೆ ಕಾರಣವಾಗಬಹುದು. ಕೆಲವು commands ಗಳನ್ನು ಕೇವಲ ಮನಪಾಠ ಮಾಡಿಕೊಂಡು ಅವನ್ನು magic
+incantations ಎಂದು ಭಾವಿಸಿ, ಏನಾದರೂ ತಪ್ಪಾದಾಗ ಮೇಲಿನ comic ನಲ್ಲಿರುವ ವಿಧಾನವನ್ನೇ ಅನುಸರಿಸುವ ಸಾಧ್ಯತೆಯಿದೆ.
 
-While Git admittedly has an ugly interface, its underlying design and ideas are
-beautiful. While an ugly interface has to be _memorized_, a beautiful design
-can be _understood_. For this reason, we give a bottom-up explanation of Git,
-starting with its data model and later covering the command-line interface.
-Once the data model is understood, the commands can be better understood in
-terms of how they manipulate the underlying data model.
+Git ನ interface ಆಕರ್ಷಕವಲ್ಲ ಎಂಬುದು ಸತ್ಯವಾದರೂ, ಅದರ ಒಳಗಿನ design ಮತ್ತು ಕಲ್ಪನೆಗಳು ಅತ್ಯಂತ ಸುಂದರವಾಗಿವೆ. ಅಂದರೆ, ಅಸ್ವಚ್ಛ interface ಅನ್ನು _memorize_ ಮಾಡಬೇಕಾಗುತ್ತದೆ, ಆದರೆ ಉತ್ತಮ design ಅನ್ನು _understand_ ಮಾಡಬಹುದು.
+ಈ ಕಾರಣಕ್ಕಾಗಿ, ನಾವು Git ನ ವಿವರಣೆಯನ್ನು bottom-up ರೀತಿಯಲ್ಲಿ ನೀಡುತ್ತೇವೆ - ಮೊದಲು ಅದರ data model, ನಂತರ command-line interface.
+ಒಮ್ಮೆ data model ಅರ್ಥವಾದ ನಂತರ, commands ಗಳು ಒಳಗಿನ data model ಅನ್ನು ಹೇಗೆ ಪ್ರಭಾವಿಸುತ್ತವೆ ಎಂಬ ದೃಷ್ಟಿಯಿಂದ ಇನ್ನೂ ಸ್ಪಷ್ಟವಾಗಿ ಅರ್ಥವಾಗುತ್ತವೆ.
 
-# Git's data model
+# Git ನ data model
 
-Git's ingenuity is in its well-thought-out data model that enables all the nice
-features of version control, like maintaining history, supporting branches, and
-enabling collaboration.
+Git ನ ಮೇಧಾವಿತ್ವವು ಅದರ ಸುಸಂರಚಿತ data model ನಲ್ಲಿ ಇದೆ; ಇದೇ version control ನ ಅನೇಕ ಉಪಯುಕ್ತ ಲಕ್ಷಣಗಳನ್ನು - ಉದಾಹರಣೆಗೆ history ನಿರ್ವಹಣೆ, branches ಬೆಂಬಲ, ಮತ್ತು collaboration - ಸಾಧ್ಯಗೊಳಿಸುತ್ತದೆ.
 
-## Snapshots
+## Snapshot ಗಳು
 
-Git models the history of a collection of files and folders within some
-top-level directory as a series of snapshots. In Git terminology, a file is
-called a "blob", and it's just a bunch of bytes. A directory is called a
-"tree", and it maps names to blobs or trees (so directories can contain other
-directories). A snapshot is the top-level tree that is being tracked. For
-example, we might have a tree as follows:
+Git, ನಿರ್ದಿಷ್ಟ top-level directory ಒಳಗಿನ files ಮತ್ತು folders ಗಳ ಇತಿಹಾಸವನ್ನು snapshots ಗಳ ಸರಣಿಯಾಗಿ ಮಾದರೀಕರಿಸುತ್ತದೆ. Git ಪದಪ್ರಯೋಗದಲ್ಲಿ file ಅನ್ನು
+"blob" ಎಂದು ಕರೆಯುತ್ತಾರೆ; ಅದು bytes ಗಳ ಸಮೂಹ ಮಾತ್ರ. directory ಅನ್ನು "tree" ಎಂದು ಕರೆಯುತ್ತಾರೆ; ಅದು ಹೆಸರುಗಳನ್ನು blobs ಅಥವಾ trees ಗಳಿಗೆ ನಕ್ಷೆಗೊಳಿಸುತ್ತದೆ (ಅಂದರೆ directories ಒಳಗೆ ಇತರ directories ಇರಬಹುದು). snapshot ಎಂದರೆ ಟ್ರ್ಯಾಕ್ ಮಾಡಲಾಗುತ್ತಿರುವ top-level tree.
+ಉದಾಹರಣೆಗೆ, ನಮ್ಮಲ್ಲಿ ಈ ಕೆಳಗಿನ tree ಇರಬಹುದು:
 
 ```
 <root> (tree)
@@ -77,24 +62,18 @@ example, we might have a tree as follows:
 +- baz.txt (blob, contents = "git is wonderful")
 ```
 
-The top-level tree contains two elements, a tree "foo" (that itself contains
-one element, a blob "bar.txt"), and a blob "baz.txt".
+ಈ top-level tree ಯಲ್ಲಿ ಎರಡು ಅಂಶಗಳಿವೆ: "foo" ಎಂಬ tree (ಅದರೊಳಗೆ ಒಂದು ಅಂಶವಾದ "bar.txt" blob ಇದೆ), ಮತ್ತು "baz.txt" blob.
 
-## Modeling history: relating snapshots
+## History ಮಾದರೀಕರಣ: snapshots ಗಳ ಸಂಬಂಧ
 
-How should a version control system relate snapshots? One simple model would be
-to have a linear history. A history would be a list of snapshots in time-order.
-For many reasons, Git doesn't use a simple model like this.
+ಒಂದು version control system snapshots ಗಳನ್ನು ಹೇಗೆ ಪರಸ್ಪರ ಸಂಬಂಧಿಸಬೇಕು? ಒಂದು ಸರಳ ಮಾದರಿ ಎಂದರೆ linear history ಇರುವುದು. history ಎಂದರೆ ಕಾಲಕ್ರಮದಲ್ಲಿ ಸರಿದಟ್ಟಲಾದ snapshots ಗಳ ಪಟ್ಟಿಯಾಗಿರಬಹುದು.
+ಅನೇಕ ಕಾರಣಗಳಿಂದ Git ಇಂತಹ ಸರಳ ಮಾದರಿಯನ್ನು ಬಳಸುವುದಿಲ್ಲ.
 
-In Git, a history is a directed acyclic graph (DAG) of snapshots. That may
-sound like a fancy math word, but don't be intimidated. All this means is that
-each snapshot in Git refers to a set of "parents", the snapshots that preceded
-it. It's a set of parents rather than a single parent (as would be the case in
-a linear history) because a snapshot might descend from multiple parents, for
-example, due to combining (merging) two parallel branches of development.
+Git ನಲ್ಲಿ history ಎಂದರೆ snapshots ಗಳ directed acyclic graph (DAG).
+ಇದು ಅತಿಯಾಗಿ ಗಣಿತಪದದಂತೆ ಕೇಳಿಸಬಹುದು, ಆದರೆ ಭಯಪಡುವ ಅಗತ್ಯವಿಲ್ಲ. ಇದರ ಅರ್ಥ, Git ನಲ್ಲಿನ ಪ್ರತಿಯೊಂದು snapshot ತನ್ನಿಗಿಂತ ಮುಂಚೆ ಬಂದ snapshots ಗಳಾದ "parents" ಗಳ ಗುಂಪನ್ನು ಸೂಚಿಸುತ್ತದೆ.
+ಇದು single parent ಅಲ್ಲ, parents ಗಳ set ಆಗಿರುವುದು (linear history ಯಲ್ಲಿ single parent ಇರುತ್ತದೆ) ಏಕೆಂದರೆ ಒಂದು snapshot ಬಹು parents ಗಳಿಂದ ಇಳಿಯಿರಬಹುದು - ಉದಾಹರಣೆಗೆ ಅಭಿವೃದ್ಧಿಯ ಎರಡು ಸಮಾಂತರ branches ಗಳನ್ನು ಸೇರಿಸುವ (merging) ಸಂದರ್ಭದಲ್ಲಿ.
 
-Git calls these snapshots "commit"s. Visualizing a commit history might look
-something like this:
+Git ಈ snapshots ಗಳನ್ನು "commit" ಗಳು ಎಂದು ಕರೆಯುತ್ತದೆ. commit history ಯನ್ನು ದೃಶ್ಯೀಕರಿಸಿದರೆ ಇದು ಹೀಗಿರಬಹುದು:
 
 ```
 o <-- o <-- o <-- o
@@ -103,14 +82,9 @@ o <-- o <-- o <-- o
               --- o <-- o
 ```
 
-In the ASCII art above, the `o`s correspond to individual commits (snapshots).
-The arrows point to the parent of each commit (it's a "comes before" relation,
-not "comes after"). After the third commit, the history branches into two
-separate branches. This might correspond to, for example, two separate features
-being developed in parallel, independently from each other. In the future,
-these branches may be merged to create a new snapshot that incorporates both of
-the features, producing a new history that looks like this, with the newly
-created merge commit shown in bold:
+ಮೇಲಿನ ASCII art ನಲ್ಲಿ `o` ಗಳು ಪ್ರತ್ಯೇಕ commits (snapshots) ಗಳಿಗೆ ಹೊಂದುತ್ತವೆ.
+ಬಾಣಗಳು ಪ್ರತಿಯೊಂದು commit ನ parent ಕಡೆ ತೋರಿಸುತ್ತವೆ (ಇದು "comes before" ಸಂಬಂಧ, "comes after" ಅಲ್ಲ). ಮೂರನೇ commit ನಂತರ history ಎರಡು ಪ್ರತ್ಯೇಕ branches ಗಳಾಗಿ ವಿಭಜಿತವಾಗುತ್ತದೆ.
+ಇದು ಉದಾಹರಣೆಗೆ ಪರಸ್ಪರ ಸ್ವತಂತ್ರವಾಗಿ ಸಮಾಂತರವಾಗಿ ಅಭಿವೃದ್ಧಿಪಡಿಸಲಾಗುತ್ತಿರುವ ಎರಡು features ಗಳಿಗೆ ತಕ್ಕಂತೆ ಇರಬಹುದು. ಭವಿಷ್ಯದಲ್ಲಿ ಈ branches ಗಳನ್ನು merge ಮಾಡಿ ಎರಡೂ features ಒಳಗೊಂಡ ಹೊಸ snapshot ರಚಿಸಬಹುದು; ಆಗ history ಈ ಕೆಳಗಿನಂತಾಗುತ್ತದೆ, ಇಲ್ಲಿ ಹೊಸ merge commit ಅನ್ನು bold ನಲ್ಲಿ ತೋರಿಸಲಾಗಿದೆ:
 
 <pre class="highlight">
 <code>
@@ -121,14 +95,11 @@ o <-- o <-- o <-- o <---- <strong>o</strong>
 </code>
 </pre>
 
-Commits in Git are immutable. This doesn't mean that mistakes can't be
-corrected, however; it's just that "edits" to the commit history are actually
-creating entirely new commits, and references (see below) are updated to point
-to the new ones.
+Git ನಲ್ಲಿನ commits immutable. ಇದರಿಂದ ತಪ್ಪುಗಳನ್ನು ಸರಿಪಡಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ ಎಂಬ ಅರ್ಥವಲ್ಲ; commit history ಗೆ ಮಾಡುವ "edits" ಎಂದರೆ ವಾಸ್ತವವಾಗಿ ಸಂಪೂರ್ಣ ಹೊಸ commits ರಚಿಸುವುದು, ಮತ್ತು references (ಕೆಳಗೆ ನೋಡಿ) ಗಳನ್ನು ಹೊಸ commits ಕಡೆ ತೋರಿಸುವಂತೆ ಅಪ್ಡೇಟ್ ಮಾಡುವುದು.
 
-## Data model, as pseudocode
+## Pseudocode ರೂಪದಲ್ಲಿನ data model
 
-It may be instructive to see Git's data model written down in pseudocode:
+Git ನ data model ಅನ್ನು pseudocode ರೂಪದಲ್ಲಿ ನೋಡಿದರೆ ಉಪಯುಕ್ತವಾಗಬಹುದು:
 
 ```
 // a file is a bunch of bytes
@@ -146,18 +117,18 @@ type commit = struct {
 }
 ```
 
-It's a clean, simple model of history.
+ಇದು history ಯ ಸ್ವಚ್ಛ ಮತ್ತು ಸರಳ ಮಾದರಿ.
 
-## Objects and content-addressing
+## Objects ಮತ್ತು content-addressing
 
-An "object" is a blob, tree, or commit:
+"object" ಎಂದರೆ blob, tree, ಅಥವಾ commit:
 
 ```
 type object = blob | tree | commit
 ```
 
-In Git's data store, all objects are content-addressed by their [SHA-1
-hash](https://en.wikipedia.org/wiki/SHA-1).
+Git ನ data store ನಲ್ಲಿ ಎಲ್ಲಾ objects ಗಳಿಗೂ ಅವುಗಳ [SHA-1
+hash](https://en.wikipedia.org/wiki/SHA-1) ಆಧಾರಿತ content-addressing ಮಾಡಲಾಗುತ್ತದೆ.
 
 ```
 objects = map<string, object>
@@ -170,38 +141,32 @@ def load(id):
     return objects[id]
 ```
 
-Blobs, trees, and commits are unified in this way: they are all objects. When
-they reference other objects, they don't actually _contain_ them in their
-on-disk representation, but have a reference to them by their hash.
+Blobs, trees, ಮತ್ತು commits ಗಳನ್ನು ಈ ರೀತಿಯಲ್ಲಿ ಏಕೀಕರಿಸಲಾಗಿದೆ: ಅವೆಲ್ಲವೂ objects.
+ಅವು ಇತರ objects ಗಳನ್ನು ಸೂಚಿಸುವಾಗ, on-disk representation ನಲ್ಲಿ ಅವನ್ನು ನೇರವಾಗಿ _contain_ ಮಾಡುವುದಿಲ್ಲ; ಬದಲಾಗಿ ಅವುಗಳ hash ಮೂಲಕ reference ಇರುತ್ತದೆ.
 
-For example, the tree for the example directory structure [above](#snapshots)
-(visualized using `git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d`),
-looks like this:
+ಉದಾಹರಣೆಗೆ, ಮೇಲಿನ [example directory structure](#snapshots) ಗೆ ಹೊಂದುವ tree
+(`git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d` ಬಳಸಿ ದೃಶ್ಯೀಕರಿಸಿದರೆ),
+ಇಂತಿದೆ:
 
 ```
 100644 blob 4448adbf7ecd394f42ae135bbeed9676e894af85    baz.txt
 040000 tree c68d233a33c5c06e0340e4c224f0afca87c8ce87    foo
 ```
 
-The tree itself contains pointers to its contents, `baz.txt` (a blob) and `foo`
-(a tree). If we look at the contents addressed by the hash corresponding to
-baz.txt with `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85`, we get
-the following:
+tree ಸ್ವತಃ ತನ್ನ ಒಳಪರಿವಿಡಿಗಳಿಗೆ pointers ಇಟ್ಟುಕೊಂಡಿದೆ: `baz.txt` (ಒಂದು blob) ಮತ್ತು `foo`
+(ಒಂದು tree). `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85` ಮೂಲಕ baz.txt ಗೆ ಹೊಂದುವ hash ನ content ನೋಡಿದರೆ, ನಮಗೆ ಈ ಕೆಳಗಿನದು ಸಿಗುತ್ತದೆ:
 
 ```
 git is wonderful
 ```
 
-## References
+## References (ಉಲ್ಲೇಖಗಳು)
 
-Now, all snapshots can be identified by their SHA-1 hashes. That's inconvenient,
-because humans aren't good at remembering strings of 40 hexadecimal characters.
+ಈಗ ಎಲ್ಲ snapshots ಗಳನ್ನೂ ಅವುಗಳ SHA-1 hashes ಮೂಲಕ ಗುರುತಿಸಬಹುದು. ಆದರೆ ಇದು ಅಸೌಕರ್ಯಕರ, ಏಕೆಂದರೆ ಮಾನವರು 40 hexadecimal ಅಕ್ಷರಗಳ ಸರಣಿಯನ್ನು ಸುಲಭವಾಗಿ ನೆನಪಿಡಲಾಗುವುದಿಲ್ಲ.
 
-Git's solution to this problem is human-readable names for SHA-1 hashes, called
-"references". References are pointers to commits. Unlike objects, which are
-immutable, references are mutable (can be updated to point to a new commit).
-For example, the `master` reference usually points to the latest commit in the
-main branch of development.
+ಈ ಸಮಸ್ಯೆಗೆ Git ನೀಡುವ ಪರಿಹಾರ SHA-1 hashes ಗಳಿಗೆ human-readable ಹೆಸರುಗಳು - ಅವನ್ನು
+"references" ಎಂದು ಕರೆಯುತ್ತಾರೆ. References ಗಳು commits ಗೆ pointers.
+immutable ಆಗಿರುವ objects ಗೆ ವಿರುದ್ಧವಾಗಿ references mutable (ಹೊಸ commit ಕಡೆ point ಮಾಡುವಂತೆ ಅಪ್ಡೇಟ್ ಮಾಡಬಹುದು). ಉದಾಹರಣೆಗೆ, `master` reference ಸಾಮಾನ್ಯವಾಗಿ ಮುಖ್ಯ development branch ನ ಇತ್ತೀಚಿನ commit ಕಡೆ ತೋರಿಸುತ್ತದೆ.
 
 ```
 references = map<string, string>
@@ -219,214 +184,155 @@ def load_reference(name_or_id):
         return load(name_or_id)
 ```
 
-With this, Git can use human-readable names like "master" to refer to a
-particular snapshot in the history, instead of a long hexadecimal string.
+ಈ ಮೂಲಕ, Git ಉದ್ದವಾದ hexadecimal string ಬದಲು "master" ಹಾಗಿನ human-readable ಹೆಸರುಗಳನ್ನು ಬಳಸಿ history ಯಲ್ಲಿನ ನಿರ್ದಿಷ್ಟ snapshot ಅನ್ನು ಸೂಚಿಸಬಹುದು.
 
-One detail is that we often want a notion of "where we currently are" in the
-history, so that when we take a new snapshot, we know what it is relative to
-(how we set the `parents` field of the commit). In Git, that "where we
-currently are" is a special reference called "HEAD".
+ಒಂದು ಸೂಕ್ಷ್ಮ ಅಂಶವೇನೆಂದರೆ, history ಯಲ್ಲಿ "ನಾವು ಈಗ ಎಲ್ಲಿದ್ದೇವೆ" ಎಂಬ ಕಲ್ಪನೆ ಬೇಕಾಗುತ್ತದೆ, ಏಕೆಂದರೆ ಹೊಸ snapshot ತೆಗೆದಾಗ ಅದು ಯಾವದಕ್ಕೆ ಸಂಬಂಧಿತ ಎಂಬುದು ತಿಳಿದಿರಬೇಕು
+(commit ನ `parents` field ಹೇಗೆ ಸೆಟ್ ಮಾಡಬೇಕು ಎಂಬ ಅರ್ಥದಲ್ಲಿ). Git ನಲ್ಲಿ ಈ "ನಾವು ಈಗ ಎಲ್ಲಿದ್ದೇವೆ" ಎಂಬುದಕ್ಕೆ "HEAD" ಎಂಬ ವಿಶೇಷ reference ಇದೆ.
 
-## Repositories
+## Repositories (ಸಂಗ್ರಹಣೆಗಳು)
 
-Finally, we can define what (roughly) is a Git _repository_: it is the data
-`objects` and `references`.
+ಕೊನೆಯಲ್ಲಿ, Git _repository_ ಅನ್ನು (ಸರಳವಾಗಿ) ಹೀಗೆ ವ್ಯಾಖ್ಯಾನಿಸಬಹುದು: ಅದು
+`objects` ಮತ್ತು `references` ಎಂಬ data.
 
-On disk, all Git stores are objects and references: that's all there is to Git's
-data model. All `git` commands map to some manipulation of the commit DAG by
-adding objects and adding/updating references.
+ಡಿಸ್ಕ್ ಮೇಲೆ Git ಸಂಗ್ರಹಿಸುವುದೆಲ್ಲ objects ಮತ್ತು references ಮಾತ್ರ: Git ನ data model ಅಷ್ಟೇ. ಎಲ್ಲಾ `git` commands ಗಳು commit DAG ಮೇಲೆ ಯಾವುದೋ ಬದಲಾವಣೆಗೇ ನಕ್ಷೆಯಾಗುತ್ತವೆ - objects ಸೇರಿಸುವುದು ಮತ್ತು references ಸೇರಿಸುವುದು/ಅಪ್ಡೇಟ್ ಮಾಡುವುದು.
 
-Whenever you're typing in any command, think about what manipulation the
-command is making to the underlying graph data structure. Conversely, if you're
-trying to make a particular kind of change to the commit DAG, e.g. "discard
-uncommitted changes and make the 'master' ref point to commit `5d83f9e`", there's
-probably a command to do it (e.g. in this case, `git checkout master; git reset
+ನೀವು ಯಾವ command ಅನ್ನು ಟೈಪ್ ಮಾಡುತ್ತಿದ್ದರೂ, ಅದು underlying graph data structure ಮೇಲೆ ಯಾವ ರೀತಿಯ manipulation ಮಾಡುತ್ತಿದೆ ಎಂದು ಯೋಚಿಸಿ. ಅದೇ ರೀತಿಯಾಗಿ, commit DAG ನಲ್ಲಿ ನಿರ್ದಿಷ್ಟ ಬದಲಾವಣೆ ಮಾಡಲು ನೀವು ಯತ್ನಿಸುತ್ತಿದ್ದರೆ - ಉದಾಹರಣೆಗೆ "uncommitted changes ತಿರಸ್ಕರಿಸಿ 'master' ref ಅನ್ನು `5d83f9e` commit ಕಡೆ ತೋರಿಸುವಂತೆ ಮಾಡು" - ಅದಕ್ಕಾಗಿ command ಇದ್ದೇ ಇರುತ್ತದೆ (ಈ ಪ್ರಕರಣದಲ್ಲಿ `git checkout master; git reset
 --hard 5d83f9e`).
 
-# Staging area
+# Staging area (ಸ್ಥಗಿತ ಪ್ರದೇಶ)
 
-This is another concept that's orthogonal to the data model, but it's a part of
-the interface to create commits.
+ಇದು data model ಗೆ orthogonal ಆಗಿರುವ ಮತ್ತೊಂದು ಕಲ್ಪನೆ, ಆದರೆ commits ರಚಿಸಲು ಬಳಸುವ interface ನ ಮಹತ್ವದ ಭಾಗವಾಗಿದೆ.
 
-One way you might imagine implementing snapshotting as described above is to have
-a "create snapshot" command that creates a new snapshot based on the _current
-state_ of the working directory. Some version control tools work like this, but
-not Git. We want clean snapshots, and it might not always be ideal to make a
-snapshot from the current state. For example, imagine a scenario where you've
-implemented two separate features, and you want to create two separate commits,
-where the first introduces the first feature, and the next introduces the
-second feature. Or imagine a scenario where you have debugging print statements
-added all over your code, along with a bugfix; you want to commit the bugfix
-while discarding all the print statements.
+ಮೇಲೆ ವಿವರಿಸಿದ snapshotting ಅನ್ನು ಜಾರಿಗೆ ತರಲು ನೀವು ಕಲ್ಪಿಸಬಹುದಾದ ಒಂದು ವಿಧಾನ ಎಂದರೆ _current
+state_ of the working directory ಆಧಾರದ ಮೇಲೆ ಹೊಸ snapshot ರಚಿಸುವ "create snapshot" command ಇರುವುದು. ಕೆಲವು version control tools ಹೀಗೆ ಕೆಲಸ ಮಾಡುತ್ತವೆ, ಆದರೆ Git ಹೀಗೆ ಅಲ್ಲ. ನಮಗೆ clean snapshots ಬೇಕು, ಮತ್ತು ಪ್ರಸ್ತುತ ಸ್ಥಿತಿಯಿಂದ snapshot ತೆಗೆದುದು ಯಾವಾಗಲೂ ಸೂಕ್ತವಾಗದೇ ಇರಬಹುದು. ಉದಾಹರಣೆಗೆ, ನೀವು ಎರಡು ಪ್ರತ್ಯೇಕ features ಜಾರಿಗೆ ತಂದಿದ್ದೀರಿ, ಆದರೆ ಎರಡು ಪ್ರತ್ಯೇಕ commits ರಚಿಸಲು ಬಯಸುತ್ತೀರಿ - ಮೊದಲ commit ಮೊದಲ feature ಅನ್ನು, ಮುಂದಿನ commit ಎರಡನೇ feature ಅನ್ನು ಪರಿಚಯಿಸುವಂತೆ. ಅಥವಾ ನೀವು bugfix ಜೊತೆಗೆ ಕೋಡ್ ತುಂಬೆಲ್ಲ debugging print statements ಸೇರಿಸಿದ್ದೀರಿ ಎಂದು ಕಲ್ಪಿಸಿ; ನೀವು print statements ಗಳನ್ನು ಬಿಟ್ಟು, bugfix ಮಾತ್ರ commit ಮಾಡಲು ಬಯಸಬಹುದು.
 
-Git accommodates such scenarios by allowing you to specify which modifications
-should be included in the next snapshot through a mechanism called the "staging
-area".
+Git ಇಂತಹ ಸಂದರ್ಭಗಳಿಗೆ ಹೊಂದಿಕೊಳ್ಳಲು, "staging
+area" ಎಂಬ ಯಾಂತ್ರಿಕತೆಯ ಮೂಲಕ ಮುಂದಿನ snapshot ನಲ್ಲಿ ಯಾವ modifications ಒಳಗೊಳ್ಳಬೇಕು ಎಂದು ನೀವು ಸ್ಪಷ್ಟವಾಗಿ ಸೂಚಿಸಲು ಅವಕಾಶ ನೀಡುತ್ತದೆ.
 
-# Git command-line interface
+# Git command-line interface (ಆಜ್ಞಾ-ಸಾಲು ಅಂತರ್ಮುಖ)
 
-To avoid duplicating information, we're not going to explain the commands below
-in detail in these lecture notes. See the highly recommended [Pro
-Git](https://git-scm.com/book/en/v2) for more information, or watch the lecture
-video.
+ಮಾಹಿತಿಯ ಪುನರಾವರ್ತನೆ ತಪ್ಪಿಸಲು, ಕೆಳಗಿನ commands ಗಳನ್ನು ಈ lecture notes ನಲ್ಲಿ ನಾವು ವಿವರವಾಗಿ ವಿವರಿಸುವುದಿಲ್ಲ. ಹೆಚ್ಚಿನ ಮಾಹಿತಿಗಾಗಿ ಬಲವಾಗಿ ಶಿಫಾರಸು ಮಾಡಲ್ಪಟ್ಟ [Pro
+Git](https://git-scm.com/book/en/v2) ನೋಡಿ, ಅಥವಾ lecture ವಿಡಿಯೋ ವೀಕ್ಷಿಸಿ.
 
-## Basics
+## ಮೂಲಭೂತಾಂಶಗಳು
 
-- `git help <command>`: get help for a git command
-- `git init`: creates a new git repo, with data stored in the `.git` directory
-- `git status`: tells you what's going on
-- `git add <filename>`: adds files to staging area
-- `git commit`: creates a new commit
-    - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)!
-    - Even more reasons to write [good commit messages](https://chris.beams.io/posts/git-commit/)!
-- `git log`: shows a flattened log of history
-- `git log --all --graph --decorate`: visualizes history as a DAG
-- `git diff <filename>`: show changes you made relative to the staging area
-- `git diff <revision> <filename>`: shows differences in a file between snapshots
-- `git checkout <revision>`: updates HEAD (and current branch if checking out a branch)
+- `git help <command>`: git command ಒಂದಕ್ಕೆ ಸಹಾಯ ಪಡೆಯಿರಿ
+- `git init`: ಹೊಸ git repo ರಚಿಸುತ್ತದೆ; data `.git` directory ಯಲ್ಲಿ ಸಂಗ್ರಹವಾಗುತ್ತದೆ
+- `git status`: ಈಗ ಏನು ನಡೆಯುತ್ತಿದೆ ಎಂಬುದನ್ನು ತಿಳಿಸುತ್ತದೆ
+- `git add <filename>`: files ಅನ್ನು staging area ಗೆ ಸೇರಿಸುತ್ತದೆ
+- `git commit`: ಹೊಸ commit ರಚಿಸುತ್ತದೆ
+    - [ಉತ್ತಮ commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) ಬರೆಯಿರಿ!
+    - [ಉತ್ತಮ commit messages](https://chris.beams.io/posts/git-commit/) ಬರೆಯಲು ಇನ್ನೂ ಹೆಚ್ಚು ಕಾರಣಗಳು!
+- `git log`: history ಯ flattened log ಅನ್ನು ತೋರಿಸುತ್ತದೆ
+- `git log --all --graph --decorate`: history ಯನ್ನು DAG ರೂಪದಲ್ಲಿ ದೃಶ್ಯೀಕರಿಸುತ್ತದೆ
+- `git diff <filename>`: staging area ಗೆ ಸಂಬಂಧಿಸಿದಂತೆ ನೀವು ಮಾಡಿದ ಬದಲಾವಣೆಗಳನ್ನು ತೋರಿಸುತ್ತದೆ
+- `git diff <revision> <filename>`: snapshots ನಡುವೆ file ನ ವ್ಯತ್ಯಾಸಗಳನ್ನು ತೋರಿಸುತ್ತದೆ
+- `git checkout <revision>`: HEAD ಅನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡುತ್ತದೆ (branch checkout ಮಾಡಿದರೆ current branch ನ್ನೂ)
 
-## Branching and merging
+## Branching ಮತ್ತು merging
 
-- `git branch`: shows branches
-- `git branch <name>`: creates a branch
-- `git switch <name>`: switches to a branch
-- `git checkout -b <name>`: creates a branch and switches to it
-    - same as `git branch <name>; git switch <name>`
-- `git merge <revision>`: merges into current branch
-- `git mergetool`: use a fancy tool to help resolve merge conflicts
-- `git rebase`: rebase set of patches onto a new base
+- `git branch`: branches ತೋರಿಸುತ್ತದೆ
+- `git branch <name>`: branch ರಚಿಸುತ್ತದೆ
+- `git switch <name>`: branch ಗೆ ಸ್ವಿಚ್ ಆಗುತ್ತದೆ
+- `git checkout -b <name>`: branch ರಚಿಸಿ ಅದಕ್ಕೆ ಸ್ವಿಚ್ ಆಗುತ್ತದೆ
+    - `git branch <name>; git switch <name>` ಗೆ ಸಮಾನ
+- `git merge <revision>`: current branch ಗೆ merge ಮಾಡುತ್ತದೆ
+- `git mergetool`: merge conflicts ಪರಿಹರಿಸಲು ಸಹಾಯಕವಾದ advanced tool ಬಳಸುತ್ತದೆ
+- `git rebase`: patches ಗಳ ಸಮೂಹವನ್ನು ಹೊಸ base ಮೇಲೆ rebase ಮಾಡುತ್ತದೆ
 
-## Remotes
+## Remotes (ದೂರದ ಸಂಗ್ರಹಣೆಗಳು)
 
-- `git remote`: list remotes
-- `git remote add <name> <url>`: add a remote
-- `git push <remote> <local branch>:<remote branch>`: send objects to remote, and update remote reference
-- `git branch --set-upstream-to=<remote>/<remote branch>`: set up correspondence between local and remote branch
-- `git fetch`: retrieve objects/references from a remote
-- `git pull`: same as `git fetch; git merge`
-- `git clone`: download repository from remote
+- `git remote`: remotes ಪಟ್ಟಿಮಾಡುತ್ತದೆ
+- `git remote add <name> <url>`: remote ಸೇರಿಸುತ್ತದೆ
+- `git push <remote> <local branch>:<remote branch>`: objects ಅನ್ನು remote ಗೆ ಕಳುಹಿಸಿ, remote reference ಅಪ್ಡೇಟ್ ಮಾಡುತ್ತದೆ
+- `git branch --set-upstream-to=<remote>/<remote branch>`: local ಮತ್ತು remote branch ನಡುವಿನ ಹೊಂದಾಣಿಕೆ ಸೆಟ್ ಮಾಡುತ್ತದೆ
+- `git fetch`: remote ನಿಂದ objects/references ಅನ್ನು ಪಡೆಯುತ್ತದೆ
+- `git pull`: `git fetch; git merge` ಗೆ ಸಮಾನ
+- `git clone`: remote ನಿಂದ repository ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತದೆ
 
-## Undo
+## Undo (ಹಿಂತಿರುಗಿಸುವುದು)
 
-- `git commit --amend`: edit a commit's contents/message
-- `git reset <file>`: unstage a file
-- `git restore`: discard changes
+- `git commit --amend`: commit ನ contents/message ಸಂಪಾದಿಸುತ್ತದೆ
+- `git reset <file>`: file ಅನ್ನು unstage ಮಾಡುತ್ತದೆ
+- `git restore`: ಬದಲಾವಣೆಗಳನ್ನು ತಿರಸ್ಕರಿಸುತ್ತದೆ
 
-# Advanced Git
+# ಉನ್ನತ Git
 
-- `git config`: Git is [highly customizable](https://git-scm.com/docs/git-config)
-- `git clone --depth=1`: shallow clone, without entire version history
+- `git config`: Git [ಅತ್ಯಂತ ಕಸ್ಟಮೈಸ್ ಮಾಡಬಹುದಾದ](https://git-scm.com/docs/git-config) ವ್ಯವಸ್ಥೆ
+- `git clone --depth=1`: ಸಂಪೂರ್ಣ version history ಇಲ್ಲದೆ shallow clone
 - `git add -p`: interactive staging
 - `git rebase -i`: interactive rebasing
-- `git blame`: show who last edited which line
-- `git stash`: temporarily remove modifications to working directory
-- `git bisect`: binary search history (e.g. for regressions)
-- `git revert`: create a new commit that reverses the effect of an earlier commit
-- `git worktree`: check out multiple branches at the same time
-- `.gitignore`: [specify](https://git-scm.com/docs/gitignore) intentionally untracked files to ignore
+- `git blame`: ಕೊನೆಯಾಗಿ ಯಾವ line ಅನ್ನು ಯಾರು ಸಂಪಾದಿಸಿದ್ದಾರೆ ಎಂಬುದನ್ನು ತೋರಿಸುತ್ತದೆ
+- `git stash`: working directory ಯಲ್ಲಿನ modifications ಅನ್ನು ತಾತ್ಕಾಲಿಕವಾಗಿ ತೆಗೆದುಹಾಕುತ್ತದೆ
+- `git bisect`: history ಯಲ್ಲಿ binary search (ಉದಾ: regressions ಗಾಗಿ)
+- `git revert`: ಹಿಂದಿನ commit ನ ಪರಿಣಾಮವನ್ನು ಹಿಂದಿರುಗಿಸುವ ಹೊಸ commit ರಚಿಸುತ್ತದೆ
+- `git worktree`: ಒಂದೇ ಸಮಯದಲ್ಲಿ ಅನೇಕ branches checkout ಮಾಡುತ್ತದೆ
+- `.gitignore`: ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ untracked ಆಗಿರುವ ಯಾವ files ಅನ್ನು ನಿರ್ಲಕ್ಷಿಸಬೇಕು ಎಂದು [ನಿರ್ದಿಷ್ಟಪಡಿಸಿ](https://git-scm.com/docs/gitignore)
 
-# Miscellaneous
+# ಇತರೆ ವಿಷಯಗಳು
 
-- **GUIs**: there are many [GUI clients](https://git-scm.com/downloads/guis)
-out there for Git. We personally don't use them and use the command-line
-interface instead.
-- **Shell integration**: it's super handy to have a Git status as part of your
-shell prompt ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
-[bash](https://github.com/magicmonty/bash-git-prompt)). Often included in
-frameworks like [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
-- **Editor integration**: similarly to the above, handy integrations with many
-features. [fugitive.vim](https://github.com/tpope/vim-fugitive) is the standard
-one for Vim.
-- **Workflows**: we taught you the data model, plus some basic commands; we
-didn't tell you what practices to follow when working on big projects (and
-there are [many](https://nvie.com/posts/a-successful-git-branching-model/)
-[different](https://www.endoflineblog.com/gitflow-considered-harmful)
-[approaches](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)).
-- **GitHub**: Git is not GitHub. GitHub has a specific way of contributing code
-to other projects, called [pull
-requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
-- **Other Git providers**: GitHub is not special: there are many Git repository
-hosts, like [GitLab](https://about.gitlab.com/) and
-[BitBucket](https://bitbucket.org/).
+- **GUIs**: Git ಗಾಗಿ ಅನೇಕ [GUI clients](https://git-scm.com/downloads/guis)
+ಲಭ್ಯವಿವೆ. ನಾವು ವೈಯಕ್ತಿಕವಾಗಿ ಅವನ್ನು ಬಳಸುವುದಿಲ್ಲ; ಬದಲಿಗೆ command-line
+interface ನ್ನೇ ಬಳಸುತ್ತೇವೆ.
+- **Shell integration**: ನಿಮ್ಮ shell prompt ನಲ್ಲಿ Git status ಕಾಣುವುದು ಬಹಳ ಉಪಯುಕ್ತ ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
+[bash](https://github.com/magicmonty/bash-git-prompt)). ಸಾಮಾನ್ಯವಾಗಿ [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh) ತರದ frameworks ಗಳಲ್ಲಿ ಒಳಗೊಂಡಿರುತ್ತದೆ.
+- **Editor integration**: ಮೇಲಿನಂತೆಯೇ, ಅನೇಕ ವೈಶಿಷ್ಟ್ಯಗಳೊಂದಿಗೆ ಸುಲಭ integrations ಲಭ್ಯ. Vim ಗಾಗಿ [fugitive.vim](https://github.com/tpope/vim-fugitive) ಮಾನದಂಡದ plugin.
+- **Workflows**: ನಾವು ನಿಮಗೆ data model ಮತ್ತು ಕೆಲವು basic commands ಕಲಿಸಿದ್ದೇವೆ; ಆದರೆ ದೊಡ್ಡ projects ಮೇಲೆ ಕೆಲಸ ಮಾಡುವಾಗ ಯಾವ ಅಭ್ಯಾಸಗಳನ್ನು ಅನುಸರಿಸಬೇಕು ಎಂದು ಹೇಳಿಲ್ಲ (ಮತ್ತು [ಹಲವಾರು](https://nvie.com/posts/a-successful-git-branching-model/)
+[ಬೇರೆ](https://www.endoflineblog.com/gitflow-considered-harmful)
+[ವಿಧಾನಗಳು](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) ಇವೆ).
+- **GitHub**: Git ಅಂದರೆ GitHub ಅಲ್ಲ. GitHub ನಲ್ಲಿ ಇತರ projects ಗೆ code ಕೊಡುಗೆ ನೀಡಲು [pull
+requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) ಎಂಬ ನಿರ್ದಿಷ್ಟ ವಿಧಾನವಿದೆ.
+- **Other Git providers**: GitHub ವಿಶಿಷ್ಟವಲ್ಲ: [GitLab](https://about.gitlab.com/) ಮತ್ತು
+[BitBucket](https://bitbucket.org/) ಮುಂತಾದ ಅನೇಕ Git repository hosts ಇವೆ.
 
-# Resources
+# ಸಂಪನ್ಮೂಲಗಳು
 
-- [Pro Git](https://git-scm.com/book/en/v2) is **highly recommended reading**.
-Going through Chapters 1--5 should teach you most of what you need to use Git
-proficiently, now that you understand the data model. The later chapters have
-some interesting, advanced material.
-- [Oh Shit, Git!?!](https://ohshitgit.com/) is a short guide on how to recover
-from some common Git mistakes.
+- [Pro Git](https://git-scm.com/book/en/v2) ಓದುವುದು **ಬಲವಾಗಿ ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ**.
+Chapters 1--5 ಓದಿದರೆ, ಈಗ ನೀವು data model ಅನ್ನು ಅರ್ಥಮಾಡಿಕೊಂಡಿರುವುದರಿಂದ, Git ಅನ್ನು ನಿಪುಣವಾಗಿ ಬಳಸಲು ಅಗತ್ಯವಿರುವ ಬಹುತೇಕ ವಿಷಯ ಕಲಿಯಬಹುದು. ನಂತರದ ಅಧ್ಯಾಯಗಳಲ್ಲಿ ಆಸಕ್ತಿದಾಯಕ advanced ವಿಷಯಗಳಿವೆ.
+- [Oh Shit, Git!?!](https://ohshitgit.com/) ಕೆಲವು ಸಾಮಾನ್ಯ Git ತಪ್ಪುಗಳಿಂದ ಹೇಗೆ ಹೊರಬರಬೇಕು ಎಂಬುದರ ಚಿಕ್ಕ ಮಾರ್ಗದರ್ಶಿ.
 - [Git for Computer
-Scientists](https://eagain.net/articles/git-for-computer-scientists/) is a
-short explanation of Git's data model, with less pseudocode and more fancy
-diagrams than these lecture notes.
+Scientists](https://eagain.net/articles/git-for-computer-scientists/) ಈ lecture notes ಗಿಂತ ಕಡಿಮೆ pseudocode ಮತ್ತು ಹೆಚ್ಚು ದೃಶ್ಯಾತ್ಮಕ diagrams ಗಳೊಂದಿಗೆ Git ನ data model ಗೆ ಚಿಕ್ಕ ವಿವರಣೆ ನೀಡುತ್ತದೆ.
 - [Git from the Bottom Up](https://jwiegley.github.io/git-from-the-bottom-up/)
-is a detailed explanation of Git's implementation details beyond just the data
-model, for the curious.
+data model ಕ್ಕಿಂತ ಮೀರಿ Git implementation ವಿವರಗಳನ್ನು ಕುತೂಹಲವುಳ್ಳವರಿಗಾಗಿ ಸವಿಸ್ತಾರವಾಗಿ ವಿವರಿಸುತ್ತದೆ.
 - [How to explain git in simple
 words](https://smusamashah.github.io/blog/2017/10/14/explain-git-in-simple-words)
-- [Learn Git Branching](https://learngitbranching.js.org/) is a browser-based
-game that teaches you Git.
+- [Learn Git Branching](https://learngitbranching.js.org/) Git ಕಲಿಸುವ browser ಆಧಾರಿತ game.
 
-# Exercises
+# ಅಭ್ಯಾಸಗಳು
 
-1. If you don't have any past experience with Git, either try reading the first
-   couple chapters of [Pro Git](https://git-scm.com/book/en/v2) or go through a
-   tutorial like [Learn Git Branching](https://learngitbranching.js.org/). As
-   you're working through it, relate Git commands to the data model.
-1. Clone the [repository for the
-class website](https://github.com/missing-semester/missing-semester).
-    1. Explore the version history by visualizing it as a graph.
-    1. Who was the last person to modify `README.md`? (Hint: use `git log` with
-       an argument).
-    1. What was the commit message associated with the last modification to the
-       `collections:` line of `_config.yml`? (Hint: use `git blame` and `git
-       show`).
-1. One common mistake when learning Git is to commit large files that should
-   not be managed by Git or adding sensitive information. Try adding a file to
-   a repository, making some commits and then deleting that file from _history_
-   (not just the latest commit). You may want to look at
-   [this](https://help.github.com/articles/removing-sensitive-data-from-a-repository/).
-1. Clone some repository from GitHub, and modify one of its existing files.
-   What happens when you do `git stash`? What do you see when running `git log
-   --all --oneline`? Run `git stash pop` to undo what you did with `git stash`.
-   In what scenario might this be useful?
-1. Like many command line tools, Git provides a configuration file (or dotfile)
-   called `~/.gitconfig`. Create an alias in `~/.gitconfig` so that when you
-   run `git graph`, you get the output of `git log --all --graph --decorate
-   --oneline`. You can do this by directly
+1. ನಿಮಗೆ Git ಬಗ್ಗೆ ಹಿಂದಿನ ಅನುಭವವಿಲ್ಲದಿದ್ದರೆ, [Pro Git](https://git-scm.com/book/en/v2) ನ ಮೊದಲ ಕೆಲವು ಅಧ್ಯಾಯಗಳನ್ನು ಓದಿ ಅಥವಾ [Learn Git Branching](https://learngitbranching.js.org/) ರೀತಿಯ tutorial ಪೂರ್ಣಗೊಳಿಸಿ. ನೀವು ಮುಂದುವರಿಯುವಂತೆ, Git commands ಗಳನ್ನು data model ಜೊತೆಗೆ ಸಂಬಂಧಿಸಿ ನೋಡಿ.
+1. [ಕ್ಲಾಸ್ ವೆಬ್‌ಸೈಟ್ repository](https://github.com/missing-semester/missing-semester) ಅನ್ನು clone ಮಾಡಿ.
+    1. version history ಅನ್ನು graph ರೂಪದಲ್ಲಿ ದೃಶ್ಯೀಕರಿಸಿ ಅನ್ವೇಷಿಸಿ.
+    1. `README.md` ಅನ್ನು ಕೊನೆಯಾಗಿ ಪರಿಷ್ಕರಿಸಿದ ವ್ಯಕ್ತಿ ಯಾರು? (ಸುಳಿವು: `git log` ಅನ್ನು argument ಜೊತೆಗೆ ಬಳಸಿ).
+    1. `_config.yml` ನ `collections:` line ಗೆ ಸಂಬಂಧಿಸಿದ ಕೊನೆಯ ಬದಲಾವಣೆಯ commit message ಏನು? (ಸುಳಿವು: `git blame` ಮತ್ತು `git
+       show` ಬಳಸಿ).
+1. Git ಕಲಿಯುವಾಗ ಸಾಮಾನ್ಯ ತಪ್ಪೊಂದೇನೆಂದರೆ Git ಮೂಲಕ ನಿರ್ವಹಿಸಬಾರದ ದೊಡ್ಡ files ಅನ್ನು commit ಮಾಡುವುದು ಅಥವಾ sensitive ಮಾಹಿತಿಯನ್ನು ಸೇರಿಸುವುದು. repository ಗೆ ಒಂದು file ಸೇರಿಸಿ, ಕೆಲವು commits ಮಾಡಿ, ನಂತರ ಆ file ಅನ್ನು _history_ ಯಿಂದ ಅಳಿಸಿ (ಇತ್ತೀಚಿನ commit ನಿಂದ ಮಾತ್ರವಲ್ಲ). ನೀವು
+   [ಇದನ್ನು](https://help.github.com/articles/removing-sensitive-data-from-a-repository/) ನೋಡಬಹುದು.
+1. GitHub ನಿಂದ ಯಾವುದಾದರೂ repository clone ಮಾಡಿ, ಅದರಲ್ಲಿನ ಇರುವ file ಒಂದನ್ನು ಪರಿಷ್ಕರಿಸಿ.
+   `git stash` ಮಾಡಿದಾಗ ಏನಾಗುತ್ತದೆ? `git log
+   --all --oneline` ಚಾಲನೆ ಮಾಡಿದಾಗ ಏನು ಕಾಣುತ್ತದೆ? `git stash` ಮೂಲಕ ಮಾಡಿದುದನ್ನು ಹಿಂತಿರುಗಿಸಲು `git stash pop` ಚಾಲನೆ ಮಾಡಿ.
+   ಇದು ಯಾವ ಸಂದರ್ಭದಲ್ಲಿ ಉಪಯುಕ್ತವಾಗಬಹುದು?
+1. ಅನೇಕ command line tools ಗಳಂತೆ, Git ಕೂಡ `~/.gitconfig` ಎಂಬ configuration file (ಅಥವಾ dotfile) ಒದಗಿಸುತ್ತದೆ. `~/.gitconfig` ನಲ್ಲಿ alias ರಚಿಸಿ, ನೀವು `git graph` ಓಡಿಸಿದಾಗ `git log --all --graph --decorate
+   --oneline` ಔಟ್‌ಪುಟ್ ಸಿಗುವಂತೆ ಮಾಡಿ. ಇದನ್ನು ನೇರವಾಗಿ `~/.gitconfig` file ಅನ್ನು
    [editing](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias)
-   the `~/.gitconfig` file, or you can use the `git config` command to add the
-   alias. Information about git aliases can be found
-   [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
-1. You can define global ignore patterns in `~/.gitignore_global` after running
-   `git config --global core.excludesfile ~/.gitignore_global`. This sets the
-   location of the global ignore file that Git will use, but you still need to
-   manually create the file at that path. Set up your global gitignore file to
-   ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
-1. Fork the [repository for the class
-   website](https://github.com/missing-semester/missing-semester), find a typo
-   or some other improvement you can make, and submit a pull request on GitHub
-   (you may want to look at [this](https://github.com/firstcontributions/first-contributions)).
-   Please only submit PRs that are useful (don't spam us, please!). If you
-   can't find an improvement to make, you can skip this exercise.
-1. Practice resolving merge conflicts by simulating a collaborative scenario:
-    1. Create a new repository with `git init` and create a file called
-       `recipe.txt` with a few lines (e.g., a simple recipe).
-    1. Commit it, then create two branches: `git branch salty` and `git branch
+   ಮಾಡುವ ಮೂಲಕ ಅಥವಾ alias ಸೇರಿಸಲು `git config` command ಬಳಸಿ ಮಾಡಬಹುದು. git aliases ಬಗ್ಗೆ ಮಾಹಿತಿ
+   [ಇಲ್ಲಿ](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) ಲಭ್ಯ.
+1. `git config --global core.excludesfile ~/.gitignore_global` ಚಾಲನೆ ಮಾಡಿದ ನಂತರ, `~/.gitignore_global` ನಲ್ಲಿ global ignore patterns ವ್ಯಾಖ್ಯಾನಿಸಬಹುದು. ಇದು Git ಬಳಸುವ global ignore file ನ ಸ್ಥಳವನ್ನು ಸೆಟ್ ಮಾಡುತ್ತದೆ, ಆದರೆ ಆ path ನಲ್ಲಿ file ಅನ್ನು ನೀವು ಕೈಯಾರೆ ರಚಿಸಬೇಕು. ನಿಮ್ಮ global gitignore file ಅನ್ನು `.DS_Store` ತರದ OS-specific ಅಥವಾ editor-specific temporary files ಅನ್ನು ignore ಮಾಡುವಂತೆ ಸಿದ್ಧಗೊಳಿಸಿ.
+1. [ಕ್ಲಾಸ್ ವೆಬ್‌ಸೈಟ್ repository](https://github.com/missing-semester/missing-semester) ಅನ್ನು fork ಮಾಡಿ, typo ಅಥವಾ ಇತರ ಸುಧಾರಣೆ ಒಂದನ್ನು ಕಂಡುಹಿಡಿದು, GitHub ನಲ್ಲಿ pull request ಸಲ್ಲಿಸಿ
+   (ನೀವು [ಇದನ್ನು](https://github.com/firstcontributions/first-contributions) ನೋಡಬಹುದು).
+   ದಯವಿಟ್ಟು ಉಪಯುಕ್ತ PRs ಮಾತ್ರ ಸಲ್ಲಿಸಿ (ದಯವಿಟ್ಟು spam ಮಾಡಬೇಡಿ). ಸುಧಾರಣೆ ಕಂಡುಬರದಿದ್ದರೆ ಈ exercise ಅನ್ನು ಬಿಡಬಹುದು.
+1. ಸಹಕಾರಾತ್ಮಕ ಪರಿಸ್ಥಿತಿಯನ್ನು ಅನುಕರಿಸಿ merge conflicts ಪರಿಹರಿಸುವ ಅಭ್ಯಾಸ ಮಾಡಿ:
+    1. `git init` ಮೂಲಕ ಹೊಸ repository ರಚಿಸಿ ಮತ್ತು ಕೆಲವು lines ಹೊಂದಿರುವ `recipe.txt` file ರಚಿಸಿ (ಉದಾ: ಸರಳ recipe).
+    1. ಅದನ್ನು commit ಮಾಡಿ, ನಂತರ ಎರಡು branches ರಚಿಸಿ: `git branch salty` ಮತ್ತು `git branch
        sweet`.
-    1. In the `salty` branch, modify a line (e.g., change "1 cup sugar" to "1
-       cup salt") and commit.
-    1. In the `sweet` branch, modify the same line differently (e.g., change "1
-       cup sugar" to "2 cups sugar") and commit.
-    1. Now switch to `master` and try `git merge salty`, then `git merge
-       sweet`. What happens? Look at the contents of `recipe.txt` - what do the
-       `<<<<<<<`, `=======`, and `>>>>>>>` markers mean?
-    1. Resolve the conflict by editing the file to keep the content you want,
-       removing the conflict markers, and completing the merge with `git add`
-       and `git commit` (or `git merge --continue`). Alternatively, try using
-       `git mergetool` to resolve the conflict with a graphical or
-       terminal-based merge tool.
-    1. Use `git log --graph --oneline` to visualize the merge history you just
-       created.
+    1. `salty` branch ನಲ್ಲಿ ಒಂದು line ಪರಿಷ್ಕರಿಸಿ (ಉದಾ: "1 cup sugar" ಅನ್ನು "1
+       cup salt" ಎಂದು ಬದಲಿಸಿ) ಮತ್ತು commit ಮಾಡಿ.
+    1. `sweet` branch ನಲ್ಲಿ ಅದೇ line ಅನ್ನು ಬೇರೆ ರೀತಿಯಲ್ಲಿ ಪರಿಷ್ಕರಿಸಿ (ಉದಾ: "1
+       cup sugar" ಅನ್ನು "2 cups sugar" ಎಂದು ಬದಲಿಸಿ) ಮತ್ತು commit ಮಾಡಿ.
+    1. ಈಗ `master` ಗೆ switch ಆಗಿ `git merge salty`, ನಂತರ `git merge
+       sweet` ಪ್ರಯತ್ನಿಸಿ. ಏನಾಗುತ್ತದೆ? `recipe.txt` ಯ ವಿಷಯವನ್ನು ನೋಡಿ -
+       `<<<<<<<`, `=======`, ಮತ್ತು `>>>>>>>` markers ಗಳ ಅರ್ಥವೇನು?
+    1. ನೀವು ಬಯಸುವ content ಉಳಿಯುವಂತೆ file ಸಂಪಾದಿಸಿ conflict ಪರಿಹರಿಸಿ,
+       conflict markers ತೆಗೆದುಹಾಕಿ, ಮತ್ತು `git add`
+       ಹಾಗೂ `git commit` (ಅಥವಾ `git merge --continue`) ಮೂಲಕ merge ಪೂರ್ಣಗೊಳಿಸಿ. ಪರ್ಯಾಯವಾಗಿ, graphical ಅಥವಾ terminal-based merge tool ಬಳಸಿಕೊಂಡು conflict ಪರಿಹರಿಸಲು `git mergetool` ಪ್ರಯತ್ನಿಸಿ.
+    1. ನೀವು ಇಷ್ಟೇ ರಚಿಸಿದ merge history ಅನ್ನು ದೃಶ್ಯೀಕರಿಸಲು `git log --graph --oneline` ಬಳಸಿ.


### PR DESCRIPTION
- Translated all files in _2026/ to Kannada (formal academic style), preserving markdown structure, code blocks, links, and front matter metadata fields.  
- Scope intentionally limited to _2026 content only; top-level pages and other years were not changed.  
- Local validation completed with Jekyll build.


####  Index page ss from local build
<img width="867" height="782" alt="index" src="https://github.com/user-attachments/assets/2114a00b-fc8b-4cce-9876-0b17af3445a3" />


#### Lecture 02 area ss
<img width="851" height="845" alt="lec-02" src="https://github.com/user-attachments/assets/97db4022-a28f-4efc-841f-4c80f038d9b8" />



