### PR TITLE
Fix greet CLI

### DIFF
--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -209,7 +209,7 @@ description = "A simple greeting library"
 dependencies = ["typer>=0.9"]
 
 [project.scripts]
-greet = "greeting:main"
+greet = "greeting:cli"
 
 [build-system]
 requires = ["setuptools>=61.0"]
@@ -228,12 +228,12 @@ def greet(name: str) -> str:
     return f"Hello, {name}!"
 
 
-def main(name: str):
-    print(greet(name))
+def cli():
+    typer.run(greet)
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    cli()
 ```
 
 With this file, we can now build the wheel:


### PR DESCRIPTION
The handout and video demo differ: the handout calls Typer.run inside an if name == "__main__" block, while the package's console_scripts entry point currently points to greeting:main. That causes the installed script to call main() directly (without typer.run()) and fail due to the missing name argument.