### PR TITLE
Add Kannada translation site

### DIFF
--- a/index.md
+++ b/index.md
@@ -102,6 +102,7 @@ benefit from these resources. You can find posts and discussion on
 - [German](https://missing-semester-de.github.io/)
 - [Italian](https://missing-semester-it.github.io/)
 - [Japanese](https://missing-semester-jp.github.io/)
+- [Kannada](https://missing-semester-kn.github.io/)
 - [Korean](https://missing-semester-kr.github.io/)
 - [Persian](https://missing-semester-fa.github.io/)
 - [Portuguese](https://missing-semester-pt.github.io/)


### PR DESCRIPTION
This PR adds the Kannada translation link to the Translations list on the homepage.
- Translation site: https://missing-semester-kn.github.io/
- Scope of translation currently hosted: 2026 lectures
- Translation source repo: https://github.com/missing-semester-kn/missing-semester-kn.github.io