### PR TITLE
Fix quoting for file existence check in script

### DIFF
--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -33,7 +33,7 @@ In contrast, shell scripts can look quite different at first glance.
 ```shell
 #!/usr/bin/env bash
 
-if [[ -f $1 ]]; then
+if [[ -f "$1" ]]; then
     echo "Target file already exists"
     exit 1
 else


### PR DESCRIPTION
### Description
This PR improves the robustness of the bash script by quoting variable expansions (e.g., "$1").

### Why this change?
**Quoting variables:** Previously, `$1` was unquoted. If a filename contains spaces or special characters, the script would fail or behave unexpectedly due to word splitting. Quoting variables is a best practice in bash scripting.

This change aligns the example code with standard shell scripting best practices.