### PR TITLE
Fix typo for shipping-code.md

### DIFF
--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -225,7 +225,7 @@ import typer
 
 
 def greet(name: str) -> str:
-    return f"Hello, {name}!"
+    print(f"Hello, {name}!")
 
 
 def cli():


### PR DESCRIPTION
Use `print` to print out the greeting in command line environment, and this is consistent with the output below using `greet Alice`.

> [!NOTE]
> The change in `greeting.py` may affect the file sizes inside `.whl` (from `unzip -l`), but not sure if that needs to be updated as well.
