### PR TITLE
Fix two typos in Lecture 2 exercises

### DIFF
--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -861,7 +861,7 @@ polo() {
 
     n=$(( RANDOM % 100 ))
 
-    if [[ n -eq 42 ]]; then
+    if [[ $n -eq 42 ]]; then
        echo "Something went wrong"
        >&2 echo "The error was using magic numbers"
        exit 1
@@ -886,7 +886,7 @@ cat out.txt
 
 ## Signals and Job Control
 
-1. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-af` flags).
+1. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-lf` flags).
 
 1. Say you don't want to start a process until another completes. How would you go about it? In this exercise, our limiting process will always be `sleep 60 &`. One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command. Try launching the sleep command and having an `ls` wait until the background process finishes.
 


### PR DESCRIPTION
two typos:

In Lecture 2 → Exercises → Return Codes, Question 1, the script appears to contain:
"if [[ n -eq 42 ]]; then"
Should this instead be:
"if [[ $n -eq 42 ]]; then"
Otherwise, it seems that n is treated literally rather than as the variable

In Lecture 2 → Signals and Job Control, Question 1, the hint suggests using -af. I tried that but it did not work on my system. Looking at the man page, it seemed that -lf was the correct option. I was wondering whether this might be a typo as well.