### PR TITLE
Add Mongolian translation link

### DIFF
--- a/index.md
+++ b/index.md
@@ -135,6 +135,7 @@ benefit from these resources. You can find posts and discussion on
 - [Thai](https://missing-semester-th.github.io/)
 - [Turkish](https://missing-semester-tr.github.io/)
 - [Vietnamese](https://missing-semester-vn.github.io/)
+- [Mongolian](https://missing-semester-mn.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.

--- a/index.md
+++ b/index.md
@@ -126,6 +126,7 @@ benefit from these resources. You can find posts and discussion on
 - [Japanese](https://missing-semester-jp.github.io/)
 - [Kannada](https://missing-semester-kn.github.io/)
 - [Korean](https://missing-semester-kr.github.io/)
+- [Mongolian](https://missing-semester-mn.github.io)
 - [Persian](https://missing-semester-fa.github.io/)
 - [Portuguese](https://missing-semester-pt.github.io/)
 - [Russian](https://missing-semester-rus.github.io/)
@@ -135,7 +136,6 @@ benefit from these resources. You can find posts and discussion on
 - [Thai](https://missing-semester-th.github.io/)
 - [Turkish](https://missing-semester-tr.github.io/)
 - [Vietnamese](https://missing-semester-vn.github.io/)
-- [Mongolian](https://missing-semester-mn.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.


### PR DESCRIPTION
This PR adds the Mongolian translation link to the Translations list on the homepage.

- Translation site: https://missing-semester-mn.github.io/
- Scope of translations currently hosted: 2026 & Special Lectures
- Translation source Repo: https://github.com/missing-semester-mn/missing-semester-mn.github.io