### PR TITLE
Use modern Docker Compose CLI ("docker compose") in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you'd prefer to develop the site in a Docker container (e.g., to avoid
 having to install Ruby and dependencies on your host machine), run:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 Then, navigate to <http://localhost:4000> on your host machine to view the


### PR DESCRIPTION
Please update the README to use the modern Docker Compose CLI command (docker compose) instead of the legacy docker-compose binary.
- docker compose (Compose V2) is the current recommended command, provided as a docker CLI subcommand and supported on recent Docker Desktop and Engine releases.
- It offers better integration with Docker BuildKit, improved performance, and additional features compared with the old docker-compose.
- Using docker compose in the README reduces confusion for new users and encourages best practices; users on older systems can still run docker-compose if needed.
