### PR TITLE
fix: terjemahkan konten kuliah yang masih dalam bahasa Inggris

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: "404: Page not found"
+title: "404: Halaman tidak ditemukan"
 permalink: /404.html
 ---
 
-<h1 class="title">404 Not Found</h1>
+<h1 class="title">404 Tidak Ditemukan</h1>
 
-<p>This usually means that you've typed or followed a bad URL. Occasionally, this can happen if the page has been moved to a new URL (though we try to avoid doing that).</p>
+<p>Biasanya ini berarti Anda salah mengetik atau mengikuti URL yang tidak valid. Terkadang, ini bisa terjadi jika halaman telah dipindahkan ke URL baru (meskipun kami berusaha menghindari hal tersebut).</p>
 
-<p>See <a href="https://en.wikipedia.org/wiki/HTTP_404">the Wikipedia page on HTTP 404 errors</a> to learn more about HTTP 404 errors in general.</p>
+<p>Lihat <a href="https://en.wikipedia.org/wiki/HTTP_404">halaman Wikipedia tentang error HTTP 404</a> untuk mempelajari lebih lanjut tentang error HTTP 404 secara umum.</p>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,33 @@
 
 This file provides guidance to AI coding agents working with this repository. See [agents.md](https://agents.md/) for the specification.
 
-## Project Overview
+## Project Context
 
-This is the website for **The Missing Semester of Your CS Education** (https://missing.csail.mit.edu/), an MIT class teaching practical computing tools. It's a Jekyll static site hosted on GitHub Pages.
+This is the **Indonesian translation** of [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/), an MIT class teaching practical computing tools.
+
+- **Upstream repo:** https://github.com/missing-semester/missing-semester
+- **This repo:** Indonesian (Bahasa Indonesia) version
+- **GitHub org:** `missing-semester-idn`
+- **Site URL:** https://missing-semester-idn.github.io/
+
+This is a community translation effort. The original content is in English; this repo maintains the Indonesian translation.
+
+## Translation Workflow
+
+Translation work is organized via GitHub milestones and issues:
+- **Milestones:** 7 milestones covering site setup, root pages, and lectures by year
+- **Issues:** 55 issues total, one per file to translate
+- **Priority order:** Setup → Root pages → 2026 lectures → 2020 lectures → 2019 lectures → Subtitles
+
+## Translation Guidelines
+
+When translating content:
+- Keep code blocks, commands, and file paths in English
+- Translate only prose, explanations, and headings
+- Preserve YAML front matter structure (translate `title` and `description` fields)
+- Keep links to external resources unchanged
+- Translate inline code comments to Indonesian where helpful
+- Maintain consistency with existing translations (reuse terminology)
 
 ## Build and Test Commands
 

--- a/TRANSLATION_GLOSSARY.md
+++ b/TRANSLATION_GLOSSARY.md
@@ -1,0 +1,267 @@
+# Glosarium Terjemahan
+
+Panduan istilah teknis untuk konsistensi terjemahan ke Bahasa Indonesia.
+
+## Prinsip Umum
+- Gunakan bahasa Indonesia baku (formal)
+- Gunakan "Anda" untuk "You"
+- Jangan terjemahkan kata-demi-kata, sesuaikan dengan tata bahasa Indonesia
+- Hindari penggunaan "di mana" sebagai penghubung
+- Istilah teknis yang sudah umum dalam bahasa Inggris boleh dipertahankan (git, grep, vim, dll)
+
+## Istilah Teknis Komputer
+
+| Inggris | Indonesia | Catatan |
+|---------|-----------|---------|
+| command | perintah | |
+| shell | shell | Pertahankan |
+| terminal | terminal | |
+| file | berkas | atau "file" jika lebih umum |
+| directory | direktori | |
+| folder | folder | |
+| path | path | atau "jalur" |
+| link | tautan | |
+| download | unduh | |
+| upload | unggah | |
+| install | pasang | |
+| uninstall | copot pemasangan | |
+| update | perbarui | |
+| upgrade | tingkatkan | |
+| delete | hapus | |
+| remove | hapus | |
+| copy | salin | |
+| paste | tempel | |
+| cut | potong | |
+| save | simpan | |
+| open | buka | |
+| close | tutup | |
+| run | jalankan | |
+| execute | eksekusi | |
+| build | bangun | atau "build" |
+| deploy | deploy | atau "sebarkan" |
+| commit | commit | Git: pertahankan |
+| push | push | Git: pertahankan |
+| pull | pull | Git: pertahankan |
+| branch | branch | Git: pertahankan atau "cabang" |
+| merge | merge | Git: pertahankan |
+| repository | repositori | |
+| commit message | pesan commit | |
+| bug | bug | atau "kutu" |
+| debug | debug | atau "awakutu" |
+| test | uji | |
+| testing | pengujian | |
+| code | kode | |
+| source code | kode sumber | |
+| function | fungsi | |
+| variable | variabel | |
+| constant | konstanta | |
+| loop | loop | atau "perulangan" |
+| array | array | atau "larik" |
+| string | string | atau "untaian" |
+| integer | integer | atau "bilangan bulat" |
+| boolean | boolean | |
+| null | null | atau "nol" |
+| error | error | atau "galat" |
+| warning | peringatan | |
+| log | log | atau "catatan" |
+| output | keluaran | |
+| input | masukan | |
+| parameter | parameter | |
+| argument | argumen | |
+| return | return | atau "kembalikan" |
+| import | impor | |
+| export | ekspor | |
+| package | paket | |
+| module | modul | |
+| library | pustaka | |
+| framework | framework | atau "kerangka kerja" |
+| API | API | |
+| server | server | atau "peladen" |
+| client | client | atau "klien" |
+| request | permintaan | |
+| response | respons | |
+| database | basis data | |
+| query | kueri | |
+| cache | cache | atau "tembolok" |
+| buffer | buffer | atau "penyangga" |
+| thread | thread | atau "utas" |
+| process | proses | |
+| daemon | daemon | |
+| service | layanan | |
+| configuration | konfigurasi | |
+| setting | pengaturan | |
+| preference | preferensi | |
+| option | opsi | |
+| feature | fitur | |
+| plugin | plugin | |
+| extension | ekstensi | |
+| theme | tema | |
+| template | templat | |
+| layout | tata letak | |
+| style | gaya | |
+| font | fon | |
+| color | warna | |
+| image | gambar | |
+| video | video | |
+| audio | audio | |
+| media | media | |
+| content | konten | |
+| user | pengguna | |
+| account | akun | |
+| password | kata sandi | |
+| username | nama pengguna | |
+| login | masuk | |
+| logout | keluar | |
+| register | daftar | |
+| sign up | mendaftar | |
+| sign in | masuk | |
+| permission | izin | |
+| access | akses | |
+| role | peran | |
+| group | grup | |
+| team | tim | |
+| project | proyek | |
+| issue | issue | atau "masalah" |
+| pull request | pull request | |
+| merge request | merge request | |
+| milestone | milestone | atau "tonggak" |
+| label | label | |
+| assignee | penerima tugas | |
+| reviewer | peninjau | |
+| approver | penyetuju | |
+| comment | komentar | |
+| discussion | diskusi | |
+| documentation | dokumentasi | |
+| tutorial | tutorial | |
+| guide | panduan | |
+| example | contoh | |
+| exercise | latihan | |
+| lecture | kuliah | atau "pelajaran" |
+| course | kursus | |
+| class | kelas | |
+| student | siswa | atau "mahasiswa" |
+| teacher | guru | atau "pengajar" |
+| professor | profesor | |
+| university | universitas | |
+| school | sekolah | |
+| education | pendidikan | |
+| learning | pembelajaran | |
+| teaching | pengajaran | |
+| research | penelitian | |
+| development | pengembangan | |
+| production | produksi | |
+| staging | staging | |
+| testing | pengujian | |
+| development | pengembangan | |
+| environment | lingkungan | |
+| local | lokal | |
+| remote | remote | atau "jauh" |
+| production | produksi | |
+| staging | staging | |
+| testing | pengujian | |
+| development | pengembangan | |
+| environment | lingkungan | |
+| local | lokal | |
+| remote | remote | atau "jauh" |
+| online | daring | |
+| offline | luring | |
+| real-time | waktu nyata | |
+| backup | cadangan | |
+| restore | pulihkan | |
+| recover | pulihkan | |
+| sync | sinkronisasi | |
+| async | asinkron | |
+| parallel | paralel | |
+| concurrent | konkuren | |
+| sequential | berurutan | |
+| recursive | rekursif | |
+| iterative | iteratif | |
+| algorithm | algoritma | |
+| data structure | struktur data | |
+| complexity | kompleksitas | |
+| performance | kinerja | |
+| optimization | optimasi | |
+| scalability | skalabilitas | |
+| maintainability | maintainability | atau "keterpeliharaan" |
+| readability | keterbacaan | |
+| reliability | keandalan | |
+| availability | ketersediaan | |
+| security | keamanan | |
+| privacy | privasi | |
+| encryption | enkripsi | |
+| decryption | dekripsi | |
+| authentication | autentikasi | |
+| authorization | otorisasi | |
+| certificate | sertifikat | |
+| key | kunci | |
+| token | token | |
+| session | sesi | |
+| cookie | cookie | |
+| header | header | |
+| payload | payload | |
+| middleware | middleware | |
+| frontend | frontend | |
+| backend | backend | |
+| fullstack | fullstack | |
+| API | API | |
+| REST | REST | |
+| GraphQL | GraphQL | |
+| JSON | JSON | |
+| XML | XML | |
+| YAML | YAML | |
+| TOML | TOML | |
+| CSV | CSV | |
+| SQL | SQL | |
+| NoSQL | NoSQL | |
+| HTTP | HTTP | |
+| HTTPS | HTTPS | |
+| FTP | FTP | |
+| SSH | SSH | |
+| SSL | SSL | |
+| TLS | TLS | |
+| TCP | TCP | |
+| UDP | UDP | |
+| IP | IP | |
+| DNS | DNS | |
+| URL | URL | |
+| URI | URI | |
+| HTML | HTML | |
+| CSS | CSS | |
+| JavaScript | JavaScript | |
+| TypeScript | TypeScript | |
+| Python | Python | |
+| Java | Java | |
+| Go | Go | |
+| Rust | Rust | |
+| C++ | C++ | |
+| C# | C# | |
+| Ruby | Ruby | |
+| PHP | PHP | |
+| Swift | Swift | |
+| Kotlin | Kotlin | |
+| Scala | Scala | |
+| R | R | |
+| MATLAB | MATLAB | |
+| Docker | Docker | |
+| Kubernetes | Kubernetes | |
+| Git | Git | |
+| GitHub | GitHub | |
+| GitLab | GitLab | |
+| Bitbucket | Bitbucket | |
+| VS Code | VS Code | |
+| Vim | Vim | |
+| Emacs | Emacs | |
+| Linux | Linux | |
+| macOS | macOS | |
+| Windows | Windows | |
+| Ubuntu | Ubuntu | |
+| Debian | Debian | |
+| Fedora | Fedora | |
+| CentOS | CentOS | |
+| Arch | Arch | |
+| BSD | BSD | |
+
+## Catatan Penggunaan
+- Untuk istilah yang sangat teknis dan tidak ada padanan yang umum, pertahankan istilah asli
+- Jika ada padanan resmi dari pemerintah (Inpres No. 2/2001), gunakan padanan tersebut
+- Konsistensi lebih penting daripada "kesempurnaan" terjemahan

--- a/_2019/automation.md
+++ b/_2019/automation.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Automation"
+title: "Otomasi"
 presenter: Jose
 date: 2019-01-24
 order: 3
@@ -10,29 +10,29 @@ video:
 special: true
 ---
 
-Sometimes you write a script that does something but you want for it to run periodically, say a backup task. You can always write an *ad hoc* solution that runs in the background and comes online periodically. However, most UNIX systems come with the cron daemon which can run task with a frequency up to a minute based on simple rules.
+Terkadang Anda menulis skrip yang melakukan sesuatu tetapi Anda ingin skrip tersebut berjalan secara berkala, misalnya tugas pencadangan. Anda selalu dapat menulis solusi *ad hoc* yang berjalan di latar belakang dan aktif secara berkala. Namun, sebagian besar sistem UNIX dilengkapi dengan daemon cron yang dapat menjalankan tugas dengan frekuensi hingga satu menit berdasarkan aturan sederhana.
 
-On most UNIX systems the cron daemon, `crond` will be running by default but you can always check using `ps aux | grep crond`.
+Pada sebagian besar sistem UNIX, daemon cron, `crond` akan berjalan secara default tetapi Anda selalu dapat memeriksanya menggunakan `ps aux | grep crond`.
 
-## The crontab
+## Crontab
 
-The configuration file for cron can be displayed running `crontab -l` edited running `crontab -e` The time format that cron uses are five space separated fields along with the user and command
+Berkas konfigurasi untuk cron dapat ditampilkan dengan menjalankan `crontab -l` dan diedit dengan menjalankan `crontab -e`. Format waktu yang digunakan cron terdiri dari lima kolom yang dipisahkan spasi beserta pengguna dan perintah
 
-- **minute** -  What minute of the hour the command will run on,
-     and is between '0' and '59'
-- **hour** -    This controls what hour the command will run on, and is specified in
-         the 24 hour clock, values must be between 0 and 23 (0 is midnight)
-- **dom** - This is the Day of Month, that you want the command run on, e.g. to
-     run a command on the 19th of each month, the dom would be 19.
-- **month** -   This is the month a specified command will run on, it may be specified
-     numerically (0-12), or as the name of the month (e.g. May)
-- **dow** - This is the Day of Week that you want a command to be run on, it can
-     also be numeric (0-7) or as the name of the day (e.g. sun).
-- **user** -    This is the user who runs the command.
-- **command** - This is the command that you want run. This field may contain
-     multiple words or spaces.
+- **minute** -  Menit berapa dalam satu jam perintah akan dijalankan,
+     dan nilainya antara '0' hingga '59'
+- **hour** -    Mengontrol jam berapa perintah akan dijalankan, dan ditentukan dalam
+          format 24 jam, nilai harus antara 0 hingga 23 (0 adalah tengah malam)
+- **dom** - Ini adalah Day of Month (Hari dalam Bulan), yang Anda inginkan perintah dijalankan, misalnya
+      untuk menjalankan perintah pada tanggal 19 setiap bulan, dom-nya adalah 19.
+- **month** -   Ini adalah bulan berapa perintah yang ditentukan akan dijalankan, dapat ditentukan
+      secara numerik (0-12), atau sebagai nama bulan (mis. May)
+- **dow** - Ini adalah Day of Week (Hari dalam Minggu) yang Anda inginkan perintah dijalankan, dapat
+      juga berupa numerik (0-7) atau sebagai nama hari (mis. sun).
+- **user** -    Ini adalah pengguna yang menjalankan perintah.
+- **command** - Ini adalah perintah yang ingin Anda jalankan. Kolom ini dapat berisi
+      beberapa kata atau spasi.
 
-Note that using an asterisk `*` means all and using an asterisk followed by a slash and number means every nth value. So `*/5` means every five. Some examples are
+Perhatikan bahwa menggunakan tanda bintang `*` berarti semua dan menggunakan tanda bintang diikuti garis miring dan angka berarti setiap nilai ke-n. Jadi `*/5` berarti setiap lima. Beberapa contohnya adalah
 
 ```shell
 */5   *    *   *   *       # Every five minutes
@@ -42,31 +42,31 @@ Note that using an asterisk `*` means all and using an asterisk followed by a sl
   0   0    *   *   5       # Every Friday at 12:00 am
   0   0    1   */2 *       # Every other month, the first day, 12:00am
 ```
-You can find many more examples of common crontab schedules in [crontab.guru](https://crontab.guru/examples.html)
+Anda dapat menemukan banyak contoh jadwal crontab umum lainnya di [crontab.guru](https://crontab.guru/examples.html)
 
-## Shell environment and logging
+## Lingkungan shell dan pencatatan log
 
-A common pitfall when using cron is that it does not load the same environment scripts that common shells do such as `.bashrc`, `.zshrc`, &c and it does not log the output anywhere by default. Combined with the maximum frequency being one minute, it can become quite painful to debug cronscripts initially.
+Kesalahan umum saat menggunakan cron adalah cron tidak memuat skrip lingkungan yang sama dengan shell biasa seperti `.bashrc`, `.zshrc`, &c dan tidak mencatat output ke mana pun secara default. Dikombinasikan dengan frekuensi maksimum satu menit, bisa menjadi cukup merepotkan untuk men-debug skrip cron pada awalnya.
 
-To deal with the environment, make sure that you use absolute paths in all your scripts and modify your environment variables such as `PATH` so the script can run successfully. To simplify logging, a good recommendation is to write your crontab in a format like this
+Untuk mengatasi masalah lingkungan, pastikan Anda menggunakan path absolut di semua skrip Anda dan ubah variabel lingkungan Anda seperti `PATH` agar skrip dapat berjalan dengan sukses. Untuk menyederhanakan pencatatan log, rekomendasi yang baik adalah menulis crontab Anda dalam format seperti ini
 
 
 ```shell
 * * * * *   user  /path/to/cronscripts/every_minute.sh >> /tmp/cron_every_minute.log 2>&1
 ```
 
-And write the script in a separate file. Remember that `>>` appends to the file and that `2>&1` redirects `stderr` to `stdout` (you might to want keep them separate though).
+Dan tulis skrip dalam berkas terpisah. Ingatlah bahwa `>>` menambahkan ke berkas dan `2>&1` mengalihkan `stderr` ke `stdout` (meskipun Anda mungkin ingin memisahkannya).
 
 ## Anacron
 
-One caveat of using cron is that if the computer is powered off or asleep when the cron script should run then it is not executed. For frequent tasks this might be fine, but if a task runs less often, you may want to ensure that it is executed. [anacron](https://linux.die.net/man/8/anacron) works similar to `cron` except that the frequency is specified in days. Unlike cron, it does not assume that the machine is running continuously. Hence, it can be used on machines that aren't running 24 hours a day, to control regular jobs as daily, weekly, and monthly jobs.
+Salah satu keterbatasan menggunakan cron adalah jika komputer mati atau tidur ketika skrip cron seharusnya dijalankan maka skrip tersebut tidak dieksekusi. Untuk tugas yang sering, ini mungkin tidak masalah, tetapi jika tugas berjalan lebih jarang, Anda mungkin ingin memastikan tugas tersebut tetap dijalankan. [anacron](https://linux.die.net/man/8/anacron) bekerja mirip dengan `cron` kecuali frekuensi ditentukan dalam hari. Berbeda dengan cron, anacron tidak mengasumsikan bahwa mesin berjalan terus-menerus. Oleh karena itu, anacron dapat digunakan pada mesin yang tidak berjalan 24 jam sehari, untuk mengontrol tugas-tugas reguler seperti tugas harian, mingguan, dan bulanan.
 
 
-## Exercises
+## Latihan
 
-1. Make a script that looks every minute in your downloads folder for any file that is a picture (you can look into [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) or use a regular expression to match common extensions) and moves them into your Pictures folder.
+1. Buatlah skrip yang setiap menit memeriksa folder downloads Anda untuk mencari berkas yang berupa gambar (Anda dapat melihat [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) atau menggunakan ekspresi reguler untuk mencocokkan ekstensi umum) dan memindahkannya ke folder Pictures Anda.
 
-1. Write a cron script to weekly check for outdated packages in your system and prompts you to update them or updates them automatically.
+1. Tulislah skrip cron untuk memeriksa paket yang kedaluwarsa di sistem Anda setiap minggu dan meminta Anda untuk memperbaruinya atau memperbaruinya secara otomatis.
 
 
 

--- a/_2019/backups.md
+++ b/_2019/backups.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Backups"
+title: "Cadangan"
 presenter: Jose
 date: 2019-01-24
 order: 2
@@ -10,94 +10,94 @@ video:
 special: true
 ---
 
-There are two types of people:
+Ada dua jenis orang:
 
-- Those who do backups
-- Those who will do backups
+- Mereka yang melakukan cadangan
+- Mereka yang akan melakukan cadangan
 
-Any data you own that you haven't backed up is data that could be gone at any moment, forever. Here we will cover some good backup basics and the pitfalls of some approaches.
+Semua data yang Anda miliki yang belum Anda cadangkan adalah data yang bisa hilang kapan saja, selamanya. Di sini kita akan membahas dasar-dasar cadangan yang baik dan jebakan dari beberapa pendekatan.
 
-## 3-2-1 Rule
+## Aturan 3-2-1
 
-The [3-2-1 rule](https://www.us-cert.gov/sites/default/files/publications/data_backup_options.pdf) is a general recommended strategy for backing up your data. It state that you should have:
+[Aturan 3-2-1](https://www.us-cert.gov/sites/default/files/publications/data_backup_options.pdf) adalah strategi umum yang direkomendasikan untuk mencadangkan data Anda. Aturan ini menyatakan bahwa Anda harus memiliki:
 
-- at least **3 copies** of your data
-- **2** copies in **different mediums**
-- **1** of the copies being **offsite**
+- setidaknya **3 salinan** data Anda
+- **2** salinan dalam **media berbeda**
+- **1** salinan berada di **lokasi terpisah (offsite)**
 
-The main idea behind this recommendation is not to put all your eggs in one basket. Having 2 different devices/disks ensures that a single hardware failure doesn't take away all your data. Similarly, if you store your only backup at home and the house burns down or gets robbed you'll lose everything! That's what the offsite copy is there for. Onsite backups give you availability and speed, offsite give you the resiliency should a disaster happen.
+Ide utama di balik rekomendasi ini adalah jangan menaruh semua telur dalam satu keranjang. Memiliki 2 perangkat/disk yang berbeda memastikan bahwa satu kegagalan perangkat keras tidak menghapus semua data Anda. Demikian pula, jika Anda hanya menyimpan cadangan di rumah dan rumah Anda terbakar atau dirampok, Anda akan kehilangan semuanya! Itulah mengapa salinan offsite diperlukan. Cadangan onsite memberikan ketersediaan dan kecepatan, sedangkan offsite memberikan ketahanan jika terjadi bencana.
 
-## Testing your backups
+## Menguji cadangan Anda
 
-A common pitfall when performing backups is blindly trusting whatever the system says it's doing and not verifying that the data can be properly recovered. Toy Story 2 was almost lost and their backups were not working, [luck](https://www.youtube.com/watch?v=8dhp_20j0Ys) ended up saving them.
+Jebakan umum saat melakukan cadangan adalah mempercayai begitu saja apa yang dikatakan sistem dan tidak memverifikasi bahwa data dapat dipulihkan dengan benar. Toy Story 2 hampir hilang dan cadangan mereka tidak berfungsi, [keberuntungan](https://www.youtube.com/watch?v=8dhp_20j0Ys) akhirnya menyelamatkan mereka.
 
 ## Versioning
 
-You should understand that [RAID](https://en.wikipedia.org/wiki/RAID) is not a backup, and in general **mirroring is not a backup solution**. Simply syncing your files somewhere will not help in several scenarios, such as:
+Anda harus memahami bahwa [RAID](https://en.wikipedia.org/wiki/RAID) bukanlah cadangan, dan secara umum **mirroring bukanlah solusi cadangan**. Hanya menyinkronkan file Anda ke suatu tempat tidak akan membantu dalam beberapa skenario, seperti:
 
-- Data corruption
-- Malicious software
-- Deleting files by mistake
+- Kerusakan data
+- Perangkat lunak berbahaya
+- Menghapus file secara tidak sengaja
 
-If the changes on your data propagate to the backup then you won't be able to recover in these scenarios. Note that this is the case for a lot of cloud storage solutions like Dropbox, Google Drive, One Drive, &c. Some of them do keep deleted data around for short amounts of time but usually the interface to recover is not something you want to be using to recover large amounts of files.
+Jika perubahan pada data Anda menyebar ke cadangan, maka Anda tidak akan bisa memulihkannya dalam skenario-skenario tersebut. Perhatikan bahwa ini adalah kasus untuk banyak solusi penyimpanan cloud seperti Dropbox, Google Drive, One Drive, &c. Beberapa di antaranya menyimpan data yang dihapus dalam waktu singkat, tetapi biasanya antarmuka untuk memulihkan bukanlah sesuatu yang ingin Anda gunakan untuk memulihkan file dalam jumlah besar.
 
-A proper backup system should be versioned in order to prevent this failure mode. By providing different snapshots in time one can easily navigate them to restore whatever was lost. The most widely known software of this kind is macOS Time Machine.
+Sistem cadangan yang seharusnya memiliki versioning untuk mencegah mode kegagalan ini. Dengan menyediakan berbagai snapshot dalam waktu, seseorang dapat dengan mudah menavigasinya untuk memulihkan apa pun yang hilang. Perangkat lunak yang paling dikenal untuk jenis ini adalah macOS Time Machine.
 
-## Deduplication
+## Deduplikasi
 
-However, making several copies of your data might be extremely costly in terms of disk space. Nevertheless, from one version to the next, most data will be identical and needs not be transferred again. This is where [data deduplication](https://en.wikipedia.org/wiki/Data_deduplication) comes into play, by keeping track of what has already been stored one can do **incremental backups** where only the changes from one version to the next need to be stored. This significantly reduces the amount of space needed for backups beyond the first copy.
+Namun, membuat beberapa salinan data Anda bisa sangat mahal dalam hal ruang disk. Meskipun demikian, dari satu versi ke versi berikutnya, sebagian besar data akan identik dan tidak perlu ditransfer lagi. Di sinilah [deduplikasi data](https://en.wikipedia.org/wiki/Data_deduplication) berperan, dengan melacak apa yang sudah disimpan, seseorang dapat melakukan **cadangan inkremental** di mana hanya perubahan dari satu versi ke versi berikutnya yang perlu disimpan. Ini secara signifikan mengurangi jumlah ruang yang dibutuhkan untuk cadangan di luar salinan pertama.
 
-## Encryption
+## Enkripsi
 
-Since we might be backing up to untrusted third parties like cloud providers it is worth considering that if you backup your data is copied *as is* then it could potentially be looked by unwanted agents. Documents like your taxes are sensitive information that should not be backed up in plain format. To prevent this, many backup solutions offer **client side encryption** where data is encrypted before being sent to the server. That way the server cannot read the data it is storing but you can decrypt it with your secret key.
+Karena kita mungkin mencadangkan ke pihak ketiga yang tidak tepercaya seperti penyedia cloud, perlu dipertimbangkan bahwa jika data cadangan Anda disalin *apa adanya*, maka data tersebut berpotensi dilihat oleh pihak yang tidak diinginkan. Dokumen seperti pajak Anda adalah informasi sensitif yang tidak boleh dicadangkan dalam format biasa. Untuk mencegah hal ini, banyak solusi cadangan menawarkan **enkripsi sisi klien** di mana data dienkripsi sebelum dikirim ke server. Dengan begitu server tidak dapat membaca data yang disimpannya, tetapi Anda dapat mendekripsinya dengan kunci rahasia Anda.
 
-As a side note, if your disk (or home partition) is not encrypted, then anyone that get hold of your computer can manage to override the user access controls and read your data. Modern hardware supports fast and efficient read and writes of encrypted data so you might want to consider enabling **full disk encryption**.
+Sebagai catatan tambahan, jika disk Anda (atau partisi home) tidak dienkripsi, maka siapa pun yang mendapatkan akses ke komputer Anda dapat melewati kontrol akses pengguna dan membaca data Anda. Perangkat keras modern mendukung pembacaan dan penulisan data terenkripsi yang cepat dan efisien, jadi Anda mungkin ingin mempertimbangkan untuk mengaktifkan **enkripsi disk penuh**.
 
 
 ## Append only
 
-The properties reviewed so far focus on hardware failure or user mistakes but fail to address what happens if a malicious agent wanted to delete your data. Namely, say someone hacks into your system, are they able to wipe all your copies of the data you care about? If you worry about that scenario then you need some sort of append only backup solution. In general, this means having a server that will allow you to send new data but will refuse to delete existing data. Usually users have two keys, an append only key that supports  creating new backups and a full access key that also allows for deleting old backups that are no longer needed. The latter one is stored offline.
+Properti yang telah ditinjau sejauh ini berfokus pada kegagalan perangkat keras atau kesalahan pengguna, tetapi gagal mengatasi apa yang terjadi jika agen berbahaya ingin menghapus data Anda. Misalnya, jika seseorang meretas sistem Anda, apakah mereka mampu menghapus semua salinan data yang Anda pedulikan? Jika Anda khawatir dengan skenario tersebut, maka Anda memerlukan solusi cadangan yang bersifat append only. Secara umum, ini berarti memiliki server yang mengizinkan Anda mengirim data baru tetapi akan menolak untuk menghapus data yang sudah ada. Biasanya pengguna memiliki dua kunci, kunci append only yang mendukung pembuatan cadangan baru dan kunci akses penuh yang juga memungkinkan penghapusan cadangan lama yang tidak diperlukan lagi. Kunci latter disimpan secara offline.
 
-Note that this is a quite challenging scenario since you need the ability to make changes whilst still preventing a malicious user from deleting your data. Existing commercial solutions include [Tarsnap](https://www.tarsnap.com/) and [Borgbase](https://www.borgbase.com/).
-
-
-## Additional considerations
-
-Some other things you may want to look into are:
-
-- **Periodic backups**: outdated backups can become pretty useless. Making backups regularly should be a consideration for your system
-- **Bootable backups**: some programs allow you to clone your entire disk. That way you have an image that contains an entire copy of your system you can boot directly from.
-- **Differential backup strategies**, you may not necessarily care the same about all your data. You can define different backup policies for different types of data.
-- **Append only backups** an additional consideration is to enforce append only operations to your backup repositories in order to prevent malicious agents to delete them if they get hold of your machine.
+Perhatikan bahwa ini adalah skenario yang cukup menantang karena Anda memerlukan kemampuan untuk membuat perubahan sambil tetap mencegah pengguna berbahaya menghapus data Anda. Solusi komersial yang ada termasuk [Tarsnap](https://www.tarsnap.com/) dan [Borgbase](https://www.borgbase.com/).
 
 
-## Webservices
+## Pertimbangan tambahan
 
-Not all the data that you use lives on your hard disk. If you use **webservices**, then it might be the case that some data you care about, such as Google Docs presentations or Spotify playlists, is stored online. Another easy example that is easy to forget is email accounts with web access, such as Gmail. Figuring out a backup solution in these cases is somewhat trickier. However, there are many services that allow you to download your data, either directly or via an API. Tools such as [gmvault](https://github.com/gaubert/gmvault) for Gmail are available to download the email files to your computer.
+Beberapa hal lain yang mungkin ingin Anda telusuri:
+
+- **Cadangan berkala**: cadangan yang usang bisa menjadi sangat tidak berguna. Membuat cadangan secara berkala harus menjadi pertimbangan untuk sistem Anda
+- **Cadangan yang dapat di-boot**: beberapa program memungkinkan Anda mengkloning seluruh disk Anda. Dengan begitu Anda memiliki image yang berisi salinan lengkap sistem Anda yang dapat langsung di-boot.
+- **Strategi cadangan diferensial**, Anda mungkin tidak perlu memperlakukan semua data dengan tingkat kepentingan yang sama. Anda dapat menentukan kebijakan cadangan berbeda untuk berbagai jenis data.
+- **Cadangan append only** - pertimbangan tambahan adalah memberlakukan operasi append only pada repositori cadangan Anda untuk mencegah agen berbahaya menghapusnya jika mereka mendapatkan akses ke mesin Anda.
 
 
-## Webpages
+## Layanan Web
 
-Similarly, some high quality content can be found online in the form of webpages. If said content is static one can easily back it up by just saving the website and all of its attachments. Another alternative is the [Wayback Machine](https://archive.org/web/), a massive digital archive of the World Wide Web managed by the [Internet Archive](https://archive.org/), a non profit organization focused on the preservation of all sorts of media. The Wayback Machine allows you to capture and archive webpages being able to later retrieve all the snapshots that have been archived for that website. If you find it useful, consider [donating](https://archive.org/donate/) to the project.
+Tidak semua data yang Anda gunakan berada di hard disk Anda. Jika Anda menggunakan **layanan web**, maka mungkin ada beberapa data yang Anda pedulikan, seperti presentasi Google Docs atau playlist Spotify, yang disimpan secara online. Contoh lain yang mudah dilupakan adalah akun email dengan akses web, seperti Gmail. Menemukan solusi cadangan untuk kasus-kasus ini agak lebih rumit. Namun, ada banyak layanan yang memungkinkan Anda mengunduh data Anda, baik secara langsung maupun melalui API. Alat seperti [gmvault](https://github.com/gaubert/gmvault) untuk Gmail tersedia untuk mengunduh file email ke komputer Anda.
 
 
-## Resources
+## Halaman Web
 
-Some good backup programs and services we have used and can honestly recommend:
+Demikian pula, beberapa konten berkualitas tinggi dapat ditemukan secara online dalam bentuk halaman web. Jika konten tersebut bersifat statis, seseorang dapat dengan mudah mencadangkannya hanya dengan menyimpan website dan semua lampirannya. Alternatif lain adalah [Wayback Machine](https://archive.org/web/), arsip digital besar dari World Wide Web yang dikelola oleh [Internet Archive](https://archive.org/), organisasi nirlaba yang fokus pada pelestarian berbagai jenis media. Wayback Machine memungkinkan Anda menangkap dan mengarsipkan halaman web, sehingga nanti Anda dapat mengambil semua snapshot yang telah diarsipkan untuk website tersebut. Jika Anda merasa berguna, pertimbangkan untuk [berdonasi](https://archive.org/donate/) ke proyek ini.
 
-- [Tarsnap](https://www.tarsnap.com/) - deduplicated, encrypted online backup service for the truly paranoid.
-- [Borg Backup](https://borgbackup.readthedocs.io) - deduplicated backup program that supports compression and authenticated encryption. If you need a cloud provider [BorgBase](https://www.borgbase.com/) is one popular option.
-- [rsync](https://rsync.samba.org/) is a utility that provides fast incremental file transfer. It is not a full backup solution.
-- [rclone](https://rclone.org/) like rsync but for cloud storage providers such as Amazon S3, Dropbox, Google Drive, rsync.net, &c. Supports client side encryption of remote folders.
 
-## Exercises
+## Sumber Daya
 
-1. Consider how you are (not) backing up your data and look into fixing/improving that.
+Beberapa program dan layanan cadangan bagus yang telah kami gunakan dan dapat kami rekomendasikan dengan jujur:
 
-1. Figure out how to backup your email accounts
+- [Tarsnap](https://www.tarsnap.com/) - layanan cadangan online terdeduplikasi dan terenkripsi untuk yang benar-benar paranoid.
+- [Borg Backup](https://borgbackup.readthedocs.io) - program cadangan terdeduplikasi yang mendukung kompresi dan enkripsi terautentikasi. Jika Anda memerlukan penyedia cloud, [BorgBase](https://www.borgbase.com/) adalah salah satu opsi populer.
+- [rsync](https://rsync.samba.org/) adalah utilitas yang menyediakan transfer file inkremental yang cepat. Ini bukan solusi cadangan lengkap.
+- [rclone](https://rclone.org/) seperti rsync tetapi untuk penyedia penyimpanan cloud seperti Amazon S3, Dropbox, Google Drive, rsync.net, &c. Mendukung enkripsi sisi klien untuk folder remote.
 
-1. Choose a webservice you use often (Spotify, Google Music, etc.) and figure out what options for backing up your data are. Often people have already made tools (such as [youtube-dl](https://ytdl-org.github.io/youtube-dl/)) solutions based on available APIs.
+## Latihan
 
-1. Think of a website you have visited repeatedly over the years and look it up in [archive.org](https://archive.org/web/), how many versions does it have?
+1. Pertimbangkan bagaimana Anda (tidak) mencadangkan data Anda dan telusuri untuk memperbaiki/meningkatkannya.
 
-1. One way to efficiently implement deduplication is to use hardlinks. Whereas symbolic link (also called a soft link or a symlink) is a file that points to another file or folder, a hardlink is a exact copy of the pointer (it uses the same inode and points to the same place in the disk). Thus if the original file is removed a symlink stops working whereas a hard link doesn't. However, hardlinks only work for files. Try using the command `ln` to create hard links and compare them to symlinks created with `ln -s`. (In macOS you will need to install the gnu coreutils or the hln package).
+1. Cari tahu cara mencadangkan akun email Anda
+
+1. Pilih layanan web yang sering Anda gunakan (Spotify, Google Music, dll.) dan cari tahu opsi apa yang tersedia untuk mencadangkan data Anda. Seringkali orang telah membuat alat (seperti [youtube-dl](https://ytdl-org.github.io/youtube-dl/)) solusi berdasarkan API yang tersedia.
+
+1. Pikirkan sebuah website yang telah Anda kunjungi berulang kali selama bertahun-tahun dan cari di [archive.org](https://archive.org/web/), berapa banyak versi yang dimilikinya?
+
+1. Salah satu cara untuk mengimplementasikan deduplikasi secara efisien adalah dengan menggunakan hardlink. Berbeda dengan symbolic link (juga disebut soft link atau symlink) yang merupakan file yang menunjuk ke file atau folder lain, hardlink adalah salinan persis dari pointer tersebut (menggunakan inode yang sama dan menunjuk ke tempat yang sama di disk). Jadi jika file asli dihapus, symlink akan berhenti berfungsi sedangkan hardlink tidak. Namun, hardlink hanya bekerja untuk file. Cobalah menggunakan perintah `ln` untuk membuat hard link dan bandingkan dengan symlink yang dibuat dengan `ln -s`. (Di macOS Anda perlu menginstal gnu coreutils atau paket hln).

--- a/_2019/command-line.md
+++ b/_2019/command-line.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Command-line environment"
+title: "Lingkungan command-line"
 presenter: Jose
 date: 2019-01-17
 order: 1
@@ -9,9 +9,9 @@ video:
   id: i0rf1gpKL1E
 ---
 
-## Aliases & Functions
+## Alias & Fungsi
 
-As you can imagine it can become tiresome typing long commands that involve many flags or verbose options. Nevertheless, most shells support **aliasing**. For instance, an alias in bash has the following structure (note there is no space around the `=` sign):
+Seperti yang dapat Anda bayangkan, mengetik perintah panjang yang melibatkan banyak flag atau opsi verbose bisa menjadi melelahkan. Meskipun demikian, sebagian besar shell mendukung **aliasing**. Sebagai contoh, alias dalam bash memiliki struktur berikut (perhatikan tidak ada spasi di sekitar tanda `=`):
 
 ```bash
 alias alias_name="command_to_alias"
@@ -19,26 +19,26 @@ alias alias_name="command_to_alias"
 
 <!-- We can alias common flags for our commands like `alias ll=ls -ltAh`. Alias can be composed  -->
 
-Alias have many convenient features
+Alias memiliki banyak fitur yang berguna
 
 ```bash
-# Alias can summarize good default flags
+# Alias dapat merangkum flag default yang baik
 alias ll="ls -lh"
 
-# Save a lot of typing for common commands
+# Menghemat banyak pengetikan untuk perintah umum
 alias gc="git commit"
 
-# Alias can overwrite existing commands
+# Alias dapat menimpa perintah yang sudah ada
 alias mv="mv -i"
 alias mkdir="mkdir -p"
 
-# Alias can be composed
+# Alias dapat digabungkan
 alias la="ls -A"
 alias lla="la -l"
 
-# To ignore an alias run it prepended with \
+# Untuk mengabaikan alias, jalankan dengan awalan \
 \ls
-# Or can be disabled using unalias
+# Atau dapat dinonaktifkan menggunakan unalias
 unalias la
 
 ```
@@ -46,9 +46,9 @@ unalias la
 To get rid of an alias you can run `unalias alias_name` or to ignore alias when running a command you can prepend the command with a backward slash `\alias_name`. This is convenient when an alias is overwriting an existing name. -->
 
 
-However in many scenarios aliases can be limiting, specially when you are trying to write chain commands together that take the same arguments. An alternative exists which is **functions** which are a midpoint between aliases and custom shell scripts.
+Namun dalam banyak skenario, alias bisa terbatas, terutama ketika Anda mencoba menulis rangkaian perintah yang mengambil argumen yang sama. Ada alternatif yaitu **fungsi** yang merupakan titik tengah antara alias dan skrip shell khusus.
 
-Here is an example function that makes a directory and move into it.
+Berikut adalah contoh fungsi yang membuat direktori dan pindah ke dalamnya.
 
 ```bash
 mcd () {
@@ -57,119 +57,119 @@ mcd () {
 }
 ```
 
-Alias and functions will not persist shell sessions by default. To make an alias persistent you need to include it a one the shell startup script files like `.bashrc` or `.zshrc`. My suggestion is to write them separately in a `.alias` and `source` that file from your different shell config files.
+Alias dan fungsi tidak akan bertahan dalam sesi shell secara default. Untuk membuat alias tetap persisten, Anda perlu memasukkannya ke dalam salah satu file skrip startup shell seperti `.bashrc` atau `.zshrc`. Saran saya adalah menulisnya secara terpisah di `.alias` dan melakukan `source` pada file tersebut dari file konfigurasi shell Anda yang berbeda.
 
 <!-- Lastly, if you decide to alias any of these tools with the "improved" version, e.g. `alias bat=cat` it is useful to know that you can tell bash to ignore aliases by doing `\cat` and ignore both aliases and functions by doing `command cat` -->
 
-## Shells & Frameworks
+## Shell & Framework
 
-During shell and scripting we covered the `bash` shell since it is by far the most ubiquitous shell and most systems have it as the default option. Nevertheless, it is not the only option.
+Selama pembahasan shell dan scripting, kita membahas shell `bash` karena ini adalah shell yang paling banyak digunakan dan sebagian besar sistem memilikinya sebagai opsi default. Meskipun demikian, ini bukan satu-satunya opsi.
 
-For example the `zsh` shell is a superset of `bash` and provides many convenient features out of the box such as:
+Sebagai contoh, shell `zsh` adalah superset dari `bash` dan menyediakan banyak fitur berguna secara langsung seperti:
 
-- Smarter globbing, `**`
-- Inline globbing/wildcard expansion
-- Spelling correction
-- Better tab completion/selection
-- Path expansion (`cd /u/lo/b` will expand as `/usr/local/bin`)
+- Globbing yang lebih cerdas, `**`
+- Ekspansi globbing/wildcard inline
+- Koreksi ejaan
+- Tab completion/selection yang lebih baik
+- Ekspansi path (`cd /u/lo/b` akan diperluas menjadi `/usr/local/bin`)
 
-Moreover many shells can be improved with **frameworks**, some popular general frameworks like [prezto](https://github.com/sorin-ionescu/prezto) or [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), and smaller ones that focus on specific features like for example [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) or [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search). Other shells like [fish](https://fishshell.com/) include a lot of these user-friendly features by default. Some of these features include:
+Selain itu, banyak shell dapat ditingkatkan dengan **framework**, beberapa framework umum populer seperti [prezto](https://github.com/sorin-ionescu/prezto) atau [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), dan yang lebih kecil yang berfokus pada fitur tertentu seperti misalnya [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) atau [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search). Shell lain seperti [fish](https://fishshell.com/) menyertakan banyak fitur ramah pengguna ini secara default. Beberapa fitur ini meliputi:
 
 - Right prompt
-- Command syntax highlighting
-- History substring search
-- manpage based flag completions
-- Smarter autocompletion
-- Prompt themes
+- Syntax highlighting perintah
+- Pencarian substring riwayat
+- Completion flag berdasarkan manpage
+- Autocompletion yang lebih cerdas
+- Tema prompt
 
-One thing to note when using these frameworks is that if the code they run is not properly optimized or it is too much code, your shell can start slowing down. You can always profile it and disable the features that you do not use often or value over speed.
+Satu hal yang perlu diperhatikan saat menggunakan framework ini adalah jika kode yang mereka jalankan tidak dioptimalkan dengan baik atau terlalu banyak kode, shell Anda bisa mulai melambat. Anda selalu dapat melakukan profiling dan menonaktifkan fitur yang tidak sering Anda gunakan atau mengutamakan kecepatan.
 
-## Terminal Emulators & Multiplexers
+## Terminal Emulator & Multiplexer
 
-Along with customizing your shell it is worth spending some time figuring out your choice of **terminal emulator** and its settings. There are many many terminal emulators out there (here is a [comparison](https://anarc.at/blog/2018-04-12-terminal-emulators-1/)).
+Selain mengkustomisasi shell Anda, ada baiknya meluangkan waktu untuk mencari pilihan **terminal emulator** Anda dan pengaturannya. Ada banyak terminal emulator di luar sana (berikut adalah [perbandingannya](https://anarc.at/blog/2018-04-12-terminal-emulators-1/)).
 
-Since you might be spending hundreds to thousands of hours in your terminal it pays off to look into its settings. Some of the aspects that you may want to modify in your terminal include:
+Karena Anda mungkin menghabiskan ratusan hingga ribuan jam di terminal Anda, ada baiknya Anda menyelidiki pengaturannya. Beberapa aspek yang mungkin ingin Anda ubah di terminal Anda meliputi:
 
-- Font choice
-- Color Scheme
-- Keyboard shortcuts
-- Tab/Pane support
-- Scrollback configuration
-- Performance (some newer terminals like [Alacritty](https://github.com/jwilm/alacritty) offer GPU acceleration)
+- Pilihan font
+- Skema Warna
+- Pintasan keyboard
+- Dukungan Tab/Pane
+- Konfigurasi scrollback
+- Performa (beberapa terminal baru seperti [Alacritty](https://github.com/jwilm/alacritty) menawarkan akselerasi GPU)
 
-It is also worth mentioning **terminal multiplexers** like [tmux](https://github.com/tmux/tmux). `tmux` allows you to pane and tab multiple shell sessions. It also supports attaching and detaching which is a very common use-case when you are working on a remote server and want to keep you shell running without having to worry about disowning you current processes (by default when you log out your processes are terminated).  This way, with `tmux` you can jump into and out of complex terminal layouts. Similar to terminal emulators `tmux` supports heavy customization by editing the `~/.tmux.conf` file.
-
-
-## Command-line utilities
-
-The command line utilities that most UNIX based operating systems have by default are more than enough to do 99% of the stuff you usually need to do.
+Perlu juga disebutkan **terminal multiplexer** seperti [tmux](https://github.com/tmux/tmux). `tmux` memungkinkan Anda melakukan pane dan tab pada beberapa sesi shell. Ini juga mendukung attaching dan detaching yang merupakan kasus penggunaan yang sangat umum ketika Anda bekerja di server remote dan ingin menjaga shell Anda tetap berjalan tanpa perlu khawatir tentang proses Anda yang dihentikan (secara default ketika Anda logout, proses Anda dihentikan). Dengan cara ini, dengan `tmux` Anda dapat masuk dan keluar dari tata letak terminal yang kompleks. Sama seperti terminal emulator, `tmux` mendukung kustomisasi berat dengan mengedit file `~/.tmux.conf`.
 
 
-In the next few subsections I will cover alternative tools for extremely common shell operations which are more convenient to use. Some of these tools add new improved functionality to the command whereas others just focus on providing a simpler, more intuitive interface with better defaults.
+## Utilitas command-line
+
+Utilitas command-line yang dimiliki sebagian besar sistem operasi berbasis UNIX secara default lebih dari cukup untuk melakukan 99% hal yang biasanya perlu Anda lakukan.
+
+
+Dalam beberapa subbagian berikutnya, saya akan membahas alat alternatif untuk operasi shell yang sangat umum yang lebih nyaman digunakan. Beberapa alat ini menambahkan fungsionalitas baru yang ditingkatkan pada perintah sedangkan yang lain hanya berfokus pada penyediaan antarmuka yang lebih sederhana dan lebih intuitif dengan default yang lebih baik.
 
 ### `fasd` vs `cd`
 
-Even with improved path expansion and tab autocomplete, changing directories can become quite repetitive. [Fasd](https://github.com/clvv/fasd) (or [autojump](https://github.com/wting/autojump)) solves this issue by keeping track of recent and frequent folders you have been to and performing fuzzy matching.
+Bahkan dengan ekspansi path yang ditingkatkan dan tab autocomplete, mengubah direktori bisa menjadi cukup repetitif. [Fasd](https://github.com/clvv/fasd) (atau [autojump](https://github.com/wting/autojump)) menyelesaikan masalah ini dengan melacak folder baru-baru ini dan yang sering Anda kunjungi serta melakukan pencocokan fuzzy.
 
-Thus if I have visited the path `/home/user/awesome_project/code` running `z code` will `cd` to it. If I have multiple folders called code I can disambiguate by running `z awe code` which will be closer match. Unlike autojump,  fasd also provides commands that instead of performing `cd` just expand frequent and /or recent files,folders or both.
+Jadi jika Anda telah mengunjungi path `/home/user/awesome_project/code`, menjalankan `z code` akan melakukan `cd` ke sana. Jika Anda memiliki beberapa folder bernama code, Anda dapat menghilangkan ambiguitas dengan menjalankan `z awe code` yang akan menjadi pencocokan yang lebih dekat. Berbeda dengan autojump, fasd juga menyediakan perintah yang alih-alih melakukan `cd`, hanya memperluas file/folder yang sering dan/atau baru-baru ini atau keduanya.
 
 
 ### `bat` vs `cat`
 
-Even though `cat` does it job perfectly, [bat](https://github.com/sharkdp/bat) improves it by providing syntax highlighting, paging, line numbers and git integration.
+Meskipun `cat` melakukan tugasnya dengan sempurna, [bat](https://github.com/sharkdp/bat) meningkatkannya dengan menyediakan syntax highlighting, paging, nomor baris, dan integrasi git.
 
 
 ### `exa`/`ranger` vs `ls`
 
-`ls` is a great command but some of the defaults can be annoying such as displaying the size in raw bytes. [exa](https://github.com/ogham/exa) provides better defaults
+`ls` adalah perintah yang hebat tetapi beberapa defaultnya bisa mengganggu seperti menampilkan ukuran dalam byte mentah. [exa](https://github.com/ogham/exa) menyediakan default yang lebih baik
 
-If you are in need of navigating many folders and/or previewing many files, [ranger](https://github.com/ranger/ranger) can be much more efficient than `cd` and `cat` due to its wonderful interface. It is quite customizable and with a correct setup you can even [preview images](https://github.com/ranger/ranger/wiki/Image-Previews) in your terminal
+Jika Anda perlu menavigasi banyak folder dan/atau melihat pratinjau banyak file, [ranger](https://github.com/ranger/ranger) bisa jauh lebih efisien daripada `cd` dan `cat` karena antarmukanya yang luar biasa. Ini cukup dapat dikustomisasi dan dengan pengaturan yang benar Anda bahkan dapat [melihat pratinjau gambar](https://github.com/ranger/ranger/wiki/Image-Previews) di terminal Anda
 
 ### `fd` vs `find`
 
-[fd](https://github.com/sharkdp/fd) is a simple, fast and user-friendly alternative to `find`. `find` defaults like having to use the `--name` flag (which is what you want to do 99% of the time) make it easier to use in an every day basis. It is also `git` aware and will skip files in your `.gitignore` and `.git` folder by default. It also has nice color coding by default.
+[fd](https://github.com/sharkdp/fd) adalah alternatif `find` yang sederhana, cepat, dan ramah pengguna. Default `find` seperti harus menggunakan flag `--name` (yang adalah apa yang ingin Anda lakukan 99% dari waktu) membuatnya lebih mudah digunakan sehari-hari. Ini juga `git` aware dan akan melewatkan file di `.gitignore` dan folder `.git` Anda secara default. Ini juga memiliki pewarnaan yang bagus secara default.
 
 ### `rg/fzf` vs `grep`
 
-`grep` is a great tool but if you want to grep through many files at once, there are better tools for that purpose. [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher) & [rg](https://github.com/BurntSushi/ripgrep) recursively search your current directory for a regex pattern while respecting your gitignore rules. They all work pretty similar but I favor `rg` due to how fast it can search my entire home directory.
+`grep` adalah alat yang hebat tetapi jika Anda ingin melakukan grep melalui banyak file sekaligus, ada alat yang lebih baik untuk tujuan tersebut. [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher) & [rg](https://github.com/BurntSushi/ripgrep) mencari secara rekursif di direktori Anda saat ini untuk pola regex sambil mematuhi aturan gitignore Anda. Semuanya bekerja cukup mirip tetapi saya lebih memilih `rg` karena seberapa cepat ia dapat mencari seluruh direktori home saya.
 
-Similarly, it can be easy to find yourself doing `CMD | grep PATTERN` over an over again. [fzf](https://github.com/junegunn/fzf) is a command line fuzzy finder that enables you to interactively filter the output of pretty much any command.
+Demikian pula, bisa jadi Anda sering melakukan `CMD | grep PATTERN` berulang-ulang. [fzf](https://github.com/junegunn/fzf) adalah command line fuzzy finder yang memungkinkan Anda memfilter output dari hampir semua perintah secara interaktif.
 
 ### `rsync` vs `cp/scp`
 
-Whereas `mv` and `scp` are perfect for most scenarios, when copying/moving around large amounts of files, large files or when some of the data is already on the destination `rsync` is a huge improvement. `rsync` will skip files that have already been transferred and with the `--partial` flag it can resume from a previously interrupted copy.
+Meskipun `mv` dan `scp` sempurna untuk sebagian besar skenario, ketika menyalin/memindahkan sejumlah besar file, file besar, atau ketika beberapa data sudah ada di tujuan, `rsync` adalah peningkatan yang besar. `rsync` akan melewatkan file yang sudah ditransfer dan dengan flag `--partial` ia dapat melanjutkan dari salinan yang sebelumnya terganggu.
 
 ### `trash` vs `rm`
 
-`rm` is a dangerous command in the sense that once you delete a file there is no turning back. However, modern OS do not behave like that when you delete something in the file explorer, they just move it to the Trash folder which is cleared periodically.
+`rm` adalah perintah yang berbahaya dalam arti bahwa setelah Anda menghapus file, tidak ada jalan kembali. Namun, OS modern tidak berperilaku seperti itu ketika Anda menghapus sesuatu di file explorer, mereka hanya memindahkannya ke folder Trash yang dikosongkan secara berkala.
 
-Since how the trash is managed varies from OS to OS there is not a single CLI utility. In macOS there is [trash](https://hasseg.org/trash/) and in linux there is [trash-cli](https://github.com/andreafrancia/trash-cli/) among others.
+Karena cara trash dikelola berbeda dari satu OS ke OS lainnya, tidak ada utilitas CLI tunggal. Di macOS ada [trash](https://hasseg.org/trash/) dan di linux ada [trash-cli](https://github.com/andreafrancia/trash-cli/) dan lain-lain.
 
 ### `mosh` vs `ssh`
 
-`ssh ` is a very handy tool but if you have a slow connection, the lag can become annoying and if the connection interrupts you have to reconnect. [mosh](https://mosh.org/) is a handy tool that works allows roaming, supports intermittent connectivity, and provides intelligent local echo.
+`ssh` adalah alat yang sangat berguna tetapi jika Anda memiliki koneksi lambat, lag bisa menjadi menjengkelkan dan jika koneksi terputus Anda harus terhubung kembali. [mosh](https://mosh.org/) adalah alat berguna yang bekerja memungkinkan roaming, mendukung konektivitas intermiten, dan menyediakan local echo yang cerdas.
 
 ### `tldr` vs `man`
 
-You can figure out what a commands does and what options it has using `man` and the `-h`/'--help' flag most of the time. However, in some cases it can be a bit daunting navigating these if they are detailed
+Anda dapat mengetahui apa yang dilakukan perintah dan opsi apa yang dimilikinya menggunakan `man` dan flag `-h`/'--help' sebagian besar waktu. Namun, dalam beberapa kasus bisa agak menakutkan menavigasi ini jika mereka detail
 
-The [tldr](https://github.com/tldr-pages/tldr) command is a community driven documentation system that's available from the command line and gives a few simple illustrative examples of what the command does and the most common argument options.
+Perintah [tldr](https://github.com/tldr-pages/tldr) adalah sistem dokumentasi berbasis komunitas yang tersedia dari command line dan memberikan beberapa contoh ilustratif sederhana tentang apa yang dilakukan perintah dan opsi argumen yang paling umum.
 
 
 ### `aunpack` vs `tar/unzip/unrar`
 
-As [this xkcd](https://xkcd.com/1168/) references, it can be quite tricky to remember the options for `tar` and sometimes you need a different tool altogether such as `unrar` for .rar files.
-The [atool](https://www.nongnu.org/atool/) package provides the `aunpack` command which will figure out the correct options and always put the extracted archives in a new folder.
+Seperti yang direferensikan [xkcd ini](https://xkcd.com/1168/), bisa cukup rumit untuk mengingat opsi untuk `tar` dan terkadang Anda memerlukan alat yang sama sekali berbeda seperti `unrar` untuk file .rar.
+Paket [atool](https://www.nongnu.org/atool/) menyediakan perintah `aunpack` yang akan mencari tahu opsi yang benar dan selalu menempatkan arsip yang diekstrak dalam folder baru.
 
 
-## Exercises
+## Latihan
 
-1. Run `cat .bash_history | sort | uniq -c | sort -rn | head -n 10` (or `cat .zhistory | sort | uniq -c | sort -rn | head -n 10` for zsh)  to get top 10 most used commands and consider writing shorter aliases for them
-1. Choose a terminal emulator and figure out how to change the following properties:
-    - Font choice
-    - Color scheme. How many colors does a standard scheme have? why?
-    - Scrollback history size
+1. Jalankan `cat .bash_history | sort | uniq -c | sort -rn | head -n 10` (atau `cat .zhistory | sort | uniq -c | sort -rn | head -n 10` untuk zsh) untuk mendapatkan 10 perintah yang paling sering digunakan dan pertimbangkan untuk menulis alias yang lebih pendek untuk mereka
+1. Pilih terminal emulator dan cari tahu cara mengubah properti berikut:
+    - Pilihan font
+    - Skema warna. Berapa banyak warna yang dimiliki skema standar? mengapa?
+    - Ukuran riwayat scrollback
 
-1. Install `fasd` or some similar software and write a bash/zsh function called `v` that performs fuzzy matching on the passed arguments and opens up the top result in your editor of choice. Then, modify it so that if there are multiple matches you can select them with `fzf`.
-1. Since `fzf` is quite convenient for performing fuzzy searches and the shell history is quite prone to those kind of searches, investigate how to bind `fzf` to `^R`. You can find some info [here](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings)
-1. What does the `--bar` option do in `ack`?
+1. Instal `fasd` atau perangkat lunak serupa dan tulis fungsi bash/zsh bernama `v` yang melakukan pencocokan fuzzy pada argumen yang diberikan dan membuka hasil teratas di editor pilihan Anda. Kemudian, modifikasi sehingga jika ada beberapa kecocokan Anda dapat memilihnya dengan `fzf`.
+1. Karena `fzf` sangat nyaman untuk melakukan pencarian fuzzy dan riwayat shell cukup rentan terhadap jenis pencarian tersebut, selidiki cara mengikat `fzf` ke `^R`. Anda dapat menemukan beberapa info [di sini](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings)
+1. Apa yang dilakukan opsi `--bar` di `ack`?

--- a/_2019/course-overview.md
+++ b/_2019/course-overview.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Course Overview"
+title: "Ikhtisar Kursus"
 presenter: Anish
 date: 2019-01-15
 order: 1
@@ -9,30 +9,30 @@ video:
   id: qw2c6ffSVOM
 ---
 
-# Motivation
+# Motivasi
 
-This class is about [hacker](https://en.wikipedia.org/wiki/Hacker_culture)
-tools, not [hacker](https://en.wikipedia.org/wiki/Security_hacker) tools.
+Kelas ini membahas tentang [hacker](https://en.wikipedia.org/wiki/Hacker_culture)
+tools, bukan [hacker](https://en.wikipedia.org/wiki/Security_hacker) tools.
 
-MIT classes do not cover any of this content in detail. It's hugely beneficial
-to be proficient with your tools: it'll save you a lot of time (and the payoff
-time is very short).
+Kelas-kelas di MIT tidak membahas konten ini secara mendalam. Sangat bermanfaat
+untuk mahir menggunakan tools Anda: ini akan menghemat banyak waktu Anda (dan waktu
+untuk melihat hasilnya sangat singkat).
 
-We want to teach you about new tools, how to make the most of your tools, how
-to customize your tools, and how to extend your tools.
+Kami ingin mengajari Anda tentang tools baru, bagaimana memaksimalkan tools Anda,
+bagaimana menyesuaikan tools Anda, dan bagaimana memperluas capabilities tools Anda.
 
-# Class structure
+# Struktur kelas
 
-We have 6 lectures covering a [variety of topics](/2019/). We have lecture
-notes online, but there will be a lot of content covered in class (e.g. in the
-form of demos) that may not be in the notes. We will be recording lectures.
+Kami memiliki 6 kuliah yang mencakup [berbagai topik](/2019/). Kami memiliki catatan
+kuliah secara online, tetapi akan ada banyak konten yang dibahas di kelas (misalnya dalam
+bentuk demo) yang mungkin tidak ada dalam catatan. Kami akan merekam kuliah.
 
-Each class is split into two 50-minute lectures with a 10-minute break in
-between. Lectures are mostly live demonstrations followed by hands-on
-exercises. We might have a short amount of time at the end of each class to get
-started on the exercises in an office-hours-style setting.
+Setiap kelas dibagi menjadi dua kuliah masing-masing 50 menit dengan istirahat 10 menit
+di antaranya. Kuliah sebagian besar adalah demonstrasi langsung diikuti dengan latihan
+praktik. Kami mungkin memiliki sedikit waktu di akhir setiap kelas untuk memulai
+mengerjakan latihan dalam suasana office-hours.
 
-To make the most of the class, you should go through all the exercises on your
-own. We'll inspire you to learn more about your tools, and we'll show you
-what's possible and cover some of the basics in detail, but we can't teach you
-everything in the time we have.
+Untuk memaksimalkan kelas ini, Anda harus mengerjakan semua latihan sendiri. Kami akan
+menginspirasi Anda untuk mempelajari lebih lanjut tentang tools Anda, dan kami akan
+menunjukkan apa yang mungkin dilakukan serta membahas beberapa dasar secara detail,
+tetapi kami tidak dapat mengajari Anda semuanya dalam waktu yang kami miliki.

--- a/_2019/data-wrangling.md
+++ b/_2019/data-wrangling.md
@@ -9,49 +9,48 @@ video:
   id: VW2jn9Okjhw
 ---
 
-Have you ever had a bunch of text and wanted to do something with it?
-Good. That's what data wrangling is all about!
-Specifically, adapting data from one format to another, until you end up
-with exactly what you wanted.
+Apakah Anda pernah memiliki sekumpulan teks dan ingin melakukan sesuatu dengannya?
+Bagus. Itulah inti dari data wrangling!
+Secara khusus, mengadaptasi data dari satu format ke format lain, sampai Anda mendapatkan
+hasil yang tepat seperti yang Anda inginkan.
 
-We've already seen basic data wrangling: `journalctl | grep -i intel`.
- - find all system log entries that mention Intel (case insensitive)
- - really, most of data wrangling is about knowing what tools you have,
-   and how to combine them.
+Kita sudah pernah melihat data wrangling dasar: `journalctl | grep -i intel`.
+ - temukan semua entri log sistem yang menyebutkan Intel (case insensitive)
+ - sebenarnya, sebagian besar data wrangling adalah tentang mengetahui alat apa yang Anda miliki,
+   dan bagaimana menggabungkannya.
 
-Let's start from the beginning: we need a data source, and something to
-do with it. Logs often make for a good use-case, because you often want
-to investigate things about them, and reading the whole thing isn't
-feasible. Let's figure out who's trying to log into my server by looking
-at my server's log:
+Mari kita mulai dari awal: kita butuh sumber data, dan sesuatu untuk
+diolah darinya. Log sering menjadi kasus penggunaan yang baik, karena Anda sering ingin
+menyelidiki sesuatu tentang log tersebut, dan membaca keseluruhan log tidaklah
+memungkinkan. Mari kita cari tahu siapa yang mencoba masuk ke server saya dengan melihat
+log server saya:
 
 ```bash
 ssh myserver journalctl
 ```
 
-That's far too much stuff. Let's limit it to ssh stuff:
+Itu terlalu banyak datanya. Mari kita batasi hanya untuk ssh:
 
 ```bash
 ssh myserver journalctl | grep sshd
 ```
 
-Notice that we're using a pipe to stream a _remote_ file through `grep`
-on our local computer! `ssh` is magical. This is still way more stuff
-than we wanted though. And pretty hard to read. Let's do better:
+Perhatikan bahwa kita menggunakan pipe untuk mengalirkan file _remote_ melalui `grep`
+di komputer lokal kita! `ssh` memang ajaib. Namun ini masih jauh lebih banyak data
+dari yang kita inginkan. Dan cukup sulit dibaca. Mari kita lakukan yang lebih baik:
 
 ```bash
 ssh myserver journalctl | grep sshd | grep "Disconnected from"
 ```
 
-There's still a lot of noise here. There are _a lot_ of ways to get rid
-of that, but let's look at one of the most powerful tools in your
-toolkit: `sed`.
+Masih ada banyak noise di sini. Ada _sangat banyak_ cara untuk menghilangkannya,
+tetapi mari kita lihat salah satu alat paling ampuh di kotak peralatan Anda: `sed`.
 
-`sed` is a "stream editor" that builds on top of the old `ed` editor. In
-it, you basically give short commands for how to modify the file, rather
-than manipulate its contents directly (although you can do that too).
-There are tons of commands, but one of the most common ones is `s`:
-substitution. For example, we can write:
+`sed` adalah "stream editor" yang dibangun di atas editor `ed` lama. Di dalamnya,
+Anda pada dasarnya memberikan perintah singkat untuk cara memodifikasi file, alih-alih
+memanipulasi isinya secara langsung (meskipun Anda juga bisa melakukan itu).
+Ada banyak perintah, tetapi salah satu yang paling umum adalah `s`:
+substitusi. Sebagai contoh, kita bisa menulis:
 
 ```bash
 ssh myserver journalctl
@@ -60,119 +59,118 @@ ssh myserver journalctl
  | sed 's/.*Disconnected from //'
 ```
 
-What we just wrote was a simple _regular expression_; a powerful
-construct that lets you match text against patterns. The `s` command is
-written on the form: `s/REGEX/SUBSTITUTION/`, where `REGEX` is the
-regular expression you want to search for, and `SUBSTITUTION` is the
-text you want to substitute matching text with.
+Apa yang baru saja kita tulis adalah _regular expression_ sederhana; sebuah konstruksi
+yang ampuh yang memungkinkan Anda mencocokkan teks terhadap pola. Perintah `s`
+ditulis dalam bentuk: `s/REGEX/SUBSTITUTION/`, di mana `REGEX` adalah
+regular expression yang ingin Anda cari, dan `SUBSTITUTION` adalah
+teks yang ingin Anda substitusikan untuk teks yang cocok.
 
 ## Regular expressions
 
-Regular expressions are common and useful enough that it's worthwhile to
-take some time to understand how they work. Let's start by looking at
-the one we used above: `/.*Disconnected from /`. Regular expressions are
-usually (though not always) surrounded by `/`. Most ASCII characters
-just carry their normal meaning, but some characters have "special"
-matching behavior. Exactly which characters do what vary somewhat
-between different implementations of regular expressions, which is a
-source of great frustration. Very common patterns are:
+Regular expression cukup umum dan berguna sehingga layak untuk
+meluangkan waktu memahami cara kerjanya. Mari kita mulai dengan melihat
+yang kita gunakan di atas: `/.*Disconnected from /`. Regular expression biasanya
+(meskipun tidak selalu) diapit oleh `/`. Sebagian besar karakter ASCII
+tetap membawa makna normalnya, tetapi beberapa karakter memiliki perilaku pencocokan
+"spesial". Karakter mana yang melakukan apa agak berbeda
+antar implementasi regular expression yang berbeda, yang merupakan
+sumber frustrasi besar. Pola yang sangat umum adalah:
 
- - `.` means "any single character" except newline
- - `*` zero or more of the preceding match
- - `+` one or more of the preceding match
- - `[abc]` any one character of `a`, `b`, and `c`
- - `(RX1|RX2)` either something that matches `RX1` or `RX2`
- - `^` the start of the line
- - `$` the end of the line
+ - `.` berarti "satu karakter apa pun" kecuali newline
+ - `*` nol atau lebih dari pencocokan sebelumnya
+ - `+` satu atau lebih dari pencocokan sebelumnya
+ - `[abc]` salah satu karakter dari `a`, `b`, dan `c`
+ - `(RX1|RX2)` sesuatu yang cocok dengan `RX1` atau `RX2`
+ - `^` awal dari baris
+ - `$` akhir dari baris
 
-`sed`'s regular expressions are somewhat weird, and will require you to
-put a `\` before most of these to give them their special meaning. Or
-you can pass `-E`.
+Regular expression `sed` agak aneh, dan akan mengharuskan Anda
+menambahkan `\` sebelum sebagian besar karakter ini untuk memberikan makna khususnya. Atau
+Anda bisa menggunakan `-E`.
 
-So, looking back at `/.*Disconnected from /`, we see that it matches
-any text that starts with any number of characters, followed by the
-literal string "Disconnected from ". Which is what we wanted. But
-beware, regular expressions are tricky. What if someone tried to log in
-with the username "Disconnected from"? We'd have:
+Jadi, melihat kembali `/.*Disconnected from /`, kita lihat bahwa itu cocok
+dengan teks apa pun yang dimulai dengan sejumlah karakter, diikuti oleh
+string literal "Disconnected from ". Itulah yang kita inginkan. Namun
+hati-hati, regular expression itu rumit. Bagaimana jika seseorang mencoba masuk
+dengan username "Disconnected from"? Kita akan mendapatkan:
 
 ```
 Jan 17 03:13:00 thesquareplanet.com sshd[2631]: Disconnected from invalid user Disconnected from 46.97.239.16 port 55920 [preauth]
 ```
 
-What would we end up with? Well, `*` and `+` are, by default, "greedy".
-They will match as much text as they can. So, in the above, we'd end up
-with just
+Apa yang akan kita dapatkan? Nah, `*` dan `+` secara default bersifat "greedy".
+Mereka akan mencocokkan sebanyak mungkin teks. Jadi, pada contoh di atas, kita akan mendapatkan
+hanya
 
 ```
 46.97.239.16 port 55920 [preauth]
 ```
 
-Which may not be what we wanted. In some regular expression
-implementations, you can just suffix `*` or `+` with a `?` to make them
-non-greedy, but sadly `sed` doesn't support that. We _could_ switch to
-perl's command-line mode though, which _does_ support that construct:
+Yang mungkin bukan yang kita inginkan. Di beberapa implementasi regular expression,
+Anda bisa menambahkan `?` setelah `*` atau `+` untuk membuatnya non-greedy,
+tetapi sayangnya `sed` tidak mendukung konstruksi tersebut. Kita _bisa_ beralih ke
+mode command-line perl, yang _mendukung_ konstruksi tersebut:
 
 ```bash
 perl -pe 's/.*?Disconnected from //'
 ```
 
-We'll stick to `sed` for the rest of this though, because it's by far
-the more common tool for these kinds of jobs. `sed` can also do other
-handy things like print lines following a given match, do multiple
-substitutions per invocation, search for things, etc. But we won't cover
-that too much here. `sed` is basically an entire topic in and of itself,
-but there are often better tools.
+Kita akan tetap menggunakan `sed` untuk sisa materi ini, karena itu adalah
+alat yang jauh lebih umum untuk pekerjaan semacam ini. `sed` juga bisa melakukan hal-hal
+berguna lainnya seperti mencetak baris setelah pencocokan tertentu, melakukan beberapa
+substitusi dalam satu pemanggilan, mencari sesuatu, dll. Tetapi kita tidak akan
+membahas itu terlalu banyak di sini. `sed` pada dasarnya merupakan topik tersendiri,
+tetapi sering kali ada alat yang lebih baik.
 
-Okay, so we also have a suffix we'd like to get rid of. How might we do
-that? It's a little tricky to match just the text that follows the
-username, especially if the username can have spaces and such! What we
-need to do is match the _whole_ line:
+Oke, jadi kita juga memiliki sufiks yang ingin kita hilangkan. Bagaimana caranya?
+Agak rumit untuk mencocokkan hanya teks yang mengikuti
+username, terutama jika username bisa memiliki spasi dan sejenisnya! Yang perlu
+kita lakukan adalah mencocokkan _seluruh_ baris:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user .* [^ ]+ port [0-9]+( \[preauth\])?$//'
 ```
 
-Let's look at what's going on with a [regex
-debugger](https://regex101.com/r/qqbZqh/2). Okay, so the start is still
-as before. Then, we're matching any of the "user" variants (there are
-two prefixes in the logs). Then we're matching on any string of
-characters where the username is. Then we're matching on any single word
-(`[^ ]+`; any non-empty sequence of non-space characters). Then the word
-"port" followed by a sequence of digits. Then possibly the suffix
-` [preauth]`, and then the end of the line.
+Mari kita lihat apa yang terjadi dengan [regex
+debugger](https://regex101.com/r/qqbZqh/2). Oke, jadi awalnya masih
+sama seperti sebelumnya. Kemudian, kita mencocokkan salah satu varian "user" (ada
+dua prefix di log). Kemudian kita mencocokkan string karakter apa pun
+di mana username berada. Kemudian kita mencocokkan satu kata apa pun
+(`[^ ]+`; urutan non-spasi apa pun yang tidak kosong). Kemudian kata
+"port" diikuti oleh urutan digit. Kemudian mungkin sufiks
+` [preauth]`, dan kemudian akhir baris.
 
-Notice that with this technique, as username of "Disconnected from"
-won't confuse us any more. Can you see why?
+Perhatikan bahwa dengan teknik ini, username "Disconnected from"
+tidak akan membingungkan kita lagi. Bisakah Anda melihat alasannya?
 
-There is one problem with this though, and that is that the entire log
-becomes empty. We want to _keep_ the username after all. For this, we
-can use "capture groups". Any text matched by a regex surrounded by
-parentheses is stored in a numbered capture group. These are available
-in the substitution (and in some engines, even in the pattern itself!)
-as `\1`, `\2`, `\3`, etc. So:
+Ada satu masalah dengan ini, yaitu seluruh log
+menjadi kosong. Padahal kita ingin _menyimpan_ username. Untuk ini,
+kita bisa menggunakan "capture group". Teks apa pun yang dicocokkan oleh regex yang diapit
+tanda kurung disimpan di capture group bernomor. Ini tersedia
+dalam substitusi (dan di beberapa engine, bahkan di pola itu sendiri!)
+sebagai `\1`, `\2`, `\3`, dst. Jadi:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-As you can probably imagine, you can come up with _really_ complicated
-regular expressions. For example, here's an article on how you might
-match an [e-mail
-address](https://www.regular-expressions.info/email.html). It's [not
-easy](https://web.archive.org/web/20221223174323/http://emailregex.com/). And there's [lots of
-discussion](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982).
-And people have [written
-tests](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php).
-And [test matrices](https://mathiasbynens.be/demo/url-regex). You can
-even write a regex for determining if a given number [is a prime
-number](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
+Seperti yang bisa Anda bayangkan, Anda bisa membuat regular expression yang _sangat_
+rumit. Sebagai contoh, berikut artikel tentang cara mencocokkan
+[alamat email](https://www.regular-expressions.info/email.html). Itu [tidak
+mudah](https://web.archive.org/web/20221223174323/http://emailregex.com/). Dan ada [banyak
+diskusi](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982).
+Dan orang-orang telah [menulis
+tes](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php).
+Dan [matriks tes](https://mathiasbynens.be/demo/url-regex). Anda bahkan
+bisa menulis regex untuk menentukan apakah suatu bilangan [adalah bilangan
+prima](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
 
-Regular expressions are notoriously hard to get right, but they are also
-very handy to have in your toolbox!
+Regular expression terkenal sulit untuk dibuat dengan benar, tetapi juga
+sangat berguna untuk dimiliki di kotak peralatan Anda!
 
-## Back to data wrangling
+## Kembali ke data wrangling
 
-Okay, so we now have
+Oke, jadi sekarang kita punya
 
 ```bash
 ssh myserver journalctl
@@ -181,7 +179,7 @@ ssh myserver journalctl
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-We could do it just with `sed`, but why would we? For fun is why.
+Kita bisa melakukannya hanya dengan `sed`, tapi untuk apa? Untuk kesenangan, itulah alasannya.
 
 ```bash
 ssh myserver journalctl
@@ -190,13 +188,12 @@ ssh myserver journalctl
    -e 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-This shows off some of `sed`'s capabilities. `sed` can also inject text
-(with the `i` command), explicitly print lines (with the `p` command),
-select lines by index, and lots of other things. Check `man sed`!
+Ini menunjukkan beberapa kemampuan `sed`. `sed` juga bisa menyisipkan teks
+(dengan perintah `i`), mencetak baris secara eksplisit (dengan perintah `p`),
+memilih baris berdasarkan indeks, dan banyak hal lainnya. Cek `man sed`!
 
-Anyway. What we have now gives us a list of all the usernames that have
-attempted to log in. But this is pretty unhelpful. Let's look for common
-ones:
+Bagaimanapun. Yang kita punya sekarang memberikan daftar semua username yang telah
+mencoba masuk. Tapi ini cukup tidak membantu. Mari kita cari yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -206,10 +203,10 @@ ssh myserver journalctl
  | sort | uniq -c
 ```
 
-`sort` will, well, sort its input. `uniq -c` will collapse consecutive
-lines that are the same into a single line, prefixed with a count of the
-number of occurrences. We probably want to sort that too and only keep
-the most common logins:
+`sort` akan, yah, mengurutkan inputnya. `uniq -c` akan menggabungkan baris-baris
+berurutan yang sama menjadi satu baris, diawali dengan hitungan jumlah
+kemunculannya. Kita mungkin ingin mengurutkannya juga dan hanya menyimpan
+login yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -220,17 +217,17 @@ ssh myserver journalctl
  | sort -nk1,1 | tail -n10
 ```
 
-`sort -n` will sort in numeric (instead of lexicographic) order. `-k1,1`
-means "sort by only the first whitespace-separated column". The `,n`
-part says "sort until the `n`th field, where the default is the end of
-the line. In this _particular_ example, sorting by the whole line
-wouldn't matter, but we're here to learn!
+`sort -n` akan mengurutkan dalam urutan numerik (bukan leksikografik). `-k1,1`
+berarti "urutkan hanya berdasarkan kolom pertama yang dipisahkan whitespace". Bagian `,n`
+berarti "urutkan sampai bidang ke-`n`, di mana defaultnya adalah akhir
+baris. Dalam contoh _khusus_ ini, mengurutkan berdasarkan seluruh baris
+tidak akan berpengaruh, tetapi kita di sini untuk belajar!
 
-If we wanted the _least_ common ones, we could use `head` instead of
-`tail`. There's also `sort -r`, which sorts in reverse order.
+Jika kita ingin yang _paling jarang_, kita bisa menggunakan `head` alih-alih
+`tail`. Ada juga `sort -r`, yang mengurutkan dalam urutan terbalik.
 
-Okay, so that's pretty cool, but we'd sort of like to only give the
-usernames, and maybe not one per line?
+Oke, jadi itu cukup keren, tapi kita ingin hanya menampilkan
+username, dan mungkin bukan satu per baris?
 
 ```bash
 ssh myserver journalctl
@@ -242,40 +239,40 @@ ssh myserver journalctl
  | awk '{print $2}' | paste -sd,
 ```
 
-Let's start with `paste`: it lets you combine lines (`-s`) by a given
-single-character delimiter (`-d`). But what's this `awk` business?
+Mari kita mulai dengan `paste`: alat ini memungkinkan Anda menggabungkan baris (`-s`) dengan
+delimiter karakter tunggal (`-d`). Tapi apa urusan `awk` ini?
 
-## awk -- another editor
+## awk -- editor lainnya
 
-`awk` is a programming language that just happens to be really good at
-processing text streams. There is _a lot_ to say about `awk` if you were
-to learn it properly, but as with many other things here, we'll just go
-through the basics.
+`awk` adalah bahasa pemrograman yang kebetulan sangat bagus dalam
+memproses stream teks. Ada _sangat banyak_ yang bisa dikatakan tentang `awk` jika Anda
+mempelajarinya dengan benar, tetapi seperti banyak hal lainnya di sini, kita hanya akan
+membahas dasar-dasarnya.
 
-First, what does `{print $2}` do? Well, `awk` programs take the form of
-an optional pattern plus a block saying what to do if the pattern
-matches a given line. The default pattern (which we used above) matches
-all lines. Inside the block, `$0` is set to the entire line's contents,
-and `$1` through `$n` are set to the `n`th _field_ of that line, when
-separated by the `awk` field separator (whitespace by default, change
-with `-F`). In this case, we're saying that, for every line, print the
-contents of the second field, which happens to be the username!
+Pertama, apa yang dilakukan `{print $2}`? Nah, program `awk` memiliki bentuk
+pola opsional ditambah blok yang menentukan apa yang harus dilakukan jika pola
+cocok dengan baris tertentu. Pola default (yang kita gunakan di atas) cocok
+dengan semua baris. Di dalam blok, `$0` diisi dengan seluruh isi baris,
+dan `$1` sampai `$n` diisi dengan bidang ke-`n` dari baris tersebut, ketika
+dipisahkan oleh field separator `awk` (whitespace secara default, bisa diubah
+dengan `-F`). Dalam kasus ini, kita mengatakan bahwa, untuk setiap baris, cetak
+isi bidang kedua, yang kebetulan adalah username!
 
-Let's see if we can do something fancier. Let's compute the number of
-single-use usernames that start with `c` and end with `e`:
+Mari kita lihat apakah kita bisa melakukan sesuatu yang lebih canggih. Mari kita hitung jumlah
+username sekali pakai yang dimulai dengan `c` dan diakhiri dengan `e`:
 
 ```bash
  | awk '$1 == 1 && $2 ~ /^c[^ ]*e$/ { print $2 }' | wc -l
 ```
 
-There's a lot to unpack here. First, notice that we now have a pattern
-(the stuff that goes before `{...}`). The pattern says that the first
-field of the line should be equal to 1 (that's the count from `uniq
--c`), and that the second field should match the given regular
-expression. And the block just says to print the username. We then count
-the number of lines in the output with `wc -l`.
+Ada banyak yang perlu diurai di sini. Pertama, perhatikan bahwa sekarang kita punya pola
+(bagian yang ada sebelum `{...}`). Pola tersebut mengatakan bahwa bidang pertama
+baris harus sama dengan 1 (itu adalah hitungan dari `uniq
+-c`), dan bidang kedua harus cocok dengan regular expression
+yang diberikan. Dan blok tersebut hanya mengatakan untuk mencetak username. Kemudian kita hitung
+jumlah baris dalam output dengan `wc -l`.
 
-However, `awk` is a programming language, remember?
+Namun, `awk` adalah bahasa pemrograman, ingat?
 
 ```awk
 BEGIN { rows = 0 }
@@ -283,17 +280,16 @@ $1 == 1 && $2 ~ /^c[^ ]*e$/ { rows += $1 }
 END { print rows }
 ```
 
-`BEGIN` is a pattern that matches the start of the input (and `END`
-matches the end). Now, the per-line block just adds the count from the
-first field (although it'll always be 1 in this case), and then we print
-it out at the end. In fact, we _could_ get rid of `grep` and `sed`
-entirely, because `awk` [can do it
-all](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/), but we'll
-leave that as an exercise to the reader.
+`BEGIN` adalah pola yang cocok dengan awal input (dan `END`
+cocok dengan akhir). Sekarang, blok per-baris hanya menambahkan hitungan dari
+bidang pertama (meskipun selalu 1 dalam kasus ini), dan kemudian kita mencetaknya
+di akhir. Sebenarnya, kita _bisa_ menghilangkan `grep` dan `sed`
+sepenuhnya, karena `awk` [bisa melakukan semuanya](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/), tetapi kita
+akan menyerahkan itu sebagai latihan bagi pembaca.
 
-## Analyzing data
+## Menganalisis data
 
-You can do math!
+Anda bisa berhitung!
 
 ```bash
  | paste -sd+ | bc -l
@@ -303,9 +299,9 @@ You can do math!
 echo "2*($(data | paste -sd+))" | bc -l
 ```
 
-You can get stats in a variety of ways.
-[`st`](https://github.com/nferraz/st) is pretty neat, but if you already
-have R:
+Anda bisa mendapatkan statistik dengan berbagai cara.
+[`st`](https://github.com/nferraz/st) cukup bagus, tetapi jika Anda sudah
+punya R:
 
 ```bash
 ssh myserver journalctl
@@ -316,13 +312,13 @@ ssh myserver journalctl
  | awk '{print $1}' | R --slave -e 'x <- scan(file="stdin", quiet=TRUE); summary(x)'
 ```
 
-R is another (weird) programming language that's great at data analysis
-and [plotting](https://ggplot2.tidyverse.org/). We won't go into too
-much detail, but suffice to say that `summary` prints summary statistics
-about a matrix, and we computed a matrix from the input stream of
-numbers, so R gives us the statistics we wanted!
+R adalah bahasa pemrograman lain (yang aneh) yang hebat untuk analisis data
+dan [plotting](https://ggplot2.tidyverse.org/). Kita tidak akan membahas terlalu
+detail, tetapi cukup dikatakan bahwa `summary` mencetak statistik ringkasan
+tentang matriks, dan kita menghitung matriks dari stream input berupa
+angka, jadi R memberi kita statistik yang kita inginkan!
 
-If you just want some simple plotting, `gnuplot` is your friend:
+Jika Anda hanya ingin plotting sederhana, `gnuplot` adalah teman Anda:
 
 ```bash
 ssh myserver journalctl
@@ -334,55 +330,54 @@ ssh myserver journalctl
  | gnuplot -p -e 'set boxwidth 0.5; plot "-" using 1:xtic(2) with boxes'
 ```
 
-## Data wrangling to make arguments
+## Data wrangling untuk membuat argumen
 
-Sometimes you want to do data wrangling to find things to install or
-remove based on some longer list. The data wrangling we've talked about
-so far + `xargs` can be a powerful combo:
+Terkadang Anda ingin melakukan data wrangling untuk menemukan hal-hal yang perlu diinstal atau
+dihapus berdasarkan daftar yang lebih panjang. Data wrangling yang telah kita bahas
+sejauh ini + `xargs` bisa menjadi kombinasi yang ampuh:
 
 ```bash
 rustup toolchain list | grep nightly | grep -vE "nightly-x86|01-17" | sed 's/-x86.*//' | xargs rustup toolchain uninstall
 ```
 
-# Exercises
+# Latihan
 
-1. If you are not familiar with Regular Expressions
-   [here](https://regexone.com/) is a short interactive tutorial that
-   covers most of the basics
-1. How is `sed s/REGEX/SUBSTITUTION/g` different from the regular sed?
-   What about `/I` or `/m`?
-1. To do in-place substitution it is quite tempting to do something like
-   `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`. However this is a
-   bad idea, why? Is this particular to `sed`?
-1. Implement a simple grep equivalent tool in a language you are familiar with using regex. If you want the output to be color highlighted like grep is, search for ANSI color escape sequences.
-1. Sometimes some operations like renaming files can be tricky with raw commands like `mv` . `rename` is a nifty tool to achieve this and has a sed-like syntax. Try creating a bunch of files with spaces in their names and use `rename` to replace them with underscores.
-1. Look for boot messages that are _not_ shared between your past three
-   reboots (see `journalctl`'s `-b` flag). You may want to just mash all
-   the boot logs together in a single file, as that may make things
-   easier.
-1. Produce some statistics of your system boot time over the last ten
-   boots using the log timestamp of the messages
+1. Jika Anda belum familiar dengan Regular Expression,
+   [di sini](https://regexone.com/) adalah tutorial interaktif singkat yang
+   mencakup sebagian besar dasar-dasarnya
+1. Apa perbedaan `sed s/REGEX/SUBSTITUTION/g` dengan sed biasa?
+   Bagaimana dengan `/I` atau `/m`?
+1. Untuk melakukan substitusi in-place, sangat menggoda untuk melakukan sesuatu seperti
+   `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`. Namun ini adalah
+   ide yang buruk, mengapa? Apakah ini khusus untuk `sed`?
+1. Implementasikan alat sederhana yang setara dengan grep menggunakan bahasa yang Anda kuasai dengan regex. Jika Anda ingin outputnya diwarnai seperti grep, cari ANSI color escape sequences.
+1. Terkadang beberapa operasi seperti mengganti nama file bisa rumit dengan perintah mentah seperti `mv`. `rename` adalah alat yang berguna untuk mencapai hal ini dan memiliki sintaks mirip sed. Cobalah buat sejumlah file dengan spasi di namanya dan gunakan `rename` untuk menggantinya dengan underscore.
+1. Cari pesan boot yang _tidak_ sama di antara tiga
+   reboot terakhir Anda (lihat flag `-b` dari `journalctl`). Anda mungkin ingin menggabungkan semua
+   log boot menjadi satu file, karena itu mungkin mempermudah.
+1. Buat beberapa statistik waktu boot sistem Anda selama sepuluh
+   boot terakhir menggunakan timestamp log dari pesan
    ```
    Logs begin at ...
    ```
-   and
+   dan
    ```
    systemd[577]: Startup finished in ...
    ```
-1. Find the number of words (in `/usr/share/dict/words`) that contain at
-   least three `a`s and don't have a `'s` ending. What are the three
-   most common last two letters of those words? `sed`'s `y` command, or
-   the `tr` program, may help you with case insensitivity. How many
-   of those two-letter combinations are there? And for a challenge:
-   which combinations do not occur?
-1. Find an online data set like [this
-   one](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab) or [this
-   one](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1).
-   Maybe another one [from
-   here](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/).
-   Fetch it using `curl` and extract out just two columns of numerical
-   data. If you're fetching HTML data,
-   [`pup`](https://github.com/EricChiang/pup) might be helpful. For JSON
-   data, try [`jq`](https://stedolan.github.io/jq/). Find the min and
-   max of one column in a single command, and the sum of the difference
-   between the two columns in another.
+1. Temukan jumlah kata (di `/usr/share/dict/words`) yang mengandung setidaknya
+   tiga `a` dan tidak berakhiran `'s`. Apa tiga
+   huruf terakhir paling umum dari kata-kata tersebut? Perintah `y` dari `sed`, atau
+   program `tr`, mungkin membantu Anda untuk case insensitivity. Berapa banyak
+   kombinasi dua huruf yang ada? Dan untuk tantangan:
+   kombinasi mana yang tidak muncul?
+1. Cari dataset online seperti [yang
+   ini](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab) atau [yang
+   ini](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1).
+   Mungkin yang lain [dari
+   sini](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/).
+   Ambil menggunakan `curl` dan ekstrak hanya dua kolom data numerik.
+   Jika Anda mengambil data HTML,
+   [`pup`](https://github.com/EricChiang/pup) mungkin berguna. Untuk data
+   JSON, coba [`jq`](https://stedolan.github.io/jq/). Temukan min dan
+   max dari satu kolom dalam satu perintah, dan jumlah selisih
+   antara dua kolom di perintah lainnya.

--- a/_2019/dotfiles.md
+++ b/_2019/dotfiles.md
@@ -9,56 +9,56 @@ video:
   id: YSZBWWJw3mI
 ---
 
-Many programs are configured using plain-text files known as "dotfiles"
-(because the file names begin with a `.`, e.g. `~/.gitconfig`, so that they are
-hidden in the directory listing `ls` by default).
+Banyak program dikonfigurasi menggunakan berkas teks biasa yang dikenal sebagai "dotfiles"
+(karena nama berkas diawali dengan `.`, misalnya `~/.gitconfig`, sehingga berkas tersebut
+tersembunyi di daftar direktori `ls` secara default).
 
-A lot of the tools you use probably have a lot of settings that can be tuned
-pretty finely. Often times, tools are customized with specialized languages,
-e.g. Vimscript for Vim or the shell's own language for a shell.
+Banyak alat yang Anda gunakan mungkin memiliki banyak pengaturan yang dapat disetel
+dengan cukup detail. Seringkali, alat disesuaikan dengan bahasa khusus,
+misalnya Vimscript untuk Vim atau bahasa shell itu sendiri untuk shell.
 
-Customizing and adapting your tools to your preferred workflow will make you
-more productive. We advise you to invest time in customizing your tool yourself
-rather than cloning someone else's dotfiles from GitHub.
+Menyesuaikan dan mengadaptasi alat-alat Anda ke alur kerja yang Anda inginkan akan membuat Anda
+lebih produktif. Kami menyarankan Anda untuk menginvestasikan waktu dalam menyesuaikan alat Anda sendiri
+daripada meng-clone dotfiles orang lain dari GitHub.
 
-You probably have some dotfiles set up already. Some places to look:
+Anda mungkin sudah memiliki beberapa dotfiles yang disiapkan. Beberapa tempat untuk melihat:
 
 - `~/.bashrc`
 - `~/.emacs`
 - `~/.vim`
 - `~/.gitconfig`
 
-Some programs don't put the files under your home folder directly and instead they put them in a folder under `~/.config`.
+Beberapa program tidak meletakkan berkas langsung di folder home Anda, melainkan meletakkannya di folder di bawah `~/.config`.
 
-Dotfiles are not exclusive to command line applications, for instance the [MPV](https://mpv.io/) video player can be configured editing files under `~/.config/mpv`
+Dotfiles tidak eksklusif untuk aplikasi baris perintah, misalnya pemutar video [MPV](https://mpv.io/) dapat dikonfigurasi dengan mengedit berkas di bawah `~/.config/mpv`
 
-# Learning to customize tools
+# Belajar menyesuaikan alat
 
-You can learn about your tool's settings by reading online documentation or
-[man pages](https://en.wikipedia.org/wiki/Man_page). Another great way is to
-search the internet for blog posts about specific programs, where authors will
-tell you about their preferred customizations. Yet another way to learn about
-customizations is to look through other people's dotfiles: you can find tons of
-[dotfiles
-repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on GitHub --- see the most popular one
-[here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
-copy configurations though).
+Anda dapat mempelajari pengaturan alat Anda dengan membaca dokumentasi daring atau
+[man pages](https://en.wikipedia.org/wiki/Man_page). Cara hebat lainnya adalah
+mencari di internet untuk postingan blog tentang program tertentu, di mana penulis akan
+memberitahu Anda tentang kustomisasi pilihan mereka. Cara lain untuk mempelajari
+kustomisasi adalah dengan melihat dotfiles milik orang lain: Anda dapat menemukan banyak
+[repositori
+dotfiles](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
+di GitHub --- lihat yang paling populer
+[di sini](https://github.com/mathiasbynens/dotfiles) (kami menyarankan Anda untuk tidak menyalin
+konfigurasi secara membabi buta).
 
-# Organization
+# Organisasi
 
-How should you organize your dotfiles? They should be in their own folder,
-under version control, and **symlinked** into place using a script. This has
-the benefits of:
+Bagaimana sebaiknya Anda mengatur dotfiles Anda? Dotfiles harus berada di folder tersendiri,
+di bawah version control, dan **di-symlink** ke tempatnya menggunakan script. Ini memiliki
+keuntungan:
 
-- **Easy installation**: if you log in to a new machine, applying your
-customizations will only take a minute
-- **Portability**: your tools will work the same way everywhere
-- **Synchronization**: you can update your dotfiles anywhere and keep them all
-in sync
-- **Change tracking**: you're probably going to be maintaining your dotfiles
-for your entire programming career, and version history is nice to have for
-long-lived projects
+- **Instalasi mudah**: jika Anda login ke mesin baru, menerapkan kustomisasi Anda
+hanya akan memakan waktu satu menit
+- **Portabilitas**: alat Anda akan bekerja dengan cara yang sama di mana pun
+- **Sinkronisasi**: Anda dapat memperbarui dotfiles Anda di mana saja dan menjaganya tetap
+sinkron
+- **Pelacakan perubahan**: Anda mungkin akan memelihara dotfiles Anda
+sepanjang karier pemrograman Anda, dan riwayat versi sangat berguna untuk
+proyek jangka panjang
 
 ```shell
 cd ~/src
@@ -80,24 +80,24 @@ git add bashrc install
 git commit -m 'Initial commit'
 ```
 
-# Advanced topics
+# Topik lanjutan
 
-## Machine-specific customizations
+## Kustomisasi khusus mesin
 
-Most of the time, you'll want the same configuration across machines, but
-sometimes, you'll want a small delta on a particular machine. Here are a couple
-ways you can handle this situation:
+Sebagian besar waktu, Anda akan menginginkan konfigurasi yang sama di semua mesin, tetapi
+terkadang, Anda akan menginginkan sedikit perbedaan di mesin tertentu. Berikut adalah beberapa
+cara yang dapat Anda gunakan untuk menangani situasi ini:
 
-### Branch per machine
+### Branch per mesin
 
-Use version control to maintain a branch per machine. This approach is
-logically straightforward but can be pretty heavyweight.
+Gunakan version control untuk mempertahankan branch per mesin. Pendekatan ini
+secara logis mudah dipahami tetapi bisa cukup berat.
 
-### If statements
+### Pernyataan if
 
-If the configuration file supports it, use the equivalent of if-statements to
-apply machine specific customizations. For example, your shell could have something
-like:
+Jika berkas konfigurasi mendukungnya, gunakan setara pernyataan if untuk
+menerapkan kustomisasi khusus mesin. Misalnya, shell Anda dapat memiliki sesuatu
+seperti:
 
 ```shell
 if [[ "$(uname)" == "Linux" ]]; then {do_something else}; fi
@@ -111,19 +111,19 @@ if [[ "$(hostname)" == "myServer" ]]; then {do_something}; fi
 
 ### Includes
 
-If the configuration file supports it, make use of includes. For example,
-a `~/.gitconfig` can have a setting:
+Jika berkas konfigurasi mendukungnya, gunakan includes. Misalnya,
+`~/.gitconfig` dapat memiliki pengaturan:
 
 ```
 [include]
     path = ~/.gitconfig_local
 ```
 
-And then on each machine, `~/.gitconfig_local` can contain machine-specific
-settings. You could even track these in a separate repository for
-machine-specific settings.
+Kemudian di setiap mesin, `~/.gitconfig_local` dapat berisi pengaturan khusus mesin.
+Anda bahkan dapat melacak ini di repositori terpisah untuk
+pengaturan khusus mesin.
 
-This idea is also useful if you want different programs to share some configurations. For instance if you want both `bash` and `zsh` to share the same set of aliases you can write them under `.aliases` and have the following block in both.
+Ide ini juga berguna jika Anda ingin program berbeda berbagi beberapa konfigurasi. Misalnya jika Anda ingin `bash` dan `zsh` berbagi set alias yang sama, Anda dapat menulisnya di `.aliases` dan memiliki blok berikut di keduanya.
 
 ```bash
 # Test if ~/.aliases exists and source it
@@ -132,34 +132,34 @@ if [ -f ~/.aliases ]; then
 fi
 ```
 
-# Resources
+# Sumber daya
 
-- Your instructors' dotfiles:
+- Dotfiles para instruktur Anda:
   [Anish](https://github.com/anishathalye/dotfiles),
   [Jon](https://github.com/jonhoo/configs),
   [Jose](https://github.com/jjgo/dotfiles)
-- [GitHub does dotfiles](https://dotfiles.github.io/): dotfile frameworks,
-utilities, examples, and tutorials
+- [GitHub does dotfiles](https://dotfiles.github.io/): framework,
+  utilitas, contoh, dan tutorial dotfile
 - [Shell startup
-  scripts](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html): an
-  explanation of the different configuration files used for your shell
+  scripts](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html):
+  penjelasan tentang berkas konfigurasi berbeda yang digunakan untuk shell Anda
 
-# Exercises
+# Latihan
 
-1. Create a folder for your dotfiles and set up [version
+1. Buat folder untuk dotfiles Anda dan siapkan [version
    control](/2019/version-control/).
 
-1. Add a configuration for at least one program, e.g. your shell, with some
-   customization (to start off, it can be something as simple as customizing
-   your shell prompt by setting `$PS1`).
+1. Tambahkan konfigurasi untuk setidaknya satu program, misalnya shell Anda, dengan beberapa
+   kustomisasi (untuk memulai, ini bisa sesederhana menyesuaikan
+   prompt shell Anda dengan menyetel `$PS1`).
 
-1. Set up a method to install your dotfiles quickly (and without manual effort)
-   on a new machine. This can be as simple as a shell script that calls `ln -s`
-   for each file, or you could use a [specialized
-   utility](https://dotfiles.github.io/utilities/).
+1. Siapkan metode untuk menginstal dotfiles Anda dengan cepat (dan tanpa usaha manual)
+   di mesin baru. Ini bisa sesederhana script shell yang memanggil `ln -s`
+   untuk setiap berkas, atau Anda dapat menggunakan [utilitas
+   khusus](https://dotfiles.github.io/utilities/).
 
-1. Test your installation script on a fresh virtual machine.
+1. Uji script instalasi Anda di virtual machine yang masih segar.
 
-1. Migrate all of your current tool configurations to your dotfiles repository.
+1. Pindahkan semua konfigurasi alat Anda saat ini ke repositori dotfiles Anda.
 
-1. Publish your dotfiles on GitHub.
+1. Publikasikan dotfiles Anda di GitHub.

--- a/_2019/editors.md
+++ b/_2019/editors.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Editors"
+title: "Editor"
 presenter: Anish
 date: 2019-01-22
 order: 1
@@ -9,284 +9,248 @@ video:
   id: 1vLcusYSrI4
 ---
 
-# Importance of Editors
+# Pentingnya Editor
 
-As programmers, we spend most of our time editing plain-text files. It's worth
-investing time learning an editor that fits your needs.
+Sebagai programmer, kita menghabiskan sebagian besar waktu untuk mengedit berkas teks biasa. Penting untuk meluangkan waktu mempelajari editor yang sesuai dengan kebutuhan Anda.
 
-How do you learn a new editor? You force yourself to use that editor for a
-while, even if it temporarily hampers your productivity. It'll pay off soon
-enough (two weeks is enough to learn the basics).
+Bagaimana cara mempelajari editor baru? Anda memaksa diri untuk menggunakan editor tersebut selama beberapa waktu, meskipun produktivitas Anda menurun untuk sementara. Ini akan segera terbayar (dua minggu cukup untuk mempelajari dasar-dasarnya).
 
-We are going to teach you Vim, but we encourage you to experiment with other
-editors. It's a very personal choice, and people have [strong
-opinions](https://en.wikipedia.org/wiki/Editor_war).
+Kami akan mengajarkan Anda Vim, tetapi kami mendorong Anda untuk bereksperimen dengan editor lain. Ini adalah pilihan yang sangat pribadi, dan orang-orang memiliki [pendapat yang kuat](https://en.wikipedia.org/wiki/Editor_war).
 
-We can't teach you how to use a powerful editor in 50 minutes, so we're going
-to focus on teaching you the basics, showing you some of the more advanced
-functionality, and giving you the resources to master the tool. We'll teach you
-lessons in the context of Vim, but most ideas will translate to any other
-powerful editor you use (and if they don't, then you probably shouldn't use
-that editor!).
+Kami tidak bisa mengajarkan Anda cara menggunakan editor yang canggih dalam 50 menit, jadi kami akan fokus mengajarkan dasar-dasarnya, menunjukkan beberapa fungsi yang lebih lanjut, dan memberikan sumber daya untuk menguasai alat ini. Kami akan mengajarkan pelajaran dalam konteks Vim, tetapi sebagian besar konsep akan berlaku untuk editor canggih lainnya yang Anda gunakan (dan jika tidak, maka Anda mungkin seharusnya tidak menggunakan editor tersebut!).
 
-![Editor Learning Curves](/2019/files/editor-learning-curves.jpg)
+![Kurva Pembelajaran Editor](/2019/files/editor-learning-curves.jpg)
 
 <!-- source: https://blogs.msdn.microsoft.com/steverowe/2004/11/17/code-editor-learning-curves/ -->
 
-The editor learning curves graph is a myth. Learning the basics of a powerful
-editor is quite easy (even though it might take years to master).
+Grafik kurva pembelajaran editor adalah mitos. Mempelajari dasar-dasar editor yang canggih cukup mudah (meskipun mungkin butuh bertahun-tahun untuk menguasainya).
 
-Which editors are popular today? See this [Stack Overflow
-survey](https://insights.stackoverflow.com/survey/2018/#development-environments-and-tools)
-(there may be some bias because Stack Overflow users may not be representative
-of programmers as a whole).
+Editor mana yang populer saat ini? Lihat [survei Stack Overflow ini](https://insights.stackoverflow.com/survey/2018/#development-environments-and-tools) (mungkin ada beberapa bias karena pengguna Stack Overflow mungkin tidak mewakili programmer secara keseluruhan).
 
-## Command-line Editors
+## Editor Baris Perintah
 
-Even if you eventually settle on using a GUI editor, it's worth learning a
-command-line editor for easily editing files on remote machines.
+Meskipun Anda akhirnya memutuskan untuk menggunakan editor GUI, ada baiknya mempelajari editor baris perintah untuk mengedit berkas di mesin remote dengan mudah.
 
 # Nano
 
-Nano is a simple command-line editor.
+Nano adalah editor baris perintah yang sederhana.
 
-- Move with arrow keys
-- All other shortcuts (save, exit) shown at the bottom
+- Pindah dengan tombol panah
+- Semua pintasan lainnya (simpan, keluar) ditampilkan di bagian bawah
 
 # Vim
 
-Vi/Vim is a powerful text editor. It's a command-line program that's usually
-installed everywhere, which makes it convenient for editing files on a remote
-machine.
+Vi/Vim adalah editor teks yang canggih. Ini adalah program baris perintah yang biasanya terinstal di mana-mana, sehingga nyaman untuk mengedit berkas di mesin remote.
 
-Vim also has graphical versions, such as GVim and
-[MacVim](https://macvim-dev.github.io/macvim/). These provide additional
-features such as 24-bit color, menus, and popups.
+Vim juga memiliki versi grafis, seperti GVim dan [MacVim](https://macvim-dev.github.io/macvim/). Ini menyediakan fitur tambahan seperti warna 24-bit, menu, dan popup.
 
-## Philosophy of Vim
+## Filosofi Vim
 
-- When programming, you spend most of your time reading/editing, not writing
-    - Vim is a **modal** editor: different modes for inserting text vs manipulating text
-- Vim is programmable (with Vimscript and also other languages like Python)
-- Vim's interface itself is like a programming language
-    - Keystrokes (with mnemonic names) are commands
-    - Commands are composable
-- Don't use the mouse: too slow
-- Editor should work at the speed you think
+- Saat pemrograman, Anda menghabiskan sebagian besar waktu membaca/mengedit, bukan menulis
+    - Vim adalah editor **modal**: mode berbeda untuk menyisipkan teks vs memanipulasi teks
+- Vim dapat diprogram (dengan Vimscript dan juga bahasa lain seperti Python)
+- Antarmuka Vim itu sendiri seperti bahasa pemrograman
+    - Penekanan tombol (dengan nama mnemonik) adalah perintah
+    - Perintah-perintah dapat dikomposisikan
+- Jangan gunakan mouse: terlalu lambat
+- Editor harus bekerja secepat Anda berpikir
 
-## Introductory Vim
+## Vim Dasar
 
-### Modes
+### Mode
 
-Vim shows the current mode in the bottom left.
+Vim menampilkan mode saat ini di pojok kiri bawah.
 
-- Normal mode: for moving around a file and making edits
-    - Spend most of your time here
-- Insert mode: for inserting text
-- Visual (visual, line, or block) mode: for selecting blocks of text
+- Mode Normal: untuk berpindah-pindah dalam berkas dan melakukan pengeditan
+    - Habiskan sebagian besar waktu Anda di sini
+- Mode Insert: untuk menyisipkan teks
+- Mode Visual (visual, line, atau block): untuk memilih blok teks
 
-You change modes by pressing `<ESC>` to switch from any mode back to normal
-mode. From normal mode, enter insert mode with `i`, visual mode with `v`,
-visual line mode with `V`, and visual block mode with `<C-v>`.
+Anda berpindah mode dengan menekan `<ESC>` untuk beralih dari mode mana pun kembali ke mode normal. Dari mode normal, masuk ke mode insert dengan `i`, mode visual dengan `v`, mode visual line dengan `V`, dan mode visual block dengan `<C-v>`.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to
-Escape.
+Anda menggunakan tombol `<ESC>` sangat sering saat menggunakan Vim: pertimbangkan untuk memetakan ulang Caps Lock ke Escape.
 
-### Basics
+### Dasar-dasar
 
-Vim ex commands are issued through `:{command}` in normal mode.
+Perintah ex Vim dijalankan melalui `:{command}` dalam mode normal.
 
-- `:q` quit (close window)
-- `:w` save
-- `:wq` save and quit
-- `:e {name of file}` open file for editing
-- `:ls` show open buffers
-- `:help {topic}` open help
-    - `:help :w` opens help for the `:w` ex command
-    - `:help w` opens help for the `w` movement
+- `:q` keluar (tutup jendela)
+- `:w` simpan
+- `:wq` simpan dan keluar
+- `:e {name of file}` buka berkas untuk diedit
+- `:ls` tampilkan buffer yang terbuka
+- `:help {topic}` buka bantuan
+    - `:help :w` membuka bantuan untuk perintah ex `:w`
+    - `:help w` membuka bantuan untuk pergerakan `w`
 
-### Movement
+### Pergerakan
 
-Vim is all about efficient movement. Navigate the file in Normal mode.
+Vim semuanya tentang pergerakan yang efisien. Navigasi berkas dalam mode Normal.
 
-- Disable arrow keys to avoid bad habits
+- Nonaktifkan tombol panah untuk menghindari kebiasaan buruk
 ```vim
 nnoremap <Left> :echoe "Use h"<CR>
 nnoremap <Right> :echoe "Use l"<CR>
 nnoremap <Up> :echoe "Use k"<CR>
 nnoremap <Down> :echoe "Use j"<CR>
 ```
-- Basic movement: `hjkl` (left, down, up, right)
-- Words: `w` (next word), `b` (beginning of word), `e` (end of word)
-- Lines: `0` (beginning of line), `^` (first non-blank character), `$` (end of line)
-- Screen: `H` (top of screen), `M` (middle of screen), `L` (bottom of screen)
-- File: `gg` (beginning of file), `G` (end of file)
-- Line numbers: `:{number}<CR>` or `{number}G` (line {number})
-- Misc: `%` (corresponding item)
-- Find: `f{character}`, `t{character}`, `F{character}`, `T{character}`
-    - find/to forward/backward {character} on the current line
-- Repeating N times: `{number}{movement}`, e.g. `10j` moves down 10 lines
-- Search: `/{regex}`, `n` / `N` for navigating matches
+- Pergerakan dasar: `hjkl` (kiri, bawah, atas, kanan)
+- Kata: `w` (kata berikutnya), `b` (awal kata), `e` (akhir kata)
+- Baris: `0` (awal baris), `^` (karakter bukan spasi pertama), `$` (akhir baris)
+- Layar: `H` (atas layar), `M` (tengah layar), `L` (bawah layar)
+- Berkas: `gg` (awal berkas), `G` (akhir berkas)
+- Nomor baris: `:{number}<CR>` atau `{number}G` (baris ke-{number})
+- Lainnya: `%` (item yang sesuai)
+- Cari: `f{character}`, `t{character}`, `F{character}`, `T{character}`
+    - cari/menuju maju/mundur {character} pada baris saat ini
+- Mengulangi N kali: `{number}{movement}`, misalnya `10j` pindah ke bawah 10 baris
+- Pencarian: `/{regex}`, `n` / `N` untuk berpindah antar kecocokan
 
-### Selection
+### Seleksi
 
-Visual modes:
+Mode Visual:
 
 - Visual
 - Visual Line
 - Visual Block
 
-Can use movement keys to make selection.
+Dapat menggunakan tombol pergerakan untuk membuat seleksi.
 
-### Manipulating text
+### Memanipulasi teks
 
-Everything that you used to do with the mouse, you now do with keyboards (and
-powerful, composable commands).
+Semua yang biasa Anda lakukan dengan mouse, sekarang Anda lakukan dengan keyboard (dan perintah yang canggih dan dapat dikomposisikan).
 
-- `i` enter insert mode
-    - but for manipulating/deleting text, want to use something more than
-    backspace
-- `o` / `O` insert line below / above
-- `d{motion}` delete {motion}
-    - e.g. `dw` is delete word, `d$` is delete to end of line, `d0` is delete
-    to beginning of line
-- `c{motion}` change {motion}
-    - e.g. `cw` is change word
-    - like `d{motion}` followed by `i`
-- `x` delete character (equal do `dl`)
-- `s` substitute character (equal to `xi`)
-- visual mode + manipulation
-    - select text, `d` to delete it or `c` to change it
-- `u` to undo, `<C-r>` to redo
-- Lots more to learn: e.g. `~` flips the case of a character
+- `i` masuk mode insert
+    - tetapi untuk memanipulasi/menghapus teks, Anda ingin menggunakan sesuatu selain backspace
+- `o` / `O` sisipkan baris di bawah / di atas
+- `d{motion}` hapus {motion}
+    - misalnya `dw` adalah hapus kata, `d$` adalah hapus sampai akhir baris, `d0` adalah hapus sampai awal baris
+- `c{motion}` ubah {motion}
+    - misalnya `cw` adalah ubah kata
+    - seperti `d{motion}` diikuti oleh `i`
+- `x` hapus karakter (sama dengan `dl`)
+- `s` substitusi karakter (sama dengan `xi`)
+- mode visual + manipulasi
+    - pilih teks, `d` untuk menghapusnya atau `c` untuk mengubahnya
+- `u` untuk membatalkan, `<C-r>` untuk mengulangi
+- Masih banyak yang harus dipelajari: misalnya `~` membalik huruf besar/kecil karakter
 
-### Resources
+### Sumber Daya
 
-- `vimtutor` command-line program to teach you vim
-- [Vim Adventures](https://vim-adventures.com/) game to learn Vim
+- `vimtutor` program baris perintah untuk mengajari Anda vim
+- [Vim Adventures](https://vim-adventures.com/) permainan untuk belajar Vim
 
-## Customizing Vim
+## Menyesuaikan Vim
 
-Vim is customized through a plain-text configuration file in `~/.vimrc`
-(containing Vimscript commands). There are probably lots of basic settings that
-you want to turn on.
+Vim disesuaikan melalui berkas konfigurasi teks biasa di `~/.vimrc` (berisi perintah Vimscript). Mungkin ada banyak pengaturan dasar yang ingin Anda aktifkan.
 
-Look at people's dotfiles on GitHub for inspiration, but try not to
-copy-and-paste people's full configuration. Read it, understand it, and take
-what you need.
+Lihat dotfiles orang-orang di GitHub untuk inspirasi, tetapi cobalah untuk tidak menyalin-tempel konfigurasi lengkap orang lain. Bacalah, pahami, dan ambil yang Anda butuhkan.
 
-Some customizations to consider:
+Beberapa penyesuaian yang bisa dipertimbangkan:
 
-- Syntax highlighting: `syntax on`
-- Color schemes
-- Line numbers: `set nu` / `set rnu`
-- Backspacing through everything: `set backspace=indent,eol,start`
+- Penyorotan sintaks: `syntax on`
+- Skema warna
+- Nomor baris: `set nu` / `set rnu`
+- Backspace melalui semua: `set backspace=indent,eol,start`
 
-## Advanced Vim
+## Vim Lanjutan
 
-Here are a few examples to show you the power of the editor. We can't teach you
-all of these kinds of things, but you'll learn them as you go. A good
-heuristic: whenever you're using your editor and you think "there must be a
-better way of doing this", there probably is: look it up online.
+Berikut beberapa contoh untuk menunjukkan kekuatan editor ini. Kami tidak bisa mengajarkan semua hal ini, tetapi Anda akan mempelajarinya seiring berjalannya waktu. Heuristik yang baik: kapan pun Anda menggunakan editor dan berpikir "pasti ada cara yang lebih baik untuk melakukan ini", kemungkinan besar ada: cari di internet.
 
-### Search and replace
+### Cari dan ganti
 
-`:s` (substitute) command ([documentation](https://vim.fandom.com/wiki/Search_and_replace)).
+Perintah `:s` (substitute) ([dokumentasi](https://vim.fandom.com/wiki/Search_and_replace)).
 
 - `%s/foo/bar/g`
-    - replace foo with bar globally in file
+    - ganti foo dengan bar secara global di berkas
 - `%s/\[.*\](\(.*\))/\1/g`
-    - replace named Markdown links with plain URLs
+    - ganti tautan Markdown bernama dengan URL biasa
 
-### Multiple windows
+### Beberapa jendela
 
-- `sp` / `vsp` to split windows
-- Can have multiple views of the same buffer.
+- `sp` / `vsp` untuk membagi jendela
+- Dapat memiliki beberapa tampilan dari buffer yang sama.
 
-### Mouse support
+### Dukungan mouse
 
 - `set mouse+=a`
-    - can click, scroll select
+    - bisa klik, gulir, pilih
 
-### Macros
+### Makro
 
-- `q{character}` to start recording a macro in register `{character}`
-- `q` to stop recording
-- `@{character}` replays the macro
-- Macro execution stops on error
-- `{number}@{character}` executes a macro {number} times
-- Macros can be recursive
-    - first clear the macro with `q{character}q`
-    - record the macro, with `@{character}` to invoke the macro recursively
-    (will be a no-op until recording is complete)
-- Example: convert xml to json ([file](/2019/files/example-data.xml))
-    - Array of objects with keys "name" / "email"
-    - Use a Python program?
-    - Use sed / regexes
+- `q{character}` untuk mulai merekam makro di register `{character}`
+- `q` untuk berhenti merekam
+- `@{character}` memutar ulang makro
+- Eksekusi makro berhenti saat ada kesalahan
+- `{number}@{character}` mengeksekusi makro {number} kali
+- Makro bisa bersifat rekursif
+    - pertama bersihkan makro dengan `q{character}q`
+    - rekam makro, dengan `@{character}` untuk memanggil makro secara rekursif
+    (akan menjadi no-op sampai perekaman selesai)
+- Contoh: konversi xml ke json ([file](/2019/files/example-data.xml))
+    - Array objek dengan kunci "name" / "email"
+    - Gunakan program Python?
+    - Gunakan sed / regex
         - `g/people/d`
         - `%s/<person>/{/g`
         - `%s/<name>\(.*\)<\/name>/"name": "\1",/g`
         - ...
-    - Vim commands / macros
-        - `Gdd`, `ggdd` delete first and last lines
-        - Macro to format a single element (register `e`)
-            - Go to line with `<name>`
+    - Perintah / makro Vim
+        - `Gdd`, `ggdd` hapus baris pertama dan terakhir
+        - Makro untuk memformat satu elemen (register `e`)
+            - Pindah ke baris dengan `<name>`
             - `qe^r"f>s": "<ESC>f<C"<ESC>q`
-        - Macro to format a person
-            - Go to line with `<person>`
+        - Makro untuk memformat satu orang
+            - Pindah ke baris dengan `<person>`
             - `qpS{<ESC>j@eA,<ESC>j@ejS},<ESC>q`
-        - Macro to format a person and go to the next person
-            - Go to line with `<person>`
+        - Makro untuk memformat satu orang dan pindah ke orang berikutnya
+            - Pindah ke baris dengan `<person>`
             - `qq@pjq`
-        - Execute macro until end of file
+        - Eksekusi makro sampai akhir berkas
             - `999@q`
-        - Manually remove last `,` and add `[` and `]` delimiters
+        - Hapus `,` terakhir secara manual dan tambahkan pembatas `[` dan `]`
 
-## Extending Vim
+## Memperluas Vim
 
-There are tons of plugins for extending vim.
+Ada banyak plugin untuk memperluas vim.
 
-First, get set up with a plugin manager like
-[vim-plug](https://github.com/junegunn/vim-plug),
-[Vundle](https://github.com/VundleVim/Vundle.vim), or
-[pathogen.vim](https://github.com/tpope/vim-pathogen).
+Pertama, siapkan plugin manager seperti [vim-plug](https://github.com/junegunn/vim-plug), [Vundle](https://github.com/VundleVim/Vundle.vim), atau [pathogen.vim](https://github.com/tpope/vim-pathogen).
 
-Some plugins to consider:
+Beberapa plugin yang bisa dipertimbangkan:
 
-- [ctrlp.vim](https://github.com/kien/ctrlp.vim): fuzzy file finder
-- [vim-fugitive](https://github.com/tpope/vim-fugitive): git integration
-- [vim-surround](https://github.com/tpope/vim-surround): manipulating "surroundings"
-- [gundo.vim](https://github.com/sjl/gundo.vim): navigate undo tree
-- [nerdtree](https://github.com/scrooloose/nerdtree): file explorer
-- [syntastic](https://github.com/vim-syntastic/syntastic): syntax checking
-- [vim-easymotion](https://github.com/easymotion/vim-easymotion): magic motions
-- [vim-over](https://github.com/osyo-manga/vim-over): substitute preview
+- [ctrlp.vim](https://github.com/kien/ctrlp.vim): pencarian berkas fuzzy
+- [vim-fugitive](https://github.com/tpope/vim-fugitive): integrasi git
+- [vim-surround](https://github.com/tpope/vim-surround): memanipulasi "lingkungan"
+- [gundo.vim](https://github.com/sjl/gundo.vim): navigasi pohon undo
+- [nerdtree](https://github.com/scrooloose/nerdtree): penjelajah berkas
+- [syntastic](https://github.com/vim-syntastic/syntastic): pemeriksaan sintaks
+- [vim-easymotion](https://github.com/easymotion/vim-easymotion): pergerakan ajaib
+- [vim-over](https://github.com/osyo-manga/vim-over): pratinjau substitusi
 
-Lists of plugins:
+Daftar plugin:
 
 - [Vim Awesome](https://vimawesome.com/)
 
-## Vim-mode in Other Programs
+## Mode Vim di Program Lain
 
-For many popular editors (e.g. vim and emacs), many other tools support editor
-emulation.
+Untuk banyak editor populer (misalnya vim dan emacs), banyak alat lain mendukung emulasi editor.
 
 - Shell
     - bash: `set -o vi`
     - zsh: `bindkey -v`
-    - `export EDITOR=vim` (environment variable used by programs like `git`)
+    - `export EDITOR=vim` (variabel lingkungan yang digunakan oleh program seperti `git`)
 - `~/.inputrc`
     - `set editing-mode vi`
 
-There are even vim keybinding extensions for web [browsers](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers), some popular ones are [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en) for Google Chrome and [Tridactyl](https://github.com/tridactyl/tridactyl) for Firefox.
+Terdapat juga ekstensi keybinding vim untuk [browser](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers) web, beberapa yang populer adalah [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en) untuk Google Chrome dan [Tridactyl](https://github.com/tridactyl/tridactyl) untuk Firefox.
 
 
-## Resources
+## Sumber Daya
 
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2018/): various Vim tips
-- [Neovim](https://neovim.io/) is a modern vim reimplementation with more active development.
-- [Vim Golf](https://www.vimgolf.com/): Various Vim challenges
+- [Vim Advent Calendar](https://vimways.org/2018/): berbagai tips Vim
+- [Neovim](https://neovim.io/) adalah implementasi ulang vim modern dengan pengembangan yang lebih aktif.
+- [Vim Golf](https://www.vimgolf.com/): Berbagai tantangan Vim
 
 {% comment %}
 # Resources
@@ -294,21 +258,14 @@ There are even vim keybinding extensions for web [browsers](https://vim.fandom.c
 TODO resources for other editors?
 {% endcomment %}
 
-# Exercises
+# Latihan
 
-1. Experiment with some editors. Try at least one command-line editor (e.g.
-   Vim) and at least one GUI editor (e.g. Atom). Learn through tutorials like
-   `vimtutor` (or the equivalents for other editors). To get a real feel for a
-   new editor, commit to using it exclusively for a couple days while going
-   about your work.
+1. Bereksperimenlah dengan beberapa editor. Cobalah setidaknya satu editor baris perintah (misalnya Vim) dan setidaknya satu editor GUI (misalnya Atom). Belajarlah melalui tutorial seperti `vimtutor` (atau yang setara untuk editor lain). Untuk mendapatkan kesan nyata terhadap editor baru, berkomitmenlah untuk menggunakannya secara eksklusif selama beberapa hari saat mengerjakan pekerjaan Anda.
 
-1. Customize your editor. Look through tips and tricks online, and look through
-   other people's configurations (often, they are well-documented).
+1. Sesuaikan editor Anda. Lihat tips dan trik di internet, dan lihat konfigurasi orang lain (seringkali, konfigurasinya terdokumentasi dengan baik).
 
-1. Experiment with plugins for your editor.
+1. Bereksperimenlah dengan plugin untuk editor Anda.
 
-1. Commit to using a powerful editor for at least a couple weeks: you should
-   start seeing the benefits by then. At some point, you should be able to get
-   your editor to work as fast as you think.
+1. Berkomitmenlah untuk menggunakan editor yang canggih selama setidaknya beberapa minggu: Anda seharusnya mulai melihat manfaatnya pada saat itu. Pada titik tertentu, Anda seharusnya bisa membuat editor Anda bekerja secepat Anda berpikir.
 
-1. Install a linter (e.g. pyflakes for python) link it to your editor and test it is working.
+1. Instal linter (misalnya pyflakes untuk python), hubungkan ke editor Anda, dan uji apakah berfungsi.

--- a/_2019/index.md
+++ b/_2019/index.md
@@ -2,7 +2,7 @@
 layout: page
 title: "2019 Lectures"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2019.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2019.
 permalink: /2019/
 phony: true
 ---

--- a/_2019/index.md
+++ b/_2019/index.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: "2019 Lectures"
+title: "Kuliah 2019"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2019.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2019.
 permalink: /2019/
 phony: true
 ---
@@ -23,9 +23,9 @@ phony: true
   </ul>
 {% endfor %}
 
-# Beyond MIT
+# Di Luar MIT
 
-We've also shared this class beyond MIT in the hopes that others may benefit from these resources. You can find posts and discussion on
+Kami juga telah membagikan kelas ini di luar MIT dengan harapan orang lain dapat memperoleh manfaat dari sumber daya ini. Anda dapat menemukan postingan dan diskusi di
 
 - [Hacker News](https://news.ycombinator.com/item?id=19078281)
 - [Lobsters](https://lobste.rs/s/h6157x/mit_hacker_tools_lecture_series_on)
@@ -34,6 +34,6 @@ We've also shared this class beyond MIT in the hopes that others may benefit fro
 - [Twitter](https://twitter.com/Jonhoo/status/1091896192332693504)
 - [YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuiujH1lpn8cA9dsyulbYRv)
 
-# Acknowledgments
+# Ucapan Terima Kasih
 
-This class was taught as part of [SIPB IAP 2019](https://sipb.mit.edu/iap/2019/) and co-sponsored by [SIPB](https://sipb.mit.edu/) and [MIT EECS](https://www.eecs.mit.edu/).
+Kelas ini diajarkan sebagai bagian dari [SIPB IAP 2019](https://sipb.mit.edu/iap/2019/) dan bersama-sama disponsori oleh [SIPB](https://sipb.mit.edu/) dan [MIT EECS](https://www.eecs.mit.edu/).

--- a/_2019/machine-introspection.md
+++ b/_2019/machine-introspection.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Machine Introspection"
+title: "Introspeksi Mesin"
 presenter: Jon
 date: 2019-01-24
 order: 4
@@ -10,112 +10,111 @@ video:
 special: true
 ---
 
-Sometimes, computers misbehave. And very often, you want to know why.
-Let's look at some tools that help you do that!
+Terkadang, komputer berperilaku tidak semestinya. Dan sangat sering, Anda ingin tahu alasannya.
+Mari kita lihat beberapa alat yang membantu Anda melakukannya!
 
-But first, let's make sure you're able to do introspection. Often,
-system introspection requires that you have certain privileges, like
-being the member of a group (like `power` for shutdown). The `root` user
-has the ultimate privilege; they can do pretty much anything. You can run
-a command as `root` (but be careful!) using `sudo`.
+Tapi pertama-tama, mari pastikan Anda mampu melakukan introspeksi. Seringkali,
+introspeksi sistem mengharuskan Anda memiliki hak akses tertentu, seperti
+menjadi anggota dari sebuah grup (seperti `power` untuk shutdown). User `root`
+memiliki hak akses tertinggi; mereka dapat melakukan hampir semuanya. Anda dapat menjalankan
+perintah sebagai `root` (tapi berhati-hatilah!) menggunakan `sudo`.
 
-## What happened?
+## Apa yang terjadi?
 
-If something goes wrong, the first place to start is to look at what
-happened around the time when things went wrong. For this, we need to
-look at logs.
+Jika sesuatu berjalan salah, tempat pertama untuk memulai adalah melihat apa
+yang terjadi di sekitar waktu ketika masalah terjadi. Untuk ini, kita perlu
+melihat log.
 
-Traditionally, logs were all stored in `/var/log`, and many still are.
-Usually there's a file or folder per program. Use `grep` or `less` to
-find your way through them.
+Secara tradisional, log disimpan di `/var/log`, dan banyak yang masih demikian.
+Biasanya terdapat file atau folder per program. Gunakan `grep` atau `less` untuk
+menemukan jalan Anda melaluinya.
 
-There's also a kernel log that you can see using the `dmesg` command.
-This used to be available as a plain-text file, but nowadays you often
-have to go through `dmesg` to get at it.
+Ada juga log kernel yang dapat Anda lihat menggunakan perintah `dmesg`.
+Dulu ini tersedia sebagai file teks biasa, tetapi saat ini Anda sering kali
+harus melalui `dmesg` untuk mengaksesnya.
 
-Finally, there is the "system log", which is increasingly where all of
-your log messages go. On _most_, though not all, Linux systems, that log
-is managed by `systemd`, the "system daemon", which controls all the
-services that run in the background (and much much more at this point).
-That log is accessible through the somewhat inconvenient `journalctl`
-tool if you are root, or part of the `admin` or `wheel` groups.
+Terakhir, ada "system log", yang semakin menjadi tempat semua pesan
+log Anda disimpan. Pada _sebagian besar_, meskipun tidak semua, sistem Linux, log tersebut
+dikelola oleh `systemd`, "system daemon", yang mengendalikan semua
+layanan yang berjalan di latar belakang (dan masih banyak lagi saat ini).
+Log tersebut dapat diakses melalui alat `journalctl` yang agak tidak nyaman
+jika Anda adalah root, atau bagian dari grup `admin` atau `wheel`.
 
-For `journalctl`, you should be aware of these flags in particular:
+Untuk `journalctl`, Anda harus mengetahui flag-flag berikut khususnya:
 
- - `-u UNIT`: show only messages related to the given systemd service
- - `--full`: don't truncate long lines (the stupidest feature)
- - `-b`: only show messages from the latest boot (see also `-b -2`)
- - `-n100`: only show last 100 entries
+ - `-u UNIT`: tampilkan hanya pesan yang terkait dengan layanan systemd yang diberikan
+ - `--full`: jangan potong baris panjang (fitur paling bodoh)
+ - `-b`: hanya tampilkan pesan dari boot terbaru (lihat juga `-b -2`)
+ - `-n100`: hanya tampilkan 100 entri terakhir
 
-## What is happening?
+## Apa yang sedang terjadi?
 
-If something _is_ wrong, or you just want to get a feel for what's going
-on in your system, you have a number of tools at your disposal for
-inspecting the currently running system:
+Jika sesuatu _sedang_ salah, atau Anda hanya ingin mendapatkan gambaran tentang apa yang terjadi
+pada sistem Anda, Anda memiliki sejumlah alat yang tersedia untuk
+memeriksa sistem yang sedang berjalan:
 
-First, there's `top`, and the improved version `htop`, which show you
-various statistics for the currently running processes on the system.
-CPU use, memory use, process trees, etc. There are lots of shortcuts,
-but `t` is particularly useful for enabling the tree view. You can also
-see the process tree with `pstree` (+ `-p` to include PIDs). If you want
-to know what those programs are doing, you'll often want to tail their
-log files. `journalctl -f`, `dmesg -w`, and `tail -f` are you friends
-here.
+Pertama, ada `top`, dan versi yang lebih baik `htop`, yang menampilkan
+berbagai statistik untuk proses yang sedang berjalan pada sistem.
+Penggunaan CPU, penggunaan memori, pohon proses, dll. Ada banyak shortcut,
+tetapi `t` sangat berguna untuk mengaktifkan tampilan tree. Anda juga dapat
+melihat pohon proses dengan `pstree` (+ `-p` untuk menyertakan PID). Jika Anda ingin
+tahu apa yang dilakukan program-program tersebut, Anda sering kali ingin melihat
+file log mereka. `journalctl -f`, `dmesg -w`, dan `tail -f` adalah teman Anda
+di sini.
 
-Sometimes, you want to know more about the resources being used overall
-on your system. [`dool`](https://github.com/scottchiefbaker/dool) is
-excellent for that. It gives you real-time resource metrics for lots of
-different subsystems like I/O, networking, CPU utilization, context
-switches, and the like. `man dool` is the place to start.
+Terkadang, Anda ingin tahu lebih banyak tentang resource yang digunakan secara keseluruhan
+pada sistem Anda. [`dool`](https://github.com/scottchiefbaker/dool) sangat
+bagus untuk itu. Alat ini memberikan metrik resource real-time untuk banyak
+subsystem yang berbeda seperti I/O, networking, penggunaan CPU, context switch, dan sejenisnya. `man dool` adalah tempat untuk memulai.
 
-If you're running out of disk space, there are two primary utilities
-you'll want to know about: `df` and `du`. The former shows you the
-status of all the partitions on your system (try it with `-h`), whereas
-the latter measures the size of all the folders you give it, including
-their contents (see also `-h` and `-s`).
+Jika Anda kehabisan ruang disk, ada dua utilitas utama
+yang perlu Anda ketahui: `df` dan `du`. Yang pertama menampilkan
+status semua partisi pada sistem Anda (coba dengan `-h`), sedangkan
+yang kedua mengukur ukuran semua folder yang Anda berikan, termasuk
+isinya (lihat juga `-h` dan `-s`).
 
-To figure out what network connections you have open, `ss` is the way to
-go. `ss -t` will show all open TCP connections. `ss -tl` will show all
-listening (i.e., server) ports on your system. `-p` will also include
-which process is using that connection, and `-n` will give you the raw
-port numbers.
+Untuk mengetahui koneksi network apa yang Anda buka, `ss` adalah caranya.
+`ss -t` akan menampilkan semua koneksi TCP yang terbuka. `ss -tl` akan menampilkan semua
+port yang mendengarkan (yaitu, server) pada sistem Anda. `-p` juga akan menyertakan
+proses mana yang menggunakan koneksi tersebut, dan `-n` akan memberi Anda
+nomor port mentah.
 
 
-## System configuration
+## Konfigurasi sistem
 
-There are _many_ ways to configure your system, but we'll go through
-two very common ones: networking and services. Most applications on your
-system tell you how to configure them in their manpage, and usually it
-will involve editing files in `/etc`; the system configuration
-directory.
+Ada _banyak_ cara untuk mengonfigurasi sistem Anda, tetapi kita akan membahas
+dua yang sangat umum: networking dan layanan. Sebagian besar aplikasi pada sistem Anda
+memberitahu Anda cara mengonfigurasinya di manpage mereka, dan biasanya
+akan melibatkan mengedit file di `/etc`; direktori konfigurasi
+sistem.
 
-If you want to configure your network, the `ip` command lets you do
-that. Its arguments take on a slightly weird form, but `ip help command`
-will get you pretty far. `ip addr` shows you information about your
-network interfaces and how they're configured (IP addresses and such),
-and `ip route` shows you how network traffic is routed to different
-network hosts. Network problems can often be resolved purely through the
-`ip` tool. There's also `iw` for managing wireless network interfaces.
-`ping` is a handy tool for checking how deeply things are broken. Try
-pinging a hostname (google.com), an external IP address (1.1.1.1), and
-an internal IP address (192.168.1.1 or default gw). You may also want to
-fiddle with `/etc/resolv.conf` to check your DNS settings (how hostnames
-are resolved to IP addresses).
+Jika Anda ingin mengonfigurasi network Anda, perintah `ip` memungkinkan Anda
+melakukannya. Argumennya memiliki bentuk yang agak aneh, tetapi `ip help command`
+akan membawa Anda cukup jauh. `ip addr` menampilkan informasi tentang
+interface network Anda dan bagaimana mereka dikonfigurasi (alamat IP dan sejenisnya),
+dan `ip route` menampilkan bagaimana traffic network di-route ke host
+network yang berbeda. Masalah network sering kali dapat diselesaikan sepenuhnya melalui
+alat `ip`. Ada juga `iw` untuk mengelola interface network nirkabel.
+`ping` adalah alat yang berguna untuk memeriksa seberapa parah kerusakan yang terjadi. Coba
+ping sebuah hostname (google.com), alamat IP eksternal (1.1.1.1), dan
+alamat IP internal (192.168.1.1 atau default gw). Anda mungkin juga ingin
+mengutak-atik `/etc/resolv.conf` untuk memeriksa pengaturan DNS Anda (bagaimana hostname
+diresolusi ke alamat IP).
 
-To configure services, you pretty much have to interact with `systemd`
-these days, for better or for worse. Most services on your system will
-have a systemd service file that defines a systemd _unit_. These files
-define what command to run when that services is started, how to stop
-it, where to log things, etc. They're usually not too bad to read, and
-you can find most of them in `/usr/lib/systemd/system/`. You can also
-define your own in `/etc/systemd/system` .
+Untuk mengonfigurasi layanan, Anda hampir pasti harus berinteraksi dengan `systemd`
+saat ini, mau tidak mau. Sebagian besar layanan pada sistem Anda akan
+memiliki file layanan systemd yang mendefinisikan _unit_ systemd. File-file ini
+mendefinisikan perintah apa yang dijalankan ketika layanan tersebut dimulai, bagaimana menghentikannya,
+di mana mencatat log, dll. Biasanya tidak terlalu sulit untuk dibaca, dan
+Anda dapat menemukan sebagian besar dari mereka di `/usr/lib/systemd/system/`. Anda juga dapat
+mendefinisikan milik Anda sendiri di `/etc/systemd/system` .
 
-Once you have a systemd service in mind, you use the `systemctl` command
-to interact with it. `systemctl enable UNIT` will set the service to
-start on boot (`disable` removes it again), and `start`, `stop`, and
-`restart` will do what you expect. If something goes wrong, systemd will
-let you know, and you can use `journalctl -u UNIT` to see the
-application's log. You can also use `systemctl status` to see how all
-your system services are doing. If your boot feels slow, it's probably
-due to a couple of slow services, and you can use `systemd-analyze` (try
-it with `blame`) to figure out which ones.
+Setelah Anda memiliki layanan systemd dalam pikiran, Anda menggunakan perintah `systemctl`
+untuk berinteraksi dengannya. `systemctl enable UNIT` akan mengatur layanan untuk
+dimulai saat boot (`disable` akan menghapusnya lagi), dan `start`, `stop`, dan
+`restart` akan melakukan apa yang Anda harapkan. Jika sesuatu berjalan salah, systemd akan
+memberitahu Anda, dan Anda dapat menggunakan `journalctl -u UNIT` untuk melihat
+log aplikasi. Anda juga dapat menggunakan `systemctl status` untuk melihat bagaimana semua
+layanan sistem Anda berjalan. Jika boot Anda terasa lambat, itu mungkin
+karena beberapa layanan yang lambat, dan Anda dapat menggunakan `systemd-analyze` (coba
+dengan `blame`) untuk mengetahui yang mana.

--- a/_2019/os-customization.md
+++ b/_2019/os-customization.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "OS Customization"
+title: "Kustomisasi OS"
 presenter: Anish
 date: 2019-01-29
 order: 3
@@ -10,81 +10,60 @@ video:
 special: true
 ---
 
-There is a lot you can do to customize your operating system beyond what is
-available in the settings menus.
+Ada banyak hal yang bisa Anda lakukan untuk menyesuaikan sistem operasi Anda di luar apa yang tersedia di menu pengaturan.
 
-# Keyboard remapping
+# Pemetaan ulang keyboard
 
-Your keyboard probably has keys that you aren't using very much. Instead of
-having useless keys, you can remap them to do useful things.
+Keyboard Anda mungkin memiliki tombol-tombol yang jarang Anda gunakan. Alih-alih membiarkan tombol-tombol tersebut tidak berguna, Anda bisa memetakannya ulang untuk melakukan hal-hal yang lebih bermanfaat.
 
-## Remapping to other keys
+## Memetakan ulang ke tombol lain
 
-The simplest thing is to remap keys to other keys. For example, if you don't
-use the caps lock key very much, then you can remap it to something more
-useful. If you are a Vim user, for example, you might want to remap caps lock
-to escape.
+Hal paling sederhana adalah memetakan ulang tombol ke tombol lain. Misalnya, jika Anda jarang menggunakan tombol caps lock, Anda bisa memetakannya ulang ke sesuatu yang lebih berguna. Jika Anda adalah pengguna Vim, misalnya, Anda mungkin ingin memetakan caps lock ke escape.
 
-On macOS, you can do some remappings through Keyboard settings in System
-Preferences; for more complicated mappings, you need special software.
+Di macOS, Anda bisa melakukan beberapa pemetaan ulang melalui pengaturan Keyboard di System Preferences; untuk pemetaan yang lebih rumit, Anda memerlukan perangkat lunak khusus.
 
-## Remapping to arbitrary commands
+## Memetakan ulang ke perintah sembarang
 
-You don't just have to remap keys to other keys: there are tools that will let
-you remap keys (or combinations of keys) to arbitrary commands. For example,
-you could make command-shift-t open a new terminal window.
+Anda tidak hanya bisa memetakan ulang tombol ke tombol lain: ada perangkat lunak yang memungkinkan Anda memetakan ulang tombol (atau kombinasi tombol) ke perintah sembarang. Misalnya, Anda bisa membuat command-shift-t membuka jendela terminal baru.
 
-# Customizing hidden OS settings
+# Menyesuaikan pengaturan OS yang tersembunyi
 
 ## macOS
 
-macOS exposes a lot of useful settings through the `defaults` command. For
-example, you can make Dock icons of hidden applications translucent:
+macOS menyediakan banyak pengaturan berguna melalui perintah `defaults`. Misalnya, Anda bisa membuat ikon Dock dari aplikasi yang tersembunyi menjadi transparan:
 
 ```shell
 defaults write com.apple.dock showhidden -bool true
 ```
 
-There is no single list of all possible settings, but you can find lists of
-specific customizations online, such as Mathias Bynens'
-[.macos](https://github.com/mathiasbynens/dotfiles/blob/master/.macos).
+Tidak ada satu daftar lengkap untuk semua pengaturan yang memungkinkan, tetapi Anda bisa menemukan daftar kustomisasi spesifik secara online, seperti [.macos](https://github.com/mathiasbynens/dotfiles/blob/master/.macos) milik Mathias Bynens.
 
-# Window management
+# Manajemen jendela
 
-## Tiling window management
+## Manajemen jendela tiling
 
-[Tiling window management](https://en.wikipedia.org/wiki/Tiling_window_manager)
-is one approach to window management, where you organize windows into
-non-overlapping frames. If you're using a Unix-based operating system, you can
-install a tiling window manager; if you're using something like Windows or
-macOS, you can install applications that let you approximate this behavior.
+[Manajemen jendela tiling](https://en.wikipedia.org/wiki/Tiling_window_manager) adalah salah satu pendekatan dalam manajemen jendela, di mana Anda mengatur jendela-jendela ke dalam bingkai yang tidak saling tumpang tindih. Jika Anda menggunakan sistem operasi berbasis Unix, Anda bisa menginstal tiling window manager; jika Anda menggunakan sesuatu seperti Windows atau macOS, Anda bisa menginstal aplikasi yang memungkinkan Anda meniru perilaku ini.
 
-## Screen management
+## Manajemen layar
 
-You can set up keyboard shortcuts to help you manipulate windows across
-screens.
+Anda bisa mengatur pintasan keyboard untuk membantu Anda memanipulasi jendela di berbagai layar.
 
-## Layouts
+## Tata letak
 
-If there are specific ways you lay out windows on a screen, rather than
-"executing" that layout manually, you can script it, making instantiating a
-layout trivial.
+Jika ada cara-cara tertentu Anda menata jendela di layar, alih-alih "menjalankan" tata letak tersebut secara manual, Anda bisa membuatnya sebagai skrip, sehingga membuat pembuatan tata letak menjadi sangat mudah.
 
-# Resources
+# Sumber Daya
 
-- [Hammerspoon](https://www.hammerspoon.org/) - macOS desktop automation
-- [Rectangle](https://rectangleapp.com/) - macOS window manager
-- [Karabiner](https://karabiner-elements.pqrs.org/) - sophisticated macOS keyboard remapping
-- [r/unixporn](https://www.reddit.com/r/unixporn/) - screenshots and
-documentation of people's fancy configurations
+- [Hammerspoon](https://www.hammerspoon.org/) - Otomasi desktop macOS
+- [Rectangle](https://rectangleapp.com/) - Window manager macOS
+- [Karabiner](https://karabiner-elements.pqrs.org/) - Pemetaan ulang keyboard macOS yang canggih
+- [r/unixporn](https://www.reddit.com/r/unixporn/) - Tangkapan layar dan dokumentasi konfigurasi mewah milik orang-orang
 
-# Exercises
+# Latihan
 
-1. Figure out how to remap your Caps Lock key to something you use more often
-   (such as Escape or Ctrl or Backspace).
+1. Cari tahu cara memetakan ulang tombol Caps Lock Anda ke sesuatu yang lebih sering Anda gunakan (seperti Escape, Ctrl, atau Backspace).
 
-1. Make a custom global keyboard shortcut to open a new terminal window or a
-   new browser window.
+1. Buat pintasan keyboard global kustom untuk membuka jendela terminal baru atau jendela browser baru.
 
 {% comment %}
 

--- a/_2019/package-management.md
+++ b/_2019/package-management.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Package Management and Dependency Management"
+title: "Manajemen Paket dan Manajemen Dependensi"
 presenter: Anish
 date: 2019-01-29
 order: 2
@@ -9,30 +9,19 @@ video:
   id: tgvt473T8xA
 ---
 
-Software usually builds on (a collection of) other software, which necessitates
-dependency management.
+Perangkat lunak biasanya dibangun dari (kumpulan) perangkat lunak lain, yang membuat manajemen dependensi menjadi diperlukan.
 
-Package/dependency management programs are language-specific, but many share
-common ideas.
+Program manajemen paket/dependensi bersifat spesifik per bahasa, tetapi banyak yang memiliki gagasan yang sama.
 
-# Package repositories
+# Repositori paket
 
-Packages are hosted in _package repositories_. There are different repositories
-for different languages (and sometimes multiple for a particular language),
-such as [PyPI](https://pypi.org/) for Python, [RubyGems](https://rubygems.org/)
-for Ruby, and [crates.io](https://crates.io/) for Rust. They generally store
-software (source code and sometimes pre-compiled binaries for specific
-platforms) for all versions of a package.
+Paket di-host di _repositori paket_. Terdapat repositori yang berbeda untuk bahasa yang berbeda (dan terkadang ada beberapa untuk bahasa tertentu), seperti [PyPI](https://pypi.org/) untuk Python, [RubyGems](https://rubygems.org/) untuk Ruby, dan [crates.io](https://crates.io/) untuk Rust. Repositori-repositori ini umumnya menyimpan perangkat lunak (kode sumber dan terkadang biner pra-kompilasi untuk platform tertentu) untuk semua versi suatu paket.
 
-# Semantic versioning
+# Versi semantik
 
-Software evolves over time, and we need a way to refer to software versions.
-Some simple ways could be to refer to software by a sequence number or a commit
-hash, but we can do better in terms of communicating more information: using
-version numbers.
+Perangkat lunak berkembang seiring waktu, dan kita membutuhkan cara untuk merujuk pada versi perangkat lunak. Beberapa cara sederhana adalah merujuk perangkat lunak berdasarkan nomor urutan atau hash commit, tetapi kita bisa melakukan lebih baik dalam hal menyampaikan lebih banyak informasi: menggunakan nomor versi.
 
-There are many approaches; one popular one is [Semantic
-Versioning](https://semver.org/):
+Ada banyak pendekatan; salah satu yang populer adalah [Semantic Versioning](https://semver.org/):
 
 ```
 x.y.z
@@ -42,69 +31,38 @@ x.y.z
 +----- major
 ```
 
-Increment **major** version when you make incompatible API changes.
+Naikkan versi **major** ketika Anda membuat perubahan API yang tidak kompatibel.
 
-Increment **minor** version when you add functionality in a backward-compatible manner.
+Naikkan versi **minor** ketika Anda menambahkan fungsionalitas yang kompatibel ke belakang.
 
-Increment **patch** when you make backward-compatible bug fixes.
+Naikkan **patch** ketika Anda memperbaiki bug yang kompatibel ke belakang.
 
-For example, if you depend on a feature introduced in `v1.2.0` of some
-software, then you can install `v1.x.y` for any minor version `x >= 2` and any
-patch version `y`. You need to install major version `1` (because `2` can
-introduce backward-incompatible changes), and you need to install a minor
-version `>= 2` (because you depend on a feature introduced in that minor
-version). You can use any newer minor version or patch version because
-they should not introduce any backward-incompatible changes.
+Sebagai contoh, jika Anda bergantung pada fitur yang diperkenalkan di `v1.2.0` dari suatu perangkat lunak, maka Anda dapat menginstal `v1.x.y` untuk versi minor `x >= 2` dan versi patch `y` berapa pun. Anda perlu menginstal versi major `1` (karena `2` dapat memperkenalkan perubahan yang tidak kompatibel ke belakang), dan Anda perlu menginstal versi minor `>= 2` (karena Anda bergantung pada fitur yang diperkenalkan di versi minor tersebut). Anda dapat menggunakan versi minor atau versi patch yang lebih baru karena seharusnya tidak memperkenalkan perubahan yang tidak kompatibel ke belakang.
 
-# Lock files
+# File kunci
 
-In addition to specifying versions, it can be nice to enforce that the
-_contents_ of the dependency have not changed to prevent tampering. Some tools
-use _lock files_ to specify cryptographic hashes of dependencies (along with
-versions) that are checked on package install.
+Selain menentukan versi, akan sangat berguna untuk memastikan bahwa _isi_ dependensi tidak berubah untuk mencegah perubahan yang tidak sah. Beberapa alat menggunakan _lock files_ untuk menentukan hash kriptografis dari dependensi (bersama dengan versi) yang diperiksa saat instalasi paket.
 
-# Specifying versions
+# Menentukan versi
 
-Tools often let you specify versions in multiple ways, such as:
+Alat-alat sering kali memungkinkan Anda menentukan versi dalam beberapa cara, seperti:
 
-- exact version, e.g. `2.3.12`
-- minimum major version, e.g. `>= 2`
-- specific major version and minimum patch version, e.g. `>= 2.3, <3.0`
+- versi tepat, misalnya `2.3.12`
+- versi major minimum, misalnya `>= 2`
+- versi major tertentu dan versi patch minimum, misalnya `>= 2.3, <3.0`
 
-Specifying an exact version can be advantageous to avoid different behaviors
-based on installed dependencies (this shouldn't happen if all dependencies
-faithfully follow semver, but sometimes people make mistakes). Specifying a
-minimum requirement has the advantage of allowing bug fixes to be installed
-(e.g. patch upgrades).
+Menentukan versi yang tepat bisa menguntungkan untuk menghindari perilaku yang berbeda tergantung pada dependensi yang terinstal (ini seharusnya tidak terjadi jika semua dependensi mengikuti semver dengan setia, tetapi terkadang orang melakukan kesalahan). Menentukan persyaratan minimum memiliki keuntungan karena memungkinkan perbaikan bug untuk diinstal (misalnya pembaruan patch).
 
-# Dependency resolution
+# Resolusi dependensi
 
-Package managers use various dependency resolution algorithms to satisfy
-dependency requirements. This often gets challenging with complex dependencies
-(e.g. a package can be indirectly depended on by multiple top-level
-dependencies, and different versions could be required). Different package
-managers have different levels of sophistication in their dependency
-resolution, but it's something to be aware of: you may need to understand this
-if you are debugging dependencies.
+Manajer paket menggunakan berbagai algoritma resolusi dependensi untuk memenuhi persyaratan dependensi. Hal ini sering kali menjadi menantang dengan dependensi yang kompleks (misalnya sebuah paket dapat secara tidak langsung dibutuhkan oleh beberapa dependensi tingkat atas, dan versi yang berbeda mungkin diperlukan). Manajer paket yang berbeda memiliki tingkat kecanggihan yang berbeda dalam resolusi dependensi mereka, tetapi ini perlu diperhatikan: Anda mungkin perlu memahaminya jika Anda melakukan debug dependensi.
 
-# Virtual environments
+# Lingkungan virtual
 
-If you're developing multiple software projects, they may depend on different
-versions of a particular piece of software. Sometimes, your build tool will
-handle this naturally (e.g. by building a static binary).
+Jika Anda mengembangkan beberapa proyek perangkat lunak, mereka mungkin bergantung pada versi yang berbeda dari suatu perangkat lunak. Terkadang, alat build Anda akan menangani hal ini secara alami (misalnya dengan membangun biner statis).
 
-For other build tools and programming languages, one approach is handling this
-with virtual environments (e.g. with the
-[virtualenv](https://docs.python-guide.org/dev/virtualenvs/) tool for Python).
-Instead of installing dependencies system-wide, you can install dependencies
-per-project in a virtual environment, and _activate_ the virtual environment
-that you want to use when you're working on a specific project.
+Untuk alat build dan bahasa pemrograman lain, salah satu pendekatan adalah menangani ini dengan lingkungan virtual (misalnya dengan alat [virtualenv](https://docs.python-guide.org/dev/virtualenvs/) untuk Python). Alih-alih menginstal dependensi secara sistem-wide, Anda dapat menginstal dependensi per-proyek di dalam lingkungan virtual, dan _mengaktifkan_ lingkungan virtual yang ingin Anda gunakan saat mengerjakan proyek tertentu.
 
 # Vendoring
 
-Another very different approach to dependency management is _vendoring_.
-Instead of using a dependency manager or build tool to fetch software, you copy
-the entire source code for a dependency into your software's repository. This
-has the advantage that you're always building against the same version of the
-dependency and you don't need to rely on a package repository, but it is more
-effort to upgrade dependencies.
+Pendekatan lain yang sangat berbeda untuk manajemen dependensi adalah _vendoring_. Alih-alih menggunakan manajer dependensi atau alat build untuk mengambil perangkat lunak, Anda menyalin seluruh kode sumber dependensi ke repositori perangkat lunak Anda. Ini memiliki keuntungan karena Anda selalu membangun terhadap versi dependensi yang sama dan Anda tidak perlu mengandalkan repositori paket, tetapi memerlukan lebih banyak usaha untuk meningkatkan dependensi.

--- a/_2019/program-introspection.md
+++ b/_2019/program-introspection.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Program Introspection"
+title: "Introspeksi Program"
 presenter: Anish
 date: 2019-01-29
 order: 1
@@ -11,29 +11,28 @@ video:
 
 # Debugging
 
-When printf-debugging isn't good enough: use a debugger.
+Ketika printf-debugging tidak cukup baik: gunakan debugger.
 
-Debuggers let you interact with the execution of a program, letting you do
-things like:
+Debugger memungkinkan Anda berinteraksi dengan eksekusi program, memungkinkan Anda melakukan hal-hal seperti:
 
-- halt execution of the program when it reaches a certain line
-- single-step through the program
-- inspect values of variables
-- many more advanced features
+- menghentikan eksekusi program ketika mencapai baris tertentu
+- melangkah satu per satu melalui program
+- memeriksa nilai variabel
+- banyak fitur lanjutan lainnya
 
 ## GDB/LLDB
 
-[GDB](https://www.gnu.org/software/gdb/) and [LLDB](https://lldb.llvm.org/).
-Supports many C-like languages.
+[GDB](https://www.gnu.org/software/gdb/) dan [LLDB](https://lldb.llvm.org/).
+Mendukung banyak bahasa mirip-C.
 
-Let's look at [example.c](/2019/files/example.c). Compile with debug flags:
+Mari kita lihat [example.c](/2019/files/example.c). Kompilasi dengan flag debug:
 `gcc -g -o example example.c`.
 
-Open GDB:
+Buka GDB:
 
 `gdb example`
 
-Some commands:
+Beberapa perintah:
 
 - `run`
 - `b {name of function}` - set a breakpoint
@@ -47,39 +46,38 @@ Some commands:
 
 ## PDB
 
-[PDB](https://docs.python.org/3/library/pdb.html) is the Python debugger.
+[PDB](https://docs.python.org/3/library/pdb.html) adalah debugger Python.
 
-Insert `import pdb; pdb.set_trace()` where you want to drop into PDB, basically
-a hybrid of a debugger (like GDB) and a Python shell.
+Sisipkan `import pdb; pdb.set_trace()` di tempat Anda ingin masuk ke PDB, pada dasarnya merupakan hibrida dari debugger (seperti GDB) dan shell Python.
 
-## Web browser Developer Tools
+## Alat Pengembang Web browser
 
-Another example of a debugger, this time with a graphical interface.
+Contoh lain dari debugger, kali ini dengan antarmuka grafis.
 
 # strace
 
-Observe system calls a program makes: `strace {program}`.
+Amati system call yang dibuat program: `strace {program}`.
 
 # Profiling
 
-Types of profiling: CPU, memory, etc.
+Jenis-jenis profiling: CPU, memori, dll.
 
-Simplest profiler: `time`.
+Profiler paling sederhana: `time`.
 
 ## Go
 
-Run test code with CPU profiler: `go test -cpuprofile=cpu.out`
+Jalankan kode tes dengan profiler CPU: `go test -cpuprofile=cpu.out`
 
-Analyze profile: `go tool pprof -web cpu.out`
+Analisis profil: `go tool pprof -web cpu.out`
 
-Run test code with Memory profiler: `go test -memprofile=mem.out`
+Jalankan kode tes dengan profiler Memori: `go test -memprofile=mem.out`
 
-Analyze profile: `go tool pprof -web mem.out`
+Analisis profil: `go tool pprof -web mem.out`
 
 ## Perf
 
-Basic performance stats: `perf stat {command}`
+Statistik performa dasar: `perf stat {command}`
 
-Run a program with the profiler: `perf record {command}`
+Jalankan program dengan profiler: `perf record {command}`
 
-Analyze profile: `perf report`
+Analisis profil: `perf report`

--- a/_2019/remote-machines.md
+++ b/_2019/remote-machines.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Remote Machines"
+title: "Mesin Remote"
 presenter: Jose
 date: 2019-01-29
 order: 4
@@ -9,59 +9,58 @@ video:
   id: X5c2Y8BCowM
 ---
 
-It has become more and more common for programmers to use remote servers in their everyday work. If you need to use remote servers in order to deploy backend software or you need a server with higher computational capabilities, you will end up using a Secure Shell (SSH). As with most tools covered, SSH is highly configurable so it is worth learning about it.
+Semakin umum bagi para programmer untuk menggunakan server remote dalam pekerjaan sehari-hari mereka. Jika Anda perlu menggunakan server remote untuk men-deploy perangkat lunak backend atau Anda membutuhkan server dengan kemampuan komputasi yang lebih tinggi, Anda akan menggunakan Secure Shell (SSH). Seperti kebanyakan alat yang dibahas, SSH sangat dapat dikonfigurasi sehingga patut untuk dipelajari.
 
 
-## Executing commands
+## Menjalankan perintah
 
-An often overlooked feature of `ssh` is the ability to run commands directly.
+Fitur `ssh` yang sering terlewatkan adalah kemampuan untuk menjalankan perintah secara langsung.
 
-- `ssh foobar@server ls` will execute ls in the home folder of foobar
-- It works with pipes, so `ssh foobar@server ls | grep PATTERN` will grep locally the remote output of `ls` and `ls | ssh foobar@server grep PATTERN` will grep remotely the local output of `ls`.
+- `ssh foobar@server ls` akan menjalankan ls di folder home dari foobar
+- Ini berfungsi dengan pipe, sehingga `ssh foobar@server ls | grep PATTERN` akan melakukan grep secara lokal pada output remote dari `ls` dan `ls | ssh foobar@server grep PATTERN` akan melakukan grep secara remote pada output lokal dari `ls`.
 
-## SSH Keys
+## Kunci SSH
 
-Key-based authentication exploits public-key cryptography to prove to the server that the client owns the secret private key without revealing the key. This way you do not need to reenter your password every time. Nevertheless the private key (e.g. `~/.ssh/id_rsa`) is effectively your password so treat it like so.
+Autentikasi berbasis kunci memanfaatkan kriptografi kunci publik untuk membuktikan kepada server bahwa klien memiliki kunci privat rahasia tanpa mengungkapkan kunci tersebut. Dengan cara ini Anda tidak perlu memasukkan ulang kata sandi setiap kali. Meskipun demikian, kunci privat (misalnya `~/.ssh/id_rsa`) secara efektif adalah kata sandi Anda, jadi perlakukan seperti itu.
 
-- Key generation. To generate a pair you can simply run `ssh-keygen -t rsa -b 4096`. If you do not choose a passphrase anyone that gets hold of your private key will be able to access authorized servers so it is recommended to choose  one and use `ssh-agent` to manage shell sessions.
+- Pembuatan kunci. Untuk membuat pasangan kunci Anda cukup menjalankan `ssh-keygen -t rsa -b 4096`. Jika Anda tidak memilih passphrase, siapa pun yang mendapatkan kunci privat Anda akan dapat mengakses server yang diotorisasi, sehingga disarankan untuk memilih satu dan menggunakan `ssh-agent` untuk mengelola sesi shell.
 
-If you have configured pushing to Github using SSH keys you have probably done the steps outlined [here](https://help.github.com/articles/connecting-to-github-with-ssh/) and have a valid pair already. To check if you have a passphrase and validate it you can run `ssh-keygen -y -f /path/to/key`.
+Jika Anda telah mengkonfigurasi push ke GitHub menggunakan kunci SSH, Anda mungkin telah melakukan langkah-langkah yang diuraikan [di sini](https://help.github.com/articles/connecting-to-github-with-ssh/) dan sudah memiliki pasangan kunci yang valid. Untuk memeriksa apakah Anda memiliki passphrase dan memvalidasinya, Anda dapat menjalankan `ssh-keygen -y -f /path/to/key`.
 
-- Key based authentication. `ssh` will look into `.ssh/authorized_keys` to determine which clients it should let in. To copy a public key over we can use the
+- Autentikasi berbasis kunci. `ssh` akan melihat ke `.ssh/authorized_keys` untuk menentukan klien mana yang seharusnya diizinkan. Untuk menyalin kunci publik, kita dapat menggunakan
 
 ```bash
 cat .ssh/id_dsa.pub | ssh foobar@remote 'cat >> ~/.ssh/authorized_keys'
 ```
 
-A simpler solution can be achieved with `ssh-copy-id` where available.
+Solusi yang lebih sederhana dapat dicapai dengan `ssh-copy-id` jika tersedia.
 
 ```bash
 ssh-copy-id -i .ssh/id_dsa.pub foobar@remote
 ```
 
-## Copying files over ssh
+## Menyalin file melalui ssh
 
-There are many ways to copy files over ssh
+Ada banyak cara untuk menyalin file melalui ssh
 
-- `ssh+tee`, the simplest is to use `ssh` command execution and stdin input by doing `cat localfile | ssh remote_server tee serverfile`
-- `scp` when copying large amounts of files/directories, the secure copy `scp` command is more convenient since it can easily recurse over paths. The syntax is `scp path/to/local_file remote_host:path/to/remote_file`
-- `rsync` improves upon `scp` by detecting identical files in local and remote and preventing copying them again. It also provides more fine grained control over symlinks, permissions and has extra features like the `--partial` flag that can resume from a previously interrupted copy. `rsync` has a similar syntax to `scp`.
+- `ssh+tee`, cara paling sederhana adalah menggunakan eksekusi perintah `ssh` dan input stdin dengan melakukan `cat localfile | ssh remote_server tee serverfile`
+- `scp` ketika menyalin sejumlah besar file/direktori, perintah secure copy `scp` lebih nyaman karena dapat melakukan rekursi dengan mudah pada path. Sintaksnya adalah `scp path/to/local_file remote_host:path/to/remote_file`
+- `rsync` meningkatkan `scp` dengan mendeteksi file yang identik di lokal dan remote serta mencegah penyalinan ulang. Ini juga menyediakan kontrol yang lebih rinci atas symlink, permission, dan memiliki fitur tambahan seperti flag `--partial` yang dapat melanjutkan salinan yang sebelumnya terinterupsi. `rsync` memiliki sintaks yang mirip dengan `scp`.
 
 
-## Backgrounding processes
+## Memproses di latar belakang
 
-By default when interrupting a ssh connection, child processes of the parent shell are killed along with it. There are a couple of alternatives
+Secara default ketika memutus koneksi ssh, proses anak dari shell induk akan dimatikan bersamanya. Ada beberapa alternatif
 
-- `nohup` - the `nohup` tool effectively allows for a process to live when the terminal gets killed. Although this can sometimes be achieved with `&` and `disown`, nohup is a better default. More details can be found [here](https://unix.stackexchange.com/questions/3886/difference-between-nohup-disown-and).
+- `nohup` - alat `nohup` secara efektif memungkinkan sebuah proses tetap hidup ketika terminal dimatikan. Meskipun ini terkadang dapat dicapai dengan `&` dan `disown`, nohup adalah pilihan default yang lebih baik. Detail lebih lanjut dapat ditemukan [di sini](https://unix.stackexchange.com/questions/3886/difference-between-nohup-disown-and).
 
-- `tmux`, `screen` - whereas `nohup` effectively backgrounds the process it is not convenient for interactive shell sessions. In that case using a terminal multiplexer like `screen` or `tmux` is a convenient choice since one can easily detach and reattach the associated shells.
+- `tmux`, `screen` - sedangkan `nohup` secara efektif memindahkan proses ke latar belakang, ini tidak nyaman untuk sesi shell interaktif. Dalam kasus tersebut, menggunakan terminal multiplexer seperti `screen` atau `tmux` adalah pilihan yang nyaman karena seseorang dapat dengan mudah melepaskan dan melampirkan kembali shell yang terkait.
 
-Lastly, if you disown a program and want to reattach it to the current terminal, you can look into [reptyr](https://github.com/nelhage/reptyr). `reptyr PID` will grab the process with id PID and attach it to your current terminal.
+Terakhir, jika Anda melepaskan sebuah program dan ingin melampirkannya kembali ke terminal saat ini, Anda dapat melihat [reptyr](https://github.com/nelhage/reptyr). `reptyr PID` akan mengambil proses dengan id PID dan melampirkannya ke terminal Anda saat ini.
 
 ## Port Forwarding
 
-In many scenarios you will run into software that works by listening to ports in the machine. When this happens in your local machine you can simply do `localhost:PORT` or `127.0.0.1:PORT`, but what do you do with a remote server that does not have its ports directly available through the network/internet?. This is called port forwarding and it
-comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the pictures for more details, credit of the pictures from [this SO post](https://unix.stackexchange.com/questions/115897/whats-ssh-port-forwarding-and-whats-the-difference-between-ssh-local-and-remot)).
+Dalam banyak skenario, Anda akan menemukan perangkat lunak yang bekerja dengan mendengarkan port di mesin. Ketika ini terjadi di mesin lokal Anda, Anda cukup melakukan `localhost:PORT` atau `127.0.0.1:PORT`, tetapi apa yang Anda lakukan dengan server remote yang port-nya tidak tersedia secara langsung melalui jaringan/internet?. Ini disebut port forwarding dan tersedia dalam dua jenis: Local Port Forwarding dan Remote Port Forwarding (lihat gambar untuk detail lebih lanjut, kredit gambar dari [postingan SO ini](https://unix.stackexchange.com/questions/115897/whats-ssh-port-forwarding-and-whats-the-difference-between-ssh-local-and-remot)).
 
 
 **Local Port Forwarding**
@@ -71,17 +70,17 @@ comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the 
 ![Remote Port Forwarding](https://i.stack.imgur.com/4iK3b.png)
 
 
-The most common scenario is local port forwarding where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus to forward that to the local port `9999` we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `localhost:9999` in our local machine.
+Skenario yang paling umum adalah local port forwarding di mana sebuah layanan di mesin remote mendengarkan pada sebuah port dan Anda ingin menautkan sebuah port di mesin lokal Anda untuk meneruskan ke port remote. Misalnya jika kita menjalankan `jupyter notebook` di server remote yang mendengarkan port `8888`. Maka untuk meneruskannya ke port lokal `9999` kita akan melakukan `ssh -L 9999:localhost:8888 foobar@remote_server` dan kemudian navigasi ke `localhost:9999` di mesin lokal kita.
 
 ## Graphics Forwarding
 
-Sometimes forwarding ports is not enough since we want to run a GUI based program in the server. You can always resort to Remote Desktop Software that sends the entire Desktop Environment (ie. options like RealVNC, Teamviewer, &c). However for a single GUI tool, SSH provides a good alternative: Graphics Forwarding.
+Terkadang mem-forward port tidak cukup karena kita ingin menjalankan program berbasis GUI di server. Anda selalu dapat menggunakan Perangkat Lunak Remote Desktop yang mengirimkan seluruh Lingkungan Desktop (yaitu opsi seperti RealVNC, Teamviewer, dll). Namun untuk satu alat GUI, SSH menyediakan alternatif yang baik: Graphics Forwarding.
 
-Using the `-X` flag tells SSH to forward
+Menggunakan flag `-X` memberitahu SSH untuk mem-forward
 
- For trusted X11 forwarding the `-Y` flag can be used.
+ Untuk forwarding X11 yang dipercaya, flag `-Y` dapat digunakan.
 
-Final note is that for this to work the `sshd_config` on the server must have the following options
+Catatan terakhir adalah agar ini berfungsi, `sshd_config` di server harus memiliki opsi berikut
 
 ```bash
 X11Forwarding yes
@@ -90,17 +89,17 @@ X11DisplayOffset 10
 
 ## Roaming
 
-A common pain when connecting to a remote server are disconnections due to shutting down/sleeping your computer or changing a network. Moreover if one has a connection with significant lag using ssh can become quite frustrating. [Mosh](https://mosh.org/), the mobile shell, improves upon ssh, allowing roaming connections, intermittent connectivity and providing intelligent local echo.
+Masalah umum saat menghubungkan ke server remote adalah pemutusan koneksi karena mematikan/memenidukan komputer Anda atau berpindah jaringan. Selain itu, jika seseorang memiliki koneksi dengan lag yang signifikan, menggunakan ssh bisa menjadi sangat frustrasi. [Mosh](https://mosh.org/), the mobile shell, meningkatkan ssh, memungkinkan koneksi roaming, konektivitas intermiten, dan menyediakan echo lokal yang cerdas.
 
-Mosh is present in all common distributions and package managers. Mosh requires an ssh server to be working in the server. You do not need to be superuser to install mosh  but it does require that ports 60000 through 60010 to be open in the server (they usually are since they are not in the privileged range).
+Mosh tersedia di semua distribusi dan package manager umum. Mosh membutuhkan server ssh yang berjalan di server. Anda tidak perlu menjadi superuser untuk menginstal mosh, tetapi memerlukan port 60000 hingga 60010 untuk dibuka di server (biasanya sudah terbuka karena tidak berada dalam rentang port yang diprivilese).
 
-A downside of `mosh` is that is does not support roaming port/graphics forwarding so if you use those often `mosh` won't be of much help.
+Kekurangan dari `mosh` adalah tidak mendukung forwarding port/graphics roaming, jadi jika Anda sering menggunakannya, `mosh` tidak akan banyak membantu.
 
-## SSH Configuration
+## Konfigurasi SSH
 
-### Client
+### Klien
 
-We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like `alias my_serer="ssh -X -i ~/.id_rsa -L 9999:localhost:8888 foobar@remote_server`, however there is a better alternative, using `~/.ssh/config`.
+Kita telah membahas banyak argumen yang dapat kita berikan. Alternatif yang menggoda adalah membuat alias shell seperti `alias my_serer="ssh -X -i ~/.id_rsa -L 9999:localhost:8888 foobar@remote_server`, namun ada alternatif yang lebih baik, menggunakan `~/.ssh/config`.
 
 ```bash
 Host vm
@@ -116,46 +115,46 @@ Host *.mit.edu
 ```
 
 
-An additional advantage of using the `~/.ssh/config` file over aliases  is that other programs like `scp`, `rsync`, `mosh`, &c are able to read it as well and convert the settings into the corresponding flags.
+Keuntungan tambahan menggunakan file `~/.ssh/config` dibandingkan alias adalah program lain seperti `scp`, `rsync`, `mosh`, dll juga dapat membacanya dan mengonversi pengaturan menjadi flag yang sesuai.
 
 
-Note that the `~/.ssh/config` file can be considered a dotfile, and in general it is fine for it to be included with the rest of your dotfiles. However if you make it public, think about the information that you are potentially providing strangers on the internet: the addresses of your servers, the users you are using, the open ports, &c. This may facilitate some types of attacks so be thoughtful about sharing your SSH configuration.
+Perhatikan bahwa file `~/.ssh/config` dapat dianggap sebagai dotfile, dan secara umum tidak masalah untuk disertakan bersama dotfile Anda lainnya. Namun jika Anda membuatnya publik, pikirkan tentang informasi yang berpotensi Anda berikan kepada orang asing di internet: alamat server Anda, pengguna yang Anda gunakan, port yang terbuka, dll. Ini dapat memfasilitasi beberapa jenis serangan, jadi berhati-hatilah dalam membagikan konfigurasi SSH Anda.
 
-Warning: Never include your RSA keys ( `~/.ssh/id_rsa*` ) in a public repository!
+Peringatan: Jangan pernah sertakan kunci RSA Anda (`~/.ssh/id_rsa*`) di repositori publik!
 
-### Server side
+### Sisi server
 
-Server side configuration is usually specified in `/etc/ssh/sshd_config`. Here you can make  changes like disabling password authentication, changing ssh ports, enabling X11 forwarding, &c. You can specify config settings in a per user basis.
+Konfigurasi sisi server biasanya ditentukan di `/etc/ssh/sshd_config`. Di sini Anda dapat melakukan perubahan seperti menonaktifkan autentikasi kata sandi, mengubah port ssh, mengaktifkan forwarding X11, dll. Anda dapat menentukan pengaturan konfigurasi per pengguna.
 
 ## Remote Filesystem
 
-Sometimes it is convenient to mount a remote folder. [sshfs](https://github.com/libfuse/sshfs) can mount a folder on a remote server
-locally, and then you can use a local editor.
+Terkadang lebih mudah untuk me-mount folder remote. [sshfs](https://github.com/libfuse/sshfs) dapat me-mount folder di server remote
+secara lokal, dan kemudian Anda dapat menggunakan editor lokal.
 
-## Exercises
+## Latihan
 
-1. For SSH to work the host needs to be running an SSH server. Install an SSH server (such as OpenSSH) in a virtual machine so you can do the rest of the exercises. To figure out what is the ip of the machine run the command `ip addr` and look for the inet field (ignore the `127.0.0.1` entry, that corresponds to the loopback interface).
+1. Agar SSH berfungsi, host perlu menjalankan server SSH. Instal server SSH (seperti OpenSSH) di mesin virtual sehingga Anda dapat melakukan latihan lainnya. Untuk mengetahui ip mesin, jalankan perintah `ip addr` dan cari field inet (abaikan entri `127.0.0.1`, yang sesuai dengan antarmuka loopback).
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -t rsa -b 4096`. It is recommended that you use a password and use `ssh-agent` , more info [here](https://www.ssh.com/ssh/agent).
+1. Pergi ke `~/.ssh/` dan periksa apakah Anda memiliki pasangan kunci SSH di sana. Jika tidak, buat dengan `ssh-keygen -t rsa -b 4096`. Disarankan agar Anda menggunakan kata sandi dan menggunakan `ssh-agent`, info lebih lanjut [di sini](https://www.ssh.com/ssh/agent).
 
-1. Use `ssh-copy-id` to copy the key to your virtual machine. Test that you can ssh without a password. Then, edit your `sshd_config` in the server to disable password authentication by editing the value of `PasswordAuthentication`. Disable root login by editing the value of `PermitRootLogin`.
+1. Gunakan `ssh-copy-id` untuk menyalin kunci ke mesin virtual Anda. Uji bahwa Anda dapat ssh tanpa kata sandi. Kemudian, edit `sshd_config` Anda di server untuk menonaktifkan autentikasi kata sandi dengan mengedit nilai `PasswordAuthentication`. Nonaktifkan login root dengan mengedit nilai `PermitRootLogin`.
 
-1. Edit the `sshd_config` in the server to change the ssh port and check that you can still ssh. If you ever have a public facing server, a non default port and key only login will throttle a significant amount of malicious attacks.
+1. Edit `sshd_config` di server untuk mengubah port ssh dan periksa bahwa Anda masih dapat ssh. Jika Anda pernah memiliki server yang terbuka untuk publik, port non-default dan login hanya dengan kunci akan memperlambat sejumlah besar serangan berbahaya.
 
-1. Install mosh in your server/VM, establish a connection and then disconnect the network adapter of the server/VM. Can mosh properly recover from it?
+1. Instal mosh di server/VM Anda, buat koneksi, dan kemudian putuskan adaptor jaringan server/VM. Dapatkah mosh pulih dengan baik dari hal tersebut?
 
-1. Another use of local port forwarding is to tunnel certain host to the server. If your network filters some website like for example `reddit.com` you can tunnel it through the server as follows:
+1. Kegunaan lain dari local port forwarding adalah untuk menunnel host tertentu ke server. Jika jaringan Anda memfilter beberapa situs web seperti misalnya `reddit.com`, Anda dapat menunnelnya melalui server sebagai berikut:
 
-    - Run `ssh remote_server -L 80:reddit.com:80`
-    - Set `reddit.com` and `www.reddit.com` to `127.0.0.1` in `/etc/hosts`
-    - Check that you are accessing that website through the server
-    - If it is not obvious use a website such as [ipinfo.io](https://ipinfo.io/) which will change depending on your host public ip.
-
-
-1. Background port forwarding can easily be achieved with a couple of extra flags. Look into what the `-N` and `-f` flags do in `ssh` and figure out what a command such as this `ssh -N -f -L 9999:localhost:8888 foobar@remote_server` does.
+    - Jalankan `ssh remote_server -L 80:reddit.com:80`
+    - Atur `reddit.com` dan `www.reddit.com` ke `127.0.0.1` di `/etc/hosts`
+    - Periksa bahwa Anda mengakses situs web tersebut melalui server
+    - Jika tidak jelas, gunakan situs web seperti [ipinfo.io](https://ipinfo.io/) yang akan berubah tergantung pada ip publik host Anda.
 
 
-## References
+1. Background port forwarding dapat dengan mudah dicapai dengan beberapa flag tambahan. Pelajari apa yang dilakukan flag `-N` dan `-f` di `ssh` dan cari tahu apa yang dilakukan perintah seperti ini `ssh -N -f -L 9999:localhost:8888 foobar@remote_server`.
+
+
+## Referensi
 
 - [SSH Hacks](https://matt.might.net/articles/ssh-hacks/)
 - [Secure Secure Shell](https://stribika.github.io/2015/01/04/secure-secure-shell.html)

--- a/_2019/security.md
+++ b/_2019/security.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Security and Privacy"
+title: "Keamanan dan Privasi"
 presenter: Jon
 date: 2019-01-31
 order: 2
@@ -10,22 +10,22 @@ video:
 special: true
 ---
 
-The world is a scary place, and everyone's out to get you.
+Dunia ini tempat yang menyeramkan, dan semua orang mengincar Anda.
 
-Okay, maybe not, but that doesn't mean you want to flaunt all your
-secrets. Security (and privacy) is generally all about raising the bar
-for attackers. Find out what your threat model is, and then design your
-security mechanisms around that! If the threat model is the NSA or
-Mossad, you're _probably_ going to have a bad time.
+Oke, mungkin tidak juga, tetapi itu bukan berarti Anda ingin memamerkan semua
+rahasia Anda. Keamanan (dan privasi) pada dasarnya adalah tentang meningkatkan
+standar bagi para penyerang. Cari tahu apa model ancaman Anda, lalu rancang
+mekanisme keamanan Anda berdasarkan model tersebut! Jika model ancamannya adalah
+NSA atau Mossad, Anda _mungkin_ akan mengalami kesulitan.
 
-There are _many_ ways to make your technical persona more secure. We'll
-touch on a lot of high-level things here, but this is a process, and
-educating yourself is one of the best things you can do. So:
+Ada _banyak_ cara untuk membuat persona teknis Anda lebih aman. Kami akan
+menyentuh banyak hal tingkat tinggi di sini, tetapi ini adalah sebuah proses, dan
+mendidik diri sendiri adalah salah satu hal terbaik yang dapat Anda lakukan. Jadi:
 
-## Follow the Right People
+## Ikuti Orang-orang yang Tepat
 
-One of the best ways to improve your security know-how is to follow
-other people who are vocal about security. Some suggestions:
+Salah satu cara terbaik untuk meningkatkan pengetahuan keamanan Anda adalah dengan mengikuti
+orang-orang lain yang vokal tentang keamanan. Beberapa saran:
 
  - [@TroyHunt](https://twitter.com/TroyHunt)
  - [@SwiftOnSecurity](https://twitter.com/SwiftOnSecurity)
@@ -35,179 +35,178 @@ other people who are vocal about security. Some suggestions:
  - [@mattblaze](https://twitter.com/mattblaze)
  - [@moxie](https://twitter.com/moxie)
 
-See also [this
-list](https://heimdalsecurity.com/blog/best-twitter-cybersec-accounts/)
-for more suggestions.
+Lihat juga [daftar
+ini](https://heimdalsecurity.com/blog/best-twitter-cybersec-accounts/)
+untuk saran lebih lanjut.
 
-## General Security Advice
+## Saran Keamanan Umum
 
-Tech Solidarity has a pretty great list of [do's and don'ts for
-journalists](https://web.archive.org/web/20221123204419/https://techsolidarity.org/resources/basic_security.htm)
-that has a lot of sane advice, and is decently up-to-date. [@thegrugq](https://medium.com/@thegrugq)
-also has a good blog post on [travel security
-advice](https://medium.com/@thegrugq/stop-fabricating-travel-security-advice-35259bf0e869)
-that's worth reading. We'll repeat much of the advice from those sources
-here, plus some more. Also, get a [USB data
-blocker](https://www.amazon.com/dp/B00QRRZ2QM/), because [USB is
-scary](https://www.bleepingcomputer.com/news/security/heres-a-list-of-29-different-types-of-usb-attacks/).
+Tech Solidarity memiliki daftar [hal yang boleh dan tidak boleh dilakukan untuk
+jurnalis](https://web.archive.org/web/20221123204419/https://techsolidarity.org/resources/basic_security.htm)
+yang cukup bagus dan memiliki banyak saran yang masuk akal, serta cukup terkini. [@thegrugq](https://medium.com/@thegrugq)
+juga memiliki postingan blog yang bagus tentang [saran keamanan
+perjalanan](https://medium.com/@thegrugq/stop-fabricating-travel-security-advice-35259bf0e869)
+yang layak dibaca. Kami akan mengulang banyak saran dari sumber-sumber tersebut
+di sini, ditambah beberapa lainnya. Selain itu, dapatkan [pemblokir data
+USB](https://www.amazon.com/dp/B00QRRZ2QM/), karena [USB itu
+menyeramkan](https://www.bleepingcomputer.com/news/security/heres-a-list-of-29-different-types-of-usb-attacks/).
 
-## Authentication
+## Autentikasi
 
-The very first thing you should do, if you haven't already, is download
-a password manager. Some good ones are:
+Hal pertama yang harus Anda lakukan, jika belum melakukannya, adalah mengunduh
+manajer kata sandi. Beberapa yang bagus adalah:
 
  - [1password](https://1password.com/)
  - [KeePass](https://keepass.info/)
  - [BitWarden](https://bitwarden.com/)
  - [`pass`](https://git.zx2c4.com/password-store/about/)
 
-If you're particularly paranoid, use one that encrypts the passwords
-locally on your computer, as opposed to storing them in plain-text at
-the server. Use it to generate passwords
-for all the web sites you care about right now. Then, switch on
-two-factor authentication, ideally with a
-[FIDO/U2F](https://fidoalliance.org/) dongle (a
-[YubiKey](https://www.yubico.com/quiz/) for example, which has [20% off
-for students](https://www.yubico.com/why-yubico/for-education/)). TOTP
-(like Google Authenticator or Duo) will also work in a pinch, but
-[doesn't protect against
-phishing](https://twitter.com/taviso/status/1082015009348104192). SMS is
-pretty much useless unless your threat model only includes random
-strangers picking up your password in transit.
+Jika Anda sangat paranoid, gunakan yang mengenkripsi kata sandi
+secara lokal di komputer Anda, bukan menyimpannya dalam teks biasa di
+server. Gunakan untuk menghasilkan kata sandi
+bagi semua situs web yang Anda pedulikan sekarang. Kemudian, aktifkan
+autentikasi dua faktor, idealnya dengan
+dongle [FIDO/U2F](https://fidoalliance.org/) (misalnya
+[YubiKey](https://www.yubico.com/quiz/), yang memiliki [diskon 20%
+untuk pelajar](https://www.yubico.com/why-yubico/for-education/)). TOTP
+(seperti Google Authenticator atau Duo) juga bisa digunakan dalam keadaan darurat, tetapi
+[tidak melindungi dari
+phishing](https://twitter.com/taviso/status/1082015009348104192). SMS pada
+dasarnya tidak berguna kecuali model ancaman Anda hanya mencakup orang asing acak
+yang mengambil kata sandi Anda dalam perjalanan.
 
-Also, a note about paper keys. Often, services will give you a "backup
-key" that you can use as a second factor if you lose your real second
-factor (btw, always keep a backup dongle somewhere safe!). While you
-_can_ stick those in your password managers, that means that should
-someone get access to your password manager, you're totally hosed (but
-maybe you're okay with that thread model). If you are truly paranoid,
-print out these paper keys, never store them digitally, and place them
-in a safe in the real world.
+Juga, catatan tentang kunci kertas. Seringkali, layanan akan memberikan Anda "kunci
+cadangan" yang dapat Anda gunakan sebagai faktor kedua jika Anda kehilangan faktor kedua
+Anda yang asli (ngomong-ngomong, selalu simpan dongle cadangan di tempat yang aman!). Meskipun Anda
+_bisa_ menyimpannya di manajer kata sandi Anda, itu berarti jika
+seseorang mendapatkan akses ke manajer kata sandi Anda, Anda benar-benar rugi (tetapi
+mungkin Anda baik-baik saja dengan model ancaman tersebut). Jika Anda benar-benar paranoid,
+cetak kunci-kunci kertas ini, jangan pernah menyimpannya secara digital, dan simpan
+di brankas di dunia nyata.
 
-## Private Communication
+## Komunikasi Pribadi
 
-Use [Signal](https://www.signal.org/) ([setup
-instructions](https://medium.com/@mshelton/signal-for-beginners-c6b44f76a1f0).
-[Wire](https://wire.com/en/) is [fine
-too](https://www.securemessagingapps.com/); WhatsApp is okay; [don't use
-Telegram](https://twitter.com/bascule/status/897187286554628096)).
-Desktop messengers are pretty broken (partially due to usually relying
-on Electron, which is a huge trust stack).
+Gunakan [Signal](https://www.signal.org/) ([petunjuk
+penyiapan](https://medium.com/@mshelton/signal-for-beginners-c6b44f76a1f0).
+[Wire](https://wire.com/en/) juga [baik-baik
+saja](https://www.securemessagingapps.com/); WhatsApp cukup oke; [jangan gunakan
+Telegram](https://twitter.com/bascule/status/897187286554628096)). Messenger desktop
+cukup bermasalah (sebagian karena biasanya bergantung pada
+Electron, yang merupakan tumpukan kepercayaan yang sangat besar).
 
-E-mail is particularly problematic, even if PGP signed. It's not
-generally forward-secure, and the key-distribution problem is pretty
-severe. [keybase.io](https://keybase.io/) helps, and is useful for a
-number of other reasons. Also, PGP keys are generally handled on desktop
-computers, which is one of the least secure computing environments.
-Relatedly, consider getting a Chromebook, or just work on a tablet with
-a keyboard.
+Email sangat bermasalah, bahkan jika ditandatangani PGP. Email secara umum
+tidak forward-secure, dan masalah distribusi kunci cukup
+parah. [keybase.io](https://keybase.io/) membantu, dan berguna untuk
+banyak alasan lainnya. Juga, kunci PGP umumnya ditangani di komputer
+desktop, yang merupakan salah satu lingkungan komputasi paling tidak aman. Terkait dengan itu, pertimbangkan untuk mendapatkan Chromebook, atau cukup bekerja di tablet dengan
+papan ketik.
 
-## File Security
+## Keamanan Berkas
 
-File security is hard, and operates on many level. What is it you're
-trying to secure against?
+Keamanan berkas itu sulit, dan beroperasi pada banyak tingkat. Apa yang ingin
+Anda amankan?
 
 [![$5 wrench](https://imgs.xkcd.com/comics/security.png)](https://xkcd.com/538/)
 
- - Offline attacks (someone steals your laptop while it's off): turn on
-   full disk encryption. ([cryptsetup +
+ - Serangan offline (seseorang mencuri laptop Anda saat sedang mati): aktifkan
+   enkripsi disk penuh. ([cryptsetup +
    LUKS](https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system)
-   on Linux,
+   di Linux,
    [BitLocker](https://fossbytes.com/enable-full-disk-encryption-windows-10/)
-   on Windows, [FileVault](https://support.apple.com/en-us/HT204837) on
-   macOS. Note that this won't help if the attacker _also_ has you and
-   really wants your secrets.
- - Online attacks (someone has your laptop and it's on): use file
-   encryption. There are two primary mechanisms for doing so
-    - Encrypted filesystems: stacked filesystem encryption software encrypts files individually rather than having encrypted block devices. You can "mount" these filesystems by providing the decryption key, and then browse the files inside it freely. When you unmount it, those files are all unavailable.  Modern solutions include [gocryptfs](https://github.com/rfjakob/gocryptfs) and [eCryptFS](https://www.ecryptfs.org/). More detailed comparisons can be found [here](https://nuetzlich.net/gocryptfs/comparison/) and [here](https://wiki.archlinux.org/index.php/disk_encryption#Comparison_table)
-    - Encrypted files: encrypt individual files with symmetric
-      encryption (see `gpg -c`) and a secret key. Or, like `pass`, also
-      encrypt the key with your public key so only you can read it back
-      later with your private key. Exact encryption settings matter a
-      lot!
- - [Plausible
-   deniability](https://en.wikipedia.org/wiki/Plausible_deniability)
-   (what seems to be the problem officer?): usually lower performance,
-   and easier to lose data. Hard to actually prove that it provides
-   [deniable
-   encryption](https://en.wikipedia.org/wiki/Deniable_encryption)! See
-   the [discussion
-   here](https://security.stackexchange.com/questions/135846/is-plausible-deniability-actually-feasible-for-encrypted-volumes-disks),
-   and then consider whether you may want to try
-   [VeraCrypt](https://www.veracrypt.fr/en/Home.html) (the maintained
-   fork of good ol' TrueCrypt).
- - Encrypted backups: use [Tarsnap](https://www.tarsnap.com/) or [Borgbase](https://www.borgbase.com/)
-    - Think about whether an attacker can delete your backups if they
-      get a hold of your laptop!
+   di Windows, [FileVault](https://support.apple.com/en-us/HT204837) di
+   macOS. Perhatikan bahwa ini tidak akan membantu jika penyerang _juga_ memiliki Anda dan
+   benar-benar menginginkan rahasia Anda.
+ - Serangan online (seseorang memiliki laptop Anda dan sedang menyala): gunakan
+   enkripsi berkas. Ada dua mekanisme utama untuk melakukannya
+    - Sistem berkas terenkripsi: perangkat lunak enkripsi sistem berkas bertumpuk mengenkripsi berkas secara individual daripada memiliki perangkat blok terenkripsi. Anda dapat "me-mount" sistem berkas ini dengan menyediakan kunci dekripsi, lalu menelusuri berkas di dalamnya dengan bebas. Ketika Anda unmount, semua berkas tersebut tidak tersedia. Solusi modern termasuk [gocryptfs](https://github.com/rfjakob/gocryptfs) dan [eCryptFS](https://www.ecryptfs.org/). Perbandingan yang lebih detail dapat ditemukan [di sini](https://nuetzlich.net/gocryptfs/comparison/) dan [di sini](https://wiki.archlinux.org/index.php/disk_encryption#Comparison_table)
+    - Berkas terenkripsi: enkripsi berkas individual dengan enkripsi
+      simetris (lihat `gpg -c`) dan kunci rahasia. Atau, seperti `pass`, juga
+      enkripsi kunci tersebut dengan kunci publik Anda sehingga hanya Anda yang dapat membacanya kembali
+      nanti dengan kunci pribadi Anda. Pengaturan enkripsi yang tepat sangat
+      penting!
+ - [Penyangkalan yang
+   masuk akal](https://en.wikipedia.org/wiki/Plausible_deniability)
+   (sepertinya ada masalah apa, Pak?): biasanya kinerja lebih rendah,
+   dan lebih mudah kehilangan data. Sulit untuk benar-benar membuktikan bahwa ini menyediakan
+   [enkripsi yang dapat
+   disangkal](https://en.wikipedia.org/wiki/Deniable_encryption)! Lihat
+   [diskusi
+   di sini](https://security.stackexchange.com/questions/135846/is-plausible-deniability-actually-feasible-for-encrypted-volumes-disks),
+   lalu pertimbangkan apakah Anda mungkin ingin mencoba
+   [VeraCrypt](https://www.veracrypt.fr/en/Home.html) (fork yang terus
+   dikembangkan dari TrueCrypt legendaris).
+ - Cadangan terenkripsi: gunakan [Tarsnap](https://www.tarsnap.com/) atau [Borgbase](https://www.borgbase.com/)
+    - Pikirkan apakah seorang penyerang dapat menghapus cadangan Anda jika mereka
+      mendapatkan akses ke laptop Anda!
 
-## Internet Security & Privacy
+## Keamanan & Privasi Internet
 
-The internet is a _very_ scary place. Open WiFi networks
-[are](https://www.troyhunt.com/the-beginners-guide-to-breaking-website/)
-[scary](https://www.troyhunt.com/talking-with-scott-hanselman-on/). Make
-sure you delete them afterwards, otherwise your phone will happily
-announce and re-connect to something with the same name later!
+Internet adalah tempat yang _sangat_ menyeramkan. Jaringan WiFi terbuka
+[itu](https://www.troyhunt.com/the-beginners-guide-to-breaking-website/)
+[menyeramkan](https://www.troyhunt.com/talking-with-scott-hanselman-on/). Pastikan
+Anda menghapusnya setelahnya, jika tidak, ponsel Anda akan dengan senang hati
+mengumumkan dan menyambungkan kembali ke sesuatu dengan nama yang sama nanti!
 
-If you're ever on a network you don't trust, a VPN _may_ be worthwhile,
-but keep in mind that you're trusting the VPN provider _a lot_. Do you
-really trust them more than your ISP? If you truly want a VPN, use a
-provider you're sure you trust, and you should probably pay for it. Or
-set up [WireGuard](https://www.wireguard.com/) for yourself -- it's
-[excellent](https://web.archive.org/web/20210526211307/https://latacora.micro.blog/there-will-be/)!
+Jika Anda sedang berada di jaringan yang tidak Anda percayai, VPN _mungkin_ bermanfaat,
+tetapi ingat bahwa Anda mempercayai penyedia VPN _sangat banyak_. Apakah
+Anda benar-benar mempercayai mereka lebih dari ISP Anda? Jika Anda benar-benar ingin VPN, gunakan
+penyedia yang Anda yakin dapat dipercaya, dan Anda sebaiknya membayarnya. Atau
+siapkan [WireGuard](https://www.wireguard.com/) untuk diri sendiri -- ini
+[sangat
+bagus](https://web.archive.org/web/20210526211307/https://latacora.micro.blog/there-will-be/)!
 
-There are also secure configuration settings for a lot of internet-enabled
-applications at [cipherlist.eu](https://cipherlist.eu/). If you're particularly
-privacy-oriented, [privacytools.io](https://privacytools.io) is also a good
-resource.
+Ada juga pengaturan konfigurasi yang aman untuk banyak aplikasi yang terhubung internet
+di [cipherlist.eu](https://cipherlist.eu/). Jika Anda sangat berorientasi pada privasi,
+[privacytools.io](https://privacytools.io) juga merupakan sumber daya yang bagus.
 
-Some of you may wonder about [Tor](https://www.torproject.org/). Keep in
-mind that Tor is _not_ particularly resistant to powerful global
-attackers, and is weak against traffic analysis attacks. It may be
-useful for hiding traffic on a small scale, but won't really buy you all
-that much in terms of privacy. You're better off using more secure
-services in the first place (Signal, TLS + certificate pinning, etc.).
+Beberapa dari Anda mungkin bertanya-tanya tentang [Tor](https://www.torproject.org/). Perlu diingat
+bahwa Tor _tidak_ sangat tahan terhadap penyerang global yang kuat,
+dan lemah terhadap serangan analisis lalu lintas. Ini mungkin
+berguna untuk menyembunyikan lalu lintas dalam skala kecil, tetapi tidak akan benar-benar memberi Anda
+banyak hal dalam hal privasi. Anda lebih baik menggunakan layanan yang lebih aman
+dari awal (Signal, TLS + certificate pinning, dll.).
 
-## Web Security
+## Keamanan Web
 
-So, you want to go on the Web too?
-Jeez, you're really pushing your luck here.
+Jadi, Anda juga ingin menjelajahi Web?
+Astaga, Anda benar-benar menguji keberuntungan Anda di sini.
 
-Install [HTTPS Everywhere](https://www.eff.org/https-everywhere).
-SSL/TLS is
-[critical](https://www.troyhunt.com/ssl-is-not-about-encryption/), and
-it's _not_ just about encryption, but also about being able to verify
-that you're talking to the right service in the first place! If you run
-your own web server, [test it](https://www.ssllabs.com/ssltest/index.html). TLS configuration
-[can get hairy](https://wiki.mozilla.org/Security/Server_Side_TLS).
-HTTPS Everywhere will do its very best to never navigate you to HTTP
-sites when there's an alternative. That doesn't save you, but it helps.
-If you're truly paranoid, blacklist any SSL/TLS CAs that you don't
-absolutely need.
+Pasang [HTTPS Everywhere](https://www.eff.org/https-everywhere).
+SSL/TLS itu
+[penting](https://www.troyhunt.com/ssl-is-not-about-encryption/), dan
+ini _bukan_ hanya tentang enkripsi, tetapi juga tentang kemampuan untuk memverifikasi
+bahwa Anda berbicara dengan layanan yang tepat sejak awal! Jika Anda menjalankan
+server web sendiri, [ujilah](https://www.ssllabs.com/ssltest/index.html). Konfigurasi TLS
+[bisa menjadi rumit](https://wiki.mozilla.org/Security/Server_Side_TLS).
+HTTPS Everywhere akan melakukan yang terbaik untuk tidak pernah mengarahkan Anda ke situs HTTP
+ketika ada alternatif. Itu tidak menyelamatkan Anda sepenuhnya, tetapi membantu.
+Jika Anda benar-benar paranoid, daftar-hitamkan CA SSL/TLS mana pun yang tidak
+benar-benar Anda butuhkan.
 
-Install [uBlock Origin](https://github.com/gorhill/uBlock). It is a
-[wide-spectrum
-blocker](https://github.com/gorhill/uBlock/wiki/Blocking-mode) that
-doesn't just stop ads, but all sorts of third-party communication a page
-may try to do. And inline scripts and such. If you're willing to spend
-some time on configuration to make things work, go to [medium
-mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-medium-mode)
-or even [hard
-mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode).
-Those _will_ make some sites not work until you've fiddled with the
-settings enough, but will also significantly improve your online
-security.
+Pasang [uBlock Origin](https://github.com/gorhill/uBlock). Ini adalah
+[pemblokir spektrum
+luas](https://github.com/gorhill/uBlock/wiki/Blocking-mode) yang
+tidak hanya menghentikan iklan, tetapi juga semua jenis komunikasi pihak ketiga yang mungkin
+dicoba oleh sebuah halaman. Dan skrip inline dan sejenisnya. Jika Anda bersedia meluangkan
+waktu untuk konfigurasi agar mọi sesuatu berfungsi, pergi ke [mode
+sedang](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-medium-mode)
+atau bahkan [mode
+sulit](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode).
+Itu _akan_ membuat beberapa situs tidak berfungsi sampai Anda cukup lama mengotak-atik
+pengaturannya, tetapi juga akan secara signifikan meningkatkan keamanan online
+Anda.
 
-If you're using Firefox, enable [Multi-Account
-Containers](https://support.mozilla.org/en-US/kb/containers). Create
-separate containers for social networks, banking, shopping, etc. Firefox
-will keep the cookies and other state for each of the containers totally
-separate, so sites you visit in one container can't snoop on sensitive
-data from the others. In Google Chrome, you can use [Chrome
-Profiles](https://support.google.com/chrome/answer/2364824) to achieve
-similar results.
+Jika Anda menggunakan Firefox, aktifkan [Multi-Account
+Containers](https://support.mozilla.org/en-US/kb/containers). Buat
+container terpisah untuk jejaring sosial, perbankan, belanja, dll. Firefox
+akan menyimpan cookie dan status lainnya untuk masing-masing container secara
+terpisah, sehingga situs yang Anda kunjungi di satu container tidak dapat mengintai data sensitif
+dari container lainnya. Di Google Chrome, Anda dapat menggunakan [Chrome
+Profiles](https://support.google.com/chrome/answer/2364824) untuk mencapai
+hasil yang serupa.
 
-## Exercises
+## Latihan
 
-1. Encrypt a file using PGP
-1. Use veracrypt to create a simple encrypted volume
-1. Enable 2FA for your most data sensitive accounts i.e. GMail, Dropbox, Github, &c
+1. Enkripsi sebuah berkas menggunakan PGP
+1. Gunakan veracrypt untuk membuat volume terenkripsi sederhana
+1. Aktifkan 2FA untuk akun Anda yang paling sensitif terhadap data, yaitu GMail, Dropbox, Github, &c

--- a/_2019/shell.md
+++ b/_2019/shell.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Shell and Scripting"
+title: "Shell dan Scripting"
 presenter: Jon
 date: 2019-01-15
 order: 3
@@ -9,276 +9,276 @@ video:
   id: dbDRfmH5uSI
 ---
 
-The shell is an efficient, textual interface to your computer.
+Shell adalah antarmuka tekstual yang efisien untuk komputer Anda.
 
-The shell prompt: what greets you when you open a terminal.
-Lets you run programs and commands; common ones are:
+Prompt shell: apa yang menyambut Anda ketika Anda membuka terminal.
+Memungkinkan Anda menjalankan program dan perintah; yang umum adalah:
 
- - `cd` to change directory
- - `ls` to list files and directories
- - `mv` and `cp` to move and copy files
+ - `cd` untuk berpindah direktori
+ - `ls` untuk menampilkan daftar file dan direktori
+ - `mv` dan `cp` untuk memindahkan dan menyalin file
 
-But the shell lets you do _so_ much more; you can invoke any program on
-your computer, and command-line tools exist for doing pretty much
-anything you may want to do. And they're often more efficient than their
-graphical counterparts. We'll go through a bunch of those in this class.
+Namun shell memungkinkan Anda melakukan _jauh_ lebih banyak; Anda dapat menjalankan program apa pun di
+komputer Anda, dan alat baris perintah tersedia untuk melakukan hampir semua
+yang mungkin ingin Anda lakukan. Dan mereka sering kali lebih efisien daripada
+padanan grafisnya. Kita akan membahas beberapa di antaranya di kelas ini.
 
-The shell provides an interactive programming language ("scripting").
-There are many shells:
+Shell menyediakan bahasa pemrograman interaktif ("scripting").
+Ada banyak shell:
 
- - You've probably used `sh` or `bash`.
- - Also shells that match languages: `csh`.
- - Or "better" shells: `fish`, `zsh`, `ksh`.
+ - Anda mungkin sudah menggunakan `sh` atau `bash`.
+ - Ada juga shell yang sesuai dengan bahasa: `csh`.
+ - Atau shell yang "lebih baik": `fish`, `zsh`, `ksh`.
 
-In this class we'll focus on the ubiquitous `sh` and `bash`, but feel
-free to play around with others. I like `fish`.
+Di kelas ini kita akan fokus pada `sh` dan `bash` yang ada di mana-mana, tetapi jangan
+ragu untuk bereksperimen dengan yang lain. Saya suka `fish`.
 
-Shell programming is a *very* useful tool in your toolbox.
-Can either write programs directly at the prompt, or into a file.
-`#!/bin/sh` + `chmod +x` to make shell executable.
+Pemrograman shell adalah alat yang *sangat* berguna dalam kotak peralatan Anda.
+Anda dapat menulis program langsung di prompt, atau ke dalam file.
+`#!/bin/sh` + `chmod +x` untuk membuat shell dapat dieksekusi.
 
-## Working with the shell
+## Bekerja dengan shell
 
-Run a command a bunch of times:
+Jalankan perintah berulang kali:
 
 ```bash
 for i in $(seq 1 5); do echo hello; done
 ```
 
-There's a lot to unpack:
+Ada banyak yang harus diurai:
 
  - `for x in list; do BODY; done`
-   - `;` terminates a command -- equivalent to newline
-   - split `list`, assign each to `x`, and run body
-   - splitting is "whitespace splitting", which we'll get back to
-   - no curly braces in shell, so `do` + `done`
+    - `;` mengakhiri perintah -- setara dengan baris baru
+    - pisahkan `list`, tetapkan masing-masing ke `x`, dan jalankan body
+    - pemisahan adalah "whitespace splitting", yang akan kita bahas kembali
+    - tidak ada kurung kurawal di shell, jadi `do` + `done`
  - `$(seq 1 5)`
-   - run the program `seq` with arguments `1` and `5`
-   - substitute entire `$()` with the output of that program
-   - equivalent to
-     ```bash
-     for i in 1 2 3 4 5
-     ```
+    - jalankan program `seq` dengan argumen `1` dan `5`
+    - ganti seluruh `$()` dengan output dari program tersebut
+    - setara dengan
+      ```bash
+      for i in 1 2 3 4 5
+      ```
  - `echo hello`
-   - everything in a shell script is a command
-   - in this case, run the `echo` command, which prints its arguments
-     with the argument `hello`.
-   - all commands are searched for in `$PATH` (colon-separated)
+    - semua hal dalam script shell adalah perintah
+    - dalam hal ini, jalankan perintah `echo`, yang mencetak argumennya
+      dengan argumen `hello`.
+    - semua perintah dicari di `$PATH` (dipisahkan dengan tanda titik dua)
 
-We have variables:
+Kita memiliki variabel:
 ```bash
 for f in $(ls); do echo $f; done
 ```
 
-Will print each file name in the current directory.
-Can also set variables using `=` (no space!):
+Akan mencetak nama setiap file di direktori saat ini.
+Anda juga dapat mengatur variabel menggunakan `=` (tanpa spasi!):
 
 ```bash
 foo=bar
 echo $foo
 ```
 
-There are a bunch of "special" variables too:
+Ada juga sejumlah variabel "khusus":
 
- - `$1` to `$9`: arguments to the script
- - `$0` name of the script itself
- - `$#` number of arguments
- - `$$` process ID of current shell
+ - `$1` hingga `$9`: argumen untuk script
+ - `$0` nama script itu sendiri
+ - `$#` jumlah argumen
+ - `$$` process ID dari shell saat ini
 
-To only print directories
+Untuk hanya mencetak direktori
 
 ```bash
 for f in $(ls); do if test -d $f; then echo dir $f; fi; done
 ```
 
-More to unpack here:
+Lebih banyak yang harus diurai di sini:
 
  - `if CONDITION; then BODY; fi`
-   - `CONDITION` is a command; if it returns with exit status 0
-     (success), then `BODY` is run.
-   - can also hook in an `else` or `elif`
-   - again, no curly braces, so `then` + `fi`
- - `test` is another program that provides various checks and
-   comparisons, and exits with 0 if they're true (`$?`)
-   - `man COMMAND` is your friend: `man test`
-   - can also be invoked with `[` + `]`: `[ -d $f ]`
-     - take a look at `man test` and `which "["`
+    - `CONDITION` adalah perintah; jika mengembalikan status keluar 0
+      (sukses), maka `BODY` dijalankan.
+    - juga dapat menambahkan `else` atau `elif`
+    - sekali lagi, tidak ada kurung kurawal, jadi `then` + `fi`
+ - `test` adalah program lain yang menyediakan berbagai pemeriksaan dan
+    perbandingan, dan keluar dengan 0 jika benar (`$?`)
+    - `man COMMAND` adalah teman Anda: `man test`
+    - juga dapat dipanggil dengan `[` + `]`: `[ -d $f ]`
+      - lihat `man test` dan `which "["`
 
-But wait! This is wrong! What if a file is called "My Documents"?
+Tapi tunggu! Ini salah! Bagaimana jika sebuah file bernama "My Documents"?
 
- - `for f in $(ls)` expands to `for f in My Documents`
- - first do the test on `My`, then on `Documents`
- - not what we wanted!
- - biggest source of bugs in shell scripts
+ - `for f in $(ls)` menjadi `for f in My Documents`
+ - pertama lakukan pengujian pada `My`, kemudian pada `Documents`
+ - bukan itu yang kita inginkan!
+ - sumber bug terbesar dalam script shell
 
-## Argument splitting
+## Pemisahan argumen
 
-Bash splits arguments by whitespace; not always what you want!
+Bash memisahkan argumen berdasarkan spasi; tidak selalu sesuai yang Anda inginkan!
 
- - need to use quoting to handle spaces in arguments
-   `for f in "My Documents"` would work correctly
- - same problem somewhere else -- do you see where?
-   `test -d $f`: if `$f` contains whitespace, `test` will error!
- - `echo` happens to be okay, because split + join by space
-   but what if a filename contains a newline?! turns into space!
- - quote all use of variables that you don't want split
- - but how do we fix our script above?
-   what do you think `for f in "$(ls)"` does?
+ - perlu menggunakan tanda kutip untuk menangani spasi dalam argumen
+    `for f in "My Documents"` akan bekerja dengan benar
+ - masalah yang sama di tempat lain -- apakah Anda melihat di mana?
+    `test -d $f`: jika `$f` mengandung spasi, `test` akan error!
+ - `echo` kebetulan aman, karena pisahkan + gabungkan dengan spasi
+    tapi bagaimana jika nama file mengandung baris baru?! berubah menjadi spasi!
+ - kutip semua penggunaan variabel yang tidak ingin Anda pisahkan
+ - tapi bagaimana kita memperbaiki script di atas?
+    menurut Anda apa yang dilakukan `for f in "$(ls)"`?
 
-Globbing is the answer!
+Globbing adalah jawabannya!
 
- - bash knows how to look for files using patterns:
-   - `*` any string of characters
-   - `?` any single character
-   - `{a,b,c}` any of these characters
- - `for f in *`: all files in this directory
- - when globbing, each matching file becomes its own argument
-   - still need to make sure to quote when _using_: `test -d "$f"`
- - can make advanced patterns:
-   - `for f in a*`: all files starting with `a` in the current directory
-   - `for f in foo/*.txt`: all `.txt` files in `foo`
-   - `for f in foo/*/p??.txt`
-     all three-letter text files starting with p in subdirs of `foo`
+ - bash tahu cara mencari file menggunakan pola:
+    - `*` string karakter apa pun
+    - `?` satu karakter apa pun
+    - `{a,b,c}` salah satu dari karakter-karakter ini
+ - `for f in *`: semua file di direktori ini
+ - saat globbing, setiap file yang cocok menjadi argumen tersendiri
+    - tetap perlu memastikan untuk mengutip saat _menggunakan_: `test -d "$f"`
+ - dapat membuat pola tingkat lanjut:
+    - `for f in a*`: semua file yang dimulai dengan `a` di direktori saat ini
+    - `for f in foo/*.txt`: semua file `.txt` di `foo`
+    - `for f in foo/*/p??.txt`
+      semua file teks tiga huruf yang dimulai dengan p di subdirektori `foo`
 
-Whitespace issues don't stop there:
+Masalah spasi tidak berhenti di situ:
 
- - `if [ $foo = "bar" ]; then` -- see the issue?
- - what if `$foo` is empty? arguments to `[` are `=` and `bar`...
- - _can_ work around this with `[ x$foo = "xbar" ]`, but bleh
- - instead, use `[[`: bash built-in comparator that has special parsing
-   - also allows `&&` instead of `-a`, `||` over `-o`, etc.
+ - `if [ $foo = "bar" ]; then` -- melihat masalahnya?
+ - bagaimana jika `$foo` kosong? argumen untuk `[` adalah `=` dan `bar`...
+ - _bisa_ mengatasinya dengan `[ x$foo = "xbar" ]`, tapi tidak elegan
+ - sebaliknya, gunakan `[[`: comparator bawaan bash yang memiliki parsing khusus
+    - juga mengizinkan `&&` sebagai ganti `-a`, `||` sebagai ganti `-o`, dll.
 
 <!-- TODO: arrays? $@. ${array[@]} vs "${array[@]}". -->
 
-## Composability
+## Komposabilitas
 
-Shell is powerful in part because of composability. Can chain multiple
-programs together rather than have one program that does everything.
+Shell sangat kuat sebagian karena komposabilitasnya. Anda dapat merantai beberapa
+program bersama-sama daripada memiliki satu program yang melakukan semuanya.
 
-The key character is `|` (pipe).
+Karakter kuncinya adalah `|` (pipe).
 
- - `a | b` means run both `a` and `b`
-   send all output of `a` as input to `b`
-   print the output of `b`
+ - `a | b` berarti jalankan `a` dan `b`
+    kirim semua output `a` sebagai input ke `b`
+    cetak output `b`
 
-All programs you launch ("processes") have three "streams":
+Semua program yang Anda jalankan ("proses") memiliki tiga "stream":
 
- - `STDIN`: when the program reads input, it comes from here
- - `STDOUT`: when the program prints something, it goes here
- - `STDERR`: a 2nd output the program can choose to use
- - by default, `STDIN` is your keyboard, `STDOUT` and `STDERR` are both
-   your terminal. but you can change that!
-   - `a | b` makes `STDOUT` of `a` `STDIN` of `b`.
-   - also have:
-     - `a > foo` (`STDOUT` of `a` goes to the file `foo`)
-     - `a 2> foo` (`STDERR` of `a` goes to the file `foo`)
-     - `a < foo` (`STDIN` of `a` is read from the file `foo`)
-     - hint: `tail -f` will print a file as it's being written
- - why is this useful? lets you manipulate output of a program!
-   - `ls | grep foo`: all files that contain the word `foo`
-   - `ps | grep foo`: all processes that contain the word `foo`
-   - `journalctl | grep -i intel | tail -n5`:
-     last 5 system log messages with the word intel (case insensitive)
-   - `who | sendmail -t me@example.com`
-     send the list of logged-in users to `me@example.com`
-   - forms the basis for much data-wrangling, as we'll cover later
+ - `STDIN`: ketika program membaca input, input berasal dari sini
+ - `STDOUT`: ketika program mencetak sesuatu, hasilnya pergi ke sini
+ - `STDERR`: output kedua yang dapat digunakan oleh program
+ - secara default, `STDIN` adalah keyboard Anda, `STDOUT` dan `STDERR` keduanya
+    adalah terminal Anda. tetapi Anda dapat mengubahnya!
+    - `a | b` membuat `STDOUT` dari `a` menjadi `STDIN` dari `b`.
+    - juga ada:
+      - `a > foo` (`STDOUT` dari `a` pergi ke file `foo`)
+      - `a 2> foo` (`STDERR` dari `a` pergi ke file `foo`)
+      - `a < foo` (`STDIN` dari `a` dibaca dari file `foo`)
+      - petunjuk: `tail -f` akan mencetak file saat file tersebut ditulis
+ - mengapa ini berguna? memungkinkan Anda memanipulasi output dari sebuah program!
+    - `ls | grep foo`: semua file yang mengandung kata `foo`
+    - `ps | grep foo`: semua proses yang mengandung kata `foo`
+    - `journalctl | grep -i intel | tail -n5`:
+      5 pesan log sistem terakhir dengan kata intel (tidak membedakan huruf besar/kecil)
+    - `who | sendmail -t me@example.com`
+      kirim daftar pengguna yang login ke `me@example.com`
+    - membentuk dasar untuk banyak pengolahan data, seperti yang akan kita bahas nanti
 
-Bash also provides a number of other ways to compose programs.
+Bash juga menyediakan sejumlah cara lain untuk menggabungkan program.
 
-You can group commands with `(a; b) | tac`: run `a`, then `b`, and send
-all their output to `tac`, which prints its input in reverse order.
+Anda dapat mengelompokkan perintah dengan `(a; b) | tac`: jalankan `a`, lalu `b`, dan kirim
+semua output mereka ke `tac`, yang mencetak inputnya dalam urutan terbalik.
 
-A lesser-known, but super useful one is _process substitution_.
-`b <(a)` will run `a`, generate a temporary file-name for its output
-stream, and pass that file-name to `b`. For example:
+Yang kurang dikenal, tetapi sangat berguna adalah _process substitution_.
+`b <(a)` akan menjalankan `a`, menghasilkan nama file sementara untuk stream
+outputnya, dan meneruskan nama file tersebut ke `b`. Sebagai contoh:
 
 ```bash
 diff <(journalctl -b -1 | head -n20) <(journalctl -b -2 | head -n20)
 ```
-will show you the difference between the first 20 lines of the last boot
-log and the one before that.
+akan menunjukkan perbedaan antara 20 baris pertama dari log boot terakhir
+dan satu sebelumnya.
 
 <!-- TODO: exit codes? -->
 
-## Job and process control
+## Kontrol job dan proses
 
-What if you want to run longer-term things in the background?
+Bagaimana jika Anda ingin menjalankan hal-hal jangka panjang di latar belakang?
 
- - the `&` suffix runs a program "in the background"
-   - it will give you back your prompt immediately
-   - handy if you want to run two programs at the same time
-     like a server and client: `server & client`
-   - note that the running program still has your terminal as `STDOUT`!
-     try: `server > server.log & client`
- - see all such processes with `jobs`
-   - notice that it shows "Running"
- - bring it to the foreground with `fg %JOB` (no argument is latest)
- - if you want to background the current program: `^Z` + `bg` (Here `^Z` means pressing `Ctrl+Z`)
-   - `^Z` stops the current process and makes it a "job"
-   - `bg` runs the last job in the background (as if you did `&`)
- - background jobs are still tied to your current session, and exit if
-   you log out. `disown` lets you sever that connection. or use `nohup`.
- - `$!` is pid of last background process
+ - sufiks `&` menjalankan program "di latar belakang"
+    - akan segera memberikan Anda prompt kembali
+    - berguna jika Anda ingin menjalankan dua program secara bersamaan
+      seperti server dan client: `server & client`
+    - perhatikan bahwa program yang berjalan masih memiliki terminal Anda sebagai `STDOUT`!
+      coba: `server > server.log & client`
+ - lihat semua proses tersebut dengan `jobs`
+    - perhatikan bahwa ia menampilkan "Running"
+ - bawa ke foreground dengan `fg %JOB` (tanpa argumen adalah yang terbaru)
+ - jika Anda ingin memindahkan program saat ini ke latar belakang: `^Z` + `bg` (Di sini `^Z` berarti menekan `Ctrl+Z`)
+    - `^Z` menghentikan proses saat ini dan menjadikannya "job"
+    - `bg` menjalankan job terakhir di latar belakang (seolah-olah Anda melakukan `&`)
+ - job latar belakang masih terikat ke sesi Anda saat ini, dan keluar jika
+    Anda logout. `disown` memungkinkan Anda memutus koneksi tersebut. atau gunakan `nohup`.
+ - `$!` adalah pid dari proses latar belakang terakhir
 
 <!-- TODO: process output control (^S and ^Q)? -->
 
-What about other stuff running on your computer?
+Bagaimana dengan hal lain yang berjalan di komputer Anda?
 
- - `ps` is your friend: lists running processes
-   - `ps -A`: print processes from all users (also `ps ax`)
-   - `ps` has *many* arguments: see `man ps`
- - `pgrep`: find processes by searching (like `ps -A | grep`)
-   - `pgrep -af`: search and display with arguments
- - `kill`: send a _signal_ to a process by ID (`pkill` by search + `-f`)
-   - signals tell a process to "do something"
-   - most common: `SIGKILL` (`-9` or `-KILL`): tell it to exit *now*
-     equivalent to `^\`
-   - also `SIGTERM` (`-15` or `-TERM`): tell it to exit gracefully
-     equivalent to `^C`
+ - `ps` adalah teman Anda: menampilkan daftar proses yang berjalan
+    - `ps -A`: cetak proses dari semua pengguna (juga `ps ax`)
+    - `ps` memiliki *banyak* argumen: lihat `man ps`
+ - `pgrep`: cari proses dengan pencarian (seperti `ps -A | grep`)
+    - `pgrep -af`: cari dan tampilkan dengan argumen
+ - `kill`: kirim _signal_ ke proses berdasarkan ID (`pkill` berdasarkan pencarian + `-f`)
+    - signal memberi tahu proses untuk "melakukan sesuatu"
+    - yang paling umum: `SIGKILL` (`-9` atau `-KILL`): menyuruhnya keluar *sekarang*
+      setara dengan `^\`
+    - juga `SIGTERM` (`-15` atau `-TERM`): menyuruhnya keluar dengan baik-baik
+      setara dengan `^C`
 
 
-## Flags
+## Flag
 
-Most command line utilities take parameters using **flags**. Flags usually come in short form (`-h`) and long form (`--help`). Usually running `CMD -h` or `man CMD` will give you a list of the flags the program takes.
-Short flags can usually be combined, running `rm -r -f` is equivalent to running `rm -rf` or `rm -fr`.
-Some common flags are a de facto standard and you will seem them in many applications:
+Sebagian besar utilitas baris perintah menerima parameter menggunakan **flag**. Flag biasanya tersedia dalam bentuk pendek (`-h`) dan bentuk panjang (`--help`). Biasanya menjalankan `CMD -h` atau `man CMD` akan memberikan daftar flag yang diterima program.
+Flag pendek biasanya dapat digabungkan, menjalankan `rm -r -f` setara dengan menjalankan `rm -rf` atau `rm -fr`.
+Beberapa flag umum adalah standar de facto dan Anda akan menemukannya di banyak aplikasi:
 
-* `-a` commonly refers to all files (i.e. also including those that start with a period)
-* `-f` usually refers to forcing something, like `rm -f`
-* `-h` displays the help for most commands
-* `-v` usually enables a verbose output
-* `-V` usually prints the version of the command
+* `-a` umumnya merujuk pada semua file (yaitu juga termasuk yang dimulai dengan titik)
+* `-f` biasanya merujuk pada memaksa sesuatu, seperti `rm -f`
+* `-h` menampilkan bantuan untuk sebagian besar perintah
+* `-v` biasanya mengaktifkan output verbose
+* `-V` biasanya mencetak versi dari perintah
 
-Also, a double dash `--` is used in built-in commands and many other commands to signify the end of command options, after which only positional parameters are accepted. So if you have a file called `-v` (which you can) and want to grep it `grep pattern -- -v` will work whereas `grep pattern -v` won't. In fact, one way to create such file is to do `touch -- -v`.
+Juga, double dash `--` digunakan dalam perintah bawaan dan banyak perintah lainnya untuk menandakan akhir dari opsi perintah, yang setelahnya hanya parameter posisional yang diterima. Jadi jika Anda memiliki file bernama `-v` (yang memang bisa) dan ingin melakukan grep pada file tersebut `grep pattern -- -v` akan berhasil sedangkan `grep pattern -v` tidak. Bahkan, salah satu cara untuk membuat file tersebut adalah dengan melakukan `touch -- -v`.
 
-## Exercises
+## Latihan
 
-1. If you are completely new to the shell you may want to read a more comprehensive guide about it such as [BashGuide](https://mywiki.wooledge.org/BashGuide). If you want a more in-depth introduction [The Linux Command Line](https://linuxcommand.org/tlcl.php) is a good resource.
+1. Jika Anda sama sekali baru menggunakan shell, Anda mungkin ingin membaca panduan yang lebih komprehensif seperti [BashGuide](https://mywiki.wooledge.org/BashGuide). Jika Anda ingin pendahuluan yang lebih mendalam [The Linux Command Line](https://linuxcommand.org/tlcl.php) adalah sumber daya yang bagus.
 
 1. **PATH, which, type**
 
-    We briefly discussed that the `PATH` environment variable is used to locate the programs that you run through the command line. Let's explore that a little further
-    - Run `echo $PATH` (or `echo $PATH | tr -s ':' '\n'` for pretty printing) and examine its contents, what locations are listed?
-    - The command `which` locates a program in the user PATH. Try running `which` for common commands like `echo`, `ls` or `mv`. Note that `which` is a bit limited since it does not understand shell aliases. Try running `type` and `command -v` for those same commands. How is the output different?
-    - Run `PATH=` and try running the previous commands again, some work and some don't, can you figure out why?
+    Kita telah membahas secara singkat bahwa variabel lingkungan `PATH` digunakan untuk menemukan program yang Anda jalankan melalui baris perintah. Mari kita eksplorasi lebih lanjut
+    - Jalankan `echo $PATH` (atau `echo $PATH | tr -s ':' '\n'` untuk tampilan yang lebih rapi) dan periksa isinya, lokasi apa saja yang tercantum?
+    - Perintah `which` menemukan program di PATH pengguna. Cobalah jalankan `which` untuk perintah umum seperti `echo`, `ls` atau `mv`. Perhatikan bahwa `which` agak terbatas karena tidak memahami alias shell. Cobalah jalankan `type` dan `command -v` untuk perintah-perintah yang sama. Bagaimana outputnya berbeda?
+    - Jalankan `PATH=` dan cobalah jalankan perintah-perintah sebelumnya lagi, beberapa berhasil dan beberapa tidak, bisakah Anda mengetahui alasannya?
 
-1. **Special Variables**
-    - What does the variable `~` expands as? What about `.`? And `..`?
-    - What does the variable `$?` do?
-    - What does the variable `$_` do?
-    - What does the variable `!!` expand to? What about `!!*`? And `!l`?
-    - Look for documentation for these options and familiarize yourself with them
+1. **Variabel Khusus**
+    - Variabel `~` diekspansi menjadi apa? Bagaimana dengan `.`? Dan `..`?
+    - Apa fungsi variabel `$?`?
+    - Apa fungsi variabel `$_`?
+    - `!!` diekspansi menjadi apa? Bagaimana dengan `!!*`? Dan `!l`?
+    - Carilah dokumentasi untuk opsi-opsi ini dan biasakan diri Anda dengan mereka
 
 1. **xargs**
 
-    Sometimes piping doesn't quite work because the command being piped into does not expect the newline separated format. For example `file` command tells you properties of the file.
+    Terkadang piping tidak cukup berhasil karena perintah yang menjadi tujuan pipe tidak mengharapkan format yang dipisahkan baris baru. Sebagai contoh, perintah `file` memberi tahu Anda properti dari file.
 
-    Try running `ls | file` and `ls | xargs file`. What is `xargs` doing?
+    Cobalah jalankan `ls | file` dan `ls | xargs file`. Apa yang dilakukan `xargs`?
 
 
 1. **Shebang**
 
-    When you write a script you can specify to your shell what interpreter should be used to interpret the script by using a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line. Write a script called `hello` with the following contentsmake  it executable with `chmod +x hello`. Then execute it with `./hello`. Then remove the first line and execute it again? How is the shell using that first line?
+    Ketika Anda menulis script, Anda dapat menentukan ke shell Anda interpreter apa yang harus digunakan untuk menginterpretasikan script dengan menggunakan baris [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)). Tulis script bernama `hello` dengan isi berikut dan jadikan dapat dieksekusi dengan `chmod +x hello`. Kemudian eksekusi dengan `./hello`. Kemudian hapus baris pertama dan eksekusi lagi? Bagaimana shell menggunakan baris pertama tersebut?
 
 
     ```bash
@@ -287,12 +287,12 @@ Also, a double dash `--` is used in built-in commands and many other commands to
       print("Hello World!")
     ```
 
-    You will often see programs that have a shebang that looks like `#! usr/bin/env bash`. This is a more portable solution with it own set of [advantages and disadvantages](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my). How is `env` different from `which`? What environment variable does `env` use to decide what program to run?
+    Anda akan sering melihat program yang memiliki shebang seperti `#! usr/bin/env bash`. Ini adalah solusi yang lebih portabel dengan [keuntungan dan kerugiannya](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my) sendiri. Bagaimana `env` berbeda dari `which`? Variabel lingkungan apa yang digunakan `env` untuk memutuskan program apa yang akan dijalankan?
 
 
-1. **Pipes, process substitution, subshell**
+1. **Pipe, process substitution, subshell**
 
-    Create a script called `slow_seq.sh` with the following contents and do `chmod +x slow_seq.sh` to make it executable.
+    Buat script bernama `slow_seq.sh` dengan isi berikut dan lakukan `chmod +x slow_seq.sh` untuk menjadikannya dapat dieksekusi.
 
     ```bash
       #! /usr/bin/env bash
@@ -303,20 +303,20 @@ Also, a double dash `--` is used in built-in commands and many other commands to
       done
     ```
 
-    There is a way in which pipes (and process substitution) differ from using subshell execution, i.e. `$()`. Run the following commands and observe the differences:
+    Ada cara di mana pipe (dan process substitution) berbeda dari penggunaan eksekusi subshell, yaitu `$()`. Jalankan perintah-perintah berikut dan amati perbedaannya:
 
     - `./slow_seq.sh | grep -P "[3-6]"`
     - `grep -P "[3-6]" <(./slow_seq.sh)`
     - `echo $(./slow_seq.sh) | grep -P "[3-6]"`
 
 
-1. **Misc**
-    - Try running `touch {a,b}{a,b}` then `ls` what did appear?
-    - Sometimes you want to keep STDIN and still pipe it to a file. Try running `echo HELLO | tee hello.txt`
-    - Try running `cat hello.txt > hello.txt ` what do you expect to happen? What does happen?
-    - Run `echo HELLO > hello.txt` and then run `echo WORLD >> hello.txt`. What are the contents of `hello.txt`? How is `>` different from `>>`?
-    - Run `printf "\e[38;5;81mfoo\e[0m\n"`. How was the output different? If you want to know more, search for ANSI color escape sequences.
-    - Run `touch a.txt` then run `^txt^log` what did bash do for you? In the same vein, run `fc`. What does it do?
+1. **Lain-lain**
+    - Cobalah jalankan `touch {a,b}{a,b}` kemudian `ls` apa yang muncul?
+    - Terkadang Anda ingin menyimpan STDIN dan tetap mem-pipe-nya ke file. Cobalah jalankan `echo HELLO | tee hello.txt`
+    - Cobalah jalankan `cat hello.txt > hello.txt` apa yang Anda perkirakan terjadi? Apa yang sebenarnya terjadi?
+    - Jalankan `echo HELLO > hello.txt` dan kemudian jalankan `echo WORLD >> hello.txt`. Apa isi dari `hello.txt`? Bagaimana `>` berbeda dari `>>`?
+    - Jalankan `printf "\e[38;5;81mfoo\e[0m\n"`. Bagaimana outputnya berbeda? Jika Anda ingin tahu lebih lanjut, carilah tentang ANSI color escape sequences.
+    - Jalankan `touch a.txt` kemudian jalankan `^txt^log` apa yang dilakukan bash untuk Anda? Dengan cara yang sama, jalankan `fc`. Apa yang dilakukannya?
 
 {% comment %}
 
@@ -328,12 +328,12 @@ TODO
 
 {% endcomment %}
 
-1. **Keyboard shortcuts**
+1. **Pintasan keyboard**
 
-    As with any application you use frequently is worth familiarising yourself with its keyboard shortcuts. Type the following ones and try figuring out what they do and in what scenarios it might be convenient knowing about them. For some of them it might be easier searching online about what they do. (remember that `^X` means pressing `Ctrl+X`)
+    Seperti halnya aplikasi apa pun yang sering Anda gunakan, ada baiknya membiasakan diri dengan pintasan keyboardnya. Ketik yang berikut ini dan cobalah figures out apa yang mereka lakukan dan dalam skenario apa mungkin berguna untuk mengetahuinya. Untuk beberapa di antaranya mungkin lebih mudah mencari secara online tentang apa yang mereka lakukan. (ingat bahwa `^X` berarti menekan `Ctrl+X`)
 
     - `^A`, `^E`
     - `^R`
     - `^L`
-    - `^C`, `^\` and  `^D`
+    - `^C`, `^\` dan  `^D`
     - `^U` and `^Y`

--- a/_2019/version-control.md
+++ b/_2019/version-control.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Version Control"
+title: "Kontrol Versi"
 presenter: Jon
 date: 2019-01-22
 order: 2
@@ -9,50 +9,53 @@ video:
   id: 3fig2Vz8QXs
 ---
 
-Whenever you are working on something that changes over time, it's
-useful to be able to _track_ those changes. This can be for a number of
-reasons: it gives you a record of what changed, how to undo it, who
-changed it, and possibly even why. Version control systems (VCS) give
-you that ability. They let you _commit_ changes to a set of files, along
-with a message describing the change, as well as look at and undo
-changes you've made in the past.
+Setiap kali Anda mengerjakan sesuatu yang berubah seiring waktu, sangat
+bermanfaat untuk dapat _melacak_ perubahan-perubahan tersebut. Hal ini bisa
+disebabkan oleh sejumlah alasan: Anda mendapatkan catatan tentang apa yang
+berubah, bagaimana cara membatalkannya, siapa yang mengubahnya, dan bahkan
+mungkin alasannya. Sistem kontrol versi (VCS) memberikan Anda kemampuan
+tersebut. Sistem ini memungkinkan Anda untuk _commit_ perubahan pada
+sekumpulan file, beserta pesan yang mendeskripsikan perubahan tersebut,
+serta melihat dan membatalkan perubahan yang telah Anda buat di masa lalu.
 
-Most VCS support sharing the commit history between multiple users. This
-allows for convenient collaboration: you can see the changes I've made,
-and I can see the changes you've made. And since the VCS tracks
-_changes_, it can often (though not always) figure out how to combine
-our changes as long as they touch relatively disjoint things.
+Sebagian besar VCS mendukung berbagi riwayat commit antar beberapa pengguna.
+Hal ini memungkinkan kolaborasi yang nyaman: Anda dapat melihat perubahan
+yang telah saya buat, dan saya dapat melihat perubahan yang telah Anda buat.
+Dan karena VCS melacak _perubahan_, sistem ini sering kali (meskipun tidak
+selalu) dapat mengetahui cara menggabungkan perubahan-perubahan kita selama
+perubahan tersebut menyentuh hal-hal yang relatif tidak tumpang tindih.
 
-There [_a
-lot_](https://en.wikipedia.org/wiki/Comparison_of_version-control_software)
-of VCSes out there that differ a lot in what they support, how they
-function, and how you interact with them. Here, we'll focus on
-[git](https://git-scm.com/), one of the more commonly used ones, but I
-recommend you also take a look at
+Ada [_sangat
+banyak_](https://en.wikipedia.org/wiki/Comparison_of_version-control_software)
+VCS di luar sana yang sangat berbeda dalam hal apa yang mereka dukung,
+bagaimana cara kerjanya, dan bagaimana Anda berinteraksi dengan mereka. Di
+sini, kita akan fokus pada [git](https://git-scm.com/), salah satu yang
+paling umum digunakan, tetapi saya juga menyarankan Anda untuk melihat
 [Mercurial](https://www.mercurial-scm.org/).
 
-With that all said -- to the cliffnotes!
+Dengan semua itu -- mari langsung ke intinya!
 
-## Is git dark magic?
+## Apakah git itu sihir gelap?
 
-not quite.. you need to understand the data model.
-we're going to skip over some of the details, but roughly speaking,
-the _core_ "thing" in git is a commit.
+tidak juga.. Anda perlu memahami model datanya.
+kita akan melewati beberapa detail, tetapi secara garis besar,
+"sesuatu" _inti_ dalam git adalah commit.
 
- - every commit has a unique name, "revision hash"
-   a long hash like `998622294a6c520db718867354bf98348ae3c7e2`
-   often shortened to a short (unique-ish) prefix: `9986222`
- - commit has author + commit message
- - also has the hash of any _ancestor commits_
-   usually just the hash of the previous commit
- - commit also represents a _diff_, a representation of how you get from
-   the commit's ancestors to the commit (e.g., remove this line in this
-   file, add these lines to this file, rename that file, etc.)
-   - in reality, git stores the full before and after state
-   - probably don't want to store big files that change!
+ - setiap commit memiliki nama unik, "revision hash"
+   hash panjang seperti `998622294a6c520db718867354bf98348ae3c7e2`
+   sering disingkat menjadi prefiks (yang cukup) unik: `9986222`
+ - commit memiliki penulis + pesan commit
+ - juga memiliki hash dari _commit ancestor_ (nenek moyang)
+   biasanya hanya hash dari commit sebelumnya
+ - commit juga mewakili _diff_, representasi dari bagaimana Anda bisa sampai
+   dari ancestor commit ke commit tersebut (misalnya, hapus baris ini di
+   file ini, tambahkan baris-baris ini di file ini, ganti nama file itu,
+   dll.)
+   - pada kenyataannya, git menyimpan keadaan penuh sebelum dan sesudah
+   - mungkin tidak ingin menyimpan file besar yang berubah!
 
-initially, the _repository_ (roughly: the folder that git manages) has
-no content, and no commits. let's set that up:
+pada awalnya, _repository_ (kurang lebih: folder yang dikelola git) tidak
+memiliki konten, dan tidak ada commit. mari kita siapkan:
 
 ```console
 $ git init hackers
@@ -60,109 +63,116 @@ $ cd hackers
 $ git status
 ```
 
-the output here actually gives us a good starting point. let's dig in
-and make sure we understand it all.
+output di sini sebenarnya memberikan kita titik awal yang baik. mari kita
+gali lebih dalam dan pastikan kita memahami semuanya.
 
-first, "On branch master".
+pertama, "On branch master".
 
- - don't want to use hashes all the time.
- - branches are names that point to hashes.
- - master is traditionally the name for the "latest" commit.
-   every time a new commit is made, the master name will be made to
-   point to the new commit's hash.
- - special name `HEAD` refers to "current" name
- - you can also make your own names with `git branch` (or `git tag`)
-   we'll get back to that
+ - tidak ingin menggunakan hash setiap saat.
+ - branch adalah nama yang menunjuk ke hash.
+ - master secara tradisional adalah nama untuk commit "terbaru".
+   setiap kali commit baru dibuat, nama master akan dibuat untuk
+   menunjuk ke hash commit baru tersebut.
+ - nama khusus `HEAD` merujuk ke nama "saat ini"
+ - Anda juga dapat membuat nama sendiri dengan `git branch` (atau `git tag`)
+   kita akan kembali ke hal itu
 
-let's skip over "No commits yet" because that's all there is to it.
+mari kita lewati "No commits yet" karena memang hanya itu isinya.
 
-then, "nothing to commit".
+kemudian, "nothing to commit".
 
- - every commit contains a diff with all the changes you made.
-   but how is that diff constructed in the first place?
- - _could_ just always commit _all_ changes you've made since the last
-   commit
-   - sometimes you want to only commit some of them (e.g., not `TODO`s)
-   - sometimes you want to break up a change into multiple commits to
-     give a separate commit message for each one
- - git lets you _stage_ changes to construct a commit
-   - add changes to a file or files to the staged changes with `git add`
-     - add only some changes in a file with `git add -p`
-     - without argument `git add` operates on "all known files"
-   - remove a file and stage its removal with `git rm`
-   - empty the set of staged changes `git reset`
-     - note that this does *not* change any of your files!
-       it *only* means that no changes will be included in a commit
-     - to remove only some staged changes:
-       `git reset FILE` or `git reset -p`
-   - check staged changes with `git diff --staged`
-   - see remaining changes with `git diff`
-   - when you're happy with the stage, make a commit with `git commit`
-     - if you just want to commit *all* changes: `git commit -a`
-     - `git help add` has a bunch more helpful info
+ - setiap commit berisi diff dengan semua perubahan yang Anda buat.
+   tetapi bagaimana diff tersebut dibuat pada awalnya?
+ - _bisa saja_ selalu commit _semua_ perubahan yang telah Anda buat sejak
+   commit terakhir
+   - terkadang Anda hanya ingin commit sebagian saja (misalnya, bukan `TODO`)
+   - terkadang Anda ingin memecah satu perubahan menjadi beberapa commit
+     untuk memberikan pesan commit yang terpisah untuk masing-masing
+ - git memungkinkan Anda untuk _stage_ perubahan untuk menyusun sebuah commit
+   - tambahkan perubahan ke file atau beberapa file ke staged changes dengan
+     `git add`
+     - tambahkan hanya beberapa perubahan dalam satu file dengan `git add -p`
+     - tanpa argumen `git add` beroperasi pada "semua file yang diketahui"
+   - hapus file dan stage penghapusannya dengan `git rm`
+   - kosongkan kumpulan staged changes dengan `git reset`
+     - perhatikan bahwa ini *tidak* mengubah file Anda sama sekali!
+       ini *hanya* berarti tidak ada perubahan yang akan dimasukkan ke commit
+     - untuk menghapus hanya beberapa staged changes:
+       `git reset FILE` atau `git reset -p`
+   - periksa staged changes dengan `git diff --staged`
+   - lihat sisa perubahan dengan `git diff`
+   - ketika Anda puas dengan stage, buat commit dengan `git commit`
+     - jika Anda hanya ingin commit *semua* perubahan: `git commit -a`
+     - `git help add` memiliki banyak informasi berguna lainnya
 
-while you're playing with the above, try to run `git status` to see what
-git thinks you're doing -- it's surprisingly helpful!
+saat Anda mencoba perintah-perintah di atas, cobalah menjalankan `git status`
+untuk melihat apa yang git pikirkan sedang Anda lakukan -- ternyata sangat
+membantu!
 
-## A commit you say...
+## Sebuah commit, kata Anda...
 
-okay, we have a commit, now what?
+oke, kita punya commit, lalu apa?
 
- - we can look at recent changes: `git log` (or `git log --oneline`)
- - we can look at the full changes: `git log -p`
- - we can show a particular commit: `git show master`
-   - or with `-p` for full diff/patch
- - we can go back to the state at a commit using `git checkout NAME`
-   - if `NAME` is a commit hash, git says we're "detached". this just
-     means there's no `NAME` that refers to this commit, so if we make
-     commits, no-one will know about them.
- - we can revert a change with `git revert NAME`
-   - applies the diff in the commit at `NAME` in reverse.
- - we can compare an older version to this one using `git diff NAME..`
-   - `a..b` is a commit _range_. if either is left out, it means `HEAD`.
- - we can show all the commits between using `git log NAME..`
-   - `-p` works here too
- - we can change `master` to point to a particular commit (effectively
-   undoing everything since) with `git reset NAME`:
-   - huh, why? wasn't `reset` to change staged changes?
-     reset has a "second" form (see `git help reset`) which sets `HEAD`
-     to the commit pointed to by the given name.
-   - notice that this didn't change any files -- `git diff` now
-     effectively shows `git diff NAME..`.
+ - kita bisa melihat perubahan terbaru: `git log` (atau `git log --oneline`)
+ - kita bisa melihat perubahan lengkap: `git log -p`
+ - kita bisa menampilkan commit tertentu: `git show master`
+   - atau dengan `-p` untuk diff/patch lengkap
+ - kita bisa kembali ke keadaan pada suatu commit menggunakan
+   `git checkout NAME`
+   - jika `NAME` adalah hash commit, git mengatakan kita "detached". ini
+     hanya berarti tidak ada `NAME` yang merujuk ke commit ini, jadi jika
+     kita membuat commit, tidak ada yang akan mengetahuinya.
+ - kita bisa membatalkan perubahan dengan `git revert NAME`
+   - menerapkan diff di commit pada `NAME` secara terbalik.
+ - kita bisa membandingkan versi lama dengan yang ini menggunakan
+   `git diff NAME..`
+   - `a..b` adalah _range_ commit. jika salah satu dikosongkan, itu berarti
+     `HEAD`.
+ - kita bisa menampilkan semua commit di antaranya dengan `git log NAME..`
+   - `-p` juga berfungsi di sini
+ - kita bisa mengubah `master` untuk menunjuk ke commit tertentu (secara
+   efektif membatalkan semuanya sejak saat itu) dengan `git reset NAME`:
+   - loh, kenapa? bukannya `reset` untuk mengubah staged changes?
+     reset memiliki bentuk "kedua" (lihat `git help reset`) yang mengatur
+     `HEAD` ke commit yang ditunjuk oleh nama yang diberikan.
+   - perhatikan bahwa ini tidak mengubah file apapun -- `git diff` sekarang
+     secara efektif menunjukkan `git diff NAME..`.
 
-## What's in a name?
+## Apa arti sebuah nama?
 
-clearly, names are important in git. and they're the key to
-understanding *a lot* of what goes on in git. so far, we've talked about
-commit hashes, master, and `HEAD`. but there's more!
+jelas, nama-nama penting dalam git. dan nama-nama tersebut adalah kunci untuk
+memahami *banyak* hal yang terjadi di git. sejauh ini, kita telah membahas
+tentang hash commit, master, dan `HEAD`. tetapi masih ada lagi!
 
- - you can make your own branches (like master) with `git branch b`
-   - creates a new name, `b`, which points to the commit at `HEAD`
-   - you're still "on" master though, so if you make a new commit,
-     master will point to that new commit, `b` will not.
-   - switch to a branch with `git checkout b`
-     - any commits you make will now update the `b` name
-     - switch back to master with `git checkout master`
-       - all your changes in `b` are hidden away
-     - a very handy way to be able to easily test out changes
- - tags are other names that never change, and that have their own
-   message. often used to mark releases + changelogs.
- - `NAME^` means "the commit before `NAME`
-   - can apply recursively: `NAME^^^`
-   - you _most likely_ mean `~` when you use `~`
-     - `~` is "temporal", whereas `^` goes by ancestors
-     - `~~` is the same as `^^`
-     - with `~` you can also write `X~3` for "3 commits older than `X`
-     - you don't want `^3`
+ - Anda dapat membuat branch sendiri (seperti master) dengan `git branch b`
+   - membuat nama baru, `b`, yang menunjuk ke commit di `HEAD`
+   - Anda masih "berada di" master, jadi jika Anda membuat commit baru,
+     master akan menunjuk ke commit baru tersebut, `b` tidak.
+   - beralih ke branch dengan `git checkout b`
+     - setiap commit yang Anda buat sekarang akan memperbarui nama `b`
+     - beralih kembali ke master dengan `git checkout master`
+       - semua perubahan Anda di `b` tersembunyi
+     - cara yang sangat berguna untuk dapat menguji perubahan dengan mudah
+ - tag adalah nama-nama lain yang tidak pernah berubah, dan memiliki pesan
+   tersendiri. sering digunakan untuk menandai rilis + changelog.
+ - `NAME^` berarti "commit sebelum `NAME`"
+   - dapat diterapkan secara rekursif: `NAME^^^`
+   - Anda _kemungkinan besar_ menggunakan `~` ketika Anda menggunakan `~`
+     - `~` bersifat "temporal", sedangkan `^` mengikuti ancestor
+     - `~~` sama dengan `^^`
+     - dengan `~` Anda juga bisa menulis `X~3` untuk "3 commit lebih lama
+       dari `X`"
+     - Anda tidak menginginkan `^3`
    - `git diff HEAD^`
- - `-` means "the previous name"
- - most commands operate on `HEAD` unless you give another argument
+ - `-` berarti "nama sebelumnya"
+ - sebagian besar perintah beroperasi pada `HEAD` kecuali Anda memberikan
+   argumen lain
 
-## Clean up your mess
+## Bersihkan kekacauan Anda
 
-your commit history will _very_ often end up as:
+riwayat commit Anda akan _sangat_ sering berakhir seperti:
 
- - `add feature x` -- maybe even with a commit message about `x`!
+ - `add feature x` -- mungkin bahkan dengan pesan commit tentang `x`!
  - `forgot to add file`
  - `fix bug`
  - `typo`
@@ -177,152 +187,163 @@ your commit history will _very_ often end up as:
  - `x`
  - `x`
 
-that's _fine_ as far as git is concerned, but is not very helpful to
-your future self, or to other people who are curious about what has
-changed. git lets you clean up these things:
+itu _tidak masalah_ bagi git, tetapi tidak sangat membantu untuk diri Anda
+di masa depan, atau untuk orang lain yang ingin tahu apa yang telah berubah.
+git memungkinkan Anda untuk membersihkan hal-hal ini:
 
- - `git commit --amend`: fold staged changes into previous commit
-   - note that this _changes_ the previous commit, giving it a new hash!
- - `git rebase -i HEAD~13` is _magical_.
-   for each commit from past 13, choose what to do:
-   - default is `pick`; do nothing
-   - `r`: change commit message
-   - `e`: change commit (add or remove files)
-   - `s`: combine commit with previous and edit commit message
-   - `f`: "fixup" -- combine commit with previous; discard commit msg
-   - at the end, `HEAD` is made to point to what is now the last commit
-   - often referred to as _squashing_ commits
-   - what it really does: rewind `HEAD` to rebase start point, then
-     re-apply the commits in order as directed.
- - `git reset --hard NAME`: reset the state of all files to that of
-   `NAME` (or `HEAD` if no name is given). handy for undoing changes.
+ - `git commit --amend`: gabungkan staged changes ke commit sebelumnya
+   - perhatikan bahwa ini _mengubah_ commit sebelumnya, memberinya hash baru!
+ - `git rebase -i HEAD~13` itu _ajaib_.
+   untuk setiap commit dari 13 terakhir, pilih apa yang harus dilakukan:
+   - default adalah `pick`; tidak melakukan apa-apa
+   - `r`: ubah pesan commit
+   - `e`: ubah commit (tambah atau hapus file)
+   - `s`: gabungkan commit dengan yang sebelumnya dan edit pesan commit
+   - `f`: "fixup" -- gabungkan commit dengan yang sebelumnya; buang pesan
+     commit
+   - pada akhirnya, `HEAD` dibuat untuk menunjuk ke apa yang sekarang menjadi
+     commit terakhir
+   - sering disebut sebagai _squashing_ commit
+   - yang sebenarnya dilakukan: memundurkan `HEAD` ke titik awal rebase,
+     kemudian menerapkan kembali commit-commit secara berurutan sesuai
+     arahan.
+ - `git reset --hard NAME`: reset keadaan semua file ke keadaan pada `NAME`
+   (atau `HEAD` jika tidak ada nama yang diberikan). berguna untuk membatalkan
+   perubahan.
 
-## Playing with others
+## Bermain dengan orang lain
 
-a common use-case for version control is to allow multiple people to
-make changes to a set of files without stepping on each other's toes.
-or rather, to make sure that _if_ they step on each other's toes, they
-won't just silently overwrite each other's changes.
+kasus penggunaan umum dari kontrol versi adalah memungkinkan beberapa orang
+untuk membuat perubahan pada sekumpulan file tanpa saling mengganggu. atau
+lebih tepatnya, untuk memastikan bahwa _jika_ mereka saling mengganggu,
+mereka tidak akan secara diam-diam menimpa perubahan satu sama lain.
 
-git is a _distributed_ VCS: everyone has a local copy of the entire
-repository (well, of everything others have chosen to publish). some
-VCSes are _centralized_ (e.g., subversion): a server has all the
-commits, clients only have the files they have "checked out". basically,
-they only have the _current_ files, and need to ask the server if they
-want anything else.
+git adalah VCS _terdistribusi_: setiap orang memiliki salinan lokal dari
+seluruh repository (yah, dari semua yang orang lain pilih untuk dipublikasikan).
+beberapa VCS bersifat _tersentralisasi_ (misalnya, subversion): sebuah server
+memiliki semua commit, klien hanya memiliki file yang telah mereka "checkout".
+pada dasarnya, mereka hanya memiliki file _saat ini_, dan perlu bertanya ke
+server jika mereka menginginkan hal lain.
 
-every copy of a git repository can be listed as a "remote". you can copy
-an existing git repository using `git clone ADDRESS` (instead of `git
-init`). this creates a remote called _origin_ that points to `ADDRESS`.
-you can fetch names and the commits they point to from a remote with
-`git fetch REMOTE`. all names at a remote are available to you as
-`REMOTE/NAME`, and you can use them just like local names.
+setiap salinan repository git dapat didaftarkan sebagai "remote". Anda dapat
+menyalin repository git yang sudah ada menggunakan `git clone ADDRESS`
+(bukan `git init`). ini membuat remote bernama _origin_ yang menunjuk ke
+`ADDRESS`. Anda dapat mengambil nama-nama dan commit yang mereka tunjukkan
+dari remote dengan `git fetch REMOTE`. semua nama di remote tersedia untuk
+Anda sebagai `REMOTE/NAME`, dan Anda dapat menggunakannya seperti nama lokal.
 
-if you have write access to a remote, you can change names at the remote
-to point to commits you've made using `git push`. for example, let's
-make the master name (branch) at the remote `origin` point to the commit
-that our master branch currently points to:
+jika Anda memiliki akses tulis ke remote, Anda dapat mengubah nama-nama di
+remote untuk menunjuk ke commit yang telah Anda buat menggunakan `git push`.
+misalnya, mari kita buat nama master (branch) di remote `origin` menunjuk ke
+commit yang saat ini ditunjuk oleh branch master kita:
 
    - `git push origin master:master`
-   - for convenience, you can set `origin/master` as the default target
-     for when you `git push` from the current branch with `-u`
-   - consider: what does this do? `git push origin master:HEAD^`
+   - untuk kemudahan, Anda dapat mengatur `origin/master` sebagai target
+     default ketika Anda `git push` dari branch saat ini dengan `-u`
+   - pertimbangkan: apa yang dilakukan ini? `git push origin master:HEAD^`
 
-often you'll use GitHub, GitLab, BitBucket, or something else as your
-remote. there's nothing "special" about that as far as git is concerned.
-it's all just names and commits. if someone makes a change to master and
-updates `github/master` to point to their commit (we'll get back to
-that in a second), then when you `git fetch github`, you'll be able to
-see their changes with `git log github/master`.
+sering kali Anda akan menggunakan GitHub, GitLab, BitBucket, atau yang lainnya
+sebagai remote. tidak ada yang "spesial" tentang hal itu sejauh yang git
+khawatirkan. semuanya hanya nama dan commit. jika seseorang membuat perubahan
+pada master dan memperbarui `github/master` untuk menunjuk ke commit mereka
+(kita akan kembali ke hal itu sebentar lagi), maka ketika Anda
+`git fetch github`, Anda akan dapat melihat perubahan mereka dengan
+`git log github/master`.
 
-## Working with others
+## Bekerja dengan orang lain
 
-so far, branches seem pretty useless: you can create them, do work on
-them, but then what? eventually, you'll just make master point to them
-anyway, right?
+sejauh ini, branch tampaknya tidak berguna: Anda dapat membuatnya, melakukan
+pekerjaan di atasnya, tetapi lalu apa? pada akhirnya, Anda hanya akan membuat
+master menunjuk ke mereka, bukan?
 
- - what if you had to fix something while working on a big feature?
- - what if someone else made a change to master in the meantime?
+ - bagaimana jika Anda harus memperbaiki sesuatu saat mengerjakan fitur besar?
+ - bagaimana jika orang lain membuat perubahan pada master sementara itu?
 
-inevitably, you will have to _merge_ changes in one branch with changes
-in another, whether those changes are made by you or someone else. git
-lets you do this with, unsurprisingly, `git merge NAME`. `merge` will:
+pada akhirnya, Anda harus _merge_ perubahan di satu branch dengan perubahan di
+branch lain, apakah perubahan tersebut dibuat oleh Anda atau orang lain. git
+memungkinkan Anda melakukan ini dengan, tidak mengherankan, `git merge NAME`.
+`merge` akan:
 
- - look for the latest point where `HEAD` and `NAME` shared a commit
-   ancestor (i.e., where they diverged)
- - (try to) apply all those changes to the current `HEAD`
- - produce a commit that contains all those changes, and lists both
-   `HEAD` and `NAME` as its ancestors
- - set `HEAD` to that commit's hash
+ - mencari titik terbaru di mana `HEAD` dan `NAME` berbagi commit ancestor
+   (yaitu, di mana mereka bercabang)
+ - (mencoba) menerapkan semua perubahan tersebut ke `HEAD` saat ini
+ - menghasilkan commit yang berisi semua perubahan tersebut, dan mencantumkan
+   `HEAD` dan `NAME` sebagai ancestor-nya
+ - mengatur `HEAD` ke hash commit tersebut
 
-once your big feature has been finished, you can merge its branch into
-master, and git will ensure that you don't lose any changes from either
-branch!
+setelah fitur besar Anda selesai, Anda dapat menggabungkan branch-nya ke
+master, dan git akan memastikan Anda tidak kehilangan perubahan dari branch
+manapun!
 
-if you've used git in the past, you may recognize `merge` by a different
-name: `pull`. when you do `git pull REMOTE BRANCH`, that is:
+jika Anda pernah menggunakan git di masa lalu, Anda mungkin mengenali `merge`
+dengan nama yang berbeda: `pull`. ketika Anda melakukan `git pull REMOTE BRANCH`,
+itu adalah:
 
  - `git fetch REMOTE`
  - `git merge REMOTE/BRANCH`
- - where, like `push`, `REMOTE` and `BRANCH` are often omitted and use
-   the "tracking" remote branch (remember `-u`?)
+ - di mana, seperti `push`, `REMOTE` dan `BRANCH` sering dihilangkan dan
+   menggunakan remote branch "tracking" (ingat `-u`?)
 
-this usually works _great_. as long as the changes to the branches being
-merged are disjoint. if they are not, you get a _merge conflict_. sounds
-scary...
+ini biasanya bekerja dengan _sangat baik_. selama perubahan pada branch yang
+digabungkan tidak tumpang tindih. jika tumpang tindih, Anda mendapatkan _merge
+conflict_. terdengar menakutkan...
 
- - a merge conflict is just git telling you that it doesn't know what
-   the final diff should look like
- - git pauses and asks you to finish staging the "merge commit"
- - open the conflicted file in your editor and look for lots of angle
-   brackets (`<<<<<<<`). the stuff above `=======` is the change made in
-   the `HEAD` since the shared ancestor commit. the stuff below is the
-   change made in the `NAME` since the shared commit.
- - `git mergetool` is pretty handy -- opens a diff editor
- - once you've _resolved_ the conflict by figuring out what the file
-   should now look like, stage those changes with `git add`.
- - when all the conflicts are resolved, finish with `git commit`
-   - you can give up with `git merge --abort`
+ - merge conflict hanyalah git yang memberi tahu Anda bahwa git tidak tahu
+   seperti apa diff akhirnya
+ - git berhenti sejenak dan meminta Anda untuk menyelesaikan staging "merge
+   commit"
+ - buka file yang konflik di editor Anda dan cari banyak tanda kurung siku
+   (`<<<<<<<`). bagian di atas `=======` adalah perubahan yang dibuat di
+   `HEAD` sejak commit ancestor bersama. bagian di bawah adalah perubahan
+   yang dibuat di `NAME` sejak commit bersama.
+ - `git mergetool` cukup berguna -- membuka editor diff
+ - setelah Anda _menyelesaikan_ konflik dengan mengetahui seperti apa file
+   yang seharusnya, stage perubahan tersebut dengan `git add`.
+ - ketika semua konflik telah diselesaikan, selesaikan dengan `git commit`
+   - Anda bisa menyerah dengan `git merge --abort`
 
-you've just resolved your first git merge conflict! \o/
-now you can publish your finished changes with `git push`
+Anda baru saja menyelesaikan merge conflict git pertama Anda! \o/
+sekarang Anda dapat mempublikasikan perubahan yang telah selesai dengan
+`git push`
 
-## When worlds collide
+## Ketika dunia bertabrakan
 
-when you `push`, git checks that no-one else's work is lost if you
-update the remote name you're pushing too. it does this by checking
-that the current commit of the remote name is an ancestor of the commit
-you are pushing. if it is, git can safely just update the name; this is
-called _fast-forwarding_. if it is not, git will refuse to update the
-remote name, and tell you there have been changes.
+ketika Anda `push`, git memeriksa bahwa tidak ada pekerjaan orang lain yang
+hilang jika Anda memperbarui nama remote yang Anda push. git melakukan ini
+dengan memeriksa bahwa commit saat ini dari nama remote adalah ancestor dari
+commit yang Anda push. jika ya, git dapat dengan aman hanya memperbarui nama
+tersebut; ini disebut _fast-forwarding_. jika tidak, git akan menolak untuk
+memperbarui nama remote, dan memberi tahu Anda bahwa ada perubahan.
 
-if your push is rejected, what do you do?
+jika push Anda ditolak, apa yang Anda lakukan?
 
- - merge remote changes with `git pull` (i.e., `fetch` + `merge`)
- - force the push with `--force`: this will lose other people's changes!
-   - there's also `--force-with-lease`, which will only force the change
-     if the remote name hasn't changed since the last time you fetched
-     from that remote. much safer!
-   - if you've rebased local commits that you've previously pushed
-     ("history rewriting"; probably don't do this), you'll have to force
-     push. think about why!
- - try to re-apply your changes "on top of" the changes made remotely
-   - this is a `rebase`!
-     - rewind all local commits since shared ancestor
-     - fast-forward `HEAD` to commit at remote name
-     - apply local commits in-order
-       - may have conflicts you have to manually resolve
-       - `git rebase --continue` or `--abort`
-     - lots more [here](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)
-   - `git pull --rebase` will start this process for you
-   - whether you should merge or rebase is a hot topic! some good reads:
-     - [this](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
-     - [this](https://web.archive.org/web/20210106220723/https://derekgourlay.com/blog/git-when-to-merge-vs-when-to-rebase/)
-     - [this](https://stackoverflow.com/questions/804115/when-do-you-use-git-rebase-instead-of-git-merge)
+ - gabungkan perubahan remote dengan `git pull` (yaitu, `fetch` + `merge`)
+ - paksa push dengan `--force`: ini akan menghilangkan perubahan orang lain!
+   - ada juga `--force-with-lease`, yang hanya akan memaksa perubahan jika
+     nama remote belum berubah sejak terakhir kali Anda mengambil dari remote
+     tersebut. jauh lebih aman!
+   - jika Anda telah melakukan rebase commit lokal yang sebelumnya Anda push
+     ("menulis ulang riwayat"; sebaiknya jangan lakukan ini), Anda harus
+     force push. pikirkan kenapa!
+ - coba terapkan kembali perubahan Anda "di atas" perubahan yang dibuat di
+   remote
+   - ini adalah `rebase`!
+     - mundurkan semua commit lokal sejak ancestor bersama
+     - fast-forward `HEAD` ke commit di nama remote
+     - terapkan commit lokal secara berurutan
+       - mungkin ada konflik yang harus Anda selesaikan secara manual
+       - `git rebase --continue` atau `--abort`
+     - lebih banyak [di sini](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)
+   - `git pull --rebase` akan memulai proses ini untuk Anda
+   - apakah Anda harus merge atau rebase adalah topik yang panas! beberapa
+     bacaan bagus:
+     - [ini](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
+     - [ini](https://web.archive.org/web/20210106220723/https://derekgourlay.com/blog/git-when-to-merge-vs-when-to-rebase/)
+     - [ini](https://stackoverflow.com/questions/804115/when-do-you-use-git-rebase-instead-of-git-merge)
 
-# Further reading
+# Bacaan lebih lanjut
 
-[![XKCD on git](https://imgs.xkcd.com/comics/git.png)](https://xkcd.com/1597/)
+[![XKCD tentang git](https://imgs.xkcd.com/comics/git.png)](https://xkcd.com/1597/)
 
  - [Learn git branching](https://learngitbranching.js.org/)
  - [How to explain git in simple words](https://smusamashah.github.io/blog/2017/10/14/explain-git-in-simple-words)
@@ -331,28 +352,28 @@ if your push is rejected, what do you do?
  - [Oh shit, git!](https://ohshitgit.com/)
  - [The Pro Git book](https://git-scm.com/book/en/v2)
 
-# Exercises
+# Latihan
 
-1. On a repo try modifying an existing file. What happens when you do `git stash`? What do you see when running `git log --all --oneline`? Run `git stash pop` to undo what you did with `git stash`. In what scenario might this be useful?
+1. Pada sebuah repo, cobalah memodifikasi file yang sudah ada. Apa yang terjadi ketika Anda menjalankan `git stash`? Apa yang Anda lihat ketika menjalankan `git log --all --oneline`? Jalankan `git stash pop` untuk membatalkan apa yang Anda lakukan dengan `git stash`. Dalam skenario apa hal ini mungkin berguna?
 
-1. One common mistake when learning git is to commit large files that should not be managed by git or adding sensitive information. Try adding a file to a repository, making some commits and then deleting that file from history (you may want to look at [this](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)). Also if you do want git to manage large  files for you, look into [Git-LFS](https://git-lfs.github.com/)
+1. Kesalahan umum saat belajar git adalah melakukan commit file besar yang seharusnya tidak dikelola oleh git atau menambahkan informasi sensitif. Cobalah menambahkan file ke repository, membuat beberapa commit, lalu menghapus file tersebut dari riwayat (Anda mungkin ingin melihat [ini](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)). Juga jika Anda ingin git mengelola file besar untuk Anda, pelajari tentang [Git-LFS](https://git-lfs.github.com/)
 
-1. Git is really convenient for undoing changes but one has to be familiar even with the most unlikely changes
-   1. If a file is mistakenly modified in some commit it can be reverted with `git revert`. However if a commit involves several changes `revert` might not be the best option. How can we use `git checkout` to recover a file version from a specific commit?
-   1. Create a branch, make a commit in said branch and then delete it. Can you still recover said commit? Try looking into `git reflog`. (Note: Recover dangling things quickly, git will periodically automatically clean up commits that nothing points to.)
-   1. If one is too trigger happy with `git reset --hard` instead of `git reset` changes can be easily lost. However since the changes were staged, we can recover them. (look into `git fsck --lost-found` and `.git/lost-found`)
+1. Git sangat nyaman untuk membatalkan perubahan, tetapi seseorang harus terbiasa bahkan dengan perubahan yang paling tidak mungkin
+   1. Jika sebuah file secara tidak sengaja dimodifikasi dalam suatu commit, file tersebut dapat dikembalikan dengan `git revert`. Namun jika sebuah commit melibatkan beberapa perubahan, `revert` mungkin bukan pilihan terbaik. Bagaimana kita bisa menggunakan `git checkout` untuk memulihkan versi file dari commit tertentu?
+   1. Buat branch, buat commit di branch tersebut, lalu hapus branch-nya. Bisakah Anda masih memulihkan commit tersebut? Cobalah melihat `git reflog`. (Catatan: Pulihkan hal-hal yang mengambang dengan cepat, git akan secara berkala membersihkan commit yang tidak ditunjuk oleh apapun secara otomatis.)
+   1. Jika seseorang terlalu cepat menggunakan `git reset --hard` alih-alih `git reset`, perubahan bisa dengan mudah hilang. Namun karena perubahan tersebut sudah di-stage, kita bisa memulihkannya. (lihat `git fsck --lost-found` dan `.git/lost-found`)
 
-1. In any git repo look under the folder `.git/hooks` you will find a bunch of scripts that end with `.sample`. If you rename them without the `.sample` they will run based on their name. For instance `pre-commit` will execute before doing a commit. Experiment with them
+1. Di repo git manapun, lihat di dalam folder `.git/hooks` Anda akan menemukan banyak skrip yang diakhiri dengan `.sample`. Jika Anda mengganti namanya tanpa `.sample`, mereka akan berjalan berdasarkan namanya. Misalnya `pre-commit` akan dieksekusi sebelum melakukan commit. Bereksperimenlah dengan mereka
 
-1. Like many command line tools `git` provides a configuration file (or dotfile) called `~/.gitconfig` . Create and alias using `~/.gitconfig` so that when you run `git graph` you get the output of `git log --oneline --decorate --all --graph` (this is a good command to quickly visualize the commit graph)
+1. Seperti banyak alat baris perintah, `git` menyediakan file konfigurasi (atau dotfile) yang disebut `~/.gitconfig`. Buat alias menggunakan `~/.gitconfig` sehingga ketika Anda menjalankan `git graph`, Anda mendapatkan output dari `git log --oneline --decorate --all --graph` (ini adalah perintah yang bagus untuk memvisualisasikan grafik commit dengan cepat)
 
-1. Git also lets you define global ignore patterns under `~/.gitignore_global`, this is useful to prevent common errors like adding RSA keys. Create a `~/.gitignore_global` file and add the pattern `*rsa`, then test that it works in a repo.
+1. Git juga memungkinkan Anda mendefinisikan pola ignore global di `~/.gitignore_global`, ini berguna untuk mencegah kesalahan umum seperti menambahkan kunci RSA. Buat file `~/.gitignore_global` dan tambahkan pola `*rsa`, lalu uji apakah itu berfungsi di sebuah repo.
 
-1. Once you start to get more familiar with `git`, you will find yourself running into common tasks, such as editing your `.gitignore`. [git extras](https://github.com/tj/git-extras/blob/master/Commands.md) provides a bunch of little utilities that integrate with `git`. For example `git ignore PATTERN` will add the specified pattern to the `.gitignore` file in your repo and `git ignore-io LANGUAGE` will fetch the common ignore patterns for that language from [gitignore.io](https://www.gitignore.io). Install `git extras` and try using some tools like `git alias` or `git ignore`.
+1. Setelah Anda mulai lebih familiar dengan `git`, Anda akan menemukan diri Anda mengerjakan tugas-tugas umum, seperti mengedit `.gitignore` Anda. [git extras](https://github.com/tj/git-extras/blob/master/Commands.md) menyediakan banyak utilitas kecil yang terintegrasi dengan `git`. Misalnya `git ignore PATTERN` akan menambahkan pola yang ditentukan ke file `.gitignore` di repo Anda dan `git ignore-io LANGUAGE` akan mengambil pola ignore umum untuk bahasa tersebut dari [gitignore.io](https://www.gitignore.io). Instal `git extras` dan cobalah menggunakan beberapa alat seperti `git alias` atau `git ignore`.
 
-1. Git GUI programs can be a great resource sometimes. Try running [gitk](https://git-scm.com/docs/gitk) in a git repo an explore the different parts of the interface. Then run `gitk --all` what are the differences?
+1. Program GUI git terkadang bisa menjadi sumber daya yang hebat. Cobalah menjalankan [gitk](https://git-scm.com/docs/gitk) di repo git dan jelajahi berbagai bagian antarmukanya. Lalu jalankan `gitk --all` apa perbedaannya?
 
-1. Once you get used to command line applications GUI tools can feel cumbersome/bloated. A nice compromise between the two are ncurses based tools which can be navigated from the command line and still provide an interactive interface. Git has [tig](https://github.com/jonas/tig), try installing it and running it in a repo. You can find some usage examples [here](https://www.atlassian.com/blog/git/git-tig).
+1. Setelah Anda terbiasa dengan aplikasi baris perintah, alat GUI bisa terasa merepotkan/boros. Kompromi yang bagus di antara keduanya adalah alat berbasis ncurses yang dapat dinavigasi dari baris perintah dan tetap menyediakan antarmuka interaktif. Git memiliki [tig](https://github.com/jonas/tig), cobalah menginstal dan menjalankannya di sebuah repo. Anda dapat menemukan beberapa contoh penggunaan [di sini](https://www.atlassian.com/blog/git/git-tig).
 
 
 {% comment %}

--- a/_2019/virtual-machines.md
+++ b/_2019/virtual-machines.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Virtual Machines and Containers"
+title: "Mesin Virtual dan Container"
 presenter: Anish, Jon
 date: 2019-01-15
 order: 2
@@ -9,125 +9,125 @@ video:
   id: LJ9ki5zq6Ik
 ---
 
-# Virtual Machines
+# Mesin Virtual
 
-Virtual machines are simulated computers. You can configure a guest virtual
-machine with some operating system and configuration and use it without
-affecting your host environment.
+Mesin virtual adalah komputer simulasi. Anda dapat mengkonfigurasi guest virtual
+machine dengan sistem operasi dan konfigurasi tertentu lalu menggunakannya tanpa
+mempengaruhi lingkungan host Anda.
 
-For this class, you can use VMs to experiment with operating systems, software,
-and configurations without risk: you won't affect your primary development
-environment.
+Untuk kelas ini, Anda dapat menggunakan VM untuk bereksperimen dengan sistem operasi, perangkat lunak,
+dan konfigurasi tanpa risiko: Anda tidak akan mempengaruhi lingkungan pengembangan
+utama Anda.
 
-In general, VMs have lots of uses. They are commonly used for running software
-that only runs on a certain operating system (e.g. using a Windows VM on Linux
-to run Windows-specific software). They are often used for experimenting with
-potentially malicious software.
+Secara umum, VM memiliki banyak kegunaan. VM sering digunakan untuk menjalankan perangkat lunak
+yang hanya berjalan pada sistem operasi tertentu (misalnya menggunakan VM Windows di Linux
+untuk menjalankan perangkat lunak khusus Windows). VM juga sering digunakan untuk bereksperimen dengan
+perangkat lunak yang berpotensi berbahaya.
 
-## Useful features
+## Fitur yang Berguna
 
-- **Isolation**: hypervisors do a pretty good job of isolating the guest from
-the host, so you can use VMs to run buggy or untrusted software reasonably
-safely.
+- **Isolasi**: hypervisor melakukan isolasi guest dari
+host dengan cukup baik, sehingga Anda dapat menggunakan VM untuk menjalankan perangkat lunak yang buggy
+atau tidak terpercaya dengan relatif aman.
 
-- **Snapshots**: you can take "snapshots" of your virtual machine, capturing
-the entire machine state (disk, memory, etc.), make changes to your machine,
-and then restore to an earlier state. This is useful for testing out
-potentially destructive actions, among other things.
+- **Snapshot**: Anda dapat mengambil "snapshot" dari virtual machine Anda, menangkap
+seluruh keadaan mesin (disk, memori, dll.), membuat perubahan pada mesin Anda,
+dan kemudian mengembalikan ke keadaan sebelumnya. Ini berguna untuk menguji
+tindakan yang berpotensi merusak, diantara hal lainnya.
 
-## Disadvantages
+## Kekurangan
 
-Virtual machines are generally slower than running on bare metal, so they may
-be unsuitable for certain applications.
+Mesin virtual umumnya lebih lambat dibandingkan berjalan langsung di bare metal, sehingga mungkin
+tidak cocok untuk aplikasi tertentu.
 
-## Setup
+## Pengaturan
 
-- **Resources**: shared with host machine; be aware of this when allocating
-physical resources.
+- **Sumber daya**: dibagi dengan mesin host; perhatikan hal ini saat mengalokasikan
+sumber daya fisik.
 
-- **Networking**: many options, default NAT should work fine for most use
-cases.
+- **Jaringan**: banyak opsi, NAT default seharusnya berfungsi baik untuk sebagian besar kasus
+penggunaan.
 
-- **Guest addons**: many hypervisors can install software in the guest to
-enable nicer integration with host system. You should use this if you can.
+- **Guest addon**: banyak hypervisor dapat menginstal perangkat lunak di guest untuk
+mengaktifkan integrasi yang lebih baik dengan sistem host. Anda harus menggunakan ini jika bisa.
 
-## Resources
+## Sumber Daya
 
-- Hypervisors
+- Hypervisor
     - [VirtualBox](https://www.virtualbox.org/) (open-source)
-    - [Virt-manager](https://virt-manager.org/) (open-source, manages KVM virtual machines and LXC containers)
-    - [VMWare](https://www.vmware.com/) (commercial, available from IS&T [for
-    MIT students](https://ist.mit.edu/vmware-fusion))
+    - [Virt-manager](https://virt-manager.org/) (open-source, mengelola virtual machine KVM dan container LXC)
+    - [VMWare](https://www.vmware.com/) (komersial, tersedia dari IS&T [untuk
+    mahasiswa MIT](https://ist.mit.edu/vmware-fusion))
 
-If you are already familiar with popular hypervisors/VMs you may want to learn more about how to do this from a command line friendly way. One option is the [libvirt](https://wiki.libvirt.org/page/UbuntuKVMWalkthrough) toolkit which allows you to manage multiple different virtualization providers/hypervisors.
+Jika Anda sudah familiar dengan hypervisor/VM populer, Anda mungkin ingin mempelajari lebih lanjut tentang cara melakukan ini melalui command line. Salah satu opsinya adalah toolkit [libvirt](https://wiki.libvirt.org/page/UbuntuKVMWalkthrough) yang memungkinkan Anda mengelola berbagai penyedia virtualisasi/hypervisor yang berbeda.
 
-## Exercises
+## Latihan
 
-1. Download and install a hypervisor.
+1. Unduh dan instal sebuah hypervisor.
 
-1. Create a new virtual machine and install a Linux distribution (e.g.
+1. Buat virtual machine baru dan instal distribusi Linux (misalnya
 [Debian](https://www.debian.org/)).
 
-1. Experiment with snapshots. Try things that you've always wanted to try, like
-   running `sudo rm -rf --no-preserve-root /`, and see if you can recover
-   easily.
+1. Bereksperimenlah dengan snapshot. Cobalah hal-hal yang selalu ingin Anda coba, seperti
+   menjalankan `sudo rm -rf --no-preserve-root /`, dan lihat apakah Anda dapat memulihkan
+   dengan mudah.
 
-1. Read what a [fork-bomb](https://en.wikipedia.org/wiki/Fork_bomb) (`:(){ :|:& };:`) is and run it on the VM to see that the resource isolation (CPU, Memory, &c) works.
+1. Baca apa itu [fork-bomb](https://en.wikipedia.org/wiki/Fork_bomb) (`:(){ :|:& };:`) dan jalankan di VM untuk melihat bahwa isolasi sumber daya (CPU, Memori, dll.) berfungsi.
 
-1. Install guest addons and experiment with different windowing modes, file
-   sharing, and other features.
+1. Instal guest addon dan bereksperimenlah dengan mode windowing yang berbeda,
+   berbagi file, dan fitur lainnya.
 
-# Containers
+# Container
 
-Virtual Machines are relatively heavy-weight; what if you want to spin
-up machines in an automated fashion? Enter containers!
+Mesin Virtual relatif berat; bagaimana jika Anda ingin menjalankan
+mesin secara otomatis? Masuk ke container!
 
  - Amazon Firecracker
  - Docker
  - rkt
  - lxc
 
-Containers are _mostly_ just an assembly of various Linux security
-features, like virtual file system, virtual network interfaces, chroots,
-virtual memory tricks, and the like, that together give the appearance
-of virtualization.
+Container _sebagian besar_ hanyalah kumpulan dari berbagai fitur keamanan Linux,
+seperti virtual file system, virtual network interfaces, chroot,
+trik virtual memory, dan sejenisnya, yang bersama-sama memberikan kesan
+virtualisasi.
 
-Not quite as secure or isolated as a VM, but pretty close and getting
-better. Usually higher performance, and much faster to start, but not
-always.
+Tidak sepenuhnya seaman atau terisolasi seperti VM, tetapi cukup dekat dan semakin
+baik. Biasanya berkinerja lebih tinggi, dan jauh lebih cepat untuk dimulai, tetapi tidak
+selalu.
 
-The performance boost comes from the fact that unlike VMs which run an entire copy of the operating system, containers share the linux kernel with the host. However note that if you are running linux containers on Windows/macOS a Linux VM will need to be active as a middle layer between the two.
+Peningkatan kinerja berasal dari fakta bahwa tidak seperti VM yang menjalankan salinan lengkap sistem operasi, container berbagi kernel Linux dengan host. Namun perhatikan bahwa jika Anda menjalankan container Linux di Windows/macOS, sebuah VM Linux perlu aktif sebagai lapisan tengah di antara keduanya.
 
 ![Docker vs VM](/2019/files/containers-vs-vms.png)
-_Comparison between Docker containers and Virtual Machines. Credit: blog.docker.com_
+_Perbandingan antara container Docker dan Mesin Virtual. Kredit: blog.docker.com_
 
-Containers are handy for when you want to run an automated task in a
-standardized setup:
+Container berguna ketika Anda ingin menjalankan tugas otomatis dalam
+setup yang terstandarisasi:
 
- - Build systems
- - Development environments
- - Pre-packaged servers
- - Running untrusted programs
-   - Grading student submissions
-   - (Some) cloud computing
+ - Build system
+ - Lingkungan pengembangan
+ - Server yang sudah dikemas
+ - Menjalankan program yang tidak terpercaya
+    - Menilai tugas mahasiswa
+    - (Beberapa) komputasi awan
  - Continuous integration
-   - Travis CI
-   - GitHub Actions
+    - Travis CI
+    - GitHub Actions
 
-Moreover, container software like Docker has also been extensively used as a solution for [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). If a machine needs to be running many services with conflicting dependencies they can be isolated using containers.
+Selain itu, perangkat lunak container seperti Docker juga telah digunakan secara luas sebagai solusi untuk [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). Jika sebuah mesin perlu menjalankan banyak layanan dengan dependency yang bertentangan, mereka dapat diisolasi menggunakan container.
 
-Usually, you write a file that defines how to construct your container.
-You start with some minimal _base image_ (like Alpine Linux), and then
-a list of commands to run to set up the environment you want (install
-packages, copy files, build stuff, write config files, etc.). Normally,
-there's also a way to specify any external ports that should be
-available, and an _entrypoint_ that dictates what command should be run
-when the container is started (like a grading script).
+Biasanya, Anda menulis file yang mendefinisikan cara membangun container Anda.
+Anda mulai dengan _base image_ minimal (seperti Alpine Linux), dan kemudian
+daftar perintah untuk dijalankan guna menyiapkan lingkungan yang Anda inginkan (instal
+paket, salin file, bangun proyek, tulis file konfigurasi, dll.). Biasanya,
+ada juga cara untuk menentukan port eksternal yang harus
+tersedia, dan _entrypoint_ yang menentukan perintah apa yang harus dijalankan
+saat container dimulai (seperti script penilaian).
 
-In a similar fashion to code repository websites (like [GitHub](https://github.com/)) there are some container repository websites (like [DockerHub](https://hub.docker.com/))where many software services have prebuilt images that one can easily deploy.
+Dengan cara yang mirip dengan situs web repositori kode (seperti [GitHub](https://github.com/)), ada beberapa situs web repositori container (seperti [DockerHub](https://hub.docker.com/)) di mana banyak layanan perangkat lunak memiliki image yang sudah dibangun sebelumnya yang dapat dengan mudah di-deploy.
 
-## Exercises
+## Latihan
 
-1. Choose a container software (Docker, LXC, …) and install a simple Linux image. Try SSHing into it.
+1. Pilih perangkat lunak container (Docker, LXC, ...) dan instal image Linux sederhana. Coba SSH ke dalamnya.
 
-1. Search and download a prebuilt container image for a popular web server (nginx, apache, …)
+1. Cari dan unduh image container yang sudah dibangun sebelumnya untuk web server populer (nginx, apache, ...)

--- a/_2019/web.md
+++ b/_2019/web.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Web and Browsers"
+title: "Web dan Browser"
 presenter: Jose
 date: 2019-01-31
 order: 1
@@ -8,67 +8,68 @@ video:
   aspect: 62.5
   id: XpZO3S8odec
 special: true
+description: "Belajar menggunakan browser web secara efisien, termasuk pintasan, operator pencarian, ekstensi privasi, kustomisasi gaya, dan otomasi web."
 ---
 
-Apart from the terminal, the web browser is a tool you will find yourself spending significant amounts of time into. Thus it is worth learning how to use it efficiently and
+Selain terminal, browser web adalah alat yang akan sering Anda gunakan dalam waktu yang cukup lama. Maka dari itu, penting untuk belajar cara menggunakannya secara efisien dan
 
-## Shortcuts
+## Pintasan
 
-Clicking around in your browser is often not the fastest option, getting familiar with common shortcuts can really pay off in the long run.
+Mengklik di browser Anda seringkali bukan cara tercepat. Membiasakan diri dengan pintasan umum akan sangat bermanfaat dalam jangka panjang.
 
-- `Middle Button Click` in a link opens it in a new tab
-- `Ctrl+T` Opens a new tab
-- `Ctrl+Shift+T` Reopens a recently closed tab
-- `Ctrl+L` selects the contents of the search bar
-- `Ctrl+F` to search within a webpage. If you do this often, you may benefit from an extension that supports regular expressions in searches.
-
-
-## Search operators
-
-Web search engines like Google or DuckDuckGo provide search operators to enable more elaborate web searches:
-
-- `"bar foo"` enforces an exact match of bar foo
-- `foo site:bar.com` searches for foo within bar.com
-- `foo -bar ` excludes the terms containing bar from the search
-- `foobar filetype:pdf` Searches for files of that extension
-- `(foo|bar)` searches for matches that have foo OR bar
-
-More through lists are available for popular engines like [Google](https://ahrefs.com/blog/google-advanced-search-operators/) and [DuckDuckGo](https://duck.co/help/results/syntax)
+- `Middle Button Click` pada tautan akan membukanya di tab baru
+- `Ctrl+T` Membuka tab baru
+- `Ctrl+Shift+T` Membuka kembali tab yang baru saja ditutup
+- `Ctrl+L` Memilih isi bilah pencarian
+- `Ctrl+F` untuk mencari di dalam halaman web. Jika Anda sering melakukan ini, Anda mungkin akan terbantu dengan ekstensi yang mendukung ekspresi reguler dalam pencarian.
 
 
-## Searchbar
+## Operator Pencarian
 
-The searchbar is a powerful tool too. Most browsers can infer search engines from websites and will store them. By editing the keyword argument
+Mesin pencari web seperti Google atau DuckDuckGo menyediakan operator pencarian untuk memungkinkan pencarian web yang lebih rinci:
 
-- In Google Chrome they are in [chrome://settings/searchEngines](chrome://settings/searchEngines)
-- In Firefox they are in [about:preferences#search](about:preferences#search)
+- `"bar foo"` memaksa pencocokan persis dari bar foo
+- `foo site:bar.com` mencari foo di dalam bar.com
+- `foo -bar ` mengecualikan istilah yang mengandung bar dari pencarian
+- `foobar filetype:pdf` Mencari file dengan ekstensi tersebut
+- `(foo|bar)` mencari kecocokan yang memiliki foo ATAU bar
 
-For example you can make so that `y SOME SEARCH TERMS` to directly search in youtube.
-
-Moreover, if you own a domain you can setup subdomain forwards using your registrar. For instance I have mapped `https://ht.josejg.com` to this course website. That way I can just type `ht.` and the searchbar will autocomplete. Another good feature of this setup is that unlike bookmarks they will work in every browser.
-
-## Privacy extensions
-
-Nowadays surfing the web can get quite annoying due to ads and invasive due to trackers. Moreover a good adblocker not only blocks most ad content but it will also block sketchy and malicious websites since they will be included in the common blacklists. They will also reduce page load times sometimes by reducing the amount of requests performed. A couple of recommendations are:
-
-- **uBlock origin** ([Chrome](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)): block ads and trackers based on predefined rules. You should also consider taking a look at the enabled blacklists in settings since you can enable more based on your region or browsing habits. You can even install filters from [around the web](https://github.com/gorhill/uBlock/wiki/Filter-lists-from-around-the-web)
-
-- **[Privacy Badger](https://privacybadger.org/)**: detects and blocks trackers automatically. For example when you go from website to website ad companies track which sites you visit and build a profile of you
-
-- **[HTTPS everywhere](https://www.eff.org/https-everywhere)** is a wonderful extension that redirects to HTTPS version of a website automatically, if available.
-
-You can find about more addons of this kind [here](https://www.privacytools.io/privacy-browser-addons/)
-
-## Style customization
-
-Web browsers are just another piece of software running in _your machine_ and thus you usually have the last say about what they should display or how they should behave. An example of this are custom styles. Browsers determine how to render the style of a  webpage using Cascading Style Sheets often abbreviated as CSS.
-
-You can access the source code of a website by inspecting it and changing its contents and styles temporarily (this is also a reason why you should never trust webpage screenshots).
-
-If you want to permanently tell your browser to override the style settings for a webpage you will need to use an extension. Our recommendation is **[Stylus](https://github.com/openstyles/stylus)** ([Firefox](https://addons.mozilla.org/en-US/firefox/addon/styl-us/), [Chrome](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne?hl=en)).
+Daftar yang lebih lengkap tersedia untuk mesin pencari populer seperti [Google](https://ahrefs.com/blog/google-advanced-search-operators/) dan [DuckDuckGo](https://duck.co/help/results/syntax)
 
 
-For example, we can write the following style for the class website
+## Bilah Pencarian
+
+Bilah pencarian juga merupakan alat yang kuat. Sebagian besar browser dapat mengenali mesin pencari dari situs web dan akan menyimpannya. Dengan mengedit argumen kata kunci
+
+- Di Google Chrome, mereka ada di [chrome://settings/searchEngines](chrome://settings/searchEngines)
+- Di Firefox, mereka ada di [about:preferences#search](about:preferences#search)
+
+Sebagai contoh, Anda bisa mengatur agar `y SOME SEARCH TERMS` langsung mencari di YouTube.
+
+Selain itu, jika Anda memiliki domain, Anda dapat mengatur penerusan subdomain melalui registrar Anda. Sebagai contoh, saya telah memetakan `https://ht.josejg.com` ke situs web kursus ini. Dengan begitu saya cukup mengetik `ht.` dan bilah pencarian akan melakukan autocomplete. Keunggulan lain dari pengaturan ini adalah tidak seperti bookmark, pengaturan ini akan berfungsi di setiap browser.
+
+## Ekstensi Privasi
+
+Saat ini menjelajahi web bisa sangat mengganggu karena iklan dan invasif karena pelacak. Selain itu, pemblokir iklan yang baik tidak hanya memblokir sebagian besar konten iklan tetapi juga akan memblokir situs web yang mencurigakan dan berbahaya karena mereka akan dimasukkan dalam daftar hitam umum. Mereka juga akan mengurangi waktu muat halaman terkadang dengan mengurangi jumlah permintaan yang dilakukan. Beberapa rekomendasi adalah:
+
+- **uBlock origin** ([Chrome](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)): memblokir iklan dan pelacak berdasarkan aturan yang telah ditentukan. Anda juga harus mempertimbangkan untuk melihat daftar hitam yang diaktifkan di pengaturan karena Anda dapat mengaktifkan lebih banyak berdasarkan wilayah atau kebiasaan penjelajahan Anda. Anda bahkan dapat menginstal filter dari [seluruh web](https://github.com/gorhill/uBlock/wiki/Filter-lists-from-around-the-web)
+
+- **[Privacy Badger](https://privacybadger.org/)**: mendeteksi dan memblokir pelacak secara otomatis. Sebagai contoh, ketika Anda berpindah dari satu situs web ke situs web lain, perusahaan iklan melacak situs mana yang Anda kunjungi dan membangun profil tentang Anda
+
+- **[HTTPS everywhere](https://www.eff.org/https-everywhere)** adalah ekstensi yang luar biasa yang mengarahkan ulang ke versi HTTPS dari sebuah situs web secara otomatis, jika tersedia.
+
+Anda dapat menemukan lebih banyak addon semacam ini [di sini](https://www.privacytools.io/privacy-browser-addons/)
+
+## Kustomisasi Gaya
+
+Browser web hanyalah perangkat lunak lain yang berjalan di _mesin Anda_ dan karenanya Anda biasanya memiliki keputusan terakhir tentang apa yang harus mereka tampilkan atau bagaimana mereka harus berperilaku. Contoh dari ini adalah gaya kustom. Browser menentukan bagaimana merender gaya halaman web menggunakan Cascading Style Sheets yang sering disingkat sebagai CSS.
+
+Anda dapat mengakses kode sumber sebuah situs web dengan cara menginspeksinya dan mengubah isi serta gayanya sementara waktu (ini juga alasan mengapa Anda tidak boleh percaya tangkapan layar halaman web).
+
+Jika Anda ingin memberi tahu browser Anda secara permanen untuk mengesampingkan pengaturan gaya untuk sebuah halaman web, Anda perlu menggunakan ekstensi. Rekomendasi kami adalah **[Stylus](https://github.com/openstyles/stylus)** ([Firefox](https://addons.mozilla.org/en-US/firefox/addon/styl-us/), [Chrome](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne?hl=en)).
+
+
+Sebagai contoh, kita dapat menulis gaya berikut untuk situs web kelas
 
 
 ```css
@@ -86,14 +87,14 @@ a:link {
 }
 ```
 
-Moreover, Stylus can find styles written by other users and published in [userstyles.org](https://userstyles.org/). Most common websites have one or several dark theme stylesheets for instance. FYI, you should not use Stylish since it was shown to leak user data, more [here](https://arstechnica.com/information-technology/2018/07/stylish-extension-with-2m-downloads-banished-for-tracking-every-site-visit/)
+Selain itu, Stylus dapat menemukan gaya yang ditulis oleh pengguna lain dan dipublikasikan di [userstyles.org](https://userstyles.org/). Sebagian besar situs web umum memiliki satu atau beberapa stylesheet tema gelap misalnya. Sebagai informasi, Anda tidak boleh menggunakan Stylish karena terbukti membocorkan data pengguna, lebih lanjut [di sini](https://arstechnica.com/information-technology/2018/07/stylish-extension-with-2m-downloads-banished-for-tracking-every-site-visit/)
 
 
-## Functionality Customization
+## Kustomisasi Fungsionalitas
 
-In the same way that you can modify the style, you can also modify the behaviour of a website by writing custom javascript and them sourcing it using a web browser extension such as [Tampermonkey](https://tampermonkey.net/)
+Sama seperti Anda dapat mengubah gaya, Anda juga dapat mengubah perilaku sebuah situs web dengan menulis javascript kustom dan memuatnya menggunakan ekstensi browser web seperti [Tampermonkey](https://tampermonkey.net/)
 
-For example the following script enables vim-like navigation using the J and K keys.
+Sebagai contoh, skrip berikut mengaktifkan navigasi mirip vim menggunakan tombol J dan K.
 
 ```js
 // ==UserScript==
@@ -122,14 +123,14 @@ For example the following script enables vim-like navigation using the J and K k
 })();
 ```
 
-There are also script repositories such as [OpenUserJS](https://openuserjs.org/) and [Greasy Fork](https://greasyfork.org/en). However, be warned, installing user scripts from others can be very dangerous since they can pretty much do anything such as steal your credit card numbers. Never install a script unless you read the whole thing yourself, understand what it does, and are absolutely sure that you know it isn't doing anything suspicious. Never install a script that contains minified or obfuscated code that you can't read!
+Terdapat juga repositori skrip seperti [OpenUserJS](https://openuserjs.org/) dan [Greasy Fork](https://greasyfork.org/en). Namun, perlu diingat, menginstal skrip pengguna dari orang lain bisa sangat berbahaya karena mereka bisa melakukan hampir semua hal seperti mencuri nomor kartu kredit Anda. Jangan pernah menginstal skrip kecuali Anda membaca seluruh isinya sendiri, memahami apa yang dilakukannya, dan benar-benar yakin bahwa skrip tersebut tidak melakukan sesuatu yang mencurigakan. Jangan pernah menginstal skrip yang berisi kode minified atau obfuscated yang tidak dapat Anda baca!
 
-## Web APIs
+## Web API
 
-It has become more and more common for webservices to offer an application interface aka web API so you can interact with the services making web requests.
-A more in depth introduction to the topic can be found [here](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Introduction). There are [many public APIs](https://github.com/toddmotto/public-apis). Web APIs can be useful for very many reasons:
+Semakin umum bagi layanan web untuk menawarkan application interface alias web API sehingga Anda dapat berinteraksi dengan layanan tersebut melalui permintaan web.
+Pengantar yang lebih mendalam tentang topik ini dapat ditemukan [di sini](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Introduction). Terdapat [banyak API publik](https://github.com/toddmotto/public-apis). Web API dapat berguna karena banyak alasan:
 
-- **Retrieval**. Web APIs can quite easily provide you information such as maps, weather or what your public ip address. For instance `curl ipinfo.io` will return a JSON object with some details about your public ip, region, location, &c. With proper parsing these tools can be integrated even with command line tools. The following bash functions talks to Googles autocompletion API and returns the first ten matches.
+- **Pengambilan Data**. Web API dapat dengan mudah menyediakan informasi seperti peta, cuaca, atau alamat IP publik Anda. Sebagai contoh, `curl ipinfo.io` akan mengembalikan objek JSON dengan beberapa detail tentang IP publik, wilayah, lokasi, dll. Dengan parsing yang tepat, alat-alat ini dapat diintegrasikan bahkan dengan alat baris perintah. Fungsi bash berikut berkomunikasi dengan API autocompletion Google dan mengembalikan sepuluh kecocokan pertama.
 
 ```bash
 function c() {
@@ -141,18 +142,18 @@ function c() {
 }
 ```
 
-- **Interaction**. Web API endpoints can also be used to trigger actions. These usually require some sort of authentication token that you can obtain through the service. For example performing the following
-`curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' "https://hooks.slack.com/services/$SLACK_TOKEN"` will send a `Hello, World!` message in a channel.
+- **Interaksi**. Endpoint Web API juga dapat digunakan untuk memicu tindakan. Ini biasanya memerlukan semacam token autentikasi yang dapat Anda peroleh melalui layanan tersebut. Sebagai contoh, menjalankan perintah berikut
+`curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' "https://hooks.slack.com/services/$SLACK_TOKEN"` akan mengirim pesan `Hello, World!` di sebuah channel.
 
-- **Piping**. Since some services with web APIs are rather popular, common web API "gluing" has already been implemented and is provided with server included. This is the case for services like [If This Then That](https://ifttt.com/) and [Zapier](https://zapier.com/)
-
-
-## Web Automation
-
-Sometimes web APIs are not enough. If only reading is needed you can use a html parser like `pup` or use a library, for example python has BeautifulSoup. However if interactivity or javascript execution is required those solutions fall short. WebDriver
+- **Piping**. Karena beberapa layanan dengan Web API cukup populer, "penyambungan" Web API umum telah diimplementasikan dan disediakan bersama dengan server. Ini berlaku untuk layanan seperti [If This Then That](https://ifttt.com/) dan [Zapier](https://zapier.com/)
 
 
-For example, the following script will save the specified url using the wayback machine simulating the interaction of typing the website.
+## Otomasi Web
+
+Terkadang Web API tidak cukup. Jika hanya diperlukan pembacaan, Anda dapat menggunakan parser html seperti `pup` atau menggunakan pustaka, misalnya python memiliki BeautifulSoup. Namun jika diperlukan interaktivitas atau eksekusi javascript, solusi tersebut tidak memadai. WebDriver
+
+
+Sebagai contoh, skrip berikut akan menyimpan url yang ditentukan menggunakan wayback machine dengan mensimulasikan interaksi pengetikan situs web.
 
 ```python
 from selenium.webdriver import Firefox
@@ -175,12 +176,10 @@ snapshot_wayback(driver, url)
 ```
 
 
-## Exercises
+## Latihan
 
-1. Edit a keyword search engine that you use often in your web browser
-1. Install the mentioned extensions. Look into how uBlock Origin/Privacy Badger can be disabled for a website. What differences do you see? Try doing it in a website with plenty of ads like YouTube.
-1. Install Stylus and write a custom style for the class website using the CSS provided. Here are some common programming characters `=   ==   ===   >=   =>   ++   /=   ~=`. What happens to them when changing the font to Fira Code? If you want to know more search for programming font ligatures.
-1. Find a web api to get the weather in your city/area.
-1. Use a WebDriver software like [Selenium](https://www.selenium.dev/documentation/) to automate some repetitive manual task that you perform often with your browser.
-
-
+1. Edit mesin pencari kata kunci yang sering Anda gunakan di browser web Anda
+1. Instal ekstensi yang disebutkan. Pelajari bagaimana uBlock Origin/Privacy Badger dapat dinonaktifkan untuk sebuah situs web. Perbedaan apa yang Anda lihat? Cobalah melakukannya di situs web dengan banyak iklan seperti YouTube.
+1. Instal Stylus dan tulis gaya kustom untuk situs web kelas menggunakan CSS yang disediakan. Berikut adalah beberapa karakter pemrograman umum `=   ==   ===   >=   =>   ++   /=   ~=`. Apa yang terjadi pada mereka ketika mengubah font ke Fira Code? Jika Anda ingin tahu lebih lanjut, cari tentang programming font ligatures.
+1. Temukan web API untuk mendapatkan cuaca di kota/wilayah Anda.
+1. Gunakan perangkat lunak WebDriver seperti [Selenium](https://www.selenium.dev/documentation/) untuk mengotomatiskan tugas manual berulang yang sering Anda lakukan dengan browser Anda.

--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Command-line Environment"
+title: "Lingkungan Command-line"
 description: >
-  Learn about job control, terminal multiplexers, dotfiles, and remote machines with SSH.
+  Pelajari tentang job control, terminal multiplexer, dotfiles, dan mesin remote dengan SSH.
 thumbnail: /static/assets/thumbnails/2020/lec5.png
 date: 2020-01-21
 ready: true
@@ -11,24 +11,24 @@ video:
   id: e8BO_dYxk5c
 ---
 
-In this lecture we will go through several ways in which you can improve your workflow when using the shell. We have been working with the shell for a while now, but we have mainly focused on executing different commands. We will now see how to run several processes at the same time while keeping track of them, how to stop or pause a specific process and how to make a process run in the background.
+Dalam kuliah ini kita akan membahas beberapa cara untuk meningkatkan alur kerja Anda saat menggunakan shell. Kita telah bekerja dengan shell selama beberapa waktu, tetapi kita terutama fokus pada menjalankan berbagai perintah. Sekarang kita akan melihat bagaimana menjalankan beberapa proses secara bersamaan sambil melacaknya, bagaimana menghentikan atau menjeda proses tertentu, dan bagaimana membuat proses berjalan di latar belakang.
 
-We will also learn about different ways to improve your shell and other tools, by defining aliases and configuring them using dotfiles. Both of these can help you save time, e.g. by using the same configurations in all your machines without having to type long commands. We will look at how to work with remote machines using SSH.
+Kita juga akan mempelajari berbagai cara untuk meningkatkan shell dan alat-alat lainnya, dengan mendefinisikan alias dan mengonfigurasinya menggunakan dotfiles. Keduanya dapat membantu Anda menghemat waktu, misalnya dengan menggunakan konfigurasi yang sama di semua mesin Anda tanpa harus mengetik perintah panjang. Kita akan melihat cara bekerja dengan mesin remote menggunakan SSH.
 
 
 # Job Control
 
-In some cases you will need to interrupt a job while it is executing, for instance if a command is taking too long to complete (such as a `find` with a very large directory structure to search through).
-Most of the time, you can do `Ctrl-C` and the command will stop.
-But how does this actually work and why does it sometimes fail to stop the process?
+Dalam beberapa kasus Anda perlu menghentikan pekerjaan saat sedang berjalan, misalnya jika suatu perintah membutuhkan waktu terlalu lama untuk selesai (seperti `find` dengan struktur direktori yang sangat besar untuk dicari).
+Sebagian besar waktu, Anda bisa melakukan `Ctrl-C` dan perintah akan berhenti.
+Tetapi bagaimana sebenarnya ini bekerja dan mengapa terkadang gagal menghentikan proses?
 
-## Killing a process
+## Membunuh sebuah proses
 
-Your shell is using a UNIX communication mechanism called a _signal_ to communicate information to the process. When a process receives a signal it stops its execution, deals with the signal and potentially changes the flow of execution based on the information that the signal delivered. For this reason, signals are _software interrupts_.
+Shell Anda menggunakan mekanisme komunikasi UNIX yang disebut _signal_ untuk menyampaikan informasi ke proses. Ketika sebuah proses menerima sinyal, ia menghentikan eksekusinya, menangani sinyal tersebut, dan mungkin mengubah alur eksekusi berdasarkan informasi yang disampaikan sinyal tersebut. Oleh karena itu, sinyal adalah _software interrupt_.
 
-In our case, when typing `Ctrl-C` this prompts the shell to deliver a `SIGINT` signal to the process.
+Dalam kasus kita, ketika mengetik `Ctrl-C` ini menyebabkan shell mengirimkan sinyal `SIGINT` ke proses.
 
-Here's a minimal example of a Python program that captures `SIGINT` and ignores it, no longer stopping. To kill this program we can now use the `SIGQUIT` signal instead, by typing `Ctrl-\`.
+Berikut adalah contoh minimal program Python yang menangkap `SIGINT` dan mengabaikannya, sehingga tidak berhenti. Untuk mematikan program ini kita bisa menggunakan sinyal `SIGQUIT` sebagai gantinya, dengan mengetik `Ctrl-\`.
 
 ```python
 #!/usr/bin/env python
@@ -45,7 +45,7 @@ while True:
     i += 1
 ```
 
-Here's what happens if we send `SIGINT` twice to this program, followed by `SIGQUIT`. Note that `^` is how `Ctrl` is displayed when typed in the terminal.
+Berikut yang terjadi jika kita mengirim `SIGINT` dua kali ke program ini, diikuti oleh `SIGQUIT`. Perhatikan bahwa `^` adalah cara `Ctrl` ditampilkan saat diketik di terminal.
 
 ```
 $ python sigint.py
@@ -56,27 +56,27 @@ I got a SIGINT, but I am not stopping
 30^\[1]    39913 quit       python sigint.py
 ```
 
-While `SIGINT` and `SIGQUIT` are both usually associated with terminal related requests, a more generic signal for asking a process to exit gracefully is the `SIGTERM` signal.
-To send this signal we can use the [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html) command, with the syntax `kill -TERM <PID>`.
+Meskipun `SIGINT` dan `SIGQUIT` keduanya biasanya terkait dengan permintaan terminal, sinyal yang lebih umum untuk meminta proses keluar dengan baik adalah sinyal `SIGTERM`.
+Untuk mengirim sinyal ini kita bisa menggunakan perintah [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html), dengan sintaks `kill -TERM <PID>`.
 
-## Pausing and backgrounding processes
+## Menjeda dan memproses di latar belakang proses
 
-Signals can do other things beyond killing a process. For instance, `SIGSTOP` pauses a process. In the terminal, typing `Ctrl-Z` will prompt the shell to send a `SIGTSTP` signal, short for Terminal Stop (i.e. the terminal's version of `SIGSTOP`).
+Sinyal dapat melakukan hal lain selain membunuh proses. Misalnya, `SIGSTOP` menjeda sebuah proses. Di terminal, mengetik `Ctrl-Z` akan menyebabkan shell mengirimkan sinyal `SIGTSTP`, singkatan dari Terminal Stop (yaitu versi terminal dari `SIGSTOP`).
 
-We can then continue the paused job in the foreground or in the background using [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) or [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), respectively.
+Kita kemudian dapat melanjutkan pekerjaan yang dijeda di latar depan atau latar belakang menggunakan [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) atau [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), masing-masing.
 
-The [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) command lists the unfinished jobs associated with the current terminal session.
-You can refer to those jobs using their pid (you can use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find that out).
-More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` special parameter.
+Perintah [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) menampilkan daftar pekerjaan yang belum selesai yang terkait dengan sesi terminal saat ini.
+Anda dapat merujuk ke pekerjaan tersebut menggunakan pid mereka (Anda bisa menggunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk mengetahuinya).
+Secara lebih intuitif, Anda juga dapat merujuk ke proses menggunakan simbol persen diikuti dengan nomor pekerjaannya (ditampilkan oleh `jobs`). Untuk merujuk ke pekerjaan terakhir yang dijalankan di latar belakang, Anda dapat menggunakan parameter khusus `$!`.
 
-One more thing to know is that the `&` suffix in a command will run the command in the background, giving you the prompt back, although it will still use the shell's STDOUT which can be annoying (use shell redirections in that case).
+Satu hal lagi yang perlu diketahui adalah bahwa sufiks `&` dalam perintah akan menjalankan perintah di latar belakang, mengembalikan prompt kepada Anda, meskipun masih akan menggunakan STDOUT shell yang bisa mengganggu (gunakan shell redirections dalam kasus tersebut).
 
-To background an already running program you can do `Ctrl-Z` followed by `bg`.
-Note that backgrounded processes are still children processes of your terminal and will die if you close the terminal (this will send yet another signal, `SIGHUP`).
-To prevent that from happening you can run the program with [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (a wrapper to ignore `SIGHUP`), or use `disown` if the process has already been started.
-Alternatively, you can use a terminal multiplexer as we will see in the next section.
+Untuk memindahkan program yang sudah berjalan ke latar belakang, Anda bisa melakukan `Ctrl-Z` diikuti oleh `bg`.
+Perhatikan bahwa proses di latar belakang masih merupakan proses anak dari terminal Anda dan akan mati jika Anda menutup terminal (ini akan mengirimkan sinyal lain, `SIGHUP`).
+Untuk mencegah hal itu terjadi, Anda bisa menjalankan program dengan [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (wrapper untuk mengabaikan `SIGHUP`), atau menggunakan `disown` jika proses sudah dimulai.
+Sebagai alternatif, Anda bisa menggunakan terminal multiplexer seperti yang akan kita lihat di bagian berikutnya.
 
-Below is a sample session to showcase some of these concepts.
+Berikut adalah sesi contoh untuk menunjukkan beberapa konsep ini.
 
 ```
 $ sleep 1000
@@ -123,255 +123,255 @@ $ jobs
 
 ```
 
-A special signal is `SIGKILL` since it cannot be captured by the process and it will always terminate it immediately. However, it can have bad side effects such as leaving orphaned children processes.
+Sinyal khusus adalah `SIGKILL` karena tidak dapat ditangkap oleh proses dan akan selalu menghentikannya segera. Namun, ini bisa memiliki efek samping yang buruk seperti meninggalkan proses anak yang yatim.
 
-You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -l`.
+Anda dapat mempelajari lebih lanjut tentang sinyal-sinyal ini dan sinyal lainnya [di sini](https://en.wikipedia.org/wiki/Signal_(IPC)) atau dengan mengetik [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) atau `kill -l`.
 
 
-# Terminal Multiplexers
+# Terminal Multiplexer
 
-When using the command line interface you will often want to run more than one thing at once.
-For instance, you might want to run your editor and your program side by side.
-Although this can be achieved by opening new terminal windows, using a terminal multiplexer is a more versatile solution.
+Saat menggunakan command-line interface, Anda sering kali ingin menjalankan lebih dari satu hal sekaligus.
+Misalnya, Anda mungkin ingin menjalankan editor dan program Anda secara berdampingan.
+Meskipun ini dapat dicapai dengan membuka jendela terminal baru, menggunakan terminal multiplexer adalah solusi yang lebih serbaguna.
 
-Terminal multiplexers like [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) allow you to multiplex terminal windows using panes and tabs so you can interact with multiple shell sessions.
-Moreover, terminal multiplexers let you detach a current terminal session and reattach at some point later in time.
-This can make your workflow much better when working with remote machines since it avoids the need to use `nohup` and similar tricks.
+Terminal multiplexer seperti [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) memungkinkan Anda melakukan multiplex jendela terminal menggunakan panel dan tab sehingga Anda dapat berinteraksi dengan beberapa sesi shell.
+Selain itu, terminal multiplexer memungkinkan Anda melepaskan sesi terminal saat ini dan menghubungkannya kembali di kemudian hari.
+Ini dapat membuat alur kerja Anda jauh lebih baik saat bekerja dengan mesin remote karena menghindari kebutuhan menggunakan `nohup` dan trik serupa.
 
-The most popular terminal multiplexer these days is [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` is highly configurable and by using the associated keybindings you can create multiple tabs and panes and quickly navigate through them.
+Terminal multiplexer yang paling populer saat ini adalah [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` sangat dapat dikonfigurasi dan dengan menggunakan keybinding yang terkait, Anda dapat membuat beberapa tab dan panel serta menavigasinya dengan cepat.
 
-`tmux` expects you to know its keybindings, and they all have the form `<C-b> x` where that means (1) press `Ctrl+b`, (2) release `Ctrl+b`, and then (3) press `x`. `tmux` has the following hierarchy of objects:
-- **Sessions** - a session is an independent workspace with one or more windows
-    + `tmux` starts a new session.
-    + `tmux new -s NAME` starts it with that name.
-    + `tmux ls` lists the current sessions
-    + Within `tmux` typing `<C-b> d`  detaches the current session
-    + `tmux a` attaches the last session. You can use `-t` flag to specify which
+`tmux` mengharuskan Anda mengetahui keybinding-nya, dan semuanya memiliki bentuk `<C-b> x` yang berarti (1) tekan `Ctrl+b`, (2) lepaskan `Ctrl+b`, lalu (3) tekan `x`. `tmux` memiliki hierarki objek berikut:
+- **Sessions** - sebuah sesi adalah ruang kerja independen dengan satu atau lebih jendela
+    + `tmux` memulai sesi baru.
+    + `tmux new -s NAME` memulainya dengan nama tersebut.
+    + `tmux ls` menampilkan sesi saat ini
+    + Di dalam `tmux` mengetik `<C-b> d`  melepaskan sesi saat ini
+    + `tmux a` menghubungkan sesi terakhir. Anda dapat menggunakan flag `-t` untuk menentukan yang mana
 
-- **Windows** - Equivalent to tabs in editors or browsers, they are visually separate parts of the same session
-    + `<C-b> c` Creates a new window. To close it you can just terminate the shells doing `<C-d>`
-    + `<C-b> N` Go to the _N_ th window. Note they are numbered
-    + `<C-b> p` Goes to the previous window
-    + `<C-b> n` Goes to the next window
-    + `<C-b> ,` Rename the current window
-    + `<C-b> w` List current windows
+- **Windows** - Setara dengan tab di editor atau browser, mereka adalah bagian yang secara visual terpisah dari sesi yang sama
+    + `<C-b> c` Membuat jendela baru. Untuk menutupnya Anda cukup menghentikan shell dengan `<C-d>`
+    + `<C-b> N` Pergi ke jendela ke-_N_. Perhatikan mereka diberi nomor
+    + `<C-b> p` Pergi ke jendela sebelumnya
+    + `<C-b> n` Pergi ke jendela berikutnya
+    + `<C-b> ,` Mengganti nama jendela saat ini
+    + `<C-b> w` Daftar jendela saat ini
 
-- **Panes** - Like vim splits, panes let you have multiple shells in the same visual display.
-    + `<C-b> "` Split the current pane horizontally
-    + `<C-b> %` Split the current pane vertically
-    + `<C-b> <direction>` Move to the pane in the specified _direction_. Direction here means arrow keys.
-    + `<C-b> z` Toggle zoom for the current pane
-    + `<C-b> [` Start scrollback. You can then press `<space>` to start a selection and `<enter>` to copy that selection.
-    + `<C-b> <space>` Cycle through pane arrangements.
+- **Panes** - Seperti split di vim, panel memungkinkan Anda memiliki beberapa shell dalam tampilan visual yang sama.
+    + `<C-b> "` Membagi panel saat ini secara horizontal
+    + `<C-b> %` Membagi panel saat ini secara vertikal
+    + `<C-b> <direction>` Pindah ke panel di _arah_ yang ditentukan. Arah di sini berarti tombol panah.
+    + `<C-b> z` Toggle zoom untuk panel saat ini
+    + `<C-b> [` Memulai scrollback. Anda kemudian dapat menekan `<space>` untuk memulai seleksi dan `<enter>` untuk menyalin seleksi tersebut.
+    + `<C-b> <space>` Berputar melalui susunan panel.
 
-For further reading,
-[here](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) is a quick tutorial on `tmux` and [this](https://linuxcommand.org/lc3_adv_termmux.php) has a more detailed explanation that covers the original `screen` command. You might also want to familiarize yourself with [`screen`](https://www.man7.org/linux/man-pages/man1/screen.1.html), since it comes installed in most UNIX systems.
+Untuk bacaan lebih lanjut,
+[di sini](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) adalah tutorial singkat tentang `tmux` dan [ini](https://linuxcommand.org/lc3_adv_termmux.php) memiliki penjelasan lebih detail yang mencakup perintah `screen` asli. Anda mungkin juga ingin membiasakan diri dengan [`screen`](https://www.man7.org/linux/man-pages/man1/screen.1.html), karena sudah terinstal di sebagian besar sistem UNIX.
 
-# Aliases
+# Alias
 
-It can become tiresome typing long commands that involve many flags or verbose options.
-For this reason, most shells support _aliasing_.
-A shell alias is a short form for another command that your shell will replace automatically for you.
-For instance, an alias in bash has the following structure:
+Bisa menjadi melelahkan mengetik perintah panjang yang melibatkan banyak flag atau opsi verbose.
+Untuk alasan ini, sebagian besar shell mendukung _alias_.
+Alias shell adalah bentuk pendek dari perintah lain yang akan diganti secara otomatis oleh shell Anda.
+Misalnya, alias di bash memiliki struktur berikut:
 
 ```bash
 alias alias_name="command_to_alias arg1 arg2"
 ```
 
-Note that there is no space around the equal sign `=`, because [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) is a shell command that takes a single argument.
+Perhatikan bahwa tidak ada spasi di sekitar tanda sama dengan `=`, karena [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) adalah perintah shell yang mengambil satu argumen.
 
-Aliases have many convenient features:
+Alias memiliki banyak fitur yang nyaman:
 
 ```bash
-# Make shorthands for common flags
+# Membuat singkatan untuk flag umum
 alias ll="ls -lh"
 
-# Save a lot of typing for common commands
+# Menghemat banyak pengetikan untuk perintah umum
 alias gs="git status"
 alias gc="git commit"
 alias v="vim"
 
-# Save you from mistyping
+# Menghindari salah ketik
 alias sl=ls
 
-# Overwrite existing commands for better defaults
-alias mv="mv -i"           # -i prompts before overwrite
-alias mkdir="mkdir -p"     # -p make parent dirs as needed
-alias df="df -h"           # -h prints human readable format
+# Menimpa perintah yang ada untuk default yang lebih baik
+alias mv="mv -i"           # -i meminta konfirmasi sebelum menimpa
+alias mkdir="mkdir -p"     # -p membuat direktori induk sesuai kebutuhan
+alias df="df -h"           # -h mencetak format yang mudah dibaca manusia
 
-# Alias can be composed
+# Alias dapat disusun
 alias la="ls -A"
 alias lla="la -l"
 
-# To ignore an alias run it prepended with \
+# Untuk mengabaikan alias, jalankan dengan awalan \
 \ls
-# Or disable an alias altogether with unalias
+# Atau nonaktifkan alias sepenuhnya dengan unalias
 unalias la
 
-# To get an alias definition just call it with alias
+# Untuk mendapatkan definisi alias cukup panggil dengan alias
 alias ll
-# Will print ll='ls -lh'
+# Akan mencetak ll='ls -lh'
 ```
 
-Note that aliases do not persist shell sessions by default.
-To make an alias persistent you need to include it in shell startup files, like `.bashrc` or `.zshrc`, which we are going to introduce in the next section.
+Perhatikan bahwa alias tidak bertahan secara default di sesi shell.
+Untuk membuat alias tetap ada, Anda perlu memasukkannya ke dalam file startup shell, seperti `.bashrc` atau `.zshrc`, yang akan kita bahas di bagian berikutnya.
 
 
 # Dotfiles
 
-Many programs are configured using plain-text files known as _dotfiles_
-(because the file names begin with a `.`, e.g. `~/.vimrc`, so that they are
-hidden in the directory listing `ls` by default).
+Banyak program dikonfigurasi menggunakan file teks biasa yang dikenal sebagai _dotfiles_
+(karena nama file dimulai dengan `.`, misalnya `~/.vimrc`, sehingga mereka
+tersembunyi di daftar direktori `ls` secara default).
 
-Shells are one example of programs configured with such files. On startup, your shell will read many files to load its configuration.
-Depending on the shell, whether you are starting a login and/or interactive the entire process can be quite complex.
-[Here](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) is an excellent resource on the topic.
+Shell adalah salah satu contoh program yang dikonfigurasi dengan file seperti ini. Saat startup, shell Anda akan membaca banyak file untuk memuat konfigurasinya.
+Tergantung pada shell, apakah Anda memulai login dan/atau interaktif, seluruh prosesnya bisa cukup kompleks.
+[Di sini](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) adalah sumber daya yang sangat baik tentang topik ini.
 
-For `bash`, editing your `.bashrc` or `.bash_profile` will work in most systems.
-Here you can include commands that you want to run on startup, like the alias we just described or modifications to your `PATH` environment variable.
-In fact, many programs will ask you to include a line like `export PATH="$PATH:/path/to/program/bin"` in your shell configuration file so their binaries can be found.
+Untuk `bash`, mengedit `.bashrc` atau `.bash_profile` akan berfungsi di sebagian besar sistem.
+Di sini Anda dapat menyertakan perintah yang ingin Anda jalankan saat startup, seperti alias yang baru saja kita deskripsikan atau modifikasi pada variabel lingkungan `PATH` Anda.
+Faktanya, banyak program akan meminta Anda untuk menyertakan baris seperti `export PATH="$PATH:/path/to/program/bin"` di file konfigurasi shell Anda sehingga biner mereka dapat ditemukan.
 
-Some other examples of tools that can be configured through dotfiles are:
+Beberapa contoh lain alat yang dapat dikonfigurasi melalui dotfiles adalah:
 
 - `bash` - `~/.bashrc`, `~/.bash_profile`
 - `git` - `~/.gitconfig`
-- `vim` - `~/.vimrc` and the `~/.vim` folder
+- `vim` - `~/.vimrc` dan folder `~/.vim`
 - `ssh` - `~/.ssh/config`
 - `tmux` - `~/.tmux.conf`
 
-How should you organize your dotfiles? They should be in their own folder,
-under version control, and **symlinked** into place using a script. This has
-the benefits of:
+Bagaimana sebaiknya Anda mengatur dotfiles Anda? Mereka harus berada di folder tersendiri,
+di bawah version control, dan **di-symlink** ke tempatnya menggunakan skrip. Ini memiliki
+keuntungan:
 
-- **Easy installation**: if you log in to a new machine, applying your
-customizations will only take a minute.
-- **Portability**: your tools will work the same way everywhere.
-- **Synchronization**: you can update your dotfiles anywhere and keep them all
-in sync.
-- **Change tracking**: you're probably going to be maintaining your dotfiles
-for your entire programming career, and version history is nice to have for
-long-lived projects.
+- **Instalasi mudah**: jika Anda login ke mesin baru, menerapkan
+  kustomisasi Anda hanya akan memakan waktu satu menit.
+- **Portabilitas**: alat-alat Anda akan bekerja dengan cara yang sama di mana saja.
+- **Sinkronisasi**: Anda dapat memperbarui dotfiles Anda di mana saja dan menjaga semuanya
+  tetap sinkron.
+- **Pelacakan perubahan**: Anda mungkin akan memelihara dotfiles Anda
+  sepanjang karier pemrograman Anda, dan riwayat versi berguna untuk
+  proyek jangka panjang.
 
-What should you put in your dotfiles?
-You can learn about your tool's settings by reading online documentation or
-[man pages](https://en.wikipedia.org/wiki/Man_page). Another great way is to
-search the internet for blog posts about specific programs, where authors will
-tell you about their preferred customizations. Yet another way to learn about
-customizations is to look through other people's dotfiles: you can find tons of
-[dotfiles
-repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on GitHub --- see the most popular one
-[here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
-copy configurations though).
-[Here](https://dotfiles.github.io/) is another good resource on the topic.
+Apa yang harus Anda masukkan ke dotfiles Anda?
+Anda dapat mempelajari tentang pengaturan alat Anda dengan membaca dokumentasi online atau
+[man page](https://en.wikipedia.org/wiki/Man_page). Cara hebat lainnya adalah
+mencari di internet postingan blog tentang program tertentu, di mana penulis akan
+memberi tahu Anda tentang kustomisasi pilihan mereka. Cara lain untuk mempelajari tentang
+kustomisasi adalah dengan melihat dotfiles orang lain: Anda dapat menemukan banyak
+[repositori
+dotfiles](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
+di GitHub --- lihat yang paling populer
+[di sini](https://github.com/mathiasbynens/dotfiles) (kami menyarankan Anda untuk tidak menyalin
+konfigurasi secara membabi buta).
+[Di sini](https://dotfiles.github.io/) adalah sumber daya bagus lainnya tentang topik ini.
 
-All of the class instructors have their dotfiles publicly accessible on GitHub: [Anish](https://github.com/anishathalye/dotfiles),
+Semua instruktur kelas memiliki dotfiles mereka yang dapat diakses secara publik di GitHub: [Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
 [Jose](https://github.com/jjgo/dotfiles).
 
 
-## Portability
+## Portabilitas
 
-A common pain with dotfiles is that the configurations might not work when working with several machines, e.g. if they have different operating systems or shells. Sometimes you also want some configuration to be applied only in a given machine.
+Masalah umum dengan dotfiles adalah bahwa konfigurasi mungkin tidak berfungsi saat bekerja dengan beberapa mesin, misalnya jika mereka memiliki sistem operasi atau shell yang berbeda. Terkadang Anda juga ingin beberapa konfigurasi hanya diterapkan pada mesin tertentu.
 
-There are some tricks for making this easier.
-If the configuration file supports it, use the equivalent of if-statements to
-apply machine specific customizations. For example, your shell could have something
-like:
+Ada beberapa trik untuk memudahkan hal ini.
+Jika file konfigurasi mendukungnya, gunakan setara if-statement untuk
+menerapkan kustomisasi spesifik mesin. Misalnya, shell Anda bisa memiliki sesuatu
+seperti:
 
 ```bash
 if [[ "$(uname)" == "Linux" ]]; then {do_something}; fi
 
-# Check before using shell-specific features
+# Periksa sebelum menggunakan fitur spesifik shell
 if [[ "$SHELL" == "zsh" ]]; then {do_something}; fi
 
-# You can also make it machine-specific
+# Anda juga bisa membuatnya spesifik mesin
 if [[ "$(hostname)" == "myServer" ]]; then {do_something}; fi
 ```
 
-If the configuration file supports it, make use of includes. For example,
-a `~/.gitconfig` can have a setting:
+Jika file konfigurasi mendukungnya, manfaatkan includes. Misalnya,
+`~/.gitconfig` bisa memiliki pengaturan:
 
 ```
 [include]
     path = ~/.gitconfig_local
 ```
 
-And then on each machine, `~/.gitconfig_local` can contain machine-specific
-settings. You could even track these in a separate repository for
-machine-specific settings.
+Dan kemudian di setiap mesin, `~/.gitconfig_local` dapat berisi pengaturan
+spesifik mesin. Anda bahkan bisa melacak ini di repositori terpisah untuk
+pengaturan spesifik mesin.
 
-This idea is also useful if you want different programs to share some configurations. For instance, if you want both `bash` and `zsh` to share the same set of aliases you can write them under `.aliases` and have the following block in both:
+Ide ini juga berguna jika Anda ingin program berbeda berbagi beberapa konfigurasi. Misalnya, jika Anda ingin `bash` dan `zsh` berbagi set alias yang sama, Anda dapat menulisnya di `.aliases` dan memiliki blok berikut di keduanya:
 
 ```bash
-# Test if ~/.aliases exists and source it
+# Uji apakah ~/.aliases ada dan source itu
 if [ -f ~/.aliases ]; then
     source ~/.aliases
 fi
 ```
 
-# Remote Machines
+# Mesin Remote
 
-It has become more and more common for programmers to use remote servers in their everyday work. If you need to use remote servers in order to deploy backend software or you need a server with higher computational capabilities, you will end up using a Secure Shell (SSH). As with most tools covered, SSH is highly configurable so it is worth learning about it.
+Sudah semakin umum bagi programmer untuk menggunakan server remote dalam pekerjaan sehari-hari mereka. Jika Anda perlu menggunakan server remote untuk mendeploy perangkat lunak backend atau Anda membutuhkan server dengan kemampuan komputasi yang lebih tinggi, Anda akan menggunakan Secure Shell (SSH). Seperti kebanyakan alat yang dibahas, SSH sangat dapat dikonfigurasi sehingga layak untuk dipelajari.
 
-To `ssh` into a server you execute a command as follows
+Untuk melakukan `ssh` ke server, Anda menjalankan perintah sebagai berikut
 
 ```bash
 ssh foo@bar.mit.edu
 ```
 
-Here we are trying to ssh as user `foo` in server `bar.mit.edu`.
-The server can be specified with a URL (like `bar.mit.edu`) or an IP (something like `foobar@192.168.1.42`). Later we will see that if we modify ssh config file you can access just using something like `ssh bar`.
+Di sini kita mencoba ssh sebagai user `foo` di server `bar.mit.edu`.
+Server dapat ditentukan dengan URL (seperti `bar.mit.edu`) atau IP (sesuatu seperti `foobar@192.168.1.42`). Nanti kita akan melihat bahwa jika kita memodifikasi file konfigurasi ssh, Anda dapat mengakses hanya dengan menggunakan sesuatu seperti `ssh bar`.
 
-## Executing commands
+## Menjalankan perintah
 
-An often overlooked feature of `ssh` is the ability to run commands directly.
-`ssh foobar@server ls` will execute `ls` in the home folder of foobar.
-It works with pipes, so `ssh foobar@server ls | grep PATTERN` will grep locally the remote output of `ls` and `ls | ssh foobar@server grep PATTERN` will grep remotely the local output of `ls`.
+Fitur `ssh` yang sering diabaikan adalah kemampuan untuk menjalankan perintah secara langsung.
+`ssh foobar@server ls` akan menjalankan `ls` di folder home foobar.
+Ini berfungsi dengan pipe, jadi `ssh foobar@server ls | grep PATTERN` akan melakukan grep secara lokal pada output remote dari `ls` dan `ls | ssh foobar@server grep PATTERN` akan melakukan grep secara remote pada output lokal dari `ls`.
 
 
 ## SSH Keys
 
-Key-based authentication exploits public-key cryptography to prove to the server that the client owns the secret private key without revealing the key. This way you do not need to reenter your password every time. Nevertheless, the private key (often `~/.ssh/id_rsa` and more recently `~/.ssh/id_ed25519`) is effectively your password, so treat it like so.
+Autentikasi berbasis key memanfaatkan kriptografi public-key untuk membuktikan kepada server bahwa klien memiliki private key rahasia tanpa mengungkapkan key tersebut. Dengan cara ini Anda tidak perlu memasukkan ulang password setiap saat. Namun demikian, private key (seringkali `~/.ssh/id_rsa` dan baru-baru ini `~/.ssh/id_ed25519`) secara efektif adalah password Anda, jadi perlakukan seperti itu.
 
-### Key generation
+### Pembuatan key
 
-To generate a pair you can run [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
+Untuk membuat pasangan key, Anda dapat menjalankan [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
 ```bash
 ssh-keygen -a 100 -t ed25519 -f ~/.ssh/id_ed25519
 ```
-You should choose a passphrase, to avoid someone who gets hold of your private key to access authorized servers. Use [`ssh-agent`](https://www.man7.org/linux/man-pages/man1/ssh-agent.1.html) or [`gpg-agent`](https://linux.die.net/man/1/gpg-agent) so you do not have to type your passphrase every time.
+Anda harus memilih passphrase, untuk menghindari seseorang yang mendapatkan private key Anda untuk mengakses server yang diotorisasi. Gunakan [`ssh-agent`](https://www.man7.org/linux/man-pages/man1/ssh-agent.1.html) atau [`gpg-agent`](https://linux.die.net/man/1/gpg-agent) sehingga Anda tidak perlu mengetik passphrase setiap saat.
 
-If you have ever configured pushing to GitHub using SSH keys, then you have probably done the steps outlined [here](https://help.github.com/articles/connecting-to-github-with-ssh/) and have a valid key pair already. To check if you have a passphrase and validate it you can run `ssh-keygen -y -f /path/to/key`.
+Jika Anda pernah mengkonfigurasi push ke GitHub menggunakan SSH keys, maka Anda mungkin telah melakukan langkah-langkah yang diuraikan [di sini](https://help.github.com/articles/connecting-to-github-with-ssh/) dan sudah memiliki pasangan key yang valid. Untuk memeriksa apakah Anda memiliki passphrase dan memvalidasinya, Anda dapat menjalankan `ssh-keygen -y -f /path/to/key`.
 
-### Key based authentication
+### Autentikasi berbasis key
 
-`ssh` will look into `.ssh/authorized_keys` to determine which clients it should let in. To copy a public key over you can use:
+`ssh` akan melihat ke `.ssh/authorized_keys` untuk menentukan klien mana yang harus diizinkan masuk. Untuk menyalin public key, Anda dapat menggunakan:
 
 ```bash
 cat .ssh/id_ed25519.pub | ssh foobar@remote 'cat >> ~/.ssh/authorized_keys'
 ```
 
-A simpler solution can be achieved with `ssh-copy-id` where available:
+Solusi yang lebih sederhana dapat dicapai dengan `ssh-copy-id` jika tersedia:
 
 ```bash
 ssh-copy-id -i .ssh/id_ed25519 foobar@remote
 ```
 
-## Copying files over SSH
+## Menyalin file melalui SSH
 
-There are many ways to copy files over ssh:
+Ada banyak cara untuk menyalin file melalui ssh:
 
-- `ssh+tee`, the simplest is to use `ssh` command execution and STDIN input by doing `cat localfile | ssh remote_server tee serverfile`. Recall that [`tee`](https://www.man7.org/linux/man-pages/man1/tee.1.html) writes the output from STDIN into a file.
-- [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) when copying large amounts of files/directories, the secure copy `scp` command is more convenient since it can easily recurse over paths. The syntax is `scp path/to/local_file remote_host:path/to/remote_file`
-- [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) improves upon `scp` by detecting identical files in local and remote, and preventing copying them again. It also provides more fine grained control over symlinks, permissions and has extra features like the `--partial` flag that can resume from a previously interrupted copy. `rsync` has a similar syntax to `scp`.
+- `ssh+tee`, yang paling sederhana adalah menggunakan eksekusi perintah `ssh` dan input STDIN dengan melakukan `cat localfile | ssh remote_server tee serverfile`. Ingat bahwa [`tee`](https://www.man7.org/linux/man-pages/man1/tee.1.html) menulis output dari STDIN ke sebuah file.
+- [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) saat menyalin banyak file/direktori, perintah secure copy `scp` lebih nyaman karena dapat dengan mudah melakukan rekursi melalui path. Sintaksnya adalah `scp path/to/local_file remote_host:path/to/remote_file`
+- [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) meningkatkan `scp` dengan mendeteksi file identik di lokal dan remote, dan mencegah penyalinan ulang. Ini juga memberikan kontrol yang lebih halus atas symlink, permission, dan memiliki fitur tambahan seperti flag `--partial` yang dapat melanjutkan salinan yang sebelumnya terganggu. `rsync` memiliki sintaks yang mirip dengan `scp`.
 
 ## Port Forwarding
 
-In many scenarios you will run into software that listens to specific ports in the machine. When this happens in your local machine you can type `localhost:PORT` or `127.0.0.1:PORT`, but what do you do with a remote server that does not have its ports directly available through the network/internet?.
+Dalam banyak skenario, Anda akan menemukan perangkat lunak yang mendengarkan port tertentu di mesin. Ketika ini terjadi di mesin lokal Anda, Anda dapat mengetik `localhost:PORT` atau `127.0.0.1:PORT`, tetapi apa yang Anda lakukan dengan server remote yang port-nya tidak tersedia secara langsung melalui jaringan/internet?
 
-This is called _port forwarding_ and it
-comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the pictures for more details, credit of the pictures from [this StackOverflow post](https://unix.stackexchange.com/questions/115897/whats-ssh-port-forwarding-and-whats-the-difference-between-ssh-local-and-remot)).
+Ini disebut _port forwarding_ dan memiliki
+dua jenis: Local Port Forwarding dan Remote Port Forwarding (lihat gambar untuk detail lebih lanjut, kredit gambar dari [postingan StackOverflow ini](https://unix.stackexchange.com/questions/115897/whats-ssh-port-forwarding-and-whats-the-difference-between-ssh-local-and-remot)).
 
 **Local Port Forwarding**
 ![Local Port Forwarding](/static/media/images/local-port-forwarding.png)
@@ -379,17 +379,17 @@ comes in two flavors: Local Port Forwarding and Remote Port Forwarding (see the 
 **Remote Port Forwarding**
 ![Remote Port Forwarding](/static/media/images/remote-port-forwarding.png)
 
-The most common scenario is local port forwarding, where a service in the remote machine listens in a port and you want to link a port in your local machine to forward to the remote port. For example, if we execute  `jupyter notebook` in the remote server that listens to the port `8888`. Thus, to forward that to the local port `9999`, we would do `ssh -L 9999:localhost:8888 foobar@remote_server` and then navigate to `localhost:9999` in our local machine.
+Skenario yang paling umum adalah local port forwarding, di mana layanan di mesin remote mendengarkan di port tertentu dan Anda ingin menghubungkan port di mesin lokal Anda untuk meneruskan ke port remote. Misalnya, jika kita menjalankan `jupyter notebook` di server remote yang mendengarkan port `8888`. Maka, untuk meneruskan itu ke port lokal `9999`, kita akan melakukan `ssh -L 9999:localhost:8888 foobar@remote_server` dan kemudian navigasi ke `localhost:9999` di mesin lokal kita.
 
 
-## SSH Configuration
+## Konfigurasi SSH
 
-We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like
+Kita telah membahas banyak argumen yang dapat kita berikan. Alternatif yang menggoda adalah membuat alias shell yang terlihat seperti
 ```bash
 alias my_server="ssh -i ~/.id_ed25519 --port 2222 -L 9999:localhost:8888 foobar@remote_server"
 ```
 
-However, there is a better alternative using `~/.ssh/config`.
+Namun, ada alternatif yang lebih baik menggunakan `~/.ssh/config`.
 
 ```bash
 Host vm
@@ -404,99 +404,99 @@ Host *.mit.edu
     User foobaz
 ```
 
-An additional advantage of using the `~/.ssh/config` file over aliases  is that other programs like `scp`, `rsync`, `mosh`, &c are able to read it as well and convert the settings into the corresponding flags.
+Keuntungan tambahan menggunakan file `~/.ssh/config` dibandingkan alias adalah bahwa program lain seperti `scp`, `rsync`, `mosh`, dll. juga dapat membacanya dan mengonversi pengaturan menjadi flag yang sesuai.
 
 
-Note that the `~/.ssh/config` file can be considered a dotfile, and in general it is fine for it to be included with the rest of your dotfiles. However, if you make it public, think about the information that you are potentially providing strangers on the internet: addresses of your servers, users, open ports, &c. This may facilitate some types of attacks so be thoughtful about sharing your SSH configuration.
+Perhatikan bahwa file `~/.ssh/config` dapat dianggap sebagai dotfile, dan secara umum tidak masalah untuk disertakan bersama dotfiles Anda lainnya. Namun, jika Anda membuatnya publik, pikirkan tentang informasi yang mungkin Anda berikan kepada orang asing di internet: alamat server Anda, user, port yang terbuka, dll. Ini dapat memfasilitasi beberapa jenis serangan jadi berhati-hatilah dalam membagikan konfigurasi SSH Anda.
 
-Server side configuration is usually specified in `/etc/ssh/sshd_config`. Here you can make changes like disabling password authentication, changing ssh ports, enabling X11 forwarding, &c. You can specify config settings on a per user basis.
+Konfigurasi sisi server biasanya ditentukan di `/etc/ssh/sshd_config`. Di sini Anda dapat membuat perubahan seperti menonaktifkan autentikasi password, mengubah port ssh, mengaktifkan X11 forwarding, dll. Anda dapat menentukan pengaturan konfigurasi per user.
 
-## Miscellaneous
+## Lain-lain
 
-A common pain when connecting to a remote server are disconnections due to your computer shutting down, going to sleep, or changing networks. Moreover if one has a connection with significant lag using ssh can become quite frustrating. [Mosh](https://mosh.org/), the mobile shell, improves upon ssh, allowing roaming connections, intermittent connectivity and providing intelligent local echo.
+Masalah umum saat menghubungkan ke server remote adalah pemutusan karena komputer Anda mati, tidur, atau berpindah jaringan. Selain itu, jika seseorang memiliki koneksi dengan lag yang signifikan, menggunakan ssh bisa menjadi sangat frustrasi. [Mosh](https://mosh.org/), the mobile shell, meningkatkan ssh, memungkinkan koneksi roaming, konektivitas terputus-putus, dan menyediakan echo lokal yang cerdas.
 
-Sometimes it is convenient to mount a remote folder. [sshfs](https://github.com/libfuse/sshfs) can mount a folder on a remote server
-locally, and then you can use a local editor.
+Terkadang nyaman untuk me-mount folder remote. [sshfs](https://github.com/libfuse/sshfs) dapat me-mount folder di server remote
+secara lokal, dan kemudian Anda dapat menggunakan editor lokal.
 
 
-# Shells & Frameworks
+# Shell & Framework
 
-During shell tool and scripting we covered the `bash` shell because it is by far the most ubiquitous shell and most systems have it as the default option. Nevertheless, it is not the only option.
+Selama alat shell dan scripting, kita telah membahas shell `bash` karena ini adalah shell yang paling umum dan sebagian besar sistem memilikinya sebagai opsi default. Namun demikian, ini bukan satu-satunya opsi.
 
-For example, the `zsh` shell is a superset of `bash` and provides many convenient features out of the box such as:
+Sebagai contoh, shell `zsh` adalah superset dari `bash` dan menyediakan banyak fitur nyaman out of the box seperti:
 
-- Smarter globbing, `**`
+- Globbing yang lebih cerdas, `**`
 - Inline globbing/wildcard expansion
-- Spelling correction
-- Better tab completion/selection
-- Path expansion (`cd /u/lo/b` will expand as `/usr/local/bin`)
+- Koreksi ejaan
+- Tab completion/seleksi yang lebih baik
+- Ekspansi path (`cd /u/lo/b` akan diekspansi sebagai `/usr/local/bin`)
 
-**Frameworks** can improve your shell as well. Some popular general frameworks are [prezto](https://github.com/sorin-ionescu/prezto) or [oh-my-zsh](https://ohmyz.sh/), and smaller ones that focus on specific features such as [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) or [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search). Shells like [fish](https://fishshell.com/) include many of these user-friendly features by default. Some of these features include:
+**Framework** dapat meningkatkan shell Anda juga. Beberapa framework umum yang populer adalah [prezto](https://github.com/sorin-ionescu/prezto) atau [oh-my-zsh](https://ohmyz.sh/), dan yang lebih kecil yang berfokus pada fitur tertentu seperti [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) atau [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search). Shell seperti [fish](https://fishshell.com/) menyertakan banyak fitur ramah pengguna ini secara default. Beberapa fitur ini termasuk:
 
 - Right prompt
 - Command syntax highlighting
 - History substring search
 - manpage based flag completions
-- Smarter autocompletion
-- Prompt themes
+- Autocompletion yang lebih cerdas
+- Tema prompt
 
-One thing to note when using these frameworks is that they may slow down your shell, especially if the code they run is not properly optimized or it is too much code. You can always profile it and disable the features that you do not use often or value over speed.
+Satu hal yang perlu diperhatikan saat menggunakan framework ini adalah mereka mungkin memperlambat shell Anda, terutama jika kode yang mereka jalankan tidak dioptimalkan dengan baik atau terlalu banyak kode. Anda selalu dapat melakukan profiling dan menonaktifkan fitur yang tidak sering Anda gunakan atau mengutamakan kecepatan.
 
-# Terminal Emulators
+# Terminal Emulator
 
-Along with customizing your shell, it is worth spending some time figuring out your choice of **terminal emulator** and its settings. There are many many terminal emulators out there (here is a [comparison](https://anarc.at/blog/2018-04-12-terminal-emulators-1/)).
+Selain mengkustomisasi shell Anda, ada baiknya meluangkan waktu untuk mencari tahu pilihan **terminal emulator** Anda dan pengaturannya. Ada banyak terminal emulator di luar sana (berikut adalah [perbandingan](https://anarc.at/blog/2018-04-12-terminal-emulators-1/)).
 
-Since you might be spending hundreds to thousands of hours in your terminal it pays off to look into its settings. Some of the aspects that you may want to modify in your terminal include:
+Karena Anda mungkin menghabiskan ratusan hingga ribuan jam di terminal Anda, ada baiknya memeriksa pengaturannya. Beberapa aspek yang mungkin ingin Anda modifikasi di terminal Anda termasuk:
 
-- Font choice
-- Color Scheme
-- Keyboard shortcuts
-- Tab/Pane support
-- Scrollback configuration
-- Performance (some newer terminals like [Alacritty](https://github.com/jwilm/alacritty) or [kitty](https://sw.kovidgoyal.net/kitty/) offer GPU acceleration).
+- Pilihan font
+- Skema warna
+- Pintasan keyboard
+- Dukungan Tab/Pane
+- Konfigurasi scrollback
+- Performa (beberapa terminal baru seperti [Alacritty](https://github.com/jwilm/alacritty) atau [kitty](https://sw.kovidgoyal.net/kitty/) menawarkan akselerasi GPU).
 
-# Exercises
+# Latihan
 
 ## Job control
 
-1. From what we have seen, we can use some `ps aux | grep` commands to get our jobs' pids and then kill them, but there are better ways to do it. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-af` flags).
+1. Dari apa yang telah kita lihat, kita dapat menggunakan beberapa perintah `ps aux | grep` untuk mendapatkan pid pekerjaan kita dan kemudian membunuhnya, tetapi ada cara yang lebih baik. Mulai pekerjaan `sleep 10000` di terminal, pindahkan ke latar belakang dengan `Ctrl-Z` dan lanjutkan eksekusinya dengan `bg`. Sekarang gunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk menemukan pid-nya dan [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) untuk membunuhnya tanpa pernah mengetik pid itu sendiri. (Petunjuk: gunakan flag `-af`).
 
-1. Say you don't want to start a process until another completes. How would you go about it? In this exercise, our limiting process will always be `sleep 60 &`.
-One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command. Try launching the sleep command and having an `ls` wait until the background process finishes.
+1. Katakanlah Anda tidak ingin memulai proses sampai proses lain selesai. Bagaimana cara Anda melakukannya? Dalam latihan ini, proses pembatas kita akan selalu menjadi `sleep 60 &`.
+Salah satu cara untuk mencapainya adalah dengan menggunakan perintah [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html). Coba luncurkan perintah sleep dan buat `ls` menunggu sampai proses latar belakang selesai.
 
-    However, this strategy will fail if we start in a different bash session, since `wait` only works for child processes. One feature we did not discuss in the notes is that the `kill` command's exit status will be zero on success and nonzero otherwise. `kill -0` does not send a signal but will give a nonzero exit status if the process does not exist.
-    Write a bash function called `pidwait` that takes a pid and waits until the given process completes. You should use `sleep` to avoid wasting CPU unnecessarily.
+    Namun, strategi ini akan gagal jika kita mulai di sesi bash yang berbeda, karena `wait` hanya bekerja untuk proses anak. Satu fitur yang tidak kita bahas dalam catatan adalah bahwa status keluar perintah `kill` akan bernilai nol jika berhasil dan bukan nol jika gagal. `kill -0` tidak mengirim sinyal tetapi akan memberikan status keluar bukan nol jika proses tidak ada.
+    Tulis fungsi bash yang disebut `pidwait` yang mengambil pid dan menunggu sampai proses yang diberikan selesai. Anda harus menggunakan `sleep` untuk menghindari penggunaan CPU secara tidak perlu.
 
 ## Terminal multiplexer
 
-1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
+1. Ikuti [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) `tmux` ini dan kemudian pelajari cara melakukan beberapa kustomisasi dasar dengan mengikuti [langkah-langkah ini](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
 
-## Aliases
+## Alias
 
-1. Create an alias `dc` that resolves to `cd` for when you type it wrong.
+1. Buat alias `dc` yang mengarah ke `cd` untuk saat Anda salah mengetiknya.
 
-1.  Run `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10`  to get your top 10 most used commands and consider writing shorter aliases for them. Note: this works for Bash; if you're using ZSH, use `history 1` instead of just `history`.
+1. Jalankan `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` untuk mendapatkan 10 perintah yang paling sering Anda gunakan dan pertimbangkan untuk menulis alias yang lebih pendek untuk mereka. Catatan: ini berfungsi untuk Bash; jika Anda menggunakan ZSH, gunakan `history 1` bukan hanya `history`.
 
 
 ## Dotfiles
 
-Let's get you up to speed with dotfiles.
-1. Create a folder for your dotfiles and set up version
+Mari kita mulai dengan dotfiles.
+1. Buat folder untuk dotfiles Anda dan atur version
    control.
-1. Add a configuration for at least one program, e.g. your shell, with some
-   customization (to start off, it can be something as simple as customizing your shell prompt by setting `$PS1`).
-1. Set up a method to install your dotfiles quickly (and without manual effort) on a new machine. This can be as simple as a shell script that calls `ln -s` for each file, or you could use a [specialized
-   utility](https://dotfiles.github.io/utilities/).
-1. Test your installation script on a fresh virtual machine.
-1. Migrate all of your current tool configurations to your dotfiles repository.
-1. Publish your dotfiles on GitHub.
+1. Tambahkan konfigurasi untuk setidaknya satu program, misalnya shell Anda, dengan beberapa
+   kustomisasi (untuk memulai, ini bisa sesederhana mengkustomisasi prompt shell Anda dengan mengatur `$PS1`).
+1. Siapkan metode untuk menginstal dotfiles Anda dengan cepat (dan tanpa usaha manual) di mesin baru. Ini bisa sesederhana skrip shell yang memanggil `ln -s` untuk setiap file, atau Anda bisa menggunakan [utilitas
+   khusus](https://dotfiles.github.io/utilities/).
+1. Uji skrip instalasi Anda di mesin virtual baru.
+1. Pindahkan semua konfigurasi alat Anda saat ini ke repositori dotfiles Anda.
+1. Publikasikan dotfiles Anda di GitHub.
 
-## Remote Machines
+## Mesin Remote
 
-Install a Linux virtual machine (or use an already existing one) for this exercise. If you are not familiar with virtual machines check out [this](https://hibbard.eu/install-ubuntu-virtual-box/) tutorial for installing one.
+Instal mesin virtual Linux (atau gunakan yang sudah ada) untuk latihan ini. Jika Anda tidak familiar dengan mesin virtual, lihat [tutorial](https://hibbard.eu/install-ubuntu-virtual-box/) ini untuk menginstalnya.
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent` , more info [here](https://www.ssh.com/ssh/agent).
-1. Edit `.ssh/config` to have an entry as follows
+1. Pergi ke `~/.ssh/` dan periksa apakah Anda memiliki pasangan SSH keys di sana. Jika tidak, buat dengan `ssh-keygen -a 100 -t ed25519`. Disarankan bahwa Anda menggunakan password dan menggunakan `ssh-agent`, info lebih lanjut [di sini](https://www.ssh.com/ssh/agent).
+1. Edit `.ssh/config` untuk memiliki entri sebagai berikut
 
     ```bash
     Host vm
@@ -505,8 +505,8 @@ Install a Linux virtual machine (or use an already existing one) for this exerci
         IdentityFile ~/.ssh/id_ed25519
         LocalForward 9999 localhost:8888
     ```
-1. Use `ssh-copy-id vm` to copy your ssh key to the server.
-1. Start a webserver in your VM by executing `python -m http.server 8888`. Access the VM webserver by navigating to `http://localhost:9999` in your machine.
-1. Edit your SSH server config by doing  `sudo vim /etc/ssh/sshd_config` and disable password authentication by editing the value of `PasswordAuthentication`. Disable root login by editing the value of `PermitRootLogin`. Restart the `ssh` service with `sudo service sshd restart`. Try sshing in again.
-1. (Challenge) Install [`mosh`](https://mosh.org/) in the VM and establish a connection. Then disconnect the network adapter of the server/VM. Can mosh properly recover from it?
-1. (Challenge) Look into what the `-N` and `-f` flags do in `ssh` and figure out a command to achieve background port forwarding.
+1. Gunakan `ssh-copy-id vm` untuk menyalin ssh key Anda ke server.
+1. Mulai webserver di VM Anda dengan menjalankan `python -m http.server 8888`. Akses webserver VM dengan navigasi ke `http://localhost:9999` di mesin Anda.
+1. Edit konfigurasi server SSH Anda dengan melakukan `sudo vim /etc/ssh/sshd_config` dan nonaktifkan autentikasi password dengan mengedit nilai `PasswordAuthentication`. Nonaktifkan root login dengan mengedit nilai `PermitRootLogin`. Restart layanan `ssh` dengan `sudo service sshd restart`. Coba ssh lagi.
+1. (Tantangan) Instal [`mosh`](https://mosh.org/) di VM dan buat koneksi. Kemudian putuskan adaptor jaringan server/VM. Dapatkah mosh pulih dengan baik?
+1. (Tantangan) Cari tahu apa yang dilakukan flag `-N` dan `-f` di `ssh` dan cari tahu perintah untuk mencapai port forwarding di latar belakang.

--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Command-line Environment"
 description: >
-  Learn about job control, terminal multiplexers, dotfiles, and remote machines with SSH.
+  Pelajari tentang job control, terminal multiplexer, dotfiles, dan mesin remote dengan SSH.
 thumbnail: /static/assets/thumbnails/2020/lec5.png
 date: 2020-01-21
 ready: true

--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -16,7 +16,7 @@ Dalam kuliah ini kita akan membahas beberapa cara untuk meningkatkan alur kerja 
 Kita juga akan mempelajari berbagai cara untuk meningkatkan shell dan alat-alat lainnya, dengan mendefinisikan alias dan mengonfigurasinya menggunakan dotfiles. Keduanya dapat membantu Anda menghemat waktu, misalnya dengan menggunakan konfigurasi yang sama di semua mesin Anda tanpa harus mengetik perintah panjang. Kita akan melihat cara bekerja dengan mesin remote menggunakan SSH.
 
 
-# Job Control
+# Kendali Tugas
 
 Dalam beberapa kasus Anda perlu menghentikan pekerjaan saat sedang berjalan, misalnya jika suatu perintah membutuhkan waktu terlalu lama untuk selesai (seperti `find` dengan struktur direktori yang sangat besar untuk dicari).
 Sebagian besar waktu, Anda bisa melakukan `Ctrl-C` dan perintah akan berhenti.
@@ -128,7 +128,7 @@ Sinyal khusus adalah `SIGKILL` karena tidak dapat ditangkap oleh proses dan akan
 Anda dapat mempelajari lebih lanjut tentang sinyal-sinyal ini dan sinyal lainnya [di sini](https://en.wikipedia.org/wiki/Signal_(IPC)) atau dengan mengetik [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) atau `kill -l`.
 
 
-# Terminal Multiplexer
+# Multiplexer Terminal
 
 Saat menggunakan command-line interface, Anda sering kali ingin menjalankan lebih dari satu hal sekaligus.
 Misalnya, Anda mungkin ingin menjalankan editor dan program Anda secara berdampingan.
@@ -366,7 +366,7 @@ Ada banyak cara untuk menyalin file melalui ssh:
 - [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) saat menyalin banyak file/direktori, perintah secure copy `scp` lebih nyaman karena dapat dengan mudah melakukan rekursi melalui path. Sintaksnya adalah `scp path/to/local_file remote_host:path/to/remote_file`
 - [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) meningkatkan `scp` dengan mendeteksi file identik di lokal dan remote, dan mencegah penyalinan ulang. Ini juga memberikan kontrol yang lebih halus atas symlink, permission, dan memiliki fitur tambahan seperti flag `--partial` yang dapat melanjutkan salinan yang sebelumnya terganggu. `rsync` memiliki sintaks yang mirip dengan `scp`.
 
-## Port Forwarding
+## Penerusan Port
 
 Dalam banyak skenario, Anda akan menemukan perangkat lunak yang mendengarkan port tertentu di mesin. Ketika ini terjadi di mesin lokal Anda, Anda dapat mengetik `localhost:PORT` atau `127.0.0.1:PORT`, tetapi apa yang Anda lakukan dengan server remote yang port-nya tidak tersedia secara langsung melalui jaringan/internet?
 
@@ -411,7 +411,7 @@ Perhatikan bahwa file `~/.ssh/config` dapat dianggap sebagai dotfile, dan secara
 
 Konfigurasi sisi server biasanya ditentukan di `/etc/ssh/sshd_config`. Di sini Anda dapat membuat perubahan seperti menonaktifkan autentikasi password, mengubah port ssh, mengaktifkan X11 forwarding, dll. Anda dapat menentukan pengaturan konfigurasi per user.
 
-## Lain-lain
+## Lainnya
 
 Masalah umum saat menghubungkan ke server remote adalah pemutusan karena komputer Anda mati, tidur, atau berpindah jaringan. Selain itu, jika seseorang memiliki koneksi dengan lag yang signifikan, menggunakan ssh bisa menjadi sangat frustrasi. [Mosh](https://mosh.org/), the mobile shell, meningkatkan ssh, memungkinkan koneksi roaming, konektivitas terputus-putus, dan menyediakan echo lokal yang cerdas.
 
@@ -442,7 +442,7 @@ Sebagai contoh, shell `zsh` adalah superset dari `bash` dan menyediakan banyak f
 
 Satu hal yang perlu diperhatikan saat menggunakan framework ini adalah mereka mungkin memperlambat shell Anda, terutama jika kode yang mereka jalankan tidak dioptimalkan dengan baik atau terlalu banyak kode. Anda selalu dapat melakukan profiling dan menonaktifkan fitur yang tidak sering Anda gunakan atau mengutamakan kecepatan.
 
-# Terminal Emulator
+# Emulator Terminal
 
 Selain mengkustomisasi shell Anda, ada baiknya meluangkan waktu untuk mencari tahu pilihan **terminal emulator** Anda dan pengaturannya. Ada banyak terminal emulator di luar sana (berikut adalah [perbandingan](https://anarc.at/blog/2018-04-12-terminal-emulators-1/)).
 
@@ -457,7 +457,7 @@ Karena Anda mungkin menghabiskan ratusan hingga ribuan jam di terminal Anda, ada
 
 # Latihan
 
-## Job control
+## Kendali tugas
 
 1. Dari apa yang telah kita lihat, kita dapat menggunakan beberapa perintah `ps aux | grep` untuk mendapatkan pid pekerjaan kita dan kemudian membunuhnya, tetapi ada cara yang lebih baik. Mulai pekerjaan `sleep 10000` di terminal, pindahkan ke latar belakang dengan `Ctrl-Z` dan lanjutkan eksekusinya dengan `bg`. Sekarang gunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk menemukan pid-nya dan [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) untuk membunuhnya tanpa pernah mengetik pid itu sendiri. (Petunjuk: gunakan flag `-af`).
 
@@ -467,7 +467,7 @@ Salah satu cara untuk mencapainya adalah dengan menggunakan perintah [`wait`](ht
     Namun, strategi ini akan gagal jika kita mulai di sesi bash yang berbeda, karena `wait` hanya bekerja untuk proses anak. Satu fitur yang tidak kita bahas dalam catatan adalah bahwa status keluar perintah `kill` akan bernilai nol jika berhasil dan bukan nol jika gagal. `kill -0` tidak mengirim sinyal tetapi akan memberikan status keluar bukan nol jika proses tidak ada.
     Tulis fungsi bash yang disebut `pidwait` yang mengambil pid dan menunggu sampai proses yang diberikan selesai. Anda harus menggunakan `sleep` untuk menghindari penggunaan CPU secara tidak perlu.
 
-## Terminal multiplexer
+## Multiplexer terminal
 
 1. Ikuti [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) `tmux` ini dan kemudian pelajari cara melakukan beberapa kustomisasi dasar dengan mengikuti [langkah-langkah ini](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
 

--- a/_2020/course-shell.md
+++ b/_2020/course-shell.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Course Overview + The Shell"
+title: "Ikhtisar Kursus + Shell"
 description: >
   Pelajari motivasi kelas ini, dan mulai menggunakan shell.
 thumbnail: /static/assets/thumbnails/2020/lec1.png
@@ -11,92 +11,92 @@ video:
   id: Z56Jmr9Z34Q
 ---
 
-# Motivation
+# Motivasi
 
-As computer scientists, we know that computers are great at aiding in
-repetitive tasks. However, far too often, we forget that this applies
-just as much to our _use_ of the computer as it does to the computations
-we want our programs to perform. We have a vast range of tools
-available at our fingertips that enable us to be more productive and
-solve more complex problems when working on any computer-related
-problem. Yet many of us utilize only a small fraction of those tools; we
-only know enough magical incantations by rote to get by, and blindly
-copy-paste commands from the internet when we get stuck.
+Sebagai ilmuwan komputer, kita tahu bahwa komputer sangat handal dalam membantu
+tugas-tugas berulang. Namun, terlalu sering kita lupa bahwa hal ini juga berlaku
+untuk _penggunaan_ komputer kita, bukan hanya komputasi yang ingin program kita
+lakukan. Kita memiliki berbagai macam alat yang siap di ujung jari yang
+memungkinkan kita untuk lebih produktif dan menyelesaikan masalah yang lebih
+kompleks ketika mengerjakan masalah terkait komputer apa pun. Namun banyak dari
+kita hanya menggunakan sebagian kecil dari alat-alat tersebut; kita hanya
+menghafal beberapa mantra ajaib secukupnya untuk bertahan, dan membabi-buta
+menyalin-tempel perintah dari internet ketika kita mengalami kebuntuan.
 
-This class is an attempt to address this.
+Kelas ini adalah upaya untuk mengatasi hal tersebut.
 
-We want to teach you how to make the most of the tools you know, show
-you new tools to add to your toolbox, and hopefully instill in you some
-excitement for exploring (and perhaps building) more tools on your own.
-This is what we believe to be the missing semester from most Computer
-Science curricula.
+Kami ingin mengajarkan Anda cara memaksimalkan alat yang Anda ketahui,
+memperkenalkan alat-alat baru untuk ditambahkan ke kotak perkakas Anda, dan
+mudah-mudahan menanamkan antusiasme bagi Anda untuk menjelajahi (dan mungkin
+membangun) lebih banyak alat sendiri. Inilah yang kami yakini sebagai semester
+yang hilang dari sebagian besar kurikulum Ilmu Komputer.
 
-# Class structure
+# Struktur kelas
 
-The class consists of 11 1-hour lectures, each one centering on a
-[particular topic](/2020/). The lectures are largely independent,
-though as the semester goes on we will presume that you are familiar
-with the content from the earlier lectures. We have lecture notes
-online, but there will be a lot of content covered in class (e.g. in the
-form of demos) that may not be in the notes. We will be recording
-lectures and posting the recordings online.
+Kelas ini terdiri dari 11 kuliah masing-masing 1 jam, setiap kuliah berpusat
+pada [topik tertentu](/2020/). Kuliah-kuliah ini sebagian besar saling bebas,
+namun seiring berjalannya semester kami akan berasumsi bahwa Anda sudah terbiasa
+dengan materi dari kuliah-kuliah sebelumnya. Kami memiliki catatan kuliah secara
+online, tetapi akan ada banyak materi yang dibahas di kelas (misalnya dalam
+bentuk demo) yang mungkin tidak ada di catatan. Kami akan merekam kuliah dan
+mengunggah rekamannya secara online.
 
-We are trying to cover a lot of ground over the course of just 11 1-hour
-lectures, so the lectures are fairly dense. To allow you some time to
-get familiar with the content at your own pace, each lecture includes a
-set of exercises that guide you through the lecture's key points. After
-each lecture, we are hosting office hours where we will be present to
-help answer any questions you might have. If you are attending the class
-online, you can send us questions at
+Kami berusaha mencakup banyak hal dalam 11 kuliah masing-masing 1 jam, sehingga
+kuliah-kuliah ini cukup padat. Untuk memberi Anda waktu mengenal materi
+dengan kecepatan Anda sendiri, setiap kuliah dilengkapi serangkaian latihan yang
+membimbing Anda melalui poin-poin kunci kuliah tersebut. Setelah setiap kuliah,
+kami mengadakan jam kantor di mana kami akan hadir untuk membantu menjawab
+pertanyaan apa pun yang mungkin Anda miliki. Jika Anda mengikuti kelas ini
+secara online, Anda dapat mengirimkan pertanyaan kepada kami di
 [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-Due to the limited time we have, we won't be able to cover all the tools
-in the same level of detail a full-scale class might. Where possible, we
-will try to point you towards resources for digging further into a tool
-or topic, but if something particularly strikes your fancy, don't
-hesitate to reach out to us and ask for pointers!
+Karena waktu yang terbatas, kami tidak akan dapat mencakup semua alat dengan
+tingkat detail yang sama seperti kelas skala penuh. Jika memungkinkan, kami
+akan mencoba mengarahkan Anda ke sumber daya untuk menggali lebih dalam tentang
+suatu alat atau topik, tetapi jika ada yang menarik perhatian Anda, jangan ragu
+untuk menghubungi kami dan meminta petunjuk!
 
-# Topic 1: The Shell
+# Topik 1: Shell
 
-## What is the shell?
+## Apa itu shell?
 
-Computers these days have a variety of interfaces for giving them
-commands; fanciful graphical user interfaces, voice interfaces, and
-even AR/VR are everywhere. These are great for 80% of use-cases, but
-they are often fundamentally restricted in what they allow you to do —
-you cannot press a button that isn't there or give a voice command that
-hasn't been programmed. To take full advantage of the tools your
-computer provides, we have to go old-school and drop down to a textual
-interface: The Shell.
+Komputer saat ini memiliki berbagai macam antarmuka untuk memberi mereka
+perintah; antarmuka grafis yang mewah, antarmuka suara, dan bahkan AR/VR ada di
+mana-mana. Ini sangat bagus untuk 80% kasus penggunaan, tetapi seringkali
+secara mendasar terbatas dalam apa yang mereka izinkan untuk Anda lakukan — Anda
+tidak dapat menekan tombol yang tidak ada atau memberi perintah suara yang belum
+diprogram. Untuk memanfaatkan sepenuhnya alat-alat yang disediakan komputer
+Anda, kita harus kembali ke cara lama dan beralih ke antarmuka tekstual: Shell.
 
-Nearly all platforms you can get your hands on have a shell in one form or
-another, and many of them have several shells for you to choose from.
-While they may vary in the details, at their core they are all roughly
-the same: they allow you to run programs, give them input, and inspect
-their output in a semi-structured way.
+Hampir semua platform yang bisa Anda gunakan memiliki shell dalam satu bentuk
+atau lainnya, dan banyak di antaranya memiliki beberapa shell untuk Anda pilih.
+Meskipun mungkin berbeda dalam detailnya, pada intinya semuanya kurang lebih
+sama: mereka memungkinkan Anda menjalankan program, memberi mereka masukan, dan
+memeriksa keluaran mereka secara semi-terstruktur.
 
-In this lecture, we will focus on the Bourne Again SHell, or "bash" for
-short. This is one of the most widely used shells, and its syntax is
-similar to what you will see in many other shells. To open a shell
-_prompt_ (where you can type commands), you first need a _terminal_.
-Your device probably shipped with one installed, or you can install one
-fairly easily.
+Dalam kuliah ini, kita akan fokus pada Bourne Again SHell, atau singkatnya
+"bash". Ini adalah salah satu shell yang paling banyak digunakan, dan sintaksnya
+mirip dengan apa yang akan Anda temui di banyak shell lainnya. Untuk membuka
+_prompt_ shell (tempat Anda bisa mengetik perintah), Anda pertama-tama
+membutuhkan sebuah _terminal_. Perangkat Anda mungkin sudah terpasang satu, atau
+Anda bisa memasangnya dengan cukup mudah.
 
-## Using the shell
+## Menggunakan shell
 
-When you launch your terminal, you will see a _prompt_ that often looks
-a little like this:
+Ketika Anda meluncurkan terminal, Anda akan melihat sebuah _prompt_ yang
+seringkali terlihat seperti ini:
 
 ```console
 missing:~$
 ```
 
-This is the main textual interface to the shell. It tells you that you
-are on the machine `missing` and that your "current working directory",
-or where you currently are, is `~` (short for "home"). The `$` tells you
-that you are not the root user (more on that later). At this prompt you
-can type a _command_, which will then be interpreted by the shell. The
-most basic command is to execute a program:
+Ini adalah antarmuka tekstual utama ke shell. Ini memberi tahu Anda bahwa Anda
+berada di mesin `missing` dan "current working directory" Anda, atau di mana
+Anda berada saat ini, adalah `~` (singkatan dari "home"). Tanda `$` memberi
+tahu bahwa Anda bukan pengguna root (lebih lanjut tentang itu nanti). Pada
+prompt ini Anda bisa mengetik sebuah _perintah_, yang kemudian akan
+diterjemahkan oleh shell. Perintah paling dasar adalah menjalankan sebuah
+program:
 
 ```console
 missing:~$ date
@@ -104,65 +104,36 @@ Fri 10 Jan 2020 11:49:31 AM EST
 missing:~$
 ```
 
-Here, we executed the `date` program, which (perhaps unsurprisingly)
-prints the current date and time. The shell then asks us for another
-command to execute. We can also execute a command with _arguments_:
+Di sini, kita menjalankan program `date`, yang (mungkin tidak mengejutkan)
+mencetak tanggal dan waktu saat ini. Shell kemudian meminta kita perintah lain
+untuk dijalankan. Kita juga bisa menjalankan perintah dengan _argumen_:
 
 ```console
 missing:~$ echo hello
 hello
 ```
 
-In this case, we told the shell to execute the program `echo` with the
-argument `hello`. The `echo` program simply prints out its arguments.
-The shell parses the command by splitting it by whitespace, and then
-runs the program indicated by the first word, supplying each subsequent
-word as an argument that the program can access. If you want to provide
-an argument that contains spaces or other special characters (e.g., a
-directory named "My Photos"), you can either quote the argument with `'`
-or `"` (`"My Photos"`), or escape just the relevant characters with `\`
-(`My\ Photos`).
+Dalam kasus ini, kita menyuruh shell untuk menjalankan program `echo` dengan
+argumen `hello`. Program `echo` cukup mencetak keluaran argumen-argumennya.
+Shell mengurai perintah dengan memisahnya berdasarkan spasi, kemudian
+menjalankan program yang ditunjukkan oleh kata pertama, menyediakan setiap kata
+selanjutnya sebagai argumen yang bisa diakses oleh program. Jika Anda ingin
+memberikan argumen yang mengandung spasi atau karakter spesial lainnya
+(misalnya, direktori bernama "My Photos"), Anda bisa mengutip argumen tersebut
+dengan `'` atau `"` (`"My Photos"`), atau meng-escape hanya karakter yang relevan
+dengan `\` (`My\ Photos`).
 
-But how does the shell know how to find the `date` or `echo` programs?
-Well, the shell is a programming environment, just like Python or Ruby,
-and so it has variables, conditionals, loops, and functions (next
-lecture!). When you run commands in your shell, you are really writing a
-small bit of code that your shell interprets. If the shell is asked to
-execute a command that doesn't match one of its programming keywords, it
-consults an _environment variable_ called `$PATH` that lists which
-directories the shell should search for programs when it is given a
-command:
+## Menavigasi shell
 
-
-```console
-missing:~$ echo $PATH
-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-missing:~$ which echo
-/bin/echo
-missing:~$ /bin/echo $PATH
-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-```
-
-When we run the `echo` command, the shell sees that it should execute
-the program `echo`, and then searches through the `:`-separated list of
-directories in `$PATH` for a file by that name. When it finds it, it
-runs it (assuming the file is _executable_; more on that later). We can
-find out which file is executed for a given program name using the
-`which` program. We can also bypass `$PATH` entirely by giving the
-_path_ to the file we want to execute.
-
-## Navigating in the shell
-
-A path on the shell is a delimited list of directories; separated by `/`
-on Linux and macOS and `\` on Windows. On Linux and macOS, the path `/`
-is the "root" of the file system, under which all directories and files
-lie, whereas on Windows there is one root for each disk partition (e.g.,
-`C:\`). We will generally assume that you are using a Linux filesystem
-in this class. A path that starts with `/` is called an _absolute_ path.
-Any other path is a _relative_ path. Relative paths are relative to the
-current working directory, which we can see with the `pwd` command and
-change with the `cd` command. In a path, `.` refers to the current
-directory, and `..` to its parent directory:
+Sebuah path pada shell adalah daftar direktori yang dipisahkan; dengan `/` pada
+Linux dan macOS dan `\` pada Windows. Pada Linux dan macOS, path `/` adalah
+"root" dari sistem file, di mana semua direktori dan file berada, sedangkan pada
+Windows terdapat satu root untuk setiap partisi disk (misalnya, `C:\`). Kita
+secara umum akan berasumsi bahwa Anda menggunakan sistem file Linux di kelas
+ini. Path yang dimulai dengan `/` disebut path _absolut_. Path lainnya adalah
+path _relatif_. Path relatif terhadap current working directory, yang bisa kita
+lihat dengan perintah `pwd` dan ubah dengan perintah `cd`. Dalam sebuah path,
+`.` merujuk ke direktori saat ini, dan `..` ke direktori induknya:
 
 ```console
 missing:~$ pwd
@@ -183,15 +154,16 @@ missing:~$ ../../bin/echo hello
 hello
 ```
 
-Notice that our shell prompt kept us informed about what our current
-working directory was. You can configure your prompt to show you all
-sorts of useful information, which we will cover in a later lecture.
+Perhatikan bahwa prompt shell kita terus memberi informasi tentang direktori
+kerja kita saat ini. Anda bisa mengonfigurasi prompt Anda untuk menampilkan
+semua sorts informasi berguna, yang akan kita bahas di kuliah berikutnya.
 
-In general, when we run a program, it will operate in the current
-directory unless we tell it otherwise. For example, it will usually
-search for files there, and create new files there if it needs to.
+Secara umum, ketika kita menjalankan sebuah program, program tersebut akan
+beroperasi di direktori saat ini kecuali kita menyuruhnya sebaliknya. Misalnya,
+program biasanya akan mencari file di sana, dan membuat file baru di sana jika
+diperlukan.
 
-To see what lives in a given directory, we use the `ls` command:
+Untuk melihat apa yang ada di direktori tertentu, kita gunakan perintah `ls`:
 
 ```console
 missing:~$ ls
@@ -208,12 +180,12 @@ home
 ...
 ```
 
-Unless a directory is given as its first argument, `ls` will print the
-contents of the current directory. Most commands accept flags and
-options (flags with values) that start with `-` to modify their
-behavior. Usually, running a program with the `-h` or `--help` flag
-will print some help text that tells you what flags
-and options are available. For example, `ls --help` tells us:
+Kecuali direktori diberikan sebagai argumen pertamanya, `ls` akan mencetak isi
+dari direktori saat ini. Sebagian besar perintah menerima flag dan opsi (flag
+dengan nilai) yang diawali dengan `-` untuk mengubah perilakunya. Biasanya,
+menjalankan program dengan flag `-h` atau `--help` akan mencetak teks bantuan
+yang memberi tahu Anda flag dan opsi apa saja yang tersedia. Misalnya,
+`ls --help` memberi tahu kita:
 
 ```
   -l                         use a long listing format
@@ -224,45 +196,47 @@ missing:~$ ls -l /home
 drwxr-xr-x 1 missing  users  4096 Jun 15  2019 missing
 ```
 
-This gives us a bunch more information about each file or directory
-present. First, the `d` at the beginning of the line tells us that
-`missing` is a directory. Then follow three groups of three characters
-(`rwx`). These indicate what permissions the owner of the file
-(`missing`), the owning group (`users`), and everyone else respectively
-have on the relevant item. A `-` indicates that the given principal does
-not have the given permission. Above, only the owner is allowed to
-modify (`w`) the `missing` directory (i.e., add/remove files in it). To
-enter a directory, a user must have "search" (represented by "execute":
-`x`) permissions on that directory (and its parents). To list its
-contents, a user must have read (`r`) permissions on that directory. For
-files, the permissions are as you would expect. Notice that nearly all
-the files in `/bin` have the `x` permission set for the last group,
-"everyone else", so that anyone can execute those programs.
+Ini memberi kita banyak informasi tambahan tentang setiap file atau direktori
+yang ada. Pertama, `d` di awal baris memberi tahu kita bahwa `missing` adalah
+sebuah direktori. Kemudian diikuti tiga kelompok berisi tiga karakter (`rwx`).
+Ini menunjukkan hak akses pemilik file (`missing`), grup pemilik (`users`), dan
+semua orang lainnya secara berturut-turut pada item yang relevan. Tanda `-`
+menunjukkan bahwa prinsipal yang diberikan tidak memiliki izin yang diberikan.
+Di atas, hanya pemilik yang diizinkan untuk memodifikasi (`w`) direktori
+`missing` (yaitu, menambah/menghapus file di dalamnya). Untuk memasuki sebuah
+direktori, pengguna harus memiliki izin "search" (direpresentasikan oleh
+"execute": `x`) pada direktori tersebut (dan induknya). Untuk menampilkan
+isinya, pengguna harus memiliki izin baca (`r`) pada direktori tersebut. Untuk
+file, izin-izin tersebut sesuai dengan yang Anda harapkan. Perhatikan bahwa
+hampir semua file di `/bin` memiliki izin `x` yang disetel untuk grup terakhir,
+"semua orang lainnya", sehingga siapa pun bisa menjalankan program-program
+tersebut.
 
-Some other handy programs to know about at this point are `mv` (to
-rename/move a file), `cp` (to copy a file), and `mkdir` (to make a new
-directory).
+Beberapa program berguna lainnya yang perlu diketahui pada titik ini adalah
+`mv` (untuk mengubah nama/memindahkan file), `cp` (untuk menyalin file), dan
+`mkdir` (untuk membuat direktori baru).
 
-If you ever want _more_ information about a program's arguments, inputs,
-outputs, or how it works in general, give the `man` program a try. It
-takes as an argument the name of a program, and shows you its _manual
-page_. Press `q` to exit.
+Jika Anda membutuhkan informasi _lebih lanjut_ tentang argumen, masukan,
+keluaran, atau cara kerja suatu program secara umum, cobalah program `man`.
+Program ini menerima argumen berupa nama program, dan menampilkan _halaman
+manual_-nya. Tekan `q` untuk keluar.
 
 ```console
 missing:~$ man ls
 ```
 
-## Connecting programs
+## Menghubungkan program
 
-In the shell, programs have two primary "streams" associated with them:
-their input stream and their output stream. When the program tries to
-read input, it reads from the input stream, and when it prints
-something, it prints to its output stream. Normally, a program's input
-and output are both your terminal. That is, your keyboard as input and
-your screen as output. However, we can also rewire those streams!
+Di shell, program memiliki dua "aliran" utama yang terkait dengannya: aliran
+masukan dan aliran keluaran. Ketika program mencoba membaca masukan, ia membaca
+dari aliran masukan, dan ketika mencetak sesuatu, ia mencetak ke aliran
+keluarannya. Biasanya, masukan dan keluaran program keduanya adalah terminal
+Anda. Artinya, keyboard Anda sebagai masukan dan layar Anda sebagai keluaran.
+Namun, kita juga bisa mengalihkan aliran-aliran tersebut!
 
-The simplest form of redirection is `< file` and `> file`. These let you
-rewire the input and output streams of a program to a file respectively:
+Bentuk paling sederhana dari pengalihan adalah `< file` dan `> file`. Ini
+memungkinkan Anda mengalihkan aliran masukan dan keluaran program ke sebuah
+file masing-masingnya:
 
 ```console
 missing:~$ echo hello > hello.txt
@@ -275,16 +249,16 @@ missing:~$ cat hello2.txt
 hello
 ```
 
-Demonstrated in the example above, `cat` is a program that con`cat`enates
-files. When given file names as arguments, it prints the contents of each of
-the files in sequence to its output stream. But when `cat` is not given any
-arguments, it prints contents from its input stream to its output stream (like
-in the third example above).
+Seperti yang ditunjukkan dalam contoh di atas, `cat` adalah program yang
+menyambung`kan` file. Ketika diberi nama file sebagai argumen, ia mencetak isi
+masing-masing file secara berurutan ke aliran keluarannya. Tetapi ketika `cat`
+tidak diberi argumen apa pun, ia mencetak isi dari aliran masukannya ke aliran
+keluarannya (seperti pada contoh ketiga di atas).
 
-You can also use `>>` to append to a file. Where this kind of
-input/output redirection really shines is in the use of _pipes_. The `|`
-operator lets you "chain" programs such that the output of one is the
-input of another:
+Anda juga bisa menggunakan `>>` untuk menambahkan ke file. Di mana pengalihan
+masukan/keluaran ini benar-benar bersinar adalah dalam penggunaan _pipe_.
+Operator `|` memungkinkan Anda "merantai" program sedemikian rupa sehingga
+keluaran satu program menjadi masukan program lainnya:
 
 ```console
 missing:~$ ls -l / | tail -n1
@@ -293,36 +267,38 @@ missing:~$ curl --head --silent google.com | grep --ignore-case content-length |
 219
 ```
 
-We will go into a lot more detail about how to take advantage of pipes
-in the lecture on data wrangling.
+Kita akan membahas lebih detail tentang cara memanfaatkan pipe di kuliah tentang
+data wrangling.
 
-## A versatile and powerful tool
+## Alat yang serbaguna dan kuat
 
-On most Unix-like systems, one user is special: the "root" user. You may
-have seen it in the file listings above. The root user is above (almost)
-all access restrictions, and can create, read, update, and delete any
-file in the system. You will not usually log into your system as the
-root user though, since it's too easy to accidentally break something.
-Instead, you will be using the `sudo` command. As its name implies, it
-lets you "do" something "as su" (short for "super user", or "root").
-When you get permission denied errors, it is usually because you need to
-do something as root. Though make sure you first double-check that you
-really wanted to do it that way!
+Pada sebagian besar sistem mirip-Unix, satu pengguna bersifat spesial: pengguna
+"root". Anda mungkin telah melihatnya dalam daftar file di atas. Pengguna root
+berada di atas (hampir) semua batasan akses, dan bisa membuat, membaca,
+memperbarui, dan menghapus file apa pun di sistem. Namun Anda biasanya tidak
+akan masuk ke sistem Anda sebagai pengguna root, karena terlalu mudah untuk
+secara tidak sengaja merusak sesuatu. Sebagai gantinya, Anda akan menggunakan
+perintah `sudo`. Seperti namanya, ini memungkinkan Anda "melakukan" sesuatu
+"sebagai su" (singkatan dari "super user", atau "root"). Ketika Anda
+mendapatkan error izin ditolak, biasanya karena Anda perlu melakukan sesuatu
+sebagai root. Meskipun pastikan Anda pertama-tama memeriksa ulang bahwa Anda
+benar-benar ingin melakukannya dengan cara itu!
 
-One thing you need to be root in order to do is writing to the `sysfs` file
-system mounted under `/sys`. `sysfs` exposes a number of kernel parameters as
-files, so that you can easily reconfigure the kernel on the fly without
-specialized tools. **Note that sysfs does not exist on Windows or macOS.**
+Salah satu hal yang mengharuskan Anda menjadi root adalah menulis ke sistem file
+`sysfs` yang di-mount di bawah `/sys`. `sysfs` menampilkan sejumlah parameter
+kernel sebagai file, sehingga Anda bisa dengan mudah mengonfigurasi ulang kernel
+secara langsung tanpa alat khusus. **Perhatikan bahwa sysfs tidak ada di Windows
+atau macOS.**
 
-For example, the brightness of your laptop's screen is exposed through a file
-called `brightness` under
+Misalnya, kecerahan layar laptop Anda ditampilkan melalui sebuah file bernama
+`brightness` di bawah
 
 ```
 /sys/class/backlight
 ```
 
-By writing a value into that file, we can change the screen brightness.
-Your first instinct might be to do something like:
+Dengan menulis nilai ke file tersebut, kita bisa mengubah kecerahan layar.
+Firasat pertama Anda mungkin melakukan sesuatu seperti:
 
 ```console
 $ sudo find -L /sys/class/backlight -maxdepth 2 -name '*brightness*'
@@ -333,87 +309,85 @@ An error occurred while redirecting file 'brightness'
 open: Permission denied
 ```
 
-This error may come as a surprise. After all, we ran the command with
-`sudo`! This is an important thing to know about the shell. Operations
-like `|`, `>`, and `<` are done _by the shell_, not by the individual
-program. `echo` and friends do not "know" about `|`. They just read from
-their input and write to their output, whatever it may be. In the case
-above, the _shell_ (which is authenticated just as your user) tries to
-open the brightness file for writing, before setting that as `sudo
-echo`'s output, but is prevented from doing so since the shell does not
-run as root. Using this knowledge, we can work around this:
+Error ini mungkin mengejutkan. Lagipula, kita menjalankan perintah dengan
+`sudo`! Ini adalah hal penting yang perlu diketahui tentang shell. Operasi
+seperti `|`, `>`, dan `<` dilakukan _oleh shell_, bukan oleh program individual.
+`echo` dan teman-temannya tidak "tahu" tentang `|`. Mereka hanya membaca dari
+masukan dan menulis ke keluaran mereka, apa pun itu. Dalam kasus di atas,
+_shell_ (yang diautentikasi sebagai pengguna Anda) mencoba membuka file
+brightness untuk ditulis, sebelum menjadikannya sebagai keluaran `sudo echo`,
+tetapi dicegah karena shell tidak berjalan sebagai root. Dengan pengetahuan ini,
+kita bisa mengatasinya:
 
 ```console
 $ echo 3 | sudo tee brightness
 ```
 
-Since the `tee` program is the one to open the `/sys` file for writing,
-and _it_ is running as `root`, the permissions all work out. You can
-control all sorts of fun and useful things through `/sys`, such as the
-state of various system LEDs (your path might be different):
+Karena program `tee` adalah yang membuka file `/sys` untuk ditulis, dan _ia_
+berjalan sebagai `root`, semua izin berfungsi dengan benar. Anda bisa
+mengendalikan berbagai hal yang menarik dan berguna melalui `/sys`, seperti
+status berbagai LED sistem (path Anda mungkin berbeda):
 
 ```console
 $ echo 1 | sudo tee /sys/class/leds/input6::scrolllock/brightness
 ```
 
-# Next steps
+# Langkah selanjutnya
 
-At this point you know your way around a shell enough to accomplish
-basic tasks. You should be able to navigate around to find files of
-interest and use the basic functionality of most programs. In the next
-lecture, we will talk about how to perform and automate more complex
-tasks using the shell and the many handy command-line programs out
-there.
+Pada titik ini Anda sudah cukup mengenal shell untuk menyelesaikan tugas-tugas
+dasar. Anda seharusnya bisa menavigasi untuk menemukan file yang menarik dan
+menggunakan fungsionalitas dasar sebagian besar program. Di kuliah berikutnya,
+kita akan membahas tentang cara melakukan dan mengotomatisasi tugas-tugas yang
+lebih kompleks menggunakan shell dan banyak program baris perintah yang berguna.
 
-# Exercises
+# Latihan
 
-All classes in this course are accompanied by a series of exercises. Some give
-you a specific task to do, while others are open-ended, like "try using X and Y
-programs". We highly encourage you to try them out.
+Semua kelas dalam kursus ini disertai serangkaian latihan. Beberapa memberi Anda
+tugas spesifik untuk dilakukan, sementara lainnya bersifat terbuka, seperti
+"coba gunakan program X dan Y". Kami sangat mendorong Anda untuk mencobanya.
 
-We have not written solutions for the exercises. If you are stuck on anything
-in particular, feel free to send us an email describing what you've tried so
-far, and we will try to help you out.
+Kami belum menulis solusi untuk latihan-latihan ini. Jika Anda mengalami
+kebuntuan pada hal tertentu, jangan ragu untuk mengirimkan email kepada kami
+yang menjelaskan apa yang sudah Anda coba sejauh ini, dan kami akan mencoba
+membantu Anda.
 
- 1. For this course, you need to be using a Unix shell like Bash or ZSH. If you
-    are on Linux or macOS, you don't have to do anything special. If you are on
-    Windows, you need to make sure you are not running cmd.exe or PowerShell;
-    you can use [Windows Subsystem for
-    Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-    machine to use Unix-style command-line tools. To make sure you're running
-    an appropriate shell, you can try the command `echo $SHELL`. If it says
-    something like `/bin/bash` or `/usr/bin/zsh`, that means you're running the
-    right program.
- 1. Create a new directory called `missing` under `/tmp`.
- 1. Look up the `touch` program. The `man` program is your friend.
- 1. Use `touch` to create a new file called `semester` in `missing`.
- 1. Write the following into that file, one line at a time:
+ 1. Untuk kursus ini, Anda perlu menggunakan shell Unix seperti Bash atau ZSH.
+    Jika Anda menggunakan Linux atau macOS, Anda tidak perlu melakukan apa-apa
+    yang khusus. Jika Anda menggunakan Windows, Anda perlu memastikan Anda tidak
+    menjalankan cmd.exe atau PowerShell; Anda bisa menggunakan [Windows
+    Subsystem for
+    Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau mesin virtual
+    Linux untuk menggunakan alat baris perintah bergaya Unix. Untuk memastikan
+    Anda menjalankan shell yang sesuai, Anda bisa mencoba perintah `echo
+    $SHELL`. Jika hasilnya sesuatu seperti `/bin/bash` atau `/usr/bin/zsh`, itu
+    berarti Anda menjalankan program yang benar.
+ 1. Buat direktori baru bernama `missing` di bawah `/tmp`.
+ 1. Cari tahu tentang program `touch`. Program `man` adalah teman Anda.
+ 1. Gunakan `touch` untuk membuat file baru bernama `semester` di `missing`.
+ 1. Tulis yang berikut ke dalam file tersebut, satu baris pada satu waktu:
     ```
     #!/bin/sh
     curl --head --silent https://missing.csail.mit.edu
     ```
-    The first line might be tricky to get working. It's helpful to know that
-    `#` starts a comment in Bash, and `!` has a special meaning even within
-    double-quoted (`"`) strings. Bash treats single-quoted strings (`'`)
-    differently: they will do the trick in this case. See the Bash
-    [quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html)
-    manual page for more information.
- 1. Try to execute the file, i.e. type the path to the script (`./semester`)
-    into your shell and press enter. Understand why it doesn't work by
-    consulting the output of `ls` (hint: look at the permission bits of the
-    file).
- 1. Run the command by explicitly starting the `sh` interpreter, and giving it
-    the file `semester` as the first argument, i.e. `sh semester`. Why does
-    this work, while `./semester` didn't?
- 1. Look up the `chmod` program (e.g. use `man chmod`).
- 1. Use `chmod` to make it possible to run the command `./semester` rather than
-    having to type `sh semester`. How does your shell know that the file is
-    supposed to be interpreted using `sh`? See this page on the
-    [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line for more
-    information.
- 1. Use `|` and `>` to write the "last modified" date output by
-    `semester` into a file called `last-modified.txt` in your home
-    directory.
- 1. Write a command that reads out your laptop battery's power level or your
-    desktop machine's CPU temperature from `/sys`. Note: if you're a macOS
-    user, your OS doesn't have sysfs, so you can skip this exercise.
+    Baris pertama mungkin agak rumit untuk dibuat berfungsi. Membantu untuk
+    diketahui bahwa `#` memulai komentar di Bash, dan `!` memiliki arti khusus
+    bahkan di dalam string bertanda kutip ganda (`"`). Bash memperlakukan string
+    bertanda kutip tunggal (`'`) secara berbeda: mereka akan berhasil dalam
+    kasus ini. Lihat halaman manual [quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html) Bash untuk informasi lebih lanjut.
+ 1. Coba jalankan file tersebut, yaitu ketik path ke skrip (`./semester`) ke
+    dalam shell Anda dan tekan enter. Pahami mengapa tidak berhasil dengan
+    melihat keluaran `ls` (petunjuk: perhatikan bit izin file tersebut).
+ 1. Jalankan perintah dengan secara eksplisit memulai interpreter `sh`, dan
+    memberinya file `semester` sebagai argumen pertama, yaitu `sh semester`.
+    Mengapa ini berhasil, sedangkan `./semester` tidak?
+ 1. Cari tahu tentang program `chmod` (misalnya gunakan `man chmod`).
+ 1. Gunakan `chmod` untuk memungkinkan menjalankan perintah `./semester` tanpa
+    harus mengetik `sh semester`. Bagaimana shell Anda tahu bahwa file tersebut
+    seharusnya diinterpretasikan menggunakan `sh`? Lihat halaman ini tentang
+    baris [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) untuk
+    informasi lebih lanjut.
+ 1. Gunakan `|` dan `>` untuk menulis keluaran tanggal "terakhir diubah" oleh
+    `semester` ke dalam file bernama `last-modified.txt` di direktori home Anda.
+ 1. Tulis perintah yang membaca level daya baterai laptop Anda atau suhu CPU
+    mesin desktop Anda dari `/sys`. Catatan: jika Anda pengguna macOS, OS Anda
+    tidak memiliki sysfs, jadi Anda bisa melewati latihan ini.

--- a/_2020/course-shell.md
+++ b/_2020/course-shell.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Course Overview + The Shell"
+title: "Ikhtisar Kursus + The Shell"
 description: >
-  Learn about the motivation for this class, and get started with the shell.
+  Pelajari motivasi kelas ini, dan mulai dengan shell.
 thumbnail: /static/assets/thumbnails/2020/lec1.png
 date: 2020-01-13
 ready: true
@@ -11,92 +11,41 @@ video:
   id: Z56Jmr9Z34Q
 ---
 
-# Motivation
+# Motivasi
 
-As computer scientists, we know that computers are great at aiding in
-repetitive tasks. However, far too often, we forget that this applies
-just as much to our _use_ of the computer as it does to the computations
-we want our programs to perform. We have a vast range of tools
-available at our fingertips that enable us to be more productive and
-solve more complex problems when working on any computer-related
-problem. Yet many of us utilize only a small fraction of those tools; we
-only know enough magical incantations by rote to get by, and blindly
-copy-paste commands from the internet when we get stuck.
+Sebagai ilmuwan komputer, kita tahu bahwa komputer sangat baik dalam membantu tugas-tugas berulang. Namun, terlalu sering kita lupa bahwa ini berlaku sama banyaknya untuk _penggunaan_ komputer kita seperti halnya untuk komputasi yang ingin kita lakukan oleh program kita. Kita memiliki berbagai macam alat yang tersedia di ujung jari kita yang memungkinkan kita untuk lebih produktif dan menyelesaikan masalah yang lebih kompleks ketika bekerja pada masalah terkait komputer apa pun. Namun banyak dari kita hanya menggunakan sebagian kecil dari alat-alat tersebut; kita hanya mengetahui cukup banyak mantra ajaib dengan hafalan untuk bertahan, dan membabi-buti menyalin-tempel perintah dari internet ketika kita terjebak.
 
-This class is an attempt to address this.
+Kelas ini adalah upaya untuk mengatasi hal tersebut.
 
-We want to teach you how to make the most of the tools you know, show
-you new tools to add to your toolbox, and hopefully instill in you some
-excitement for exploring (and perhaps building) more tools on your own.
-This is what we believe to be the missing semester from most Computer
-Science curricula.
+Kami ingin mengajarkan Anda cara memaksimalkan alat-alat yang Anda ketahui, menunjukkan alat-alat baru untuk ditambahkan ke kotak peralatan Anda, dan semoga menanamkan dalam diri Anda beberapa kegembiraan untuk menjelajahi (dan mungkin membangun) lebih banyak alat sendiri. Ini adalah apa yang kami yakini sebagai semester yang hilang dari sebagian besar kurikulum Ilmu Komputer.
 
-# Class structure
+# Struktur kelas
 
-The class consists of 11 1-hour lectures, each one centering on a
-[particular topic](/2020/). The lectures are largely independent,
-though as the semester goes on we will presume that you are familiar
-with the content from the earlier lectures. We have lecture notes
-online, but there will be a lot of content covered in class (e.g. in the
-form of demos) that may not be in the notes. We will be recording
-lectures and posting the recordings online.
+Kelas ini terdiri dari 11 kuliah 1 jam, masing-masing berpusat pada [topik tertentu](/2020/). Kuliah-kuliah sebagian besar independen, meskipun seiring berjalannya semester kami akan berasumsi bahwa Anda sudah terbiasa dengan konten dari kuliah-kuliah sebelumnya. Kami memiliki catatan kuliah online, tetapi akan ada banyak konten yang dibahas di kelas (misalnya dalam bentuk demo) yang mungkin tidak ada dalam catatan. Kami akan merekam kuliah dan memposting rekaman secara online.
 
-We are trying to cover a lot of ground over the course of just 11 1-hour
-lectures, so the lectures are fairly dense. To allow you some time to
-get familiar with the content at your own pace, each lecture includes a
-set of exercises that guide you through the lecture's key points. After
-each lecture, we are hosting office hours where we will be present to
-help answer any questions you might have. If you are attending the class
-online, you can send us questions at
-[missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+Kami mencoba mencakup banyak hal dalam kurun waktu hanya 11 kuliah 1 jam, jadi kuliah-kuliah cukup padat. Untuk memberi Anda waktu untuk membiasakan diri dengan konten sesuai kecepatan Anda sendiri, setiap kuliah mencakup serangkaian latihan yang memandu Anda melalui poin-poin kunci kuliah. Setelah setiap kuliah, kami mengadakan jam kantor di mana kami akan hadir untuk membantu menjawab pertanyaan apa pun yang mungkin Anda miliki. Jika Anda mengikuti kelas secara online, Anda dapat mengirim pertanyaan kepada kami di [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-Due to the limited time we have, we won't be able to cover all the tools
-in the same level of detail a full-scale class might. Where possible, we
-will try to point you towards resources for digging further into a tool
-or topic, but if something particularly strikes your fancy, don't
-hesitate to reach out to us and ask for pointers!
+Karena waktu yang terbatas, kami tidak akan dapat mencakup semua alat dengan tingkat detail yang sama seperti kelas skala penuh. Jika memungkinkan, kami akan mencoba mengarahkan Anda ke sumber daya untuk menggali lebih dalam ke alat atau topik, tetapi jika ada sesuatu yang特别 menarik perhatian Anda, jangan ragu untuk menghubungi kami dan meminta petunjuk!
 
-# Topic 1: The Shell
+# Topik 1: The Shell
 
-## What is the shell?
+## Apa itu shell?
 
-Computers these days have a variety of interfaces for giving them
-commands; fanciful graphical user interfaces, voice interfaces, and
-even AR/VR are everywhere. These are great for 80% of use-cases, but
-they are often fundamentally restricted in what they allow you to do —
-you cannot press a button that isn't there or give a voice command that
-hasn't been programmed. To take full advantage of the tools your
-computer provides, we have to go old-school and drop down to a textual
-interface: The Shell.
+Komputer saat ini memiliki berbagai antarmuka untuk memberi mereka perintah; antarmuka pengguna grafis yang mewah, antarmuka suara, dan bahkan AR/VR ada di mana-mana. Ini sangat bagus untuk 80% kasus penggunaan, tetapi mereka sering kali terbatas secara mendasar dalam apa yang mereka izinkan Anda lakukan — Anda tidak dapat menekan tombol yang tidak ada atau memberi perintah suara yang belum diprogram. Untuk memanfaatkan sepenuhnya alat-alat yang disediakan komputer Anda, kita harus kembali ke cara lama dan turun ke antarmuka tekstual: The Shell.
 
-Nearly all platforms you can get your hands on have a shell in one form or
-another, and many of them have several shells for you to choose from.
-While they may vary in the details, at their core they are all roughly
-the same: they allow you to run programs, give them input, and inspect
-their output in a semi-structured way.
+Hampir semua platform yang bisa Anda dapatkan memiliki shell dalam satu bentuk atau lainnya, dan banyak dari mereka memiliki beberapa shell untuk Anda pilih. Meskipun mereka mungkin berbeda dalam detail, pada intinya mereka semua kurang lebih sama: mereka memungkinkan Anda menjalankan program, memberi mereka input, dan memeriksa output mereka dengan cara semi-terstruktur.
 
-In this lecture, we will focus on the Bourne Again SHell, or "bash" for
-short. This is one of the most widely used shells, and its syntax is
-similar to what you will see in many other shells. To open a shell
-_prompt_ (where you can type commands), you first need a _terminal_.
-Your device probably shipped with one installed, or you can install one
-fairly easily.
+Dalam kuliah ini, kita akan fokus pada Bourne Again SHell, atau "bash" singkatnya. Ini adalah salah satu shell yang paling banyak digunakan, dan sintaksnya mirip dengan apa yang akan Anda lihat di banyak shell lainnya. Untuk membuka _prompt_ shell (tempat Anda dapat mengetik perintah), Anda pertama-tama membutuhkan _terminal_. Perangkat Anda mungkin sudah dilengkapi dengan yang terinstal, atau Anda dapat menginstalnya dengan cukup mudah.
 
-## Using the shell
+## Menggunakan shell
 
-When you launch your terminal, you will see a _prompt_ that often looks
-a little like this:
+Ketika Anda meluncurkan terminal, Anda akan melihat _prompt_ yang sering terlihat seperti ini:
 
 ```console
 missing:~$
 ```
 
-This is the main textual interface to the shell. It tells you that you
-are on the machine `missing` and that your "current working directory",
-or where you currently are, is `~` (short for "home"). The `$` tells you
-that you are not the root user (more on that later). At this prompt you
-can type a _command_, which will then be interpreted by the shell. The
-most basic command is to execute a program:
+Ini adalah antarmuka tekstual utama ke shell. Ini memberi tahu Anda bahwa Anda berada di mesin `missing` dan bahwa "directori kerja saat ini" Anda, atau di mana Anda berada saat ini, adalah `~` (singkatan dari "home"). `$` memberi tahu Anda bahwa Anda bukan pengguna root (lebih lanjut tentang itu nanti). Pada prompt ini Anda dapat mengetik _perintah_, yang kemudian akan diinterpretasikan oleh shell. Perintah paling dasar adalah menjalankan program:
 
 ```console
 missing:~$ date
@@ -104,34 +53,16 @@ Fri 10 Jan 2020 11:49:31 AM EST
 missing:~$
 ```
 
-Here, we executed the `date` program, which (perhaps unsurprisingly)
-prints the current date and time. The shell then asks us for another
-command to execute. We can also execute a command with _arguments_:
+Di sini, kita menjalankan program `date`, yang (mungkin tidak mengejutkan) mencetak tanggal dan waktu saat ini. Shell kemudian meminta kita untuk perintah lain untuk dijalankan. Kita juga dapat menjalankan perintah dengan _argumen_:
 
 ```console
 missing:~$ echo hello
 hello
 ```
 
-In this case, we told the shell to execute the program `echo` with the
-argument `hello`. The `echo` program simply prints out its arguments.
-The shell parses the command by splitting it by whitespace, and then
-runs the program indicated by the first word, supplying each subsequent
-word as an argument that the program can access. If you want to provide
-an argument that contains spaces or other special characters (e.g., a
-directory named "My Photos"), you can either quote the argument with `'`
-or `"` (`"My Photos"`), or escape just the relevant characters with `\`
-(`My\ Photos`).
+Dalam kasus ini, kita memberi tahu shell untuk menjalankan program `echo` dengan argumen `hello`. Program `echo` hanya mencetak argumennya. Shell mem-parsing perintah dengan memecahnya berdasarkan spasi, dan kemudian menjalankan program yang ditunjukkan oleh kata pertama, menyediakan setiap kata berikutnya sebagai argumen yang dapat diakses oleh program. Jika Anda ingin menyediakan argumen yang mengandung spasi atau karakter khusus lainnya (misalnya, direktori bernama "My Photos"), Anda dapat mengutip argumen dengan `'` atau `"` (`"My Photos"`), atau escape hanya karakter yang relevan dengan `\` (`My\ Photos`).
 
-But how does the shell know how to find the `date` or `echo` programs?
-Well, the shell is a programming environment, just like Python or Ruby,
-and so it has variables, conditionals, loops, and functions (next
-lecture!). When you run commands in your shell, you are really writing a
-small bit of code that your shell interprets. If the shell is asked to
-execute a command that doesn't match one of its programming keywords, it
-consults an _environment variable_ called `$PATH` that lists which
-directories the shell should search for programs when it is given a
-command:
+Tetapi bagaimana shell tahu cara menemukan program `date` atau `echo`? Yah, shell adalah lingkungan pemrograman, sama seperti Python atau Ruby, dan jadi memiliki variabel, kondisional, loop, dan fungsi (kuliah berikutnya!). Ketika Anda menjalankan perintah di shell Anda, Anda benar-benar menulis sedikit kode yang diinterpretasikan shell Anda. Jika shell diminta untuk menjalankan perintah yang tidak cocok dengan salah satu kata kunci pemrogramannya, ia berkonsultasi dengan _variabel lingkungan_ yang disebut `$PATH` yang mencantumkan direktori mana yang harus dicari shell untuk program ketika diberi perintah:
 
 
 ```console
@@ -143,26 +74,11 @@ missing:~$ /bin/echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
-When we run the `echo` command, the shell sees that it should execute
-the program `echo`, and then searches through the `:`-separated list of
-directories in `$PATH` for a file by that name. When it finds it, it
-runs it (assuming the file is _executable_; more on that later). We can
-find out which file is executed for a given program name using the
-`which` program. We can also bypass `$PATH` entirely by giving the
-_path_ to the file we want to execute.
+Ketika kita menjalankan perintah `echo`, shell melihat bahwa ia harus menjalankan program `echo`, dan kemudian mencari melalui daftar direktori yang dipisahkan `:` di `$PATH` untuk file dengan nama tersebut. Ketika menemukannya, ia menjalankannya (dengan asumsi file tersebut _dapat dieksekusi_; lebih lanjut tentang itu nanti). Kita dapat mengetahui file mana yang dijalankan untuk nama program tertentu menggunakan program `which`. Kita juga dapat melewati `$PATH` sepenuhnya dengan memberi _path_ ke file yang ingin kita jalankan.
 
-## Navigating in the shell
+## Navigasi di shell
 
-A path on the shell is a delimited list of directories; separated by `/`
-on Linux and macOS and `\` on Windows. On Linux and macOS, the path `/`
-is the "root" of the file system, under which all directories and files
-lie, whereas on Windows there is one root for each disk partition (e.g.,
-`C:\`). We will generally assume that you are using a Linux filesystem
-in this class. A path that starts with `/` is called an _absolute_ path.
-Any other path is a _relative_ path. Relative paths are relative to the
-current working directory, which we can see with the `pwd` command and
-change with the `cd` command. In a path, `.` refers to the current
-directory, and `..` to its parent directory:
+Path di shell adalah daftar direktori yang dipisahkan; dipisahkan oleh `/` di Linux dan macOS dan `\` di Windows. Di Linux dan macOS, path `/` adalah "root" dari sistem file, di bawah mana semua direktori dan file berada, sedangkan di Windows ada satu root untuk setiap partisi disk (misalnya, `C:\`). Kami umumnya akan berasumsi bahwa Anda menggunakan sistem file Linux di kelas ini. Path yang dimulai dengan `/` disebut path _absolut_. Path lainnya adalah path _relatif_. Path relatif terhadap direktori kerja saat ini, yang dapat kita lihat dengan perintah `pwd` dan ubah dengan perintah `cd`. Dalam path, `.` mengacu pada direktori saat ini, dan `..` ke direktori induknya:
 
 ```console
 missing:~$ pwd
@@ -183,15 +99,11 @@ missing:~$ ../../bin/echo hello
 hello
 ```
 
-Notice that our shell prompt kept us informed about what our current
-working directory was. You can configure your prompt to show you all
-sorts of useful information, which we will cover in a later lecture.
+Perhatikan bahwa prompt shell kita terus memberi informasi tentang apa direktori kerja saat ini kita. Anda dapat mengonfigurasi prompt Anda untuk menunjukkan semua jenis informasi berguna, yang akan kita bahas dalam kuliah nanti.
 
-In general, when we run a program, it will operate in the current
-directory unless we tell it otherwise. For example, it will usually
-search for files there, and create new files there if it needs to.
+Secara umum, ketika kita menjalankan program, ia akan beroperasi di direktori saat ini kecuali kita memberitahunya sebaliknya. Misalnya, ia biasanya akan mencari file di sana, dan membuat file baru di sana jika diperlukan.
 
-To see what lives in a given directory, we use the `ls` command:
+Untuk melihat apa yang ada di direktori tertentu, kita gunakan perintah `ls`:
 
 ```console
 missing:~$ ls
@@ -208,12 +120,7 @@ home
 ...
 ```
 
-Unless a directory is given as its first argument, `ls` will print the
-contents of the current directory. Most commands accept flags and
-options (flags with values) that start with `-` to modify their
-behavior. Usually, running a program with the `-h` or `--help` flag
-will print some help text that tells you what flags
-and options are available. For example, `ls --help` tells us:
+Kecuali direktori diberikan sebagai argumen pertamanya, `ls` akan mencetak isi direktori saat ini. Sebagian besar perintah menerima flag dan opsi (flag dengan nilai) yang dimulai dengan `-` untuk memodifikasi perilakunya. Biasanya, menjalankan program dengan flag `-h` atau `--help` akan mencetak beberapa teks bantuan yang memberi tahu Anda flag dan opsi mana yang tersedia. Misalnya, `ls --help` memberi tahu kita:
 
 ```
   -l                         use a long listing format
@@ -224,45 +131,21 @@ missing:~$ ls -l /home
 drwxr-xr-x 1 missing  users  4096 Jun 15  2019 missing
 ```
 
-This gives us a bunch more information about each file or directory
-present. First, the `d` at the beginning of the line tells us that
-`missing` is a directory. Then follow three groups of three characters
-(`rwx`). These indicate what permissions the owner of the file
-(`missing`), the owning group (`users`), and everyone else respectively
-have on the relevant item. A `-` indicates that the given principal does
-not have the given permission. Above, only the owner is allowed to
-modify (`w`) the `missing` directory (i.e., add/remove files in it). To
-enter a directory, a user must have "search" (represented by "execute":
-`x`) permissions on that directory (and its parents). To list its
-contents, a user must have read (`r`) permissions on that directory. For
-files, the permissions are as you would expect. Notice that nearly all
-the files in `/bin` have the `x` permission set for the last group,
-"everyone else", so that anyone can execute those programs.
+Ini memberi kita banyak informasi tambahan tentang setiap file atau direktori yang ada. Pertama, `d` di awal baris memberi tahu kita bahwa `missing` adalah direktori. Kemudian ikuti tiga kelompok tiga karakter (`rwx`). Ini menunjukkan izin apa yang dimiliki pemilik file (`missing`), grup pemilik (`users`), dan orang lain masing-masing pada item yang relevan. `-` menunjukkan bahwa prinsipal yang diberikan tidak memiliki izin yang diberikan. Di atas, hanya pemilik yang diizinkan untuk memodifikasi (`w`) direktori `missing` (yaitu, menambah/menghapus file di dalamnya). Untuk masuk ke direktori, pengguna harus memiliki izin "search" (diwakili oleh "execute": `x`) pada direktori tersebut (dan induknya). Untuk mendaftarkan isinya, pengguna harus memiliki izin read (`r`) pada direktori tersebut. Untuk file, izinnya seperti yang Anda harapkan. Perhatikan bahwa hampir semua file di `/bin` memiliki izin `x` yang diatur untuk grup terakhir, "orang lain", sehingga siapa pun dapat menjalankan program-program tersebut.
 
-Some other handy programs to know about at this point are `mv` (to
-rename/move a file), `cp` (to copy a file), and `mkdir` (to make a new
-directory).
+Beberapa program berguna lainnya untuk diketahui pada titik ini adalah `mv` (untuk mengganti nama/memindahkan file), `cp` (untuk menyalin file), dan `mkdir` (untuk membuat direktori baru).
 
-If you ever want _more_ information about a program's arguments, inputs,
-outputs, or how it works in general, give the `man` program a try. It
-takes as an argument the name of a program, and shows you its _manual
-page_. Press `q` to exit.
+Jika Anda pernah menginginkan informasi _lebih lanjut_ tentang argumen, input, output program, atau cara kerjanya secara umum, coba program `man`. Ini mengambil sebagai argumen nama program, dan menunjukkan halaman _manual_ nya. Tekan `q` untuk keluar.
 
 ```console
 missing:~$ man ls
 ```
 
-## Connecting programs
+## Menghubungkan program
 
-In the shell, programs have two primary "streams" associated with them:
-their input stream and their output stream. When the program tries to
-read input, it reads from the input stream, and when it prints
-something, it prints to its output stream. Normally, a program's input
-and output are both your terminal. That is, your keyboard as input and
-your screen as output. However, we can also rewire those streams!
+Di shell, program memiliki dua "stream" utama yang terkait dengannya: stream input mereka dan stream output mereka. Ketika program mencoba membaca input, ia membaca dari stream input, dan ketika mencetak sesuatu, ia mencetak ke stream outputnya. Biasanya, input dan output program keduanya adalah terminal Anda. Artinya, keyboard Anda sebagai input dan layar Anda sebagai output. Namun, kita juga dapat mengubah aliran stream tersebut!
 
-The simplest form of redirection is `< file` and `> file`. These let you
-rewire the input and output streams of a program to a file respectively:
+Bentuk paling sederhana dari redirection adalah `< file` dan `> file`. Ini memungkinkan Anda mengubah stream input dan output program ke file masing-masing:
 
 ```console
 missing:~$ echo hello > hello.txt
@@ -275,16 +158,9 @@ missing:~$ cat hello2.txt
 hello
 ```
 
-Demonstrated in the example above, `cat` is a program that con`cat`enates
-files. When given file names as arguments, it prints the contents of each of
-the files in sequence to its output stream. But when `cat` is not given any
-arguments, it prints contents from its input stream to its output stream (like
-in the third example above).
+Seperti yang ditunjukkan dalam contoh di atas, `cat` adalah program yang menyam`bung`kan file. Ketika diberi nama file sebagai argumen, ia mencetak isi masing-masing file secara berurutan ke stream outputnya. Tetapi ketika `cat` tidak diberi argumen, ia mencetak isi dari stream inputnya ke stream outputnya (seperti dalam contoh ketiga di atas).
 
-You can also use `>>` to append to a file. Where this kind of
-input/output redirection really shines is in the use of _pipes_. The `|`
-operator lets you "chain" programs such that the output of one is the
-input of another:
+Anda juga dapat menggunakan `>>` untuk menambahkan ke file. Di mana jenis redirection input/output ini benar-benar bersinar adalah dalam penggunaan _pipes_. Operator `|` memungkinkan Anda "merantai" program sedemikian rupa sehingga output satu adalah input yang lain:
 
 ```console
 missing:~$ ls -l / | tail -n1
@@ -293,36 +169,21 @@ missing:~$ curl --head --silent google.com | grep --ignore-case content-length |
 219
 ```
 
-We will go into a lot more detail about how to take advantage of pipes
-in the lecture on data wrangling.
+Kita akan masuk ke lebih banyak detail tentang cara memanfaatkan pipes dalam kuliah tentang data wrangling.
 
-## A versatile and powerful tool
+## Alat yang serbaguna dan kuat
 
-On most Unix-like systems, one user is special: the "root" user. You may
-have seen it in the file listings above. The root user is above (almost)
-all access restrictions, and can create, read, update, and delete any
-file in the system. You will not usually log into your system as the
-root user though, since it's too easy to accidentally break something.
-Instead, you will be using the `sudo` command. As its name implies, it
-lets you "do" something "as su" (short for "super user", or "root").
-When you get permission denied errors, it is usually because you need to
-do something as root. Though make sure you first double-check that you
-really wanted to do it that way!
+Pada kebanyakan sistem mirip Unix, satu pengguna istimewa: pengguna "root". Anda mungkin telah melihatnya dalam daftar file di atas. Pengguna root berada di atas (hampir) semua pembatasan akses, dan dapat membuat, membaca, memperbarui, dan menghapus file apa pun di sistem. Anda biasanya tidak akan masuk ke sistem Anda sebagai pengguna root, karena terlalu mudah untuk secara tidak sengaja merusak sesuatu. Sebaliknya, Anda akan menggunakan perintah `sudo`. Seperti namanya, ini membiarkan Anda "melakukan" sesuatu "sebagai su" (singkatan dari "super user", atau "root"). Ketika Anda mendapat kesalahan izin ditolak, biasanya karena Anda perlu melakukan sesuatu sebagai root. Meskipun pastikan Anda pertama-tama memeriksa ulang bahwa Anda benar-benar ingin melakukannya dengan cara itu!
 
-One thing you need to be root in order to do is writing to the `sysfs` file
-system mounted under `/sys`. `sysfs` exposes a number of kernel parameters as
-files, so that you can easily reconfigure the kernel on the fly without
-specialized tools. **Note that sysfs does not exist on Windows or macOS.**
+Satu hal yang perlu Anda menjadi root untuk lakukan adalah menulis ke sistem file `sysfs` yang dipasang di bawah `/sys`. `sysfs` mengekspos sejumlah parameter kernel sebagai file, sehingga Anda dapat dengan mudah mengonfigurasi ulang kernel dengan cepat tanpa alat khusus. **Perhatikan bahwa sysfs tidak ada di Windows atau macOS.**
 
-For example, the brightness of your laptop's screen is exposed through a file
-called `brightness` under
+Misalnya, kecerahan layar laptop Anda diekspos melalui file yang disebut `brightness` di bawah
 
 ```
 /sys/class/backlight
 ```
 
-By writing a value into that file, we can change the screen brightness.
-Your first instinct might be to do something like:
+Dengan menulis nilai ke file tersebut, kita dapat mengubah kecerahan layar. Firasat pertama Anda mungkin melakukan sesuatu seperti:
 
 ```console
 $ sudo find -L /sys/class/backlight -maxdepth 2 -name '*brightness*'
@@ -333,87 +194,41 @@ An error occurred while redirecting file 'brightness'
 open: Permission denied
 ```
 
-This error may come as a surprise. After all, we ran the command with
-`sudo`! This is an important thing to know about the shell. Operations
-like `|`, `>`, and `<` are done _by the shell_, not by the individual
-program. `echo` and friends do not "know" about `|`. They just read from
-their input and write to their output, whatever it may be. In the case
-above, the _shell_ (which is authenticated just as your user) tries to
-open the brightness file for writing, before setting that as `sudo
-echo`'s output, but is prevented from doing so since the shell does not
-run as root. Using this knowledge, we can work around this:
+Kesalahan ini mungkin datang sebagai kejutan. Lagipula, kita menjalankan perintah dengan `sudo`! Ini adalah hal penting untuk diketahui tentang shell. Operasi seperti `|`, `>`, dan `<` dilakukan _oleh shell_, bukan oleh program individual. `echo` dan teman-temannya tidak "tahu" tentang `|`. Mereka hanya membaca dari input mereka dan menulis ke output mereka, apa pun itu. Dalam kasus di atas, _shell_ (yang diautentikasi sebagai pengguna Anda) mencoba membuka file brightness untuk ditulis, sebelum mengaturnya sebagai output `sudo echo`, tetapi dicegah dari melakukannya karena shell tidak berjalan sebagai root. Menggunakan pengetahuan ini, kita dapat mengatasinya:
 
 ```console
 $ echo 3 | sudo tee brightness
 ```
 
-Since the `tee` program is the one to open the `/sys` file for writing,
-and _it_ is running as `root`, the permissions all work out. You can
-control all sorts of fun and useful things through `/sys`, such as the
-state of various system LEDs (your path might be different):
+Karena program `tee` adalah yang membuka file `/sys` untuk ditulis, dan _itu_ berjalan sebagai `root`, semua izin berfungsi. Anda dapat mengontrol semua jenis hal yang menyenangkan dan berguna melalui `/sys`, seperti status berbagai LED sistem (path Anda mungkin berbeda):
 
 ```console
 $ echo 1 | sudo tee /sys/class/leds/input6::scrolllock/brightness
 ```
 
-# Next steps
+# Langkah selanjutnya
 
-At this point you know your way around a shell enough to accomplish
-basic tasks. You should be able to navigate around to find files of
-interest and use the basic functionality of most programs. In the next
-lecture, we will talk about how to perform and automate more complex
-tasks using the shell and the many handy command-line programs out
-there.
+Pada titik ini Anda tahu jalan Anda di sekitar shell cukup untuk menyelesaikan tugas-tugas dasar. Anda seharusnya dapat bernavigasi untuk menemukan file yang menarik dan menggunakan fungsi dasar sebagian besar program. Dalam kuliah berikutnya, kita akan berbicara tentang cara melakukan dan mengotomatisasi tugas yang lebih kompleks menggunakan shell dan banyak program baris perintah yang berguna di luar sana.
 
-# Exercises
+# Latihan
 
-All classes in this course are accompanied by a series of exercises. Some give
-you a specific task to do, while others are open-ended, like "try using X and Y
-programs". We highly encourage you to try them out.
+Semua kelas dalam kursus ini disertai dengan serangkaian latihan. Beberapa memberi Anda tugas spesifik untuk dilakukan, sementara yang lain terbuka, seperti "coba gunakan program X dan Y". Kami sangat mendorong Anda untuk mencobanya.
 
-We have not written solutions for the exercises. If you are stuck on anything
-in particular, feel free to send us an email describing what you've tried so
-far, and we will try to help you out.
+Kami belum menulis solusi untuk latihan. Jika Anda terjebak pada sesuatu secara khusus, jangan ragu untuk mengirim email kepada kami yang menjelaskan apa yang telah Anda coba sejauh ini, dan kami akan mencoba membantu Anda.
 
- 1. For this course, you need to be using a Unix shell like Bash or ZSH. If you
-    are on Linux or macOS, you don't have to do anything special. If you are on
-    Windows, you need to make sure you are not running cmd.exe or PowerShell;
-    you can use [Windows Subsystem for
-    Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-    machine to use Unix-style command-line tools. To make sure you're running
-    an appropriate shell, you can try the command `echo $SHELL`. If it says
-    something like `/bin/bash` or `/usr/bin/zsh`, that means you're running the
-    right program.
- 1. Create a new directory called `missing` under `/tmp`.
- 1. Look up the `touch` program. The `man` program is your friend.
- 1. Use `touch` to create a new file called `semester` in `missing`.
- 1. Write the following into that file, one line at a time:
+ 1. Untuk kursus ini, Anda perlu menggunakan shell Unix seperti Bash atau ZSH. Jika Anda berada di Linux atau macOS, Anda tidak perlu melakukan apa pun yang istimewa. Jika Anda berada di Windows, Anda perlu memastikan Anda tidak menjalankan cmd.exe atau PowerShell; Anda dapat menggunakan [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau mesin virtual Linux untuk menggunakan alat baris perintah gaya Unix. Untuk memastikan Anda menjalankan shell yang sesuai, Anda dapat mencoba perintah `echo $SHELL`. Jika mengatakan sesuatu seperti `/bin/bash` atau `/usr/bin/zsh`, itu berarti Anda menjalankan program yang benar.
+ 1. Buat direktori baru bernama `missing` di bawah `/tmp`.
+ 1. Cari program `touch`. Program `man` adalah teman Anda.
+ 1. Gunakan `touch` untuk membuat file baru bernama `semester` di `missing`.
+ 1. Tulis yang berikut ke file tersebut, satu baris pada satu waktu:
     ```
     #!/bin/sh
     curl --head --silent https://missing.csail.mit.edu
     ```
-    The first line might be tricky to get working. It's helpful to know that
-    `#` starts a comment in Bash, and `!` has a special meaning even within
-    double-quoted (`"`) strings. Bash treats single-quoted strings (`'`)
-    differently: they will do the trick in this case. See the Bash
-    [quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html)
-    manual page for more information.
- 1. Try to execute the file, i.e. type the path to the script (`./semester`)
-    into your shell and press enter. Understand why it doesn't work by
-    consulting the output of `ls` (hint: look at the permission bits of the
-    file).
- 1. Run the command by explicitly starting the `sh` interpreter, and giving it
-    the file `semester` as the first argument, i.e. `sh semester`. Why does
-    this work, while `./semester` didn't?
- 1. Look up the `chmod` program (e.g. use `man chmod`).
- 1. Use `chmod` to make it possible to run the command `./semester` rather than
-    having to type `sh semester`. How does your shell know that the file is
-    supposed to be interpreted using `sh`? See this page on the
-    [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line for more
-    information.
- 1. Use `|` and `>` to write the "last modified" date output by
-    `semester` into a file called `last-modified.txt` in your home
-    directory.
- 1. Write a command that reads out your laptop battery's power level or your
-    desktop machine's CPU temperature from `/sys`. Note: if you're a macOS
-    user, your OS doesn't have sysfs, so you can skip this exercise.
+    Baris pertama mungkin sulit untuk bekerja. Membantu untuk mengetahui bahwa `#` memulai komentar di Bash, dan `!` memiliki arti khusus bahkan dalam string yang dikutip ganda (`"`). Bash memperlakukan string yang dikutip tunggal (`'`) secara berbeda: mereka akan berhasil dalam kasus ini. Lihat halaman manual [quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html) Bash untuk informasi lebih lanjut.
+ 1. Coba jalankan file tersebut, yaitu ketik path ke script (`./semester`) ke shell Anda dan tekan enter. Pahami mengapa itu tidak berfungsi dengan berkonsultasi pada output `ls` (petunjuk: lihat bit izin file).
+ 1. Jalankan perintah dengan secara eksplisit memulai interpreter `sh`, dan memberinya file `semester` sebagai argumen pertama, yaitu `sh semester`. Mengapa ini berfungsi, sementara `./semester` tidak?
+ 1. Cari program `chmod` (misalnya gunakan `man chmod`).
+ 1. Gunakan `chmod` untuk membuatnya mungkin menjalankan perintah `./semester` daripada harus mengetik `sh semester`. Bagaimana shell Anda tahu bahwa file tersebut seharusnya diinterpretasikan menggunakan `sh`? Lihat halaman ini tentang baris [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) untuk informasi lebih lanjut.
+ 1. Gunakan `|` dan `>` untuk menulis output tanggal "terakhir dimodifikasi" oleh `semester` ke file bernama `last-modified.txt` di direktori home Anda.
+ 1. Tulis perintah yang membaca level daya baterai laptop Anda atau suhu CPU mesin desktop Anda dari `/sys`. Catatan: jika Anda pengguna macOS, OS Anda tidak memiliki sysfs, jadi Anda dapat melewatkan latihan ini.

--- a/_2020/course-shell.md
+++ b/_2020/course-shell.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Course Overview + The Shell"
 description: >
-  Learn about the motivation for this class, and get started with the shell.
+  Pelajari motivasi kelas ini, dan mulai menggunakan shell.
 thumbnail: /static/assets/thumbnails/2020/lec1.png
 date: 2020-01-13
 ready: true

--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Data Wrangling"
 description: >
-  Learn how to manipulate and transform data using command-line tools like sed, awk, and regular expressions.
+  Pelajari cara memanipulasi dan mentransformasi data menggunakan alat baris perintah seperti sed, awk, dan ekspresi reguler.
 thumbnail: /static/assets/thumbnails/2020/lec4.png
 date: 2020-01-16
 ready: true
@@ -12,69 +12,75 @@ video:
 special: true
 ---
 
-Have you ever wanted to take data in one format and turn it into a
-different format? Of course you have! That, in very general terms, is
-what this lecture is all about. Specifically, massaging data, whether in
-text or binary format, until you end up with exactly what you wanted.
+Pernahkah Anda ingin mengambil data dalam satu format dan mengubahnya
+menjadi format yang berbeda? Tentu saja pernah! Secara umum, itulah
+yang menjadi pembahasan utama kuliah ini. Secara khusus, mengolah data,
+baik dalam format teks maupun biner, hingga Anda mendapatkan apa yang
+Anda inginkan.
 
-We've already seen some basic data wrangling in past lectures. Pretty
-much any time you use the `|` operator, you are performing some kind of
-data wrangling. Consider a command like `journalctl | grep -i intel`. It
-finds all system log entries that mention Intel (case insensitive). You
-may not think of it as wrangling data, but it is going from one format
-(your entire system log) to a format that is more useful to you (just
-the intel log entries). Most data wrangling is about knowing what tools
-you have at your disposal, and how to combine them.
+Kita sudah pernah melihat beberapa dasar data wrangling di kuliah-kuliah
+sebelumnya. Hampir setiap kali Anda menggunakan operator `|`, Anda
+sedang melakukan semacam data wrangling. Perhatikan perintah seperti
+`journalctl | grep -i intel`. Perintah ini mencari semua entri log
+sistem yang menyebutkan Intel (tidak membedakan huruf besar/kecil).
+Anda mungkin tidak menganggapnya sebagai pengolahan data, tetapi ini
+berubah dari satu format (seluruh log sistem Anda) menjadi format yang
+lebih berguna bagi Anda (hanya entri log intel). Sebagian besar data
+wrangling adalah tentang mengetahui alat apa yang Anda miliki, dan
+bagaimana menggabungkannya.
 
-Let's start from the beginning. To wrangle data, we need two things:
-data to wrangle, and something to do with it. Logs often make for a good
-use-case, because you often want to investigate things about them, and
-reading the whole thing isn't feasible. Let's figure out who's trying to
-log into my server by looking at my server's log:
+Mari kita mulai dari awal. Untuk mengolah data, kita membutuhkan dua
+hal: data untuk diolah, dan sesuatu untuk dilakukan dengannya. Log
+seringkali menjadi kasus penggunaan yang baik, karena Anda sering ingin
+menyelidiki sesuatu tentang log tersebut, dan membaca seluruhnya tidak
+memungkinkan. Mari kita cari tahu siapa yang mencoba masuk ke server
+saya dengan melihat log server:
 
 ```bash
 ssh myserver journalctl
 ```
 
-That's far too much stuff. Let's limit it to ssh stuff:
+Itu terlalu banyak data. Mari kita batasi hanya untuk ssh:
 
 ```bash
 ssh myserver journalctl | grep sshd
 ```
 
-Notice that we're using a pipe to stream a _remote_ file through `grep`
-on our local computer! `ssh` is magical, and we will talk more about it
-in the next lecture on the command-line environment. This is still way
-more stuff than we wanted though. And pretty hard to read. Let's do
-better:
+Perhatikan bahwa kita menggunakan pipe untuk mengalirkan file _remote_
+melalui `grep` di komputer lokal kita! `ssh` sangat luar biasa, dan
+kita akan membahas lebih lanjut di kuliah berikutnya tentang command-line
+environment. Ini masih jauh lebih banyak data dari yang kita inginkan.
+Dan cukup sulit dibaca. Mari kita lakukan yang lebih baik:
 
 ```bash
 ssh myserver 'journalctl | grep sshd | grep "Disconnected from"' | less
 ```
 
-Why the additional quoting? Well, our logs may be quite large, and it's
-wasteful to stream it all to our computer and then do the filtering.
-Instead, we can do the filtering on the remote server, and then massage
-the data locally. `less` gives us a "pager" that allows us to scroll up
-and down through the long output. To save some additional traffic while
-we debug our command-line, we can even stick the current filtered logs
-into a file so that we don't have to access the network while
-developing:
+Mengapa ada tanda kutip tambahan? Well, log kita bisa sangat besar, dan
+boros jika mengalirkan semuanya ke komputer kita baru kemudian melakukan
+penyaringan. Sebagai gantinya, kita bisa melakukan penyaringan di server
+remote, dan kemudian mengolah data tersebut secara lokal. `less`
+memberikan kita "pager" yang memungkinkan kita menggulir ke atas dan ke
+bawah melalui output yang panjang. Untuk menghemat lalu lintas tambahan
+saat kita men-debug baris perintah, kita bahkan bisa menyimpan log yang
+sudah difilter ke dalam file sehingga kita tidak perlu mengakses jaringan
+saat mengembangkan:
 
 ```console
 $ ssh myserver 'journalctl | grep sshd | grep "Disconnected from"' > ssh.log
 $ less ssh.log
 ```
 
-There's still a lot of noise here. There are _a lot_ of ways to get rid
-of that, but let's look at one of the most powerful tools in your
-toolkit: `sed`.
+Masih ada banyak noise di sini. Ada _sangat banyak_ cara untuk
+menghilangkannya, tetapi mari kita lihat salah satu alat paling kuat
+dalam kotak peralatan Anda: `sed`.
 
-`sed` is a "stream editor" that builds on top of the old `ed` editor. In
-it, you basically give short commands for how to modify the file, rather
-than manipulate its contents directly (although you can do that too).
-There are tons of commands, but one of the most common ones is `s`:
-substitution. For example, we can write:
+`sed` adalah "stream editor" yang dibangun di atas editor `ed` yang lama.
+Di dalamnya, Anda pada dasarnya memberikan perintah singkat untuk
+mengubah file, daripada memanipulasi isinya secara langsung (meskipun
+Anda juga bisa melakukannya). Ada banyak perintah, tetapi salah satu
+yang paling umum adalah `s`: substitusi. Sebagai contoh, kita bisa
+menulis:
 
 ```bash
 ssh myserver journalctl
@@ -83,124 +89,126 @@ ssh myserver journalctl
  | sed 's/.*Disconnected from //'
 ```
 
-What we just wrote was a simple _regular expression_; a powerful
-construct that lets you match text against patterns. The `s` command is
-written in the form: `s/REGEX/SUBSTITUTION/`, where `REGEX` is the
-regular expression you want to search for, and `SUBSTITUTION` is the
-text you want to substitute matching text with.
+Apa yang baru saja kita tulis adalah _ekspresi reguler_ sederhana; sebuah
+konstruksi kuat yang memungkinkan Anda mencocokkan teks terhadap pola.
+Perintah `s` ditulis dalam bentuk: `s/REGEX/SUBSTITUTION/`, di mana
+`REGEX` adalah ekspresi reguler yang ingin Anda cari, dan `SUBSTITUTION`
+adalah teks yang ingin Anda substitusikan untuk teks yang cocok.
 
-(You may recognize this syntax from the "Search and replace" section of our Vim
-[lecture notes](/2020/editors/#advanced-vim)! Indeed, Vim uses a syntax for
-searching and replacing that is similar to `sed`'s substitution command.
-Learning one tool often helps you become more proficient with others.)
+(Anda mungkin mengenali sintaks ini dari bagian "Search and replace" di
+[catatan kuliah](/2020/editors/#advanced-vim) Vim kita! Memang, Vim
+menggunakan sintaks untuk mencari dan mengganti yang mirip dengan
+perintah substitusi `sed`. Mempelajari satu alat sering kali membantu
+Anda menjadi lebih mahir dengan alat lainnya.)
 
 ## Regular expressions
 
-Regular expressions are common and useful enough that it's worthwhile to
-take some time to understand how they work. Let's start by looking at
-the one we used above: `/.*Disconnected from /`. Regular expressions are
-usually (though not always) surrounded by `/`. Most ASCII characters
-just carry their normal meaning, but some characters have "special"
-matching behavior. Exactly which characters do what vary somewhat
-between different implementations of regular expressions, which is a
-source of great frustration. Very common patterns are:
+Regular expressions cukup umum dan berguna sehingga layak untuk
+meluangkan waktu memahami cara kerjanya. Mari kita mulai dengan melihat
+yang kita gunakan di atas: `/.*Disconnected from /`. Regular expressions
+biasanya (meskipun tidak selalu) diapit oleh `/`. Sebagian besar
+karakter ASCII membawa arti normalnya, tetapi beberapa karakter memiliki
+perilaku pencocokan "spesial". Tepatnya karakter mana yang melakukan apa
+sangat bervariasi antara implementasi regular expressions yang berbeda,
+yang menjadi sumber frustrasi besar. Pola yang sangat umum adalah:
 
- - `.` means "any single character" except newline
- - `*` zero or more of the preceding match
- - `+` one or more of the preceding match
- - `[abc]` any one character of `a`, `b`, and `c`
- - `(RX1|RX2)` either something that matches `RX1` or `RX2`
- - `^` the start of the line
- - `$` the end of the line
+ - `.` berarti "satu karakter apa saja" kecuali newline
+ - `*` nol atau lebih dari pencocokan sebelumnya
+ - `+` satu atau lebih dari pencocokan sebelumnya
+ - `[abc]` salah satu karakter dari `a`, `b`, dan `c`
+ - `(RX1|RX2)` sesuatu yang cocok dengan `RX1` atau `RX2`
+ - `^` awal dari baris
+ - `$` akhir dari baris
 
-`sed`'s regular expressions are somewhat weird, and will require you to
-put a `\` before most of these to give them their special meaning. Or
-you can pass `-E`.
+Regular expressions `sed` agak aneh, dan akan mengharuskan Anda
+menambahkan `\` sebelum sebagian besar karakter ini untuk memberikan
+arti spesialnya. Atau Anda bisa menggunakan `-E`.
 
-So, looking back at `/.*Disconnected from /`, we see that it matches
-any text that starts with any number of characters, followed by the
-literal string "Disconnected from &rdquo;. Which is what we wanted. But
-beware, regular expressions are tricky. What if someone tried to log in
-with the username "Disconnected from"? We'd have:
+Jadi, melihat kembali `/.*Disconnected from /`, kita melihat bahwa ini
+mencocokkan teks apa pun yang dimulai dengan sejumlah karakter, diikuti
+oleh string literal "Disconnected from &rdquo;. Itulah yang kita
+inginkan. Tetapi hati-hati, regular expressions bisa rumit. Bagaimana
+jika seseorang mencoba masuk dengan nama pengguna "Disconnected from"?
+Kita akan mendapatkan:
 
 ```
 Jan 17 03:13:00 thesquareplanet.com sshd[2631]: Disconnected from invalid user Disconnected from 46.97.239.16 port 55920 [preauth]
 ```
 
-What would we end up with? Well, `*` and `+` are, by default, "greedy".
-They will match as much text as they can. So, in the above, we'd end up
-with just
+Apa yang akan kita dapatkan? Well, `*` dan `+` secara default bersifat
+"greedy". Mereka akan mencocokkan sebanyak mungkin teks. Jadi, pada
+contoh di atas, kita akan mendapatkan
 
 ```
 46.97.239.16 port 55920 [preauth]
 ```
 
-Which may not be what we wanted. In some regular expression
-implementations, you can just suffix `*` or `+` with a `?` to make them
-non-greedy, but sadly `sed` doesn't support that. We _could_ switch to
-perl's command-line mode though, which _does_ support that construct:
+Yang mungkin bukan yang kita inginkan. Pada beberapa implementasi regular
+expression, Anda bisa menambahkan `?` setelah `*` atau `+` untuk
+membuatnya non-greedy, tetapi sayangnya `sed` tidak mendukung konstruk
+tersebut. Kita _bisa_ beralih ke mode command-line perl, yang _mendukung_
+konstruk tersebut:
 
 ```bash
 perl -pe 's/.*?Disconnected from //'
 ```
 
-We'll stick to `sed` for the rest of this, because it's by far the more
-common tool for these kinds of jobs. `sed` can also do other handy
-things like print lines following a given match, do multiple
-substitutions per invocation, search for things, etc. But we won't cover
-that too much here. `sed` is basically an entire topic in and of itself,
-but there are often better tools.
+Kita akan tetap menggunakan `sed` untuk sisa ini, karena ini adalah alat
+yang jauh lebih umum untuk pekerjaan semacam ini. `sed` juga bisa
+melakukan hal-hal berguna lainnya seperti mencetak baris setelah
+pencocokan tertentu, melakukan beberapa substitusi dalam satu pemanggilan,
+mencari sesuatu, dll. Tetapi kita tidak akan membahasnya terlalu banyak
+di sini. `sed` pada dasarnya merupakan topik tersendiri, tetapi sering
+kali ada alat yang lebih baik.
 
-Okay, so we also have a suffix we'd like to get rid of. How might we do
-that? It's a little tricky to match just the text that follows the
-username, especially if the username can have spaces and such! What we
-need to do is match the _whole_ line:
+Oke, jadi kita juga memiliki sufiks yang ingin kita hilangkan. Bagaimana
+cara melakukannya? Agak rumit untuk mencocokkan hanya teks yang mengikut
+nama pengguna, terutama jika nama pengguna bisa memiliki spasi dan
+sebagainya! Yang perlu kita lakukan adalah mencocokkan _seluruh_ baris:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user .* [^ ]+ port [0-9]+( \[preauth\])?$//'
 ```
 
-Let's look at what's going on with a [regex
-debugger](https://regex101.com/r/qqbZqh/2). Okay, so the start is still
-as before. Then, we're matching any of the "user" variants (there are
-two prefixes in the logs). Then we're matching on any string of
-characters where the username is. Then we're matching on any single word
-(`[^ ]+`; any non-empty sequence of non-space characters). Then the word
-"port" followed by a sequence of digits. Then possibly the suffix
-`[preauth]`, and then the end of the line.
+Mari kita lihat apa yang terjadi dengan [regex
+debugger](https://regex101.com/r/qqbZqh/2). Oke, jadi awalnya masih
+sama seperti sebelumnya. Kemudian, kita mencocokkan salah satu varian
+"user" (ada dua prefiks di log). Kemudian kita mencocokkan string apa
+pun di mana nama pengguna berada. Kemudian kita mencocokkan satu kata
+apa pun (`[^ ]+`; urutan non-kosong dari karakter bukan spasi). Kemudian
+kata "port" diikuti oleh urutan angka. Kemudian mungkin sufiks
+`[preauth]`, dan kemudian akhir baris.
 
-Notice that with this technique, a username of "Disconnected from"
-won't confuse us any more. Can you see why?
+Perhatikan bahwa dengan teknik ini, nama pengguna "Disconnected from"
+tidak akan membingungkan kita lagi. Bisakah Anda melihat mengapa?
 
-There is one problem with this though, and that is that the entire log
-becomes empty. We want to _keep_ the username after all. For this, we
-can use "capture groups". Any text matched by a regex surrounded by
-parentheses is stored in a numbered capture group. These are available
-in the substitution (and in some engines, even in the pattern itself!)
-as `\1`, `\2`, `\3`, etc. So:
+Ada satu masalah dengan ini, yaitu seluruh log menjadi kosong. Kita
+ingin _mempertahankan_ nama pengguna. Untuk ini, kita bisa menggunakan
+"capture groups". Teks apa pun yang dicocokkan oleh regex yang diapit
+oleh tanda kurung disimpan dalam capture group bernomor. Ini tersedia
+dalam substitusi (dan di beberapa engine, bahkan dalam pola itu sendiri!)
+sebagai `\1`, `\2`, `\3`, dst. Jadi:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-As you can probably imagine, you can come up with _really_ complicated
-regular expressions. For example, here's an article on how you might
-match an [e-mail
-address](https://www.regular-expressions.info/email.html). It's [not
-easy](https://web.archive.org/web/20221223174323/http://emailregex.com/). And there's [lots of
-discussion](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982).
-And people have [written
-tests](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php).
-And [test matrices](https://mathiasbynens.be/demo/url-regex). You can
-even write a regex for determining if a given number [is a prime
-number](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
+Seperti yang bisa Anda bayangkan, Anda bisa membuat regular expression
+yang _sangat_ rumit. Sebagai contoh, berikut artikel tentang cara
+mencocokkan [alamat email](https://www.regular-expressions.info/email.html).
+Ini [tidak mudah](https://web.archive.org/web/20221223174323/http://emailregex.com/).
+Dan ada [banyak diskusi](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982).
+Dan orang-orang telah [menulis tes](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php).
+Dan [matriks tes](https://mathiasbynens.be/demo/url-regex). Anda bahkan
+bisa menulis regex untuk menentukan apakah suatu bilangan [adalah bilangan
+prima](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
 
-Regular expressions are notoriously hard to get right, but they are also
-very handy to have in your toolbox!
+Regular expressions terkenal sulit untuk dibuat benar, tetapi juga sangat
+berguna untuk dimiliki di kotak peralatan Anda!
 
-## Back to data wrangling
+## Kembali ke data wrangling
 
-Okay, so we now have
+Oke, jadi sekarang kita punya
 
 ```bash
 ssh myserver journalctl
@@ -209,14 +217,14 @@ ssh myserver journalctl
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-`sed` can do all sorts of other interesting things, like injecting text
-(with the `i` command), explicitly printing lines (with the `p`
-command), selecting lines by index, and lots of other things. Check `man
-sed`!
+`sed` bisa melakukan berbagai hal menarik lainnya, seperti menyisipkan
+teks (dengan perintah `i`), mencetak baris secara eksplisit (dengan
+perintah `p`), memilih baris berdasarkan indeks, dan banyak hal lainnya.
+Cek `man sed`!
 
-Anyway. What we have now gives us a list of all the usernames that have
-attempted to log in. But this is pretty unhelpful. Let's look for common
-ones:
+Bagaimanapun. Apa yang kita miliki sekarang memberi kita daftar semua
+nama pengguna yang pernah mencoba masuk. Tetapi ini cukup tidak berguna.
+Mari kita cari yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -226,10 +234,10 @@ ssh myserver journalctl
  | sort | uniq -c
 ```
 
-`sort` will, well, sort its input. `uniq -c` will collapse consecutive
-lines that are the same into a single line, prefixed with a count of the
-number of occurrences. We probably want to sort that too and only keep
-the most common usernames:
+`sort` akan, well, mengurutkan inputnya. `uniq -c` akan menggabungkan
+baris-baris berurutan yang sama menjadi satu baris, diawali dengan jumlah
+kemunculan. Kita mungkin ingin mengurutkannya juga dan hanya menyimpan
+nama pengguna yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -240,17 +248,20 @@ ssh myserver journalctl
  | sort -nk1,1 | tail -n10
 ```
 
-`sort -n` will sort in numeric (instead of lexicographic) order. `-k1,1`
-means "sort by only the first whitespace-separated column". The `,n`
-part says "sort until the `n`th field, where the default is the end of
-the line. In this _particular_ example, sorting by the whole line
-wouldn't matter, but we're here to learn!
+`sort -n` akan mengurutkan dalam urutan numerik (bukan leksikografis).
+`-k1,1` berarti "urutkan hanya berdasarkan kolom pertama yang dipisahkan
+oleh whitespace". Bagian `,n` berarti "urutkan hingga bidang ke-`n`,
+di mana defaultnya adalah akhir baris. Dalam contoh _khusus_ ini,
+mengurutkan berdasarkan seluruh baris tidak akan berpengaruh, tetapi
+kita di sini untuk belajar!
 
-If we wanted the _least_ common ones, we could use `head` instead of
-`tail`. There's also `sort -r`, which sorts in reverse order.
+Jika kita ingin yang _paling jarang_ muncul, kita bisa menggunakan `head`
+alih-alih `tail`. Ada juga `sort -r`, yang mengurutkan dalam urutan
+terbalik.
 
-Okay, so that's pretty cool, but what if we'd like to extract only the usernames
-as a comma-separated list instead of one per line, perhaps for a config file?
+Oke, jadi itu cukup keren, tetapi bagaimana jika kita ingin mengekstrak
+hanya nama pengguna sebagai daftar yang dipisahkan koma, bukan satu per
+baris, mungkin untuk file konfigurasi?
 
 ```bash
 ssh myserver journalctl
@@ -262,45 +273,51 @@ ssh myserver journalctl
  | awk '{print $2}' | paste -sd,
 ```
 
-If you're using macOS: note that the command as shown won't work with the BSD
-`paste` shipped with macOS. See [exercise 4 from the shell tools
-lecture](/2020/shell-tools/#exercises) for more on the difference between BSD
-and GNU coreutils and instructions for how to install GNU coreutils on macOS.
+Jika Anda menggunakan macOS: perhatikan bahwa perintah seperti yang
+ditunjukkan tidak akan bekerja dengan `paste` BSD yang disertakan dengan
+macOS. Lihat [latihan 4 dari kuliah shell
+tools](/2020/shell-tools/#exercises) untuk lebih lanjut tentang
+perbedaan antara BSD dan GNU coreutils serta petunjuk cara menginstal
+GNU coreutils di macOS.
 
-Let's start with `paste`: it lets you combine lines (`-s`) by a given
-single-character delimiter (`-d`; `,` in this case). But what's this `awk` business?
+Mari kita mulai dengan `paste`: alat ini memungkinkan Anda menggabungkan
+baris (`-s`) dengan delimiter karakter tunggal (`-d`; `,` dalam kasus
+ini). Tetapi apa urusan `awk` ini?
 
-## awk -- another editor
+## awk -- editor lainnya
 
-`awk` is a programming language that just happens to be really good at
-processing text streams. There is _a lot_ to say about `awk` if you were
-to learn it properly, but as with many other things here, we'll just go
-through the basics.
+`awk` adalah bahasa pemrograman yang kebetulan sangat bagus dalam
+memproses stream teks. Ada _sangat banyak_ yang bisa dikatakan tentang
+`awk` jika Anda mempelajarinya dengan benar, tetapi seperti banyak hal
+lain di sini, kita hanya akan membahas dasar-dasarnya.
 
-First, what does `{print $2}` do? Well, `awk` programs take the form of
-an optional pattern plus a block saying what to do if the pattern
-matches a given line. The default pattern (which we used above) matches
-all lines. Inside the block, `$0` is set to the entire line's contents,
-and `$1` through `$n` are set to the `n`th _field_ of that line, when
-separated by the `awk` field separator (whitespace by default, change
-with `-F`). In this case, we're saying that, for every line, print the
-contents of the second field, which happens to be the username!
+Pertama, apa yang dilakukan `{print $2}`? Well, program `awk` memiliki
+bentuk pola opsional ditambah blok yang menentukan apa yang harus
+dilakukan jika pola cocok dengan baris tertentu. Pola default (yang kita
+gunakan di atas) mencocokkan semua baris. Di dalam blok, `$0` diisi
+dengan seluruh isi baris, dan `$1` hingga `$n` diisi dengan bidang ke-`n`
+dari baris tersebut, ketika dipisahkan oleh field separator `awk`
+(whitespace secara default, ubah dengan `-F`). Dalam kasus ini, kita
+mengatakan bahwa, untuk setiap baris, cetak isi dari bidang kedua, yang
+kebetulan adalah nama pengguna!
 
-Let's see if we can do something fancier. Let's compute the number of
-single-use usernames that start with `c` and end with `e`:
+Mari kita lihat apakah kita bisa melakukan sesuatu yang lebih menarik.
+Mari kita hitung jumlah nama pengguna yang hanya digunakan sekali yang
+dimulai dengan `c` dan diakhiri dengan `e`:
 
 ```bash
  | awk '$1 == 1 && $2 ~ /^c[^ ]*e$/ { print $2 }' | wc -l
 ```
 
-There's a lot to unpack here. First, notice that we now have a pattern
-(the stuff that goes before `{...}`). The pattern says that the first
-field of the line should be equal to 1 (that's the count from `uniq
--c`), and that the second field should match the given regular
-expression. And the block just says to print the username. We then count
-the number of lines in the output with `wc -l`.
+Ada banyak yang harus diurai di sini. Pertama, perhatikan bahwa sekarang
+kita memiliki pola (sesuatu yang ada sebelum `{...}`). Pola tersebut
+mengatakan bahwa bidang pertama baris harus sama dengan 1 (itu adalah
+hitungan dari `uniq -c`), dan bidang kedua harus cocok dengan regular
+expression yang diberikan. Dan blok tersebut hanya mengatakan untuk
+mencetak nama pengguna. Kemudian kita menghitung jumlah baris dalam
+output dengan `wc -l`.
 
-However, `awk` is a programming language, remember?
+Namun, `awk` adalah bahasa pemrograman, ingat?
 
 ```awk
 BEGIN { rows = 0 }
@@ -308,33 +325,34 @@ $1 == 1 && $2 ~ /^c[^ ]*e$/ { rows += $1 }
 END { print rows }
 ```
 
-`BEGIN` is a pattern that matches the start of the input (and `END`
-matches the end). Now, the per-line block just adds the count from the
-first field (although it'll always be 1 in this case), and then we print
-it out at the end. In fact, we _could_ get rid of `grep` and `sed`
-entirely, because `awk` [can do it
-all](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/), but we'll
-leave that as an exercise to the reader.
+`BEGIN` adalah pola yang mencocokkan awal input (dan `END` mencocokkan
+akhir). Sekarang, blok per-baris hanya menambahkan hitungan dari bidang
+pertama (meskipun akan selalu 1 dalam kasus ini), dan kemudian kita
+mencetaknya di akhir. Bahkan, kita _bisa_ menghilangkan `grep` dan `sed`
+sepenuhnya, karena `awk` [bisa melakukan
+semuanya](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/),
+tetapi kita serahkan itu sebagai latihan bagi pembaca.
 
-## Analyzing data
+## Menganalisis data
 
-You can do math directly in your shell using `bc`, a calculator that can read
-from STDIN! For example, add the numbers on each line together by concatenating
-them together, delimited by `+`:
+Anda bisa melakukan perhitungan matematika langsung di shell menggunakan
+`bc`, kalkulator yang bisa membaca dari STDIN! Sebagai contoh, jumlahkan
+angka-angka pada setiap baris dengan menggabungkannya, dipisahkan oleh
+`+`:
 
 ```bash
  | paste -sd+ | bc -l
 ```
 
-Or produce more elaborate expressions:
+Atau buat ekspresi yang lebih rumit:
 
 ```bash
 echo "2*($(data | paste -sd+))" | bc -l
 ```
 
-You can get stats in a variety of ways.
-[`st`](https://github.com/nferraz/st) is pretty neat, but if you already
-have [R](https://www.r-project.org/):
+Anda bisa mendapatkan statistik dengan berbagai cara.
+[`st`](https://github.com/nferraz/st) cukup menarik, tetapi jika Anda
+sudah memiliki [R](https://www.r-project.org/):
 
 ```bash
 ssh myserver journalctl
@@ -345,13 +363,14 @@ ssh myserver journalctl
  | awk '{print $1}' | R --no-echo -e 'x <- scan(file="stdin", quiet=TRUE); summary(x)'
 ```
 
-R is another (weird) programming language that's great at data analysis
-and [plotting](https://ggplot2.tidyverse.org/). We won't go into too
-much detail, but suffice to say that `summary` prints summary statistics
-for a vector, and we created a vector containing the input stream of
-numbers, so R gives us the statistics we wanted!
+R adalah bahasa pemrograman lain (yang aneh) yang sangat bagus untuk
+analisis data dan [plotting](https://ggplot2.tidyverse.org/). Kita tidak
+akan membahas terlalu detail, tetapi cukup dikatakan bahwa `summary`
+mencetak statistik ringkasan untuk sebuah vektor, dan kita membuat vektor
+yang berisi aliran input angka, sehingga R memberikan statistik yang
+kita inginkan!
 
-If you just want some simple plotting, `gnuplot` is your friend:
+Jika Anda hanya ingin plotting sederhana, `gnuplot` adalah teman Anda:
 
 ```bash
 ssh myserver journalctl
@@ -363,28 +382,30 @@ ssh myserver journalctl
  | gnuplot -p -e 'set boxwidth 0.5; plot "-" using 1:xtic(2) with boxes'
 ```
 
-## Data wrangling to make arguments
+## Data wrangling untuk membuat argumen
 
-Sometimes you want to do data wrangling to find things to install or
-remove based on some longer list. The data wrangling we've talked about
-so far + `xargs` can be a powerful combo.
+Terkadang Anda ingin melakukan data wrangling untuk menemukan hal-hal
+yang akan diinstal atau dihapus berdasarkan daftar yang lebih panjang.
+Data wrangling yang telah kita bahas sejauh ini + `xargs` bisa menjadi
+kombinasi yang kuat.
 
-For example, as seen in lecture, I can use the following command to uninstall
-old nightly builds of Rust from my system by extracting the old build names
-using data wrangling tools and then passing them via `xargs` to the
-uninstaller:
+Sebagai contoh, seperti yang terlihat di kuliah, saya bisa menggunakan
+perintah berikut untuk menghapus build nightly lama Rust dari sistem saya
+dengan mengekstrak nama build lama menggunakan alat data wrangling dan
+kemudian melewatkannya melalui `xargs` ke uninstaller:
 
 ```bash
 rustup toolchain list | grep nightly | grep -vE "nightly-x86" | sed 's/-x86.*//' | xargs rustup toolchain uninstall
 ```
 
-## Wrangling binary data
+## Mengolah data biner
 
-So far, we have mostly talked about wrangling textual data, but pipes
-are just as useful for binary data. For example, we can use ffmpeg to
-capture an image from our camera, convert it to grayscale, compress it,
-send it to a remote machine over SSH, decompress it there, make a copy,
-and then display it.
+Sejauh ini, kita sebagian besar telah membahas mengolah data tekstual,
+tetapi pipe sama bergunanya untuk data biner. Sebagai contoh, kita bisa
+menggunakan ffmpeg untuk mengambil gambar dari kamera kita, mengubahnya
+menjadi grayscale, mengompresnya, mengirimkannya ke mesin remote melalui
+SSH, mendekompresnya di sana, membuat salinan, dan kemudian
+menampilkannya.
 
 ```bash
 ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
@@ -393,57 +414,54 @@ ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
  | ssh mymachine 'gzip -d | tee copy.jpg | env DISPLAY=:0 feh -'
 ```
 
-# Exercises
+# Latihan
 
-1. Take this [short interactive regex tutorial](https://regexone.com/).
-2. Find the number of words (in `/usr/share/dict/words`) that contain at
-   least three `a`s and don't have a `'s` ending. What are the three
-   most common last two letters of those words? `sed`'s `y` command, or
-   the `tr` program, may help you with case insensitivity. How many
-   of those two-letter combinations are there? And for a challenge:
-   which combinations do not occur?
-3. To do in-place substitution it is quite tempting to do something like
-   `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`. However this is a
-   bad idea, why? Is this particular to `sed`? Use `man sed` to find out
-   how to accomplish this.
-4. Find your average, median, and max system boot time over the last ten
-   boots. Use `journalctl` on Linux and `log show` on macOS, and look
-   for log timestamps near the beginning and end of each boot. On Linux,
-   they may look something like:
+1. Ikuti [tutorial interaktif singkat tentang regex](https://regexone.com/) ini.
+2. Temukan jumlah kata (dalam `/usr/share/dict/words`) yang mengandung
+   setidaknya tiga `a` dan tidak berakhiran `'s`. Apa tiga kombinasi dua
+   huruf terakhir yang paling umum dari kata-kata tersebut? Perintah `y`
+   dari `sed`, atau program `tr`, mungkin membantu Anda untuk case
+   insensitivity. Berapa banyak kombinasi dua huruf yang ada? Dan untuk
+   tantangan: kombinasi mana yang tidak muncul?
+3. Untuk melakukan substitusi in-place, sangat menggoda untuk melakukan
+   sesuatu seperti `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`.
+   Namun ini adalah ide buruk, mengapa? Apakah ini khusus untuk `sed`?
+   Gunakan `man sed` untuk mencari tahu cara melakukannya.
+4. Temukan rata-rata, median, dan max waktu boot sistem Anda selama
+   sepuluh boot terakhir. Gunakan `journalctl` di Linux dan `log show`
+   di macOS, dan cari timestamp log dekat awal dan akhir setiap boot.
+   Di Linux, mungkin terlihat seperti:
    ```
    Logs begin at ...
    ```
-   and
+   dan
    ```
    systemd[577]: Startup finished in ...
    ```
-   On macOS, [look
-   for](https://eclecticlight.co/2018/03/21/macos-unified-log-3-finding-your-way/):
+   Di macOS, [cari](https://eclecticlight.co/2018/03/21/macos-unified-log-3-finding-your-way/):
    ```
    === system boot:
    ```
-   and
+   dan
    ```
    Previous shutdown cause: 5
    ```
-5. Look for boot messages that are _not_ shared between your past three
-   reboots (see `journalctl`'s `-b` flag). Break this task down into
-   multiple steps. First, find a way to get just the logs from the past
-   three boots. There may be an applicable flag on the tool you use to
-   extract the boot logs, or you can use `sed '0,/STRING/d'` to remove
-   all lines previous to one that matches `STRING`. Next, remove any
-   parts of the line that _always_ varies (like the timestamp). Then,
-   de-duplicate the input lines and keep a count of each one (`uniq` is
-   your friend). And finally, eliminate any line whose count is 3 (since
-   it _was_ shared among all the boots).
-6. Find an online data set like [this
-   one](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab), [this
-   one](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1),
-   or maybe one [from
-   here](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/).
-   Fetch it using `curl` and extract out just two columns of numerical
-   data. If you're fetching HTML data,
-   [`pup`](https://github.com/EricChiang/pup) might be helpful. For JSON
-   data, try [`jq`](https://stedolan.github.io/jq/). Find the min and
-   max of one column in a single command, and the difference of the sum
-   of each column in another.
+5. Cari pesan boot yang _tidak_ dibagi antara tiga reboot terakhir Anda
+   (lihat flag `-b` dari `journalctl`). Pecah tugas ini menjadi beberapa
+   langkah. Pertama, temukan cara untuk mendapatkan hanya log dari tiga
+   boot terakhir. Mungkin ada flag yang berlaku pada alat yang Anda
+   gunakan untuk mengekstrak log boot, atau Anda bisa menggunakan
+   `sed '0,/STRING/d'` untuk menghapus semua baris sebelum baris yang
+   cocok dengan `STRING`. Selanjutnya, hapus bagian baris yang _selalu_
+   bervariasi (seperti timestamp). Kemudian, hapus duplikasi baris input
+   dan simpan hitungan masing-masing (`uniq` adalah teman Anda). Dan
+   terakhir, hilangkan baris yang hitungannya 3 (karena _ada_ di semua
+   boot).
+6. Cari dataset online seperti [yang ini](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab),
+   [yang ini](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1),
+   atau mungkin [dari sini](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/).
+   Ambil menggunakan `curl` dan ekstrak hanya dua kolom data numerik.
+   Jika Anda mengambil data HTML, [`pup`](https://github.com/EricChiang/pup)
+   mungkin membantu. Untuk data JSON, coba [`jq`](https://stedolan.github.io/jq/).
+   Temukan min dan max dari satu kolom dalam satu perintah, dan selisih
+   jumlah dari masing-masing kolom di perintah lain.

--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -12,69 +12,38 @@ video:
 special: true
 ---
 
-Have you ever wanted to take data in one format and turn it into a
-different format? Of course you have! That, in very general terms, is
-what this lecture is all about. Specifically, massaging data, whether in
-text or binary format, until you end up with exactly what you wanted.
+Apakah Anda pernah ingin mengambil data dalam satu format dan mengubahnya menjadi format yang berbeda? Tentu saja pernah! Secara umum, itulah yang menjadi pembahasan utama kuliah ini. Secara khusus, mengolah data, baik dalam format teks maupun biner, hingga Anda mendapatkan hasil yang tepat sesuai keinginan.
 
-We've already seen some basic data wrangling in past lectures. Pretty
-much any time you use the `|` operator, you are performing some kind of
-data wrangling. Consider a command like `journalctl | grep -i intel`. It
-finds all system log entries that mention Intel (case insensitive). You
-may not think of it as wrangling data, but it is going from one format
-(your entire system log) to a format that is more useful to you (just
-the intel log entries). Most data wrangling is about knowing what tools
-you have at your disposal, and how to combine them.
+Kita sudah pernah melihat beberapa dasar data wrangling di kuliah-kuliah sebelumnya. Hampir setiap kali Anda menggunakan operator `|`, Anda sedang melakukan suatu bentuk data wrangling. Perhatikan perintah seperti `journalctl | grep -i intel`. Perintah tersebut mencari semua entri log sistem yang menyebutkan Intel (tanpa membedakan huruf besar/kecil). Anda mungkin tidak menganggapnya sebagai wrangling data, tetapi proses ini mengubah dari satu format (seluruh log sistem Anda) menjadi format yang lebih berguna bagi Anda (hanya entri log intel). Sebagian besar data wrangling berkaitan dengan mengetahui tools apa saja yang Anda miliki dan bagaimana cara menggabungkannya.
 
-Let's start from the beginning. To wrangle data, we need two things:
-data to wrangle, and something to do with it. Logs often make for a good
-use-case, because you often want to investigate things about them, and
-reading the whole thing isn't feasible. Let's figure out who's trying to
-log into my server by looking at my server's log:
+Mari kita mulai dari awal. Untuk melakukan wrangling data, kita membutuhkan dua hal: data untuk diolah, dan sesuatu untuk dilakukan dengan data tersebut. Log sering kali menjadi kasus penggunaan yang baik, karena Anda sering ingin menyelidiki sesuatu tentang log tersebut, dan membaca seluruhnya tidak feasibel. Mari kita cari tahu siapa yang mencoba masuk ke server saya dengan melihat log server saya:
 
 ```bash
 ssh myserver journalctl
 ```
 
-That's far too much stuff. Let's limit it to ssh stuff:
+Itu terlalu banyak datanya. Mari kita batasi hanya untuk ssh:
 
 ```bash
 ssh myserver journalctl | grep sshd
 ```
 
-Notice that we're using a pipe to stream a _remote_ file through `grep`
-on our local computer! `ssh` is magical, and we will talk more about it
-in the next lecture on the command-line environment. This is still way
-more stuff than we wanted though. And pretty hard to read. Let's do
-better:
+Perhatikan bahwa kita menggunakan pipe untuk mengalirkan file _remote_ melalui `grep` di komputer lokal kita! `ssh` memang ajaib, dan kita akan membahas lebih lanjut tentang hal ini di kuliah berikutnya mengenai command-line environment. Meskipun demikian, ini masih jauh lebih banyak data dari yang kita inginkan. Dan cukup sulit dibaca. Mari kita lakukan yang lebih baik:
 
 ```bash
 ssh myserver 'journalctl | grep sshd | grep "Disconnected from"' | less
 ```
 
-Why the additional quoting? Well, our logs may be quite large, and it's
-wasteful to stream it all to our computer and then do the filtering.
-Instead, we can do the filtering on the remote server, and then massage
-the data locally. `less` gives us a "pager" that allows us to scroll up
-and down through the long output. To save some additional traffic while
-we debug our command-line, we can even stick the current filtered logs
-into a file so that we don't have to access the network while
-developing:
+Mengapa ada quoting tambahan? Well, log kita bisa sangat besar, dan tidak efisien untuk mengalirkan semuanya ke komputer kita lalu melakukan filtering. Sebaliknya, kita bisa melakukan filtering di server remote, dan kemudian mengolah datanya secara lokal. `less` memberikan kita "pager" yang memungkinkan kita menggulir ke atas dan ke bawah melalui output yang panjang. Untuk menghemat lalu lintas jaringan tambahan saat kita men-debug command-line, kita bahkan bisa menyimpan log yang sudah difilter ke dalam file sehingga kita tidak perlu mengakses jaringan selama pengembangan:
 
 ```console
 $ ssh myserver 'journalctl | grep sshd | grep "Disconnected from"' > ssh.log
 $ less ssh.log
 ```
 
-There's still a lot of noise here. There are _a lot_ of ways to get rid
-of that, but let's look at one of the most powerful tools in your
-toolkit: `sed`.
+Masih ada banyak noise di sini. Ada _sangat banyak_ cara untuk menghilangkannya, tetapi mari kita lihat salah satu tools paling kuat dalam toolkit Anda: `sed`.
 
-`sed` is a "stream editor" that builds on top of the old `ed` editor. In
-it, you basically give short commands for how to modify the file, rather
-than manipulate its contents directly (although you can do that too).
-There are tons of commands, but one of the most common ones is `s`:
-substitution. For example, we can write:
+`sed` adalah "stream editor" yang dibangun di atas editor `ed` lama. Di dalamnya, Anda pada dasarnya memberikan perintah-perintah singkat untuk memodifikasi file, alih-alih memanipulasi isinya secara langsung (meskipun Anda juga bisa melakukannya). Ada banyak sekali perintah, tetapi salah satu yang paling umum adalah `s`: substitution. Sebagai contoh, kita bisa menulis:
 
 ```bash
 ssh myserver journalctl
@@ -83,124 +52,67 @@ ssh myserver journalctl
  | sed 's/.*Disconnected from //'
 ```
 
-What we just wrote was a simple _regular expression_; a powerful
-construct that lets you match text against patterns. The `s` command is
-written in the form: `s/REGEX/SUBSTITUTION/`, where `REGEX` is the
-regular expression you want to search for, and `SUBSTITUTION` is the
-text you want to substitute matching text with.
+Apa yang baru saja kita tulis adalah sebuah _regular expression_ sederhana; sebuah konstruksi kuat yang memungkinkan Anda mencocokkan teks terhadap pola. Perintah `s` ditulis dalam bentuk: `s/REGEX/SUBSTITUTION/`, di mana `REGEX` adalah regular expression yang ingin Anda cari, dan `SUBSTITUTION` adalah teks yang ingin Anda substitusikan untuk teks yang cocok.
 
-(You may recognize this syntax from the "Search and replace" section of our Vim
-[lecture notes](/2020/editors/#advanced-vim)! Indeed, Vim uses a syntax for
-searching and replacing that is similar to `sed`'s substitution command.
-Learning one tool often helps you become more proficient with others.)
+(Anda mungkin mengenali sintaks ini dari bagian "Search and replace" di [catatan kuliah](/2020/editors/#advanced-vim) Vim kita! Memang, Vim menggunakan sintaks untuk mencari dan mengganti yang mirip dengan perintah substitution `sed`. Mempelajari satu tools sering kali membantu Anda menjadi lebih mahir dengan tools lainnya.)
 
 ## Regular expressions
 
-Regular expressions are common and useful enough that it's worthwhile to
-take some time to understand how they work. Let's start by looking at
-the one we used above: `/.*Disconnected from /`. Regular expressions are
-usually (though not always) surrounded by `/`. Most ASCII characters
-just carry their normal meaning, but some characters have "special"
-matching behavior. Exactly which characters do what vary somewhat
-between different implementations of regular expressions, which is a
-source of great frustration. Very common patterns are:
+Regular expressions cukup umum dan berguna sehingga layak untuk meluangkan waktu memahami cara kerjanya. Mari kita mulai dengan melihat yang kita gunakan di atas: `/.*Disconnected from /`. Regular expressions biasanya (meskipun tidak selalu) dikelilingi oleh `/`. Sebagian besar karakter ASCII membawa makna normalnya, tetapi beberapa karakter memiliki perilaku pencocokan "spesial". Tepatnya karakter mana yang melakukan apa bervariasi antar implementasi regular expressions yang berbeda, yang menjadi sumber frustrasi besar. Pola-pola yang sangat umum adalah:
 
- - `.` means "any single character" except newline
- - `*` zero or more of the preceding match
- - `+` one or more of the preceding match
- - `[abc]` any one character of `a`, `b`, and `c`
- - `(RX1|RX2)` either something that matches `RX1` or `RX2`
- - `^` the start of the line
- - `$` the end of the line
+ - `.` berarti "satu karakter apa pun" kecuali newline
+ - `*` nol atau lebih dari pencocokan sebelumnya
+ - `+` satu atau lebih dari pencocokan sebelumnya
+ - `[abc]` salah satu karakter dari `a`, `b`, dan `c`
+ - `(RX1|RX2)` mencocokkan `RX1` atau `RX2`
+ - `^` awal dari baris
+ - `$` akhir dari baris
 
-`sed`'s regular expressions are somewhat weird, and will require you to
-put a `\` before most of these to give them their special meaning. Or
-you can pass `-E`.
+Regular expressions milik `sed` agak aneh, dan akan mengharuskan Anda menempatkan `\` sebelum sebagian besar karakter ini untuk memberikan makna khususnya. Atau Anda bisa menggunakan `-E`.
 
-So, looking back at `/.*Disconnected from /`, we see that it matches
-any text that starts with any number of characters, followed by the
-literal string "Disconnected from &rdquo;. Which is what we wanted. But
-beware, regular expressions are tricky. What if someone tried to log in
-with the username "Disconnected from"? We'd have:
+Jadi, melihat kembali `/.*Disconnected from /`, kita melihat bahwa ini mencocokkan teks apa pun yang dimulai dengan sejumlah karakter, diikuti oleh string literal "Disconnected from &rdquo;. Itulah yang kita inginkan. Tetapi hati-hati, regular expressions bisa rumit. Bagaimana jika seseorang mencoba masuk dengan username "Disconnected from"? Kita akan mendapatkan:
 
 ```
 Jan 17 03:13:00 thesquareplanet.com sshd[2631]: Disconnected from invalid user Disconnected from 46.97.239.16 port 55920 [preauth]
 ```
 
-What would we end up with? Well, `*` and `+` are, by default, "greedy".
-They will match as much text as they can. So, in the above, we'd end up
-with just
+Apa yang akan kita dapatkan? Well, `*` dan `+` secara default bersifat "greedy". Mereka akan mencocokkan sebanyak mungkin teks. Jadi, pada contoh di atas, kita akan mendapatkan
 
 ```
 46.97.239.16 port 55920 [preauth]
 ```
 
-Which may not be what we wanted. In some regular expression
-implementations, you can just suffix `*` or `+` with a `?` to make them
-non-greedy, but sadly `sed` doesn't support that. We _could_ switch to
-perl's command-line mode though, which _does_ support that construct:
+Yang mungkin bukan yang kita inginkan. Dalam beberapa implementasi regular expression, Anda bisa menambahkan sufiks `?` pada `*` atau `+` untuk membuatnya non-greedy, tetapi sayangnya `sed` tidak mendukung konstruk tersebut. Kita _bisa_ beralih ke mode command-line perl, yang _mendukung_ konstruk tersebut:
 
 ```bash
 perl -pe 's/.*?Disconnected from //'
 ```
 
-We'll stick to `sed` for the rest of this, because it's by far the more
-common tool for these kinds of jobs. `sed` can also do other handy
-things like print lines following a given match, do multiple
-substitutions per invocation, search for things, etc. But we won't cover
-that too much here. `sed` is basically an entire topic in and of itself,
-but there are often better tools.
+Kita akan tetap menggunakan `sed` untuk sisa pembahasan ini, karena ini adalah tools yang jauh lebih umum untuk pekerjaan semacam ini. `sed` juga bisa melakukan hal-hal berguna lainnya seperti mencetak baris setelah pencocokan tertentu, melakukan beberapa substitusi dalam satu pemanggilan, mencari sesuatu, dll. Tetapi kita tidak akan membahasnya terlalu banyak di sini. `sed` pada dasarnya merupakan topik tersendiri, tetapi sering kali ada tools yang lebih baik.
 
-Okay, so we also have a suffix we'd like to get rid of. How might we do
-that? It's a little tricky to match just the text that follows the
-username, especially if the username can have spaces and such! What we
-need to do is match the _whole_ line:
+Oke, jadi kita juga memiliki sufiks yang ingin kita hilangkan. Bagaimana cara melakukannya? Agak sulit untuk mencocokkan hanya teks yang mengikuti username, terutama jika username bisa mengandung spasi dan sejenisnya! Yang perlu kita lakukan adalah mencocokkan _seluruh_ baris:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user .* [^ ]+ port [0-9]+( \[preauth\])?$//'
 ```
 
-Let's look at what's going on with a [regex
-debugger](https://regex101.com/r/qqbZqh/2). Okay, so the start is still
-as before. Then, we're matching any of the "user" variants (there are
-two prefixes in the logs). Then we're matching on any string of
-characters where the username is. Then we're matching on any single word
-(`[^ ]+`; any non-empty sequence of non-space characters). Then the word
-"port" followed by a sequence of digits. Then possibly the suffix
-`[preauth]`, and then the end of the line.
+Mari kita lihat apa yang terjadi dengan [regex debugger](https://regex101.com/r/qqbZqh/2). Oke, jadi bagian awalnya masih sama seperti sebelumnya. Kemudian, kita mencocokkan salah satu varian "user" (ada dua prefix dalam log). Kemudian kita mencocokkan string karakter apa pun di mana username berada. Kemudian kita mencocokkan satu kata apa pun (`[^ ]+`; urutan karakter non-spasi yang tidak kosong). Kemudian kata "port" diikuti oleh urutan digit. Kemudian mungkin sufiks `[preauth]`, dan kemudian akhir baris.
 
-Notice that with this technique, a username of "Disconnected from"
-won't confuse us any more. Can you see why?
+Perhatikan bahwa dengan teknik ini, username "Disconnected from" tidak akan membingungkan kita lagi. Bisakah Anda melihat mengapa?
 
-There is one problem with this though, and that is that the entire log
-becomes empty. We want to _keep_ the username after all. For this, we
-can use "capture groups". Any text matched by a regex surrounded by
-parentheses is stored in a numbered capture group. These are available
-in the substitution (and in some engines, even in the pattern itself!)
-as `\1`, `\2`, `\3`, etc. So:
+Ada satu masalah dengan ini, yaitu seluruh log menjadi kosong. Kita ingin _menyimpan_ username setelah semuanya. Untuk ini, kita bisa menggunakan "capture groups". Teks apa pun yang dicocokkan oleh regex yang dikelilingi oleh tanda kurung disimpan dalam capture group bernomor. Ini tersedia dalam substitusi (dan dalam beberapa engine, bahkan dalam pola itu sendiri!) sebagai `\1`, `\2`, `\3`, dst. Jadi:
 
 ```bash
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-As you can probably imagine, you can come up with _really_ complicated
-regular expressions. For example, here's an article on how you might
-match an [e-mail
-address](https://www.regular-expressions.info/email.html). It's [not
-easy](https://web.archive.org/web/20221223174323/http://emailregex.com/). And there's [lots of
-discussion](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982).
-And people have [written
-tests](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php).
-And [test matrices](https://mathiasbynens.be/demo/url-regex). You can
-even write a regex for determining if a given number [is a prime
-number](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
+Seperti yang bisa Anda bayangkan, Anda bisa membuat regular expression yang _sangat_ rumit. Sebagai contoh, berikut adalah artikel tentang bagaimana Anda bisa mencocokkan [alamat email](https://www.regular-expressions.info/email.html). Ini [tidak mudah](https://web.archive.org/web/20221223174323/http://emailregex.com/). Dan ada [banyak diskusi](https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression/1917982). Dan orang-orang telah [menulis tes](https://fightingforalostcause.net/content/misc/2006/compare-email-regex.php). Dan [matriks tes](https://mathiasbynens.be/demo/url-regex). Anda bahkan bisa menulis regex untuk menentukan apakah suatu bilangan [adalah bilangan prima](https://www.noulakaz.net/2007/03/18/a-regular-expression-to-check-for-prime-numbers/).
 
-Regular expressions are notoriously hard to get right, but they are also
-very handy to have in your toolbox!
+Regular expressions terkenal sulit untuk dibuat dengan benar, tetapi juga sangat berguna untuk dimiliki di toolkit Anda!
 
-## Back to data wrangling
+## Kembali ke data wrangling
 
-Okay, so we now have
+Oke, jadi sekarang kita punya
 
 ```bash
 ssh myserver journalctl
@@ -209,14 +121,9 @@ ssh myserver journalctl
  | sed -E 's/.*Disconnected from (invalid |authenticating )?user (.*) [^ ]+ port [0-9]+( \[preauth\])?$/\2/'
 ```
 
-`sed` can do all sorts of other interesting things, like injecting text
-(with the `i` command), explicitly printing lines (with the `p`
-command), selecting lines by index, and lots of other things. Check `man
-sed`!
+`sed` bisa melakukan berbagai hal menarik lainnya, seperti menyisipkan teks (dengan perintah `i`), mencetak baris secara eksplisit (dengan perintah `p`), memilih baris berdasarkan indeks, dan banyak hal lainnya. Cek `man sed`!
 
-Anyway. What we have now gives us a list of all the usernames that have
-attempted to log in. But this is pretty unhelpful. Let's look for common
-ones:
+Bagaimanapun. Yang kita miliki sekarang memberikan daftar semua username yang pernah mencoba masuk. Tetapi ini cukup tidak berguna. Mari kita cari yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -226,10 +133,7 @@ ssh myserver journalctl
  | sort | uniq -c
 ```
 
-`sort` will, well, sort its input. `uniq -c` will collapse consecutive
-lines that are the same into a single line, prefixed with a count of the
-number of occurrences. We probably want to sort that too and only keep
-the most common usernames:
+`sort` akan, sesuai namanya, mengurutkan inputnya. `uniq -c` akan menggabungkan baris-baris berurutan yang sama menjadi satu baris, dengan prefiks berupa jumlah kemunculan. Kita mungkin ingin mengurutkannya juga dan hanya menyimpan username yang paling umum:
 
 ```bash
 ssh myserver journalctl
@@ -240,17 +144,11 @@ ssh myserver journalctl
  | sort -nk1,1 | tail -n10
 ```
 
-`sort -n` will sort in numeric (instead of lexicographic) order. `-k1,1`
-means "sort by only the first whitespace-separated column". The `,n`
-part says "sort until the `n`th field, where the default is the end of
-the line. In this _particular_ example, sorting by the whole line
-wouldn't matter, but we're here to learn!
+`sort -n` akan mengurutkan dalam urutan numerik (bukan leksikografik). `-k1,1` berarti "urutkan hanya berdasarkan kolom pertama yang dipisahkan oleh whitespace". Bagian `,n` berarti "urutkan hingga field ke-`n`, di mana defaultnya adalah akhir baris. Dalam contoh _khusus_ ini, mengurutkan berdasarkan seluruh baris tidak akan berpengaruh, tetapi kita di sini untuk belajar!
 
-If we wanted the _least_ common ones, we could use `head` instead of
-`tail`. There's also `sort -r`, which sorts in reverse order.
+Jika kita ingin yang _paling jarang_ muncul, kita bisa menggunakan `head` alih-alih `tail`. Ada juga `sort -r`, yang mengurutkan dalam urutan terbalik.
 
-Okay, so that's pretty cool, but what if we'd like to extract only the usernames
-as a comma-separated list instead of one per line, perhaps for a config file?
+Oke, jadi itu cukup keren, tetapi bagaimana jika kita ingin mengekstrak hanya username sebagai daftar yang dipisahkan koma alih-alih satu per baris, mungkin untuk file konfigurasi?
 
 ```bash
 ssh myserver journalctl
@@ -262,45 +160,25 @@ ssh myserver journalctl
  | awk '{print $2}' | paste -sd,
 ```
 
-If you're using macOS: note that the command as shown won't work with the BSD
-`paste` shipped with macOS. See [exercise 4 from the shell tools
-lecture](/2020/shell-tools/#exercises) for more on the difference between BSD
-and GNU coreutils and instructions for how to install GNU coreutils on macOS.
+Jika Anda menggunakan macOS: perhatikan bahwa perintah seperti yang ditunjukkan tidak akan bekerja dengan `paste` BSD yang disertakan dengan macOS. Lihat [latihan 4 dari kuliah shell tools](/2020/shell-tools/#exercises) untuk lebih lanjut tentang perbedaan antara BSD dan GNU coreutils serta petunjuk cara menginstal GNU coreutils di macOS.
 
-Let's start with `paste`: it lets you combine lines (`-s`) by a given
-single-character delimiter (`-d`; `,` in this case). But what's this `awk` business?
+Mari kita mulai dengan `paste`: tools ini memungkinkan Anda menggabungkan baris (`-s`) dengan delimiter karakter tunggal (`-d`; `,` dalam kasus ini). Tetapi apa urusan `awk` ini?
 
-## awk -- another editor
+## awk -- editor lainnya
 
-`awk` is a programming language that just happens to be really good at
-processing text streams. There is _a lot_ to say about `awk` if you were
-to learn it properly, but as with many other things here, we'll just go
-through the basics.
+`awk` adalah bahasa pemrograman yang kebetulan sangat bagus dalam memproses stream teks. Ada _sangat banyak_ yang bisa dikatakan tentang `awk` jika Anda mempelajarinya dengan sungguh-sungguh, tetapi seperti banyak hal lainnya di sini, kita hanya akan melewati dasar-dasarnya.
 
-First, what does `{print $2}` do? Well, `awk` programs take the form of
-an optional pattern plus a block saying what to do if the pattern
-matches a given line. The default pattern (which we used above) matches
-all lines. Inside the block, `$0` is set to the entire line's contents,
-and `$1` through `$n` are set to the `n`th _field_ of that line, when
-separated by the `awk` field separator (whitespace by default, change
-with `-F`). In this case, we're saying that, for every line, print the
-contents of the second field, which happens to be the username!
+Pertama, apa yang dilakukan `{print $2}`? Well, program `awk` memiliki bentuk pola opsional ditambah blok yang menentukan apa yang harus dilakukan jika pola cocok dengan baris tertentu. Pola default (yang kita gunakan di atas) mencocokkan semua baris. Di dalam blok, `$0` diisi dengan seluruh isi baris, dan `$1` hingga `$n` diisi dengan field ke-`n` dari baris tersebut, ketika dipisahkan oleh field separator `awk` (whitespace secara default, ubah dengan `-F`). Dalam kasus ini, kita mengatakan bahwa, untuk setiap baris, cetak isi field kedua, yang kebetulan adalah username!
 
-Let's see if we can do something fancier. Let's compute the number of
-single-use usernames that start with `c` and end with `e`:
+Mari kita lihat apakah kita bisa melakukan sesuatu yang lebih canggih. Mari kita hitung jumlah username sekali pakai yang dimulai dengan `c` dan diakhiri dengan `e`:
 
 ```bash
  | awk '$1 == 1 && $2 ~ /^c[^ ]*e$/ { print $2 }' | wc -l
 ```
 
-There's a lot to unpack here. First, notice that we now have a pattern
-(the stuff that goes before `{...}`). The pattern says that the first
-field of the line should be equal to 1 (that's the count from `uniq
--c`), and that the second field should match the given regular
-expression. And the block just says to print the username. We then count
-the number of lines in the output with `wc -l`.
+Ada banyak yang harus diurai di sini. Pertama, perhatikan bahwa sekarang kita memiliki pola (bagian yang berada sebelum `{...}`). Pola tersebut mengatakan bahwa field pertama baris harus sama dengan 1 (itu adalah hitungan dari `uniq -c`), dan field kedua harus cocok dengan regular expression yang diberikan. Dan blok tersebut hanya mengatakan untuk mencetak username. Kemudian kita menghitung jumlah baris dalam output dengan `wc -l`.
 
-However, `awk` is a programming language, remember?
+Namun, `awk` adalah bahasa pemrograman, ingat?
 
 ```awk
 BEGIN { rows = 0 }
@@ -308,33 +186,23 @@ $1 == 1 && $2 ~ /^c[^ ]*e$/ { rows += $1 }
 END { print rows }
 ```
 
-`BEGIN` is a pattern that matches the start of the input (and `END`
-matches the end). Now, the per-line block just adds the count from the
-first field (although it'll always be 1 in this case), and then we print
-it out at the end. In fact, we _could_ get rid of `grep` and `sed`
-entirely, because `awk` [can do it
-all](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/), but we'll
-leave that as an exercise to the reader.
+`BEGIN` adalah pola yang mencocokkan awal input (dan `END` mencocokkan akhir). Sekarang, blok per-baris hanya menambahkan hitungan dari field pertama (meskipun akan selalu 1 dalam kasus ini), dan kemudian kita mencetaknya di akhir. Bahkan, kita _bisa_ menghilangkan `grep` dan `sed` sepenuhnya, karena `awk` [bisa melakukan semuanya](https://web.archive.org/web/20251210045942/https://backreference.org/2010/02/10/idiomatic-awk/), tetapi kita serahkan itu sebagai latihan bagi pembaca.
 
-## Analyzing data
+## Menganalisis data
 
-You can do math directly in your shell using `bc`, a calculator that can read
-from STDIN! For example, add the numbers on each line together by concatenating
-them together, delimited by `+`:
+Anda bisa melakukan perhitungan matematika langsung di shell Anda menggunakan `bc`, kalkulator yang bisa membaca dari STDIN! Sebagai contoh, jumlahkan angka-angka pada setiap baris dengan menggabungkannya, dipisahkan oleh `+`:
 
 ```bash
  | paste -sd+ | bc -l
 ```
 
-Or produce more elaborate expressions:
+Atau buat ekspresi yang lebih rumit:
 
 ```bash
 echo "2*($(data | paste -sd+))" | bc -l
 ```
 
-You can get stats in a variety of ways.
-[`st`](https://github.com/nferraz/st) is pretty neat, but if you already
-have [R](https://www.r-project.org/):
+Anda bisa mendapatkan statistik dalam berbagai cara. [`st`](https://github.com/nferraz/st) cukup bagus, tetapi jika Anda sudah memiliki [R](https://www.r-project.org/):
 
 ```bash
 ssh myserver journalctl
@@ -345,13 +213,9 @@ ssh myserver journalctl
  | awk '{print $1}' | R --no-echo -e 'x <- scan(file="stdin", quiet=TRUE); summary(x)'
 ```
 
-R is another (weird) programming language that's great at data analysis
-and [plotting](https://ggplot2.tidyverse.org/). We won't go into too
-much detail, but suffice to say that `summary` prints summary statistics
-for a vector, and we created a vector containing the input stream of
-numbers, so R gives us the statistics we wanted!
+R adalah bahasa pemrograman lain (yang aneh) yang sangat hebat dalam analisis data dan [plotting](https://ggplot2.tidyverse.org/). Kita tidak akan membahas terlalu detail, tetapi cukup dikatakan bahwa `summary` mencetak statistik ringkasan untuk sebuah vektor, dan kita membuat vektor yang berisi stream input angka, sehingga R memberikan statistik yang kita inginkan!
 
-If you just want some simple plotting, `gnuplot` is your friend:
+Jika Anda hanya ingin plotting sederhana, `gnuplot` adalah teman Anda:
 
 ```bash
 ssh myserver journalctl
@@ -363,28 +227,19 @@ ssh myserver journalctl
  | gnuplot -p -e 'set boxwidth 0.5; plot "-" using 1:xtic(2) with boxes'
 ```
 
-## Data wrangling to make arguments
+## Data wrangling untuk membuat argumen
 
-Sometimes you want to do data wrangling to find things to install or
-remove based on some longer list. The data wrangling we've talked about
-so far + `xargs` can be a powerful combo.
+Terkadang Anda ingin melakukan data wrangling untuk menemukan hal-hal yang perlu diinstal atau dihapus berdasarkan daftar yang lebih panjang. Data wrangling yang telah kita bahas sejauh ini + `xargs` bisa menjadi kombinasi yang kuat.
 
-For example, as seen in lecture, I can use the following command to uninstall
-old nightly builds of Rust from my system by extracting the old build names
-using data wrangling tools and then passing them via `xargs` to the
-uninstaller:
+Sebagai contoh, seperti yang terlihat di kuliah, saya bisa menggunakan perintah berikut untuk menghapus nightly build Rust lama dari sistem saya dengan mengekstrak nama build lama menggunakan tools data wrangling dan kemudian melewatkannya melalui `xargs` ke uninstaller:
 
 ```bash
 rustup toolchain list | grep nightly | grep -vE "nightly-x86" | sed 's/-x86.*//' | xargs rustup toolchain uninstall
 ```
 
-## Wrangling binary data
+## Wrangling data biner
 
-So far, we have mostly talked about wrangling textual data, but pipes
-are just as useful for binary data. For example, we can use ffmpeg to
-capture an image from our camera, convert it to grayscale, compress it,
-send it to a remote machine over SSH, decompress it there, make a copy,
-and then display it.
+Sejauh ini, kita sebagian besar membahas wrangling data tekstual, tetapi pipe sama bergunanya untuk data biner. Sebagai contoh, kita bisa menggunakan ffmpeg untuk menangkap gambar dari kamera kita, mengonversinya ke grayscale, mengompresnya, mengirimkannya ke mesin remote melalui SSH, mendekompresnya di sana, membuat salinan, dan kemudian menampilkannya.
 
 ```bash
 ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
@@ -393,57 +248,26 @@ ffmpeg -loglevel panic -i /dev/video0 -frames 1 -f image2 -
  | ssh mymachine 'gzip -d | tee copy.jpg | env DISPLAY=:0 feh -'
 ```
 
-# Exercises
+# Latihan
 
-1. Take this [short interactive regex tutorial](https://regexone.com/).
-2. Find the number of words (in `/usr/share/dict/words`) that contain at
-   least three `a`s and don't have a `'s` ending. What are the three
-   most common last two letters of those words? `sed`'s `y` command, or
-   the `tr` program, may help you with case insensitivity. How many
-   of those two-letter combinations are there? And for a challenge:
-   which combinations do not occur?
-3. To do in-place substitution it is quite tempting to do something like
-   `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`. However this is a
-   bad idea, why? Is this particular to `sed`? Use `man sed` to find out
-   how to accomplish this.
-4. Find your average, median, and max system boot time over the last ten
-   boots. Use `journalctl` on Linux and `log show` on macOS, and look
-   for log timestamps near the beginning and end of each boot. On Linux,
-   they may look something like:
+1. Ikuti [tutorial interaktif regex singkat](https://regexone.com/) ini.
+2. Temukan jumlah kata (dalam `/usr/share/dict/words`) yang mengandung setidaknya tiga `a` dan tidak berakhiran `'s`. Apa tiga kombinasi dua huruf terakhir yang paling umum dari kata-kata tersebut? Perintah `y` milik `sed`, atau program `tr`, mungkin bisa membantu Anda untuk case insensitivity. Berapa banyak kombinasi dua huruf yang ada? Dan untuk tantangan: kombinasi mana yang tidak muncul?
+3. Untuk melakukan substitusi in-place, sangat menggoda untuk melakukan sesuatu seperti `sed s/REGEX/SUBSTITUTION/ input.txt > input.txt`. Namun ini adalah ide yang buruk, mengapa? Apakah ini khusus untuk `sed`? Gunakan `man sed` untuk mengetahui cara melakukannya.
+4. Temukan waktu boot sistem rata-rata, median, dan maks dari sepuluh boot terakhir. Gunakan `journalctl` di Linux dan `log show` di macOS, dan cari timestamp log dekat awal dan akhir setiap boot. Di Linux, mungkin terlihat seperti:
    ```
    Logs begin at ...
    ```
-   and
+   dan
    ```
    systemd[577]: Startup finished in ...
    ```
-   On macOS, [look
-   for](https://eclecticlight.co/2018/03/21/macos-unified-log-3-finding-your-way/):
+   Di macOS, [cari](https://eclecticlight.co/2018/03/21/macos-unified-log-3-finding-your-way/):
    ```
    === system boot:
    ```
-   and
+   dan
    ```
    Previous shutdown cause: 5
    ```
-5. Look for boot messages that are _not_ shared between your past three
-   reboots (see `journalctl`'s `-b` flag). Break this task down into
-   multiple steps. First, find a way to get just the logs from the past
-   three boots. There may be an applicable flag on the tool you use to
-   extract the boot logs, or you can use `sed '0,/STRING/d'` to remove
-   all lines previous to one that matches `STRING`. Next, remove any
-   parts of the line that _always_ varies (like the timestamp). Then,
-   de-duplicate the input lines and keep a count of each one (`uniq` is
-   your friend). And finally, eliminate any line whose count is 3 (since
-   it _was_ shared among all the boots).
-6. Find an online data set like [this
-   one](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab), [this
-   one](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1),
-   or maybe one [from
-   here](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/).
-   Fetch it using `curl` and extract out just two columns of numerical
-   data. If you're fetching HTML data,
-   [`pup`](https://github.com/EricChiang/pup) might be helpful. For JSON
-   data, try [`jq`](https://stedolan.github.io/jq/). Find the min and
-   max of one column in a single command, and the difference of the sum
-   of each column in another.
+5. Cari pesan boot yang _tidak_ dibagi antara tiga reboot terakhir Anda (lihat flag `-b` milik `journalctl`). Pecah tugas ini menjadi beberapa langkah. Pertama, temukan cara untuk mendapatkan hanya log dari tiga boot terakhir. Mungkin ada flag yang berlaku pada tools yang Anda gunakan untuk mengekstrak log boot, atau Anda bisa menggunakan `sed '0,/STRING/d'` untuk menghapus semua baris sebelum baris yang cocok dengan `STRING`. Selanjutnya, hapus bagian-bagian baris yang _selalu_ bervariasi (seperti timestamp). Kemudian, hilangkan duplikasi baris input dan simpan hitungan masing-masing (`uniq` adalah teman Anda). Dan terakhir, hilangkan baris mana pun yang hitungannya 3 (karena _memang_ dibagi di semua boot).
+6. Cari dataset online seperti [yang ini](https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab), [yang ini](https://ucr.fbi.gov/crime-in-the-u.s/2016/crime-in-the-u.s.-2016/topic-pages/tables/table-1), atau mungkin [dari sini](https://www.springboard.com/blog/data-science/free-public-data-sets-data-science-project/). Ambil menggunakan `curl` dan ekstrak hanya dua kolom data numerik. Jika Anda mengambil data HTML, [`pup`](https://github.com/EricChiang/pup) mungkin berguna. Untuk data JSON, coba [`jq`](https://stedolan.github.io/jq/). Temukan min dan maks dari satu kolom dalam satu perintah, dan selisih jumlah dari masing-masing kolom di perintah lainnya.

--- a/_2020/data-wrangling.md
+++ b/_2020/data-wrangling.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Data Wrangling"
 description: >
-  Learn how to manipulate and transform data using command-line tools like sed, awk, and regular expressions.
+  Pelajari cara memanipulasi dan mentransformasi data menggunakan tools command-line seperti sed, awk, dan regular expressions.
 thumbnail: /static/assets/thumbnails/2020/lec4.png
 date: 2020-01-16
 ready: true

--- a/_2020/debugging-profiling.md
+++ b/_2020/debugging-profiling.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Debugging and Profiling"
+title: "Debugging dan Profiling"
 description: >
-  Learn how to debug programs using logging, debuggers, and static analysis, and how to profile code for performance.
+  Pelajari cara men-debug program menggunakan logging, debugger, dan analisis statis, serta cara memprofil kode untuk performa.
 thumbnail: /static/assets/thumbnails/2020/lec7.png
 date: 2020-01-23
 ready: true
@@ -11,25 +11,23 @@ video:
   id: l812pUnKxME
 ---
 
-A golden rule in programming is that code does not do what you expect it to do, but what you tell it to do.
-Bridging that gap can sometimes be a quite difficult feat.
-In this lecture we are going to cover useful techniques for dealing with buggy and resource hungry code: debugging and profiling.
+Aturan emas dalam pemrograman adalah kode tidak melakukan apa yang Anda harapkan, melainkan apa yang Anda perintahkan. Menjembatani kesenjangan tersebut terkadang bisa menjadi hal yang cukup sulit. Dalam kuliah ini kita akan membahas teknik-teknik berguna untuk menangani kode yang bermasalah dan boros sumber daya: debugging dan profiling.
 
 # Debugging
 
-## Printf debugging and Logging
+## Printf debugging dan Logging
 
-"The most effective debugging tool is still careful thought, coupled with judiciously placed print statements" — Brian Kernighan, _Unix for Beginners_.
+"Alat debugging yang paling efektif tetaplah pemikiran yang cermat, dipadukan dengan pernyataan print yang ditempatkan secara bijaksana" — Brian Kernighan, _Unix for Beginners_.
 
-A first approach to debug a program is to add print statements around where you have detected the problem, and keep iterating until you have extracted enough information to understand what is responsible for the issue.
+Pendekatan pertama untuk men-debug program adalah dengan menambahkan pernyataan print di sekitar bagian yang Anda deteksi bermasalah, dan terus melakukan iterasi hingga Anda mengekstrak cukup informasi untuk memahami apa yang menyebabkan masalah tersebut.
 
-A second approach is to use logging in your program, instead of ad hoc print statements. Logging is better than regular print statements for several reasons:
+Pendekatan kedua adalah menggunakan logging dalam program Anda, alih-alih pernyataan print yang bersifat ad hoc. Logging lebih baik daripada pernyataan print biasa karena beberapa alasan:
 
-- You can log to files, sockets or even remote servers instead of standard output.
-- Logging supports severity levels (such as INFO, DEBUG, WARN, ERROR, &c), that allow you to filter the output accordingly.
-- For new issues, there's a fair chance that your logs will contain enough information to detect what is going wrong.
+- Anda dapat melakukan log ke file, socket, atau bahkan server jarak jauh alih-alih standard output.
+- Logging mendukung level tingkat keparahan (seperti INFO, DEBUG, WARN, ERROR, &c), yang memungkinkan Anda memfilter output sesuai kebutuhan.
+- Untuk masalah baru, ada kemungkinan besar log Anda akan berisi cukup informasi untuk mendeteksi apa yang salah.
 
-[Here](/static/files/logger.py) is an example code that logs messages:
+[Berikut](/static/files/logger.py) contoh kode yang melakukan log pesan:
 
 ```bash
 $ python logger.py
@@ -42,11 +40,9 @@ $ python logger.py color
 # Color formatted output
 ```
 
-One of my favorite tips for making logs more readable is to color code them.
-By now you probably have realized that your terminal uses colors to make things more readable. But how does it do it?
-Programs like `ls` or `grep` are using [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code), which are special sequences of characters to indicate your shell to change the color of the output. For example, executing `echo -e "\e[38;2;255;0;0mThis is red\e[0m"` prints the message `This is red` in red on your terminal, as long as it supports [true color](https://github.com/termstandard/colors#truecolor-support-in-output-devices). If your terminal doesn't support this (e.g. macOS's Terminal.app), you can use the more universally supported escape codes for 16 color choices, for example `echo -e "\e[31;1mThis is red\e[0m"`.
+Salah satu tips favorit saya untuk membuat log lebih mudah dibaca adalah memberi kode warna. Sampai saat ini Anda mungkin sudah menyadari bahwa terminal Anda menggunakan warna untuk membuat semuanya lebih mudah dibaca. Tapi bagaimana cara kerjanya? Program seperti `ls` atau `grep` menggunakan [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code), yaitu urutan karakter khusus untuk memberi instruksi kepada shell agar mengubah warna output. Sebagai contoh, menjalankan `echo -e "\e[38;2;255;0;0mThis is red\e[0m"` akan mencetak pesan `This is red` berwarna merah pada terminal Anda, selama terminal tersebut mendukung [true color](https://github.com/termstandard/colors#truecolor-support-in-output-devices). Jika terminal Anda tidak mendukung hal ini (misalnya Terminal.app di macOS), Anda dapat menggunakan escape codes yang lebih universal untuk 16 pilihan warna, misalnya `echo -e "\e[31;1mThis is red\e[0m"`.
 
-The following script shows how to print many RGB colors into your terminal (again, as long as it supports true color).
+Skrip berikut menunjukkan cara mencetak banyak warna RGB ke terminal Anda (sekali lagi, selama mendukung true color).
 
 ```bash
 #!/usr/bin/env bash
@@ -59,24 +55,13 @@ for R in $(seq 0 20 255); do
 done
 ```
 
-## Third party logs
+## Log pihak ketiga
 
-As you start building larger software systems you will most probably run into dependencies that run as separate programs.
-Web servers, databases or message brokers are common examples of this kind of dependencies.
-When interacting with these systems it is often necessary to read their logs, since client side error messages might not suffice.
+Saat Anda mulai membangun sistem perangkat lunak yang lebih besar, Anda kemungkinan besar akan menemukan dependensi yang berjalan sebagai program terpisah. Server web, database, atau message broker adalah contoh umum dari jenis dependensi ini. Saat berinteraksi dengan sistem-sistem ini, seringkali perlu untuk membaca log mereka, karena pesan error dari sisi klien mungkin tidak cukup.
 
-Luckily, most programs write their own logs somewhere in your system.
-In UNIX systems, it is commonplace for programs to write their logs under `/var/log`.
-For instance, the [NGINX](https://www.nginx.com/) webserver places its logs under `/var/log/nginx`.
-More recently, systems have started using a **system log**, which is increasingly where all of your log messages go.
-Most (but not all) Linux systems use `systemd`, a system daemon that controls many things in your system such as which services are enabled and running.
-`systemd` places the logs under `/var/log/journal` in a specialized format and you can use the [`journalctl`](https://www.man7.org/linux/man-pages/man1/journalctl.1.html) command to display the messages.
-Similarly, on macOS there is still `/var/log/system.log` but an increasing number of tools use the system log, that can be displayed with [`log show`](https://www.manpagez.com/man/1/log/).
-On most UNIX systems you can also use the [`dmesg`](https://www.man7.org/linux/man-pages/man1/dmesg.1.html) command to access the kernel log.
+Untungnya, sebagian besar program menulis log mereka di suatu tempat dalam sistem Anda. Di sistem UNIX, umumnya program menulis log mereka di bawah `/var/log`. Sebagai contoh, web server [NGINX](https://www.nginx.com/) menyimpan log-nya di `/var/log/nginx`. Belakangan ini, sistem-sistem mulai menggunakan **system log**, yang semakin menjadi tempat semua pesan log Anda masuk. Sebagian besar (tetapi tidak semua) sistem Linux menggunakan `systemd`, sebuah system daemon yang mengontrol banyak hal dalam sistem Anda seperti layanan mana yang diaktifkan dan berjalan. `systemd` menyimpan log di bawah `/var/log/journal` dalam format khusus dan Anda dapat menggunakan perintah [`journalctl`](https://www.man7.org/linux/man-pages/man1/journalctl.1.html) untuk menampilkan pesan-pesan tersebut. Demikian pula, di macOS masih ada `/var/log/system.log` tetapi semakin banyak alat yang menggunakan system log, yang dapat ditampilkan dengan [`log show`](https://www.manpagez.com/man/1/log/). Di sebagian besar sistem UNIX Anda juga dapat menggunakan perintah [`dmesg`](https://www.man7.org/linux/man-pages/man1/dmesg.1.html) untuk mengakses log kernel.
 
-For logging under the system logs you can use the [`logger`](https://www.man7.org/linux/man-pages/man1/logger.1.html) shell program.
-Here's an example of using `logger` and how to check that the entry made it to the system logs.
-Moreover, most programming languages have bindings logging to the system log.
+Untuk logging ke system logs Anda dapat menggunakan program shell [`logger`](https://www.man7.org/linux/man-pages/man1/logger.1.html). Berikut contoh penggunaan `logger` dan cara memeriksa bahwa entri tersebut masuk ke system logs. Selain itu, sebagian besar bahasa pemrograman memiliki binding untuk melakukan logging ke system log.
 
 ```bash
 logger "Hello Logs"
@@ -86,35 +71,31 @@ log show --last 1m | grep Hello
 journalctl --since "1m ago" | grep Hello
 ```
 
-As we saw in the data wrangling lecture, logs can be quite verbose and they require some level of processing and filtering to get the information you want.
-If you find yourself heavily filtering through `journalctl` and `log show` you can consider using their flags, which can perform a first pass of filtering of their output.
-There are also some tools like  [`lnav`](https://lnav.org/), that provide an improved presentation and navigation for log files.
+Seperti yang kita lihat di kuliah data wrangling, log bisa sangat panjang dan memerlukan beberapa tingkat pemrosesan serta penyaringan untuk mendapatkan informasi yang Anda inginkan. Jika Anda sering melakukan penyaringan melalui `journalctl` dan `log show`, Anda dapat mempertimbangkan untuk menggunakan flag-flag mereka, yang dapat melakukan penyaringan awal terhadap output mereka. Ada juga beberapa alat seperti [`lnav`](https://lnav.org/), yang menyediakan presentasi dan navigasi yang lebih baik untuk file log.
 
-## Debuggers
+## Debugger
 
-When printf debugging is not enough you should use a debugger.
-Debuggers are programs that let you interact with the execution of a program, allowing the following:
+Ketika printf debugging tidak cukup, Anda harus menggunakan debugger. Debugger adalah program yang memungkinkan Anda berinteraksi dengan eksekusi suatu program, yang memungkinkan hal-hal berikut:
 
-- Halt execution of the program when it reaches a certain line.
-- Step through the program one instruction at a time.
-- Inspect values of variables after the program crashed.
-- Conditionally halt the execution when a given condition is met.
-- And many more advanced features
+- Menghentikan eksekusi program saat mencapai baris tertentu.
+- Menjalankan program satu instruksi pada satu waktu.
+- Memeriksa nilai variabel setelah program crash.
+- Menghentikan eksekusi secara kondisional ketika suatu kondisi terpenuhi.
+- Dan banyak fitur lanjutan lainnya
 
-Many programming languages come with some form of debugger.
-In Python this is the Python Debugger [`pdb`](https://docs.python.org/3/library/pdb.html).
+Banyak bahasa pemrograman yang dilengkapi dengan semacam debugger. Dalam Python, ini adalah Python Debugger [`pdb`](https://docs.python.org/3/library/pdb.html).
 
-Here is a brief description of some of the commands `pdb` supports:
+Berikut deskripsi singkat beberapa perintah yang didukung `pdb`:
 
-- **l**(ist) - Displays 11 lines around the current line or continue the previous listing.
-- **s**(tep) - Execute the current line, stop at the first possible occasion.
-- **n**(ext) - Continue execution until the next line in the current function is reached or it returns.
-- **b**(reak) - Set a breakpoint (depending on the argument provided).
-- **p**(rint) - Evaluate the expression in the current context and print its value. There's also **pp** to display using [`pprint`](https://docs.python.org/3/library/pprint.html) instead.
-- **r**(eturn) - Continue execution until the current function returns.
-- **q**(uit) - Quit the debugger.
+- **l**(ist) - Menampilkan 11 baris di sekitar baris saat ini atau melanjutkan listing sebelumnya.
+- **s**(tep) - Menjalankan baris saat ini, berhenti di kesempatan pertama yang memungkinkan.
+- **n**(ext) - Melanjutkan eksekusi hingga baris berikutnya dalam fungsi saat ini tercapai atau fungsi tersebut kembali.
+- **b**(reak) - Mengatur breakpoint (tergantung pada argumen yang diberikan).
+- **p**(rint) - Mengevaluasi ekspresi dalam konteks saat ini dan mencetak nilainya. Ada juga **pp** untuk menampilkan menggunakan [`pprint`](https://docs.python.org/3/library/pprint.html) sebagai gantinya.
+- **r**(eturn) - Melanjutkan eksekusi hingga fungsi saat ini kembali.
+- **q**(uit) - Keluar dari debugger.
 
-Let's go through an example of using `pdb` to fix the following buggy python code. (See the lecture video).
+Mari kita lihat contoh penggunaan `pdb` untuk memperbaiki kode Python yang bermasalah berikut. (Lihat video kuliah).
 
 ```python
 def bubble_sort(arr):
@@ -130,20 +111,16 @@ print(bubble_sort([4, 2, 1, 8, 7, 6]))
 ```
 
 
-Note that since Python is an interpreted language we can use the `pdb` shell to execute commands and to execute instructions.
-[`ipdb`](https://pypi.org/project/ipdb/) is an improved `pdb` that uses the [`IPython`](https://ipython.org) REPL enabling tab completion, syntax highlighting, better tracebacks, and better introspection while retaining the same interface as the `pdb` module.
+Perhatikan bahwa karena Python adalah bahasa interpreted, kita dapat menggunakan shell `pdb` untuk menjalankan perintah dan mengeksekusi instruksi. [`ipdb`](https://pypi.org/project/ipdb/) adalah `pdb` yang lebih baik yang menggunakan REPL [`IPython`](https://ipython.org) yang memungkinkan tab completion, syntax highlighting, traceback yang lebih baik, dan introspeksi yang lebih baik sambil tetap mempertahankan antarmuka yang sama dengan modul `pdb`.
 
-For more low level programming you will probably want to look into [`gdb`](https://www.gnu.org/software/gdb/) (and its quality of life modification [`pwndbg`](https://github.com/pwndbg/pwndbg)) and [`lldb`](https://lldb.llvm.org/).
-They are optimized for C-like language debugging but will let you probe pretty much any process and get its current machine state: registers, stack, program counter, &c.
+Untuk pemrograman yang lebih low level, Anda mungkin ingin melihat [`gdb`](https://www.gnu.org/software/gdb/) (dan modifikasi quality of life-nya [`pwndbg`](https://github.com/pwndbg/pwndbg)) dan [`lldb`](https://lldb.llvm.org/). Keduanya dioptimalkan untuk debugging bahasa mirip C tetapi memungkinkan Anda memeriksa hampir semua proses dan mendapatkan status mesin saat ini: register, stack, program counter, &c.
 
 
-## Specialized Tools
+## Alat-Alat Khusus
 
-Even if what you are trying to debug is a black box binary there are tools that can help you with that.
-Whenever programs need to perform actions that only the kernel can, they use [System Calls](https://en.wikipedia.org/wiki/System_call).
-There are commands that let you trace the syscalls your program makes. In Linux there's [`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) and macOS and BSD have [`dtrace`](https://dtrace.org/about/). `dtrace` can be tricky to use because it uses its own `D` language, but there is a wrapper called [`dtruss`](https://www.manpagez.com/man/1/dtruss/) that provides an interface more similar to `strace` (more details [here](https://8thlight.com/blog/colin-jones/2015/11/06/dtrace-even-better-than-strace-for-osx.html)).
+Bahkan jika apa yang Anda coba debug adalah biner black box, ada alat yang dapat membantu Anda. Setiap kali program perlu melakukan tindakan yang hanya bisa dilakukan oleh kernel, mereka menggunakan [System Calls](https://en.wikipedia.org/wiki/System_call). Ada perintah yang memungkinkan Anda menelusuri syscalls yang dibuat program Anda. Di Linux ada [`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) dan macOS serta BSD memiliki [`dtrace`](https://dtrace.org/about/). `dtrace` bisa rumit untuk digunakan karena menggunakan bahasa `D` tersendiri, tetapi ada wrapper bernama [`dtruss`](https://www.manpagez.com/man/1/dtruss/) yang menyediakan antarmuka yang lebih mirip dengan `strace` (detail lebih lanjut [di sini](https://8thlight.com/blog/colin-jones/2015/11/06/dtrace-even-better-than-strace-for-osx.html)).
 
-Below are some examples of using `strace` or `dtruss` to show [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) syscall traces for an execution of `ls`. For a deeper dive into `strace`, [this article](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) and [this zine](https://jvns.ca/strace-zine-unfolded.pdf) are good reads.
+Berikut beberapa contoh penggunaan `strace` atau `dtruss` untuk menampilkan jejak syscall [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) dari eksekusi `ls`. Untuk pembahasan lebih mendalam tentang `strace`, [artikel ini](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) dan [zine ini](https://jvns.ca/strace-zine-unfolded.pdf) adalah bacaan yang bagus.
 
 ```bash
 # On Linux
@@ -152,25 +129,20 @@ sudo strace -e lstat ls -l > /dev/null
 sudo dtruss -t lstat64_extended ls -l > /dev/null
 ```
 
-Under some circumstances, you may need to look at the network packets to figure out the issue in your program.
-Tools like [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) and [Wireshark](https://www.wireshark.org/) are network packet analyzers that let you read the contents of network packets and filter them based on different criteria.
+Dalam beberapa kondisi, Anda mungkin perlu melihat paket jaringan untuk menemukan masalah dalam program Anda. Alat seperti [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) dan [Wireshark](https://www.wireshark.org/) adalah network packet analyzer yang memungkinkan Anda membaca isi paket jaringan dan memfilternya berdasarkan berbagai kriteria.
 
-For web development, the Chrome/Firefox developer tools are quite handy. They feature a large number of tools, including:
-- Source code - Inspect the HTML/CSS/JS source code of any website.
-- Live HTML, CSS, JS modification - Change the website content, styles and behavior to test (you can see for yourself that website screenshots are not valid proofs).
-- Javascript shell - Execute commands in the JS REPL.
-- Network - Analyze the requests timeline.
-- Storage - Look into the Cookies and local application storage.
+Untuk pengembangan web, developer tools Chrome/Firefox sangat berguna. Alat-alat ini memiliki banyak perangkat, termasuk:
+- Source code - Memeriksa kode sumber HTML/CSS/JS dari situs web mana pun.
+- Live HTML, CSS, JS modification - Mengubah konten, gaya, dan perilaku situs web untuk pengujian (Anda bisa melihat sendiri bahwa screenshot situs web bukan bukti yang valid).
+- Javascript shell - Menjalankan perintah di JS REPL.
+- Network - Menganalisis timeline request.
+- Storage - Melihat Cookies dan penyimpanan aplikasi lokal.
 
-## Static Analysis
+## Analisis Statis
 
-For some issues you do not need to run any code.
-For example, just by carefully looking at a piece of code you could realize that your loop variable is shadowing an already existing variable or function name; or that a program reads a variable before defining it.
-Here is where [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis) tools come into play.
-Static analysis programs take source code as input and analyze it using coding rules to reason about its correctness.
+Untuk beberapa masalah, Anda tidak perlu menjalankan kode sama sekali. Misalnya, hanya dengan melihat kode secara cermat Anda bisa menyadari bahwa variabel loop Anda membayangi variabel atau nama fungsi yang sudah ada sebelumnya; atau bahwa sebuah program membaca variabel sebelum mendefinisikannya. Di sinilah alat [analisis statis](https://en.wikipedia.org/wiki/Static_program_analysis) berperan. Program analisis statis menerima kode sumber sebagai input dan menganalisisnya menggunakan aturan-aturan coding untuk menilai kebenarannya.
 
-In the following Python snippet there are several mistakes.
-First, our loop variable `foo` shadows the previous definition of the function `foo`. We also wrote `baz` instead of `bar` in the last line, so the program will crash after completing the `sleep` call (which will take one minute).
+Pada potongan Python berikut terdapat beberapa kesalahan. Pertama, variabel loop kita `foo` membayangi definisi fungsi `foo` sebelumnya. Kita juga menulis `baz` alih-alih `bar` di baris terakhir, sehingga program akan crash setelah menyelesaikan pemanggilan `sleep` (yang akan memakan waktu satu menit).
 
 ```python
 import time
@@ -186,8 +158,7 @@ time.sleep(60)
 print(baz)
 ```
 
-Static analysis tools can identify these kinds of issues. When we run [`pyflakes`](https://pypi.org/project/pyflakes) on the code we get the errors related to both bugs. [`mypy`](https://mypy-lang.org/) is another tool that can detect type checking issues. Here, `mypy` will warn us that `bar` is initially an `int` and is then casted to a `float`.
-Again, note that all these issues were detected without having to run the code.
+Alat analisis statis dapat mengidentifikasi masalah-masalah semacam ini. Ketika kita menjalankan [`pyflakes`](https://pypi.org/project/pyflakes) pada kode tersebut, kita mendapatkan error terkait kedua bug. [`mypy`](https://mypy-lang.org/) adalah alat lain yang dapat mendeteksi masalah type checking. Di sini, `mypy` akan memperingatkan kita bahwa `bar` awalnya adalah `int` dan kemudian di-cast menjadi `float`. Sekali lagi, perhatikan bahwa semua masalah ini terdeteksi tanpa harus menjalankan kode.
 
 ```bash
 $ pyflakes foobar.py
@@ -201,29 +172,21 @@ foobar.py:11: error: Name 'baz' is not defined
 Found 3 errors in 1 file (checked 1 source file)
 ```
 
-In the shell tools lecture we covered [`shellcheck`](https://www.shellcheck.net/), which is a similar tool for shell scripts.
+Di kuliah shell tools kita telah membahas [`shellcheck`](https://www.shellcheck.net/), yang merupakan alat serupa untuk shell script.
 
-Most editors and IDEs support displaying the output of these tools within the editor itself, highlighting the locations of warnings and errors.
-This is often called **code linting** and it can also be used to display other types of issues such as stylistic violations or insecure constructs.
+Sebagian besar editor dan IDE mendukung menampilkan output dari alat-alat ini dalam editor itu sendiri, menyoroti lokasi peringatan dan error. Ini sering disebut **code linting** dan juga dapat digunakan untuk menampilkan jenis masalah lain seperti pelanggaran gaya atau konstruksi yang tidak aman.
 
-In vim, the plugins [`ale`](https://vimawesome.com/plugin/ale) or [`syntastic`](https://vimawesome.com/plugin/syntastic) will let you do that.
-For Python, [`pylint`](https://github.com/PyCQA/pylint) and [`pep8`](https://pypi.org/project/pep8/) are examples of stylistic linters and [`bandit`](https://pypi.org/project/bandit/) is a tool designed to find common security issues.
-For other languages people have compiled comprehensive lists of useful static analysis tools, such as [Awesome Static Analysis](https://github.com/mre/awesome-static-analysis) (you may want to take a look at the _Writing_ section) and for linters there is [Awesome Linters](https://github.com/caramelomartins/awesome-linters).
+Di vim, plugin [`ale`](https://vimawesome.com/plugin/ale) atau [`syntastic`](https://vimawesome.com/plugin/syntastic) akan memungkinkan Anda melakukan hal itu. Untuk Python, [`pylint`](https://github.com/PyCQA/pylint) dan [`pep8`](https://pypi.org/project/pep8/) adalah contoh linter gaya dan [`bandit`](https://pypi.org/project/bandit/) adalah alat yang dirancang untuk menemukan masalah keamanan umum. Untuk bahasa lain, orang-orang telah menyusun daftar komprehensif alat analisis statis yang berguna, seperti [Awesome Static Analysis](https://github.com/mre/awesome-static-analysis) (Anda mungkin ingin melihat bagian _Writing_) dan untuk linter ada [Awesome Linters](https://github.com/caramelomartins/awesome-linters).
 
-A complementary tool to stylistic linting are code formatters such as [`black`](https://github.com/psf/black) for Python, `gofmt` for Go, `rustfmt` for Rust or [`prettier`](https://prettier.io/) for JavaScript, HTML and CSS.
-These tools autoformat your code so that it's consistent with common stylistic patterns for the given programming language.
-Although you might be unwilling to give stylistic control about your code, standardizing code format will help other people read your code and will make you better at reading other people's (stylistically standardized) code.
+Alat pelengkap untuk stylistic linting adalah code formatter seperti [`black`](https://github.com/psf/black) untuk Python, `gofmt` untuk Go, `rustfmt` untuk Rust, atau [`prettier`](https://prettier.io/) untuk JavaScript, HTML, dan CSS. Alat-alat ini memformat kode Anda secara otomatis sehingga konsisten dengan pola gaya umum untuk bahasa pemrograman tertentu. Meskipun Anda mungkin enggan menyerahkan kontrol gaya tentang kode Anda, menstandarisasi format kode akan membantu orang lain membaca kode Anda dan akan membuat Anda lebih baik dalam membaca kode orang lain (yang telah distandarisasi secara gaya).
 
 # Profiling
 
-Even if your code functionally behaves as you would expect, that might not be good enough if it takes all your CPU or memory in the process.
-Algorithms classes often teach big _O_ notation but not how to find hot spots in your programs.
-Since [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), you should learn about profilers and monitoring tools. They will help you understand which parts of your program are taking most of the time and/or resources so you can focus on optimizing those parts.
+Bahkan jika kode Anda secara fungsional berperilaku seperti yang Anda harapkan, itu mungkin tidak cukup baik jika memakan semua CPU atau memori Anda dalam prosesnya. Kelas algoritma sering mengajarkan notasi big _O_ tetapi tidak cara menemukan hot spot dalam program Anda. Karena [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), Anda harus mempelajari profiler dan alat monitoring. Mereka akan membantu Anda memahami bagian mana dari program Anda yang memakan sebagian besar waktu dan/atau sumber daya sehingga Anda dapat fokus mengoptimalkan bagian-bagian tersebut.
 
 ## Timing
 
-Similarly to the debugging case, in many scenarios it can be enough to just print the time it took your code between two points.
-Here is an example in Python using the [`time`](https://docs.python.org/3/library/time.html) module.
+Sama seperti kasus debugging, dalam banyak skenario cukup dengan mencetak waktu yang dibutuhkan kode Anda antara dua titik. Berikut contoh di Python menggunakan modul [`time`](https://docs.python.org/3/library/time.html).
 
 ```python
 import time, random
@@ -244,13 +207,13 @@ print(time.time() - start)
 # 0.5713930130004883
 ```
 
-However, wall clock time can be misleading since your computer might be running other processes at the same time or waiting for events to happen. It is common for tools to make a distinction between _Real_, _User_ and _Sys_ time. In general, _User_ + _Sys_ tells you how much time your process actually spent in the CPU (more detailed explanation [here](https://stackoverflow.com/questions/556405/what-do-real-user-and-sys-mean-in-the-output-of-time1)).
+Namun, wall clock time bisa menyesatkan karena komputer Anda mungkin menjalankan proses lain pada saat yang sama atau menunggu peristiwa terjadi. Alat-alat biasanya membedakan antara waktu _Real_, _User_, dan _Sys_. Secara umum, _User_ + _Sys_ memberi tahu Anda berapa banyak waktu yang sebenarnya dihabiskan proses Anda di CPU (penjelasan lebih detail [di sini](https://stackoverflow.com/questions/556405/what-do-real-user-and-sys-mean-in-the-output-of-time1)).
 
-- _Real_ - Wall clock elapsed time from start to finish of the program, including the time taken by other processes and time taken while blocked (e.g. waiting for I/O or network)
-- _User_ - Amount of time spent in the CPU running user code
-- _Sys_ - Amount of time spent in the CPU running kernel code
+- _Real_ - Waktu wall clock yang berlalu dari awal hingga akhir program, termasuk waktu yang dihabiskan oleh proses lain dan waktu saat diblokir (misalnya menunggu I/O atau jaringan)
+- _User_ - Jumlah waktu yang dihabiskan di CPU untuk menjalankan kode user
+- _Sys_ - Jumlah waktu yang dihabiskan di CPU untuk menjalankan kode kernel
 
-For example, try running a command that performs an HTTP request and prefixing it with [`time`](https://www.man7.org/linux/man-pages/man1/time.1.html). Under a slow connection you might get an output like the one below. Here it took over 2 seconds for the request to complete but the process only took 15ms of CPU user time and 12ms of kernel CPU time.
+Sebagai contoh, coba jalankan perintah yang melakukan request HTTP dan awali dengan [`time`](https://www.man7.org/linux/man-pages/man1/time.1.html). Pada koneksi lambat Anda mungkin mendapatkan output seperti di bawah ini. Di sini dibutuhkan lebih dari 2 detik untuk request selesai tetapi proses hanya menggunakan 15ms waktu CPU user dan 12ms waktu CPU kernel.
 
 ```bash
 $ time curl https://missing.csail.mit.edu &> /dev/null
@@ -259,20 +222,15 @@ user    0m0.015s
 sys     0m0.012s
 ```
 
-## Profilers
+## Profiler
 
 ### CPU
 
-Most of the time when people refer to _profilers_ they actually mean _CPU profilers_,  which are the most common.
-There are two main types of CPU profilers: _tracing_ and _sampling_ profilers.
-Tracing profilers keep a record of every function call your program makes whereas sampling profilers probe your program periodically (commonly every millisecond) and record the program's stack.
-They use these records to present aggregate statistics of what your program spent the most time doing.
-[Here](https://jvns.ca/blog/2017/12/17/how-do-ruby---python-profilers-work-) is a good intro article if you want more detail on this topic.
+Sebagian besar waktu ketika orang menyebut _profiler_, mereka sebenarnya berarti _CPU profiler_, yang merupakan yang paling umum. Ada dua jenis utama CPU profiler: profiler _tracing_ dan _sampling_. Tracing profiler menyimpan catatan setiap pemanggilan fungsi yang dibuat program Anda, sedangkan sampling profiler memeriksa program Anda secara berkala (umumnya setiap milidetik) dan merekam stack program. Mereka menggunakan catatan ini untuk menyajikan statistik agregat tentang apa yang paling banyak dilakukan program Anda. [Berikut](https://jvns.ca/blog/2017/12/17/how-do-ruby---python-profilers-work-) artikel pengantar yang bagus jika Anda ingin detail lebih lanjut tentang topik ini.
 
-Most programming languages have some sort of command line profiler that you can use to analyze your code.
-They often integrate with full fledged IDEs but for this lecture we are going to focus on the command line tools themselves.
+Sebagian besar bahasa pemrograman memiliki semacam profiler command line yang dapat Anda gunakan untuk menganalisis kode Anda. Mereka sering terintegrasi dengan IDE lengkap tetapi untuk kuliah ini kita akan fokus pada alat command line itu sendiri.
 
-In Python we can use the `cProfile` module to profile time per function call. Here is a simple example that implements a rudimentary grep in Python:
+Di Python kita dapat menggunakan modul `cProfile` untuk memprofil waktu per pemanggilan fungsi. Berikut contoh sederhana yang mengimplementasikan grep dasar di Python:
 
 ```python
 #!/usr/bin/env python
@@ -296,7 +254,7 @@ if __name__ == '__main__':
             grep(pattern, file)
 ```
 
-We can profile this code using the following command. Analyzing the output we can see that IO is taking most of the time and that compiling the regex takes a fair amount of time as well. Since the regex only needs to be compiled once, we can factor it out of the for.
+Kita dapat memprofil kode ini menggunakan perintah berikut. Menganalisis output, kita dapat melihat bahwa IO memakan sebagian besar waktu dan bahwa kompilasi regex juga memakan waktu yang cukup banyak. Karena regex hanya perlu dikompilasi sekali, kita dapat memfaktorkannya keluar dari for.
 
 ```
 $ python -m cProfile -s tottime grep.py 1000 '^(import|\s*def)[^,]*$' *.py
@@ -318,10 +276,9 @@ $ python -m cProfile -s tottime grep.py 1000 '^(import|\s*def)[^,]*$' *.py
 ```
 
 
-A caveat of Python's `cProfile` profiler (and many profilers for that matter) is that they display time per function call. That can become unintuitive really fast, especially if you are using third party libraries in your code since internal function calls are also accounted for.
-A more intuitive way of displaying profiling information is to include the time taken per line of code, which is what _line profilers_ do.
+Catatan tentang profiler `cProfile` Python (dan banyak profiler lainnya) adalah mereka menampilkan waktu per pemanggilan fungsi. Hal ini bisa menjadi tidak intuitif dengan cepat, terutama jika Anda menggunakan pustaka pihak ketiga dalam kode Anda karena pemanggilan fungsi internal juga diperhitungkan. Cara yang lebih intuitif untuk menampilkan informasi profiling adalah dengan menyertakan waktu yang dihabiskan per baris kode, yang merupakan apa yang dilakukan _line profiler_.
 
-For instance, the following piece of Python code performs a request to the class website and parses the response to get all URLs in the page:
+Sebagai contoh, potongan kode Python berikut melakukan request ke situs web kelas dan mengurai respons untuk mendapatkan semua URL di halaman:
 
 ```python
 #!/usr/bin/env python
@@ -342,7 +299,7 @@ if __name__ == '__main__':
     get_urls()
 ```
 
-If we used Python's `cProfile` profiler we'd get over 2500 lines of output, and even with sorting it'd be hard to understand where the time is being spent. A quick run with [`line_profiler`](https://github.com/pyutils/line_profiler) shows the time taken per line:
+Jika kita menggunakan profiler `cProfile` Python, kita akan mendapatkan lebih dari 2500 baris output, dan bahkan dengan pengurutan akan sulit memahami di mana waktu dihabiskan. Jalankan cepat dengan [`line_profiler`](https://github.com/pyutils/line_profiler) menunjukkan waktu yang dihabiskan per baris:
 
 ```bash
 $ kernprof -l -v a.py
@@ -364,13 +321,11 @@ Line #  Hits         Time  Per Hit   % Time  Line Contents
 11        24         33.0      1.4      0.0          urls.append(url['href'])
 ```
 
-### Memory
+### Memori
 
-In languages like C or C++ memory leaks can cause your program to never release memory that it doesn't need anymore.
-To help in the process of memory debugging you can use tools like [Valgrind](https://valgrind.org/) that will help you identify memory leaks.
+Dalam bahasa seperti C atau C++, memory leak dapat menyebabkan program Anda tidak pernah melepaskan memori yang tidak lagi dibutuhkan. Untuk membantu dalam proses debugging memori, Anda dapat menggunakan alat seperti [Valgrind](https://valgrind.org/) yang akan membantu Anda mengidentifikasi memory leak.
 
-In garbage collected languages like Python it is still useful to use a memory profiler because as long as you have pointers to objects in memory they won't be garbage collected.
-Here's an example program and its associated output when running it with [memory-profiler](https://pypi.org/project/memory-profiler/) (note the decorator like in `line-profiler`).
+Dalam bahasa dengan garbage collection seperti Python, tetap berguna untuk menggunakan memory profiler karena selama Anda memiliki pointer ke objek di memori, mereka tidak akan di-garbage collect. Berikut contoh program dan output terkait saat menjalankannya dengan [memory-profiler](https://pypi.org/project/memory-profiler/) (perhatikan decorator seperti pada `line-profiler`).
 
 ```python
 @profile
@@ -398,58 +353,47 @@ Line #    Mem usage  Increment   Line Contents
 
 ### Event Profiling
 
-As it was the case for `strace` for debugging, you might want to ignore the specifics of the code that you are running and treat it like a black box when profiling.
-The [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) command abstracts CPU differences away and does not report time or memory, but instead it reports system events related to your programs.
-For example, `perf` can easily report poor cache locality, high amounts of page faults or livelocks. Here is an overview of the command:
+Seperti halnya `strace` untuk debugging, Anda mungkin ingin mengabaikan detail spesifik dari kode yang Anda jalankan dan memperlakukannya seperti black box saat melakukan profiling. Perintah [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) mengabstraksikan perbedaan CPU dan tidak melaporkan waktu atau memori, melainkan melaporkan event sistem yang terkait dengan program Anda. Sebagai contoh, `perf` dapat dengan mudah melaporkan poor cache locality, page faults dalam jumlah tinggi, atau livelocks. Berikut gambaran umum perintah tersebut:
 
-- `perf list` - List the events that can be traced with perf
-- `perf stat COMMAND ARG1 ARG2` - Gets counts of different events related to a process or command
-- `perf record COMMAND ARG1 ARG2` - Records the run of a command and saves the statistical data into a file called `perf.data`
-- `perf report` - Formats and prints the data collected in `perf.data`
+- `perf list` - Mencantumkan event yang dapat ditelusuri dengan perf
+- `perf stat COMMAND ARG1 ARG2` - Mendapatkan hitungan dari berbagai event yang terkait dengan suatu proses atau perintah
+- `perf record COMMAND ARG1 ARG2` - Merekam eksekusi suatu perintah dan menyimpan data statistik ke file bernama `perf.data`
+- `perf report` - Memformat dan mencetak data yang dikumpulkan di `perf.data`
 
 
-### Visualization
+### Visualisasi
 
-Profiler output for real world programs will contain large amounts of information because of the inherent complexity of software projects.
-Humans are visual creatures and are quite terrible at reading large amounts of numbers and making sense of them.
-Thus there are many tools for displaying profiler's output in an easier to parse way.
+Output profiler untuk program dunia nyata akan berisi sejumlah besar informasi karena kompleksitas inheren dari proyek perangkat lunak. Manusia adalah makhluk visual dan sangat buruk dalam membaca sejumlah besar angka dan memahaminya. Oleh karena itu ada banyak alat untuk menampilkan output profiler dengan cara yang lebih mudah dipahami.
 
-One common way to display CPU profiling information for sampling profilers is to use a [Flame Graph](https://www.brendangregg.com/flamegraphs.html), which will display a hierarchy of function calls across the Y axis and time taken proportional to the X axis. They are also interactive, letting you zoom into specific parts of the program and get their stack traces (try clicking in the image below).
+Salah satu cara umum untuk menampilkan informasi profiling CPU untuk sampling profiler adalah menggunakan [Flame Graph](https://www.brendangregg.com/flamegraphs.html), yang akan menampilkan hierarki pemanggilan fungsi pada sumbu Y dan waktu yang dihabiskan secara proporsional pada sumbu X. Mereka juga interaktif, memungkinkan Anda memperbesar bagian tertentu dari program dan mendapatkan stack trace-nya (coba klik gambar di bawah).
 
 [![FlameGraph](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)
 
-Call graphs or control flow graphs display the relationships between subroutines within a program by including functions as nodes and functions calls between them as directed edges. When coupled with profiling information such as the number of calls and time taken, call graphs can be quite useful for interpreting the flow of a program.
-In Python you can use the [`pycallgraph`](https://pycallgraph.readthedocs.io/) library to generate them.
+Call graph atau control flow graph menampilkan hubungan antar subroutine dalam suatu program dengan menyertakan fungsi sebagai node dan pemanggilan fungsi di antara mereka sebagai edge berarah. Ketika dipasangkan dengan informasi profiling seperti jumlah pemanggilan dan waktu yang dihabiskan, call graph bisa sangat berguna untuk menginterpretasikan alur program. Di Python Anda dapat menggunakan pustaka [`pycallgraph`](https://pycallgraph.readthedocs.io/) untuk menghasilkan mereka.
 
 ![Call Graph](https://upload.wikimedia.org/wikipedia/commons/2/2f/A_Call_Graph_generated_by_pycallgraph.png)
 
 
-## Resource Monitoring
+## Monitoring Sumber Daya
 
-Sometimes, the first step towards analyzing the performance of your program is to understand what its actual resource consumption is.
-Programs often run slowly when they are resource constrained, e.g. without enough memory or on a slow network connection.
-There are a myriad of command line tools for probing and displaying different system resources like CPU usage, memory usage, network, disk usage and so on.
+Terkadang, langkah pertama untuk menganalisis performa program Anda adalah memahami konsumsi sumber daya sebenarnya. Program sering berjalan lambat ketika mereka kekurangan sumber daya, misalnya tanpa memori yang cukup atau pada koneksi jaringan yang lambat. Ada banyak alat command line untuk memeriksa dan menampilkan berbagai sumber daya sistem seperti penggunaan CPU, penggunaan memori, jaringan, penggunaan disk, dan sebagainya.
 
-- **General Monitoring** - Probably the most popular is [`htop`](https://htop.dev/), which is an improved version of [`top`](https://www.man7.org/linux/man-pages/man1/top.1.html).
-`htop` presents various statistics for the currently running processes on the system. `htop` has a myriad of options and keybinds, some useful ones  are: `<F6>` to sort processes, `t` to show tree hierarchy and `h` to toggle threads.
-See also [`glances`](https://nicolargo.github.io/glances/) for similar implementation with a great UI. For getting aggregate measures across all processes, [`dool`](https://github.com/scottchiefbaker/dool) is another nifty tool that computes real-time resource metrics for lots of different subsystems like I/O, networking, CPU utilization, context switches, &c.
-- **I/O operations** - [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) displays live I/O usage information and is handy to check if a process is doing heavy I/O disk operations
-- **Disk Usage** - [`df`](https://www.man7.org/linux/man-pages/man1/df.1.html) displays metrics per partitions and [`du`](https://man7.org/linux/man-pages/man1/du.1.html) displays **d**isk **u**sage per file for the current directory. In these tools the `-h` flag tells the program to print with **h**uman readable format.
-A more interactive version of `du` is [`ncdu`](https://dev.yorhel.nl/ncdu) which lets you navigate folders and delete files and folders as you navigate.
-- **Memory Usage** - [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) displays the total amount of free and used memory in the system. Memory is also displayed in tools like `htop`.
-- **Open Files** - [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html)  lists file information about files opened by processes. It can be quite useful for checking which process has opened a specific file.
-- **Network Connections and Config** - [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) lets you monitor incoming and outgoing network packets statistics as well as interface statistics. A common use case of `ss` is figuring out what process is using a given port in a machine. For displaying routing, network devices and interfaces you can use [`ip`](https://man7.org/linux/man-pages/man8/ip.8.html). Note that `netstat` and `ifconfig` have been deprecated in favor of the former tools respectively.
-- **Network Usage** -  [`nethogs`](https://github.com/raboof/nethogs) and [`iftop`](https://pdw.ex-parrot.com/iftop/) are good interactive CLI tools for monitoring network usage.
+- **Monitoring Umum** - Mungkin yang paling populer adalah [`htop`](https://htop.dev/), yang merupakan versi perbaikan dari [`top`](https://www.man7.org/linux/man-pages/man1/top.1.html).
+`htop` menyajikan berbagai statistik untuk proses yang sedang berjalan di sistem. `htop` memiliki banyak opsi dan keybind, beberapa yang berguna adalah: `<F6>` untuk mengurutkan proses, `t` untuk menampilkan hierarki tree, dan `h` untuk toggle thread. Lihat juga [`glances`](https://nicolargo.github.io/glances/) untuk implementasi serupa dengan UI yang hebat. Untuk mendapatkan pengukuran agregat di semua proses, [`dool`](https://github.com/scottchiefbaker/dool) adalah alat lain yang berguna yang menghitung metrik sumber daya real-time untuk banyak subsistem berbeda seperti I/O, jaringan, penggunaan CPU, context switch, &c.
+- **Operasi I/O** - [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) menampilkan informasi penggunaan I/O secara langsung dan berguna untuk memeriksa apakah suatu proses melakukan operasi disk I/O yang berat
+- **Penggunaan Disk** - [`df`](https://www.man7.org/linux/man-pages/man1/df.1.html) menampilkan metrik per partisi dan [`du`](https://man7.org/linux/man-pages/man1/du.1.html) menampilkan penggunaan **d**isk per file untuk direktori saat ini. Pada alat-alat ini flag `-h` memberitahu program untuk mencetak dalam format yang mudah dibaca manusia (**h**uman readable).
+Versi lebih interaktif dari `du` adalah [`ncdu`](https://dev.yorhel.nl/ncdu) yang memungkinkan Anda menavigasi folder dan menghapus file serta folder saat Anda menavigasi.
+- **Penggunaan Memori** - [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) menampilkan jumlah total memori yang bebas dan digunakan dalam sistem. Memori juga ditampilkan di alat seperti `htop`.
+- **File Terbuka** - [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) mencantumkan informasi file tentang file yang dibuka oleh proses. Ini bisa sangat berguna untuk memeriksa proses mana yang telah membuka file tertentu.
+- **Koneksi dan Konfigurasi Jaringan** - [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) memungkinkan Anda memantau statistik paket jaringan masuk dan keluar serta statistik antarmuka. Kasus penggunaan umum `ss` adalah mencari tahu proses mana yang menggunakan port tertentu di suatu mesin. Untuk menampilkan routing, perangkat jaringan, dan antarmuka Anda dapat menggunakan [`ip`](https://man7.org/linux/man-pages/man8/ip.8.html). Perhatikan bahwa `netstat` dan `ifconfig` telah didepresiasi demi alat-alat sebelumnya masing-masing.
+- **Penggunaan Jaringan** - [`nethogs`](https://github.com/raboof/nethogs) dan [`iftop`](https://pdw.ex-parrot.com/iftop/) adalah alat CLI interaktif yang bagus untuk memantau penggunaan jaringan.
 
-If you want to test these tools you can also artificially impose loads on the machine using the [`stress`](https://linux.die.net/man/1/stress) command.
+Jika Anda ingin menguji alat-alat ini, Anda juga dapat membebani mesin secara buatan menggunakan perintah [`stress`](https://linux.die.net/man/1/stress).
 
 
-### Specialized tools
+### Alat-Alat Khusus
 
-Sometimes, black box benchmarking is all you need to determine what software to use.
-Tools like [`hyperfine`](https://github.com/sharkdp/hyperfine) let you quickly benchmark command line programs.
-For instance, in the shell tools and scripting lecture we recommended `fd` over `find`. We can use `hyperfine` to compare them in tasks we run often.
-E.g. in the example below `fd` was 20x faster than `find` in my machine.
+Terkadang, benchmarking black box adalah semua yang Anda butuhkan untuk menentukan perangkat lunak mana yang akan digunakan. Alat seperti [`hyperfine`](https://github.com/sharkdp/hyperfine) memungkinkan Anda dengan cepat melakukan benchmark program command line. Sebagai contoh, di kuliah shell tools dan scripting kami merekomendasikan `fd` daripada `find`. Kita dapat menggunakan `hyperfine` untuk membandingkan mereka dalam tugas yang sering kita jalankan. Misalnya, pada contoh di bawah `fd` 20x lebih cepat daripada `find` di mesin saya.
 
 ```bash
 $ hyperfine --warmup 3 'fd -e jpg' 'find . -iname "*.jpg"'
@@ -466,18 +410,16 @@ Summary
    21.89 ± 2.33 times faster than 'find . -iname "*.jpg"'
 ```
 
-As it was the case for debugging, browsers also come with a fantastic set of tools for profiling webpage loading, letting you figure out where time is being spent (loading, rendering, scripting, &c).
-More info for [Firefox](https://profiler.firefox.com/docs/) and [Chrome](https://developers.google.com/web/tools/chrome-devtools/rendering-tools).
+Seperti halnya debugging, browser juga dilengkapi dengan seperangkat alat fantastis untuk memprofil pemuatan halaman web, memungkinkan Anda mengetahui di mana waktu dihabiskan (memuat, rendering, scripting, &c). Info lebih lanjut untuk [Firefox](https://profiler.firefox.com/docs/) dan [Chrome](https://developers.google.com/web/tools/chrome-devtools/rendering-tools).
 
-# Exercises
+# Latihan
 
 ## Debugging
-1. Use `journalctl` on Linux or `log show` on macOS to get the super user accesses and commands in the last day.
-If there aren't any you can execute some harmless commands such as `sudo ls` and check again.
+1. Gunakan `journalctl` di Linux atau `log show` di macOS untuk mendapatkan akses super user dan perintah di hari terakhir. Jika tidak ada, Anda dapat menjalankan beberapa perintah yang tidak berbahaya seperti `sudo ls` dan periksa lagi.
 
-1. Do [this](https://github.com/spiside/pdb-tutorial) hands on `pdb` tutorial to familiarize yourself with the commands. For a more in depth tutorial read [this](https://realpython.com/python-debugging-pdb).
+1. Lakukan tutorial hands-on `pdb` [ini](https://github.com/spiside/pdb-tutorial) untuk membiasakan diri dengan perintah-perintahnya. Untuk tutorial yang lebih mendalam baca [ini](https://realpython.com/python-debugging-pdb).
 
-1. Install [`shellcheck`](https://www.shellcheck.net/) and try checking the following script. What is wrong with the code? Fix it. Install a linter plugin in your editor so you can get your warnings automatically.
+1. Instal [`shellcheck`](https://www.shellcheck.net/) dan coba periksa skrip berikut. Apa yang salah dengan kode tersebut? Perbaiki. Instal plugin linter di editor Anda sehingga Anda bisa mendapatkan peringatan secara otomatis.
 
    ```bash
    #!/bin/sh
@@ -489,12 +431,12 @@ If there aren't any you can execute some harmless commands such as `sudo ls` and
    done
    ```
 
-1. (Advanced) Read about [reversible debugging](https://undo.io/resources/reverse-debugging-whitepaper/) and get a simple example working using [`rr`](https://rr-project.org/) or [`RevPDB`](https://morepypy.blogspot.com/2016/07/reverse-debugging-for-python.html).
+1. (Lanjutan) Baca tentang [reversible debugging](https://undo.io/resources/reverse-debugging-whitepaper/) dan dapatkan contoh sederhana yang bekerja menggunakan [`rr`](https://rr-project.org/) atau [`RevPDB`](https://morepypy.blogspot.com/2016/07/reverse-debugging-for-python.html).
 ## Profiling
 
-1. [Here](/static/files/sorts.py) are some sorting algorithm implementations. Use [`cProfile`](https://docs.python.org/3/library/profile.html) and [`line_profiler`](https://github.com/pyutils/line_profiler) to compare the runtime of insertion sort and quicksort. What is the bottleneck of each algorithm? Use then `memory_profiler` to check the memory consumption, why is insertion sort better? Check now the inplace version of quicksort. Challenge: Use `perf` to look at the cycle counts and cache hits and misses of each algorithm.
+1. [Berikut](/static/files/sorts.py) beberapa implementasi algoritma pengurutan. Gunakan [`cProfile`](https://docs.python.org/3/library/profile.html) dan [`line_profiler`](https://github.com/pyutils/line_profiler) untuk membandingkan runtime insertion sort dan quicksort. Apa bottleneck dari masing-masing algoritma? Kemudian gunakan `memory_profiler` untuk memeriksa konsumsi memori, mengapa insertion sort lebih baik? Sekarang periksa versi inplace dari quicksort. Tantangan: Gunakan `perf` untuk melihat cycle count dan cache hits dan misses dari masing-masing algoritma.
 
-1. Here's some (arguably convoluted) Python code for computing Fibonacci numbers using a function for each number.
+1. Berikut kode Python (yang mungkin agak berbelit-belit) untuk menghitung bilangan Fibonacci menggunakan sebuah fungsi untuk setiap bilangan.
 
    ```python
    #!/usr/bin/env python
@@ -514,13 +456,10 @@ If there aren't any you can execute some harmless commands such as `sudo ls` and
        print(eval("fib9()"))
    ```
 
-   Put the code into a file and make it executable. Install prerequisites: [`pycallgraph`](https://lewiscowles1986.github.io/py-call-graph/) and [`graphviz`](https://graphviz.org/). (If you can run `dot`, you already have GraphViz.) Run the code as is with `pycallgraph graphviz -- ./fib.py` and check the `pycallgraph.png` file. How many times is `fib0` called?. We can do better than that by memoizing the functions. Uncomment the commented lines and regenerate the images. How many times are we calling each `fibN` function now?
+   Simpan kode ke dalam file dan jadikan executable. Instal prasyarat: [`pycallgraph`](https://lewiscowles1986.github.io/py-call-graph/) dan [`graphviz`](https://graphviz.org/). (Jika Anda bisa menjalankan `dot`, Anda sudah memiliki GraphViz.) Jalankan kode apa adanya dengan `pycallgraph graphviz -- ./fib.py` dan periksa file `pycallgraph.png`. Berapa kali `fib0` dipanggil?. Kita bisa melakukan lebih baik dari itu dengan memoize fungsi-fungsinya. Hapus komentar pada baris yang dikomentari dan generate ulang gambar. Berapa kali kita memanggil setiap fungsi `fibN` sekarang?
 
-1. A common issue is that a port you want to listen on is already taken by another process. Let's learn how to discover that process pid. First execute `python -m http.server 4444` to start a minimal web server listening on port `4444`. On a separate terminal run `lsof | grep LISTEN` to print all listening processes and ports. Find that process pid and terminate it by running `kill <PID>`.
+1. Masalah umum adalah port yang ingin Anda dengarkan sudah digunakan oleh proses lain. Mari kita pelajari cara menemukan pid proses tersebut. Pertama jalankan `python -m http.server 4444` untuk memulai server web minimal yang mendengarkan di port `4444`. Di terminal terpisah jalankan `lsof | grep LISTEN` untuk mencetak semua proses dan port yang mendengarkan. Temukan pid proses tersebut dan hentikan dengan menjalankan `kill <PID>`.
 
-1. Limiting a process's resources can be another handy tool in your toolbox.
-Try running `stress -c 3` and visualize the CPU consumption with `htop`. Now, execute `taskset --cpu-list 0,2 stress -c 3` and visualize it. Is `stress` taking three CPUs? Why not? Read [`man taskset`](https://www.man7.org/linux/man-pages/man1/taskset.1.html).
-Challenge: achieve the same using [`cgroups`](https://www.man7.org/linux/man-pages/man7/cgroups.7.html). Try limiting the memory consumption of `stress -m`.
+1. Membatasi sumber daya proses bisa menjadi alat berguna lainnya dalam kotak peralatan Anda. Coba jalankan `stress -c 3` dan visualisasikan konsumsi CPU dengan `htop`. Sekarang, jalankan `taskset --cpu-list 0,2 stress -c 3` dan visualisasikan. Apakah `stress` menggunakan tiga CPU? Mengapa tidak? Baca [`man taskset`](https://www.man7.org/linux/man-pages/man1/taskset.1.html). Tantangan: capai hal yang sama menggunakan [`cgroups`](https://www.man7.org/linux/man-pages/man7/cgroups.7.html). Coba batasi konsumsi memori `stress -m`.
 
-1. (Advanced) The command `curl ipinfo.io` performs a HTTP request and fetches information about your public IP. Open [Wireshark](https://www.wireshark.org/) and try to sniff the request and reply packets that `curl` sent and received. (Hint: Use the `http` filter to just watch HTTP packets).
-
+1. (Lanjutan) Perintah `curl ipinfo.io` melakukan request HTTP dan mengambil informasi tentang IP publik Anda. Buka [Wireshark](https://www.wireshark.org/) dan coba sniff paket request dan reply yang dikirim dan diterima `curl`. (Petunjuk: Gunakan filter `http` untuk hanya melihat paket HTTP).

--- a/_2020/debugging-profiling.md
+++ b/_2020/debugging-profiling.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Debugging and Profiling"
+title: "Debugging dan Profiling"
 description: >
   Pelajari cara men-debug program menggunakan logging, debugger, dan analisis statis, serta cara melakukan profiling kode untuk performa.
 thumbnail: /static/assets/thumbnails/2020/lec7.png
@@ -11,25 +11,25 @@ video:
   id: l812pUnKxME
 ---
 
-A golden rule in programming is that code does not do what you expect it to do, but what you tell it to do.
-Bridging that gap can sometimes be a quite difficult feat.
-In this lecture we are going to cover useful techniques for dealing with buggy and resource hungry code: debugging and profiling.
+Aturan emas dalam pemrograman adalah kode tidak melakukan apa yang Anda harapkan, melainkan apa yang Anda perintahkan.
+Menjembatani kesenjangan tersebut terkadang bisa menjadi hal yang cukup sulit.
+Dalam kuliah ini kita akan membahas teknik-teknik berguna untuk menangani kode yang bermasalah dan boros sumber daya: debugging dan profiling.
 
 # Debugging
 
-## Printf debugging and Logging
+## Printf debugging dan Logging
 
-"The most effective debugging tool is still careful thought, coupled with judiciously placed print statements" — Brian Kernighan, _Unix for Beginners_.
+"Alat debugging yang paling efektif tetaplah pemikiran yang cermat, dipasangkan dengan pernyataan print yang ditempatkan secara bijaksana" — Brian Kernighan, _Unix for Beginners_.
 
-A first approach to debug a program is to add print statements around where you have detected the problem, and keep iterating until you have extracted enough information to understand what is responsible for the issue.
+Pendekatan pertama untuk men-debug program adalah dengan menambahkan pernyataan print di sekitar tempat Anda mendeteksi masalah, dan terus melakukan iterasi hingga Anda mengekstrak cukup informasi untuk memahami apa yang menyebabkan masalah tersebut.
 
-A second approach is to use logging in your program, instead of ad hoc print statements. Logging is better than regular print statements for several reasons:
+Pendekatan kedua adalah menggunakan logging dalam program Anda, alih-alih pernyataan print ad hoc. Logging lebih baik daripada pernyataan print biasa karena beberapa alasan:
 
-- You can log to files, sockets or even remote servers instead of standard output.
-- Logging supports severity levels (such as INFO, DEBUG, WARN, ERROR, &c), that allow you to filter the output accordingly.
-- For new issues, there's a fair chance that your logs will contain enough information to detect what is going wrong.
+- Anda dapat mencatat log ke file, socket, atau bahkan server jarak jauh alih-alih output standar.
+- Logging mendukung level tingkat keparahan (seperti INFO, DEBUG, WARN, ERROR, &c), yang memungkinkan Anda memfilter output sesuai kebutuhan.
+- Untuk masalah baru, ada kemungkinan besar log Anda akan berisi cukup informasi untuk mendeteksi apa yang salah.
 
-[Here](/static/files/logger.py) is an example code that logs messages:
+[Berikut](/static/files/logger.py) contoh kode yang mencatat pesan log:
 
 ```bash
 $ python logger.py
@@ -42,11 +42,11 @@ $ python logger.py color
 # Color formatted output
 ```
 
-One of my favorite tips for making logs more readable is to color code them.
-By now you probably have realized that your terminal uses colors to make things more readable. But how does it do it?
-Programs like `ls` or `grep` are using [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code), which are special sequences of characters to indicate your shell to change the color of the output. For example, executing `echo -e "\e[38;2;255;0;0mThis is red\e[0m"` prints the message `This is red` in red on your terminal, as long as it supports [true color](https://github.com/termstandard/colors#truecolor-support-in-output-devices). If your terminal doesn't support this (e.g. macOS's Terminal.app), you can use the more universally supported escape codes for 16 color choices, for example `echo -e "\e[31;1mThis is red\e[0m"`.
+Salah satu tips favorit saya untuk membuat log lebih mudah dibaca adalah memberikan kode warna.
+Mungkin Anda sudah menyadari bahwa terminal Anda menggunakan warna untuk membuat mọi hal lebih mudah dibaca. Tapi bagaimana caranya?
+Program seperti `ls` atau `grep` menggunakan [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code), yaitu urutan karakter khusus untuk menginstruksikan shell Anda mengubah warna output. Sebagai contoh, menjalankan `echo -e "\e[38;2;255;0;0mThis is red\e[0m"` akan mencetak pesan `This is red` berwarna merah di terminal Anda, selama terminal mendukung [true color](https://github.com/termstandard/colors#truecolor-support-in-output-devices). Jika terminal Anda tidak mendukungnya (misalnya Terminal.app di macOS), Anda dapat menggunakan escape codes yang lebih universal untuk 16 pilihan warna, misalnya `echo -e "\e[31;1mThis is red\e[0m"`.
 
-The following script shows how to print many RGB colors into your terminal (again, as long as it supports true color).
+Script berikut menunjukkan cara mencetak banyak warna RGB ke terminal Anda (sekali lagi, selama mendukung true color).
 
 ```bash
 #!/usr/bin/env bash
@@ -59,24 +59,24 @@ for R in $(seq 0 20 255); do
 done
 ```
 
-## Third party logs
+## Log pihak ketiga
 
-As you start building larger software systems you will most probably run into dependencies that run as separate programs.
-Web servers, databases or message brokers are common examples of this kind of dependencies.
-When interacting with these systems it is often necessary to read their logs, since client side error messages might not suffice.
+Saat Anda mulai membangun sistem perangkat lunak yang lebih besar, Anda kemungkinan besar akan menemukan dependensi yang berjalan sebagai program terpisah.
+Web server, database, atau message broker adalah contoh umum dari jenis dependensi ini.
+Saat berinteraksi dengan sistem-sistem ini, seringkali perlu membaca log mereka, karena pesan error dari sisi klien mungkin tidak cukup.
 
-Luckily, most programs write their own logs somewhere in your system.
-In UNIX systems, it is commonplace for programs to write their logs under `/var/log`.
-For instance, the [NGINX](https://www.nginx.com/) webserver places its logs under `/var/log/nginx`.
-More recently, systems have started using a **system log**, which is increasingly where all of your log messages go.
-Most (but not all) Linux systems use `systemd`, a system daemon that controls many things in your system such as which services are enabled and running.
-`systemd` places the logs under `/var/log/journal` in a specialized format and you can use the [`journalctl`](https://www.man7.org/linux/man-pages/man1/journalctl.1.html) command to display the messages.
-Similarly, on macOS there is still `/var/log/system.log` but an increasing number of tools use the system log, that can be displayed with [`log show`](https://www.manpagez.com/man/1/log/).
-On most UNIX systems you can also use the [`dmesg`](https://www.man7.org/linux/man-pages/man1/dmesg.1.html) command to access the kernel log.
+Untungnya, sebagian besar program menulis log mereka sendiri di suatu tempat di sistem Anda.
+Di sistem UNIX, umumnya program menulis log mereka di bawah `/var/log`.
+Sebagai contoh, web server [NGINX](https://www.nginx.com/) menempatkan log-nya di `/var/log/nginx`.
+Belakangan ini, sistem telah mulai menggunakan **system log**, yang semakin menjadi tempat semua pesan log Anda masuk.
+Sebagian besar (tetapi tidak semua) sistem Linux menggunakan `systemd`, sebuah system daemon yang mengontrol banyak hal di sistem Anda seperti layanan mana yang diaktifkan dan berjalan.
+`systemd` menempatkan log di bawah `/var/log/journal` dalam format khusus dan Anda dapat menggunakan perintah [`journalctl`](https://www.man7.org/linux/man-pages/man1/journalctl.1.html) untuk menampilkan pesan.
+Demikian pula, di macOS masih ada `/var/log/system.log` tetapi semakin banyak alat yang menggunakan system log, yang dapat ditampilkan dengan [`log show`](https://www.manpagez.com/man/1/log/).
+Pada sebagian besar sistem UNIX Anda juga dapat menggunakan perintah [`dmesg`](https://www.man7.org/linux/man-pages/man1/dmesg.1.html) untuk mengakses log kernel.
 
-For logging under the system logs you can use the [`logger`](https://www.man7.org/linux/man-pages/man1/logger.1.html) shell program.
-Here's an example of using `logger` and how to check that the entry made it to the system logs.
-Moreover, most programming languages have bindings logging to the system log.
+Untuk mencatat log ke system log, Anda dapat menggunakan program shell [`logger`](https://www.man7.org/linux/man-pages/man1/logger.1.html).
+Berikut contoh penggunaan `logger` dan cara memeriksa bahwa entri tersebut masuk ke system log.
+Selain itu, sebagian besar bahasa pemrograman memiliki binding untuk mencatat log ke system log.
 
 ```bash
 logger "Hello Logs"
@@ -86,35 +86,35 @@ log show --last 1m | grep Hello
 journalctl --since "1m ago" | grep Hello
 ```
 
-As we saw in the data wrangling lecture, logs can be quite verbose and they require some level of processing and filtering to get the information you want.
-If you find yourself heavily filtering through `journalctl` and `log show` you can consider using their flags, which can perform a first pass of filtering of their output.
-There are also some tools like  [`lnav`](https://lnav.org/), that provide an improved presentation and navigation for log files.
+Seperti yang kita lihat di kuliah data wrangling, log bisa sangat panjang dan memerlukan beberapa tingkat pemrosesan dan penyaringan untuk mendapatkan informasi yang Anda inginkan.
+Jika Anda sering melakukan penyaringan melalui `journalctl` dan `log show`, Anda dapat mempertimbangkan menggunakan flag mereka, yang dapat melakukan penyaringan awal output mereka.
+Ada juga beberapa alat seperti [`lnav`](https://lnav.org/), yang menyediakan presentasi dan navigasi yang lebih baik untuk file log.
 
-## Debuggers
+## Debugger
 
-When printf debugging is not enough you should use a debugger.
-Debuggers are programs that let you interact with the execution of a program, allowing the following:
+Ketika printf debugging tidak cukup, Anda harus menggunakan debugger.
+Debugger adalah program yang memungkinkan Anda berinteraksi dengan eksekusi suatu program, memungkinkan hal-hal berikut:
 
-- Halt execution of the program when it reaches a certain line.
-- Step through the program one instruction at a time.
-- Inspect values of variables after the program crashed.
-- Conditionally halt the execution when a given condition is met.
-- And many more advanced features
+- Menghentikan eksekusi program saat mencapai baris tertentu.
+- Menelusuri program satu instruksi pada satu waktu.
+- Memeriksa nilai variabel setelah program crash.
+- Menghentikan eksekusi secara kondisional ketika kondisi tertentu terpenuhi.
+- Dan banyak fitur canggih lainnya
 
-Many programming languages come with some form of debugger.
-In Python this is the Python Debugger [`pdb`](https://docs.python.org/3/library/pdb.html).
+Banyak bahasa pemrograman dilengkapi dengan semacam debugger.
+Di Python, ini adalah Python Debugger [`pdb`](https://docs.python.org/3/library/pdb.html).
 
-Here is a brief description of some of the commands `pdb` supports:
+Berikut deskripsi singkat beberapa perintah yang didukung `pdb`:
 
-- **l**(ist) - Displays 11 lines around the current line or continue the previous listing.
-- **s**(tep) - Execute the current line, stop at the first possible occasion.
-- **n**(ext) - Continue execution until the next line in the current function is reached or it returns.
-- **b**(reak) - Set a breakpoint (depending on the argument provided).
-- **p**(rint) - Evaluate the expression in the current context and print its value. There's also **pp** to display using [`pprint`](https://docs.python.org/3/library/pprint.html) instead.
-- **r**(eturn) - Continue execution until the current function returns.
-- **q**(uit) - Quit the debugger.
+- **l**(ist) - Menampilkan 11 baris di sekitar baris saat ini atau melanjutkan listing sebelumnya.
+- **s**(tep) - Mengeksekusi baris saat ini, berhenti pada kesempatan pertama yang memungkinkan.
+- **n**(ext) - Melanjutkan eksekusi hingga baris berikutnya dalam fungsi saat ini tercapai atau fungsi tersebut return.
+- **b**(reak) - Menetapkan breakpoint (tergantung pada argumen yang diberikan).
+- **p**(rint) - Mengevaluasi ekspresi dalam konteks saat ini dan mencetak nilainya. Ada juga **pp** untuk menampilkan menggunakan [`pprint`](https://docs.python.org/3/library/pprint.html) sebagai gantinya.
+- **r**(eturn) - Melanjutkan eksekusi hingga fungsi saat ini return.
+- **q**(uit) - Keluar dari debugger.
 
-Let's go through an example of using `pdb` to fix the following buggy python code. (See the lecture video).
+Mari kita lihat contoh penggunaan `pdb` untuk memperbaiki kode python buggy berikut. (Lihat video kuliah).
 
 ```python
 def bubble_sort(arr):
@@ -130,20 +130,20 @@ print(bubble_sort([4, 2, 1, 8, 7, 6]))
 ```
 
 
-Note that since Python is an interpreted language we can use the `pdb` shell to execute commands and to execute instructions.
-[`ipdb`](https://pypi.org/project/ipdb/) is an improved `pdb` that uses the [`IPython`](https://ipython.org) REPL enabling tab completion, syntax highlighting, better tracebacks, and better introspection while retaining the same interface as the `pdb` module.
+Perhatikan bahwa karena Python adalah bahasa interpreted, kita dapat menggunakan shell `pdb` untuk mengeksekusi perintah dan menjalankan instruksi.
+[`ipdb`](https://pypi.org/project/ipdb/) adalah `pdb` yang lebih canggih yang menggunakan REPL [`IPython`](https://ipython.org) yang memungkinkan tab completion, syntax highlighting, traceback yang lebih baik, dan introspeksi yang lebih baik sambil tetap mempertahankan antarmuka yang sama dengan modul `pdb`.
 
-For more low level programming you will probably want to look into [`gdb`](https://www.gnu.org/software/gdb/) (and its quality of life modification [`pwndbg`](https://github.com/pwndbg/pwndbg)) and [`lldb`](https://lldb.llvm.org/).
-They are optimized for C-like language debugging but will let you probe pretty much any process and get its current machine state: registers, stack, program counter, &c.
+Untuk pemrograman yang lebih low level, Anda mungkin ingin melihat [`gdb`](https://www.gnu.org/software/gdb/) (dan modifikasi quality of life-nya [`pwndbg`](https://github.com/pwndbg/pwndbg)) dan [`lldb`](https://lldb.llvm.org/).
+Mereka dioptimalkan untuk debugging bahasa mirip C tetapi memungkinkan Anda memeriksa hampir semua proses dan mendapatkan status mesin saat ini: register, stack, program counter, &c.
 
 
-## Specialized Tools
+## Alat Khusus
 
-Even if what you are trying to debug is a black box binary there are tools that can help you with that.
-Whenever programs need to perform actions that only the kernel can, they use [System Calls](https://en.wikipedia.org/wiki/System_call).
-There are commands that let you trace the syscalls your program makes. In Linux there's [`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) and macOS and BSD have [`dtrace`](https://dtrace.org/about/). `dtrace` can be tricky to use because it uses its own `D` language, but there is a wrapper called [`dtruss`](https://www.manpagez.com/man/1/dtruss/) that provides an interface more similar to `strace` (more details [here](https://8thlight.com/blog/colin-jones/2015/11/06/dtrace-even-better-than-strace-for-osx.html)).
+Meskipun apa yang Anda coba debug adalah biner black box, ada alat yang dapat membantu Anda.
+Setiap kali program perlu melakukan tindakan yang hanya bisa dilakukan kernel, mereka menggunakan [System Calls](https://en.wikipedia.org/wiki/System_call).
+Ada perintah yang memungkinkan Anda menelusuri syscall yang dibuat program Anda. Di Linux ada [`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) dan macOS serta BSD memiliki [`dtrace`](https://dtrace.org/about/). `dtrace` bisa sulit digunakan karena menggunakan bahasa `D`-nya sendiri, tetapi ada wrapper bernama [`dtruss`](https://www.manpagez.com/man/1/dtruss/) yang menyediakan antarmuka yang lebih mirip dengan `strace` (detail lebih lanjut [di sini](https://8thlight.com/blog/colin-jones/2015/11/06/dtrace-even-better-than-strace-for-osx.html)).
 
-Below are some examples of using `strace` or `dtruss` to show [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) syscall traces for an execution of `ls`. For a deeper dive into `strace`, [this article](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) and [this zine](https://jvns.ca/strace-zine-unfolded.pdf) are good reads.
+Berikut beberapa contoh penggunaan `strace` atau `dtruss` untuk menampilkan trace syscall [`stat`](https://www.man7.org/linux/man-pages/man2/stat.2.html) dari eksekusi `ls`. Untuk pembahasan lebih dalam tentang `strace`, [artikel ini](https://blogs.oracle.com/linux/strace-the-sysadmins-microscope-v2) dan [zine ini](https://jvns.ca/strace-zine-unfolded.pdf) adalah bacaan yang bagus.
 
 ```bash
 # On Linux
@@ -152,25 +152,25 @@ sudo strace -e lstat ls -l > /dev/null
 sudo dtruss -t lstat64_extended ls -l > /dev/null
 ```
 
-Under some circumstances, you may need to look at the network packets to figure out the issue in your program.
-Tools like [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) and [Wireshark](https://www.wireshark.org/) are network packet analyzers that let you read the contents of network packets and filter them based on different criteria.
+Dalam beberapa situasi, Anda mungkin perlu melihat paket jaringan untuk mengetahui masalah dalam program Anda.
+Alat seperti [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) dan [Wireshark](https://www.wireshark.org/) adalah network packet analyzer yang memungkinkan Anda membaca isi paket jaringan dan memfilternya berdasarkan berbagai kriteria.
 
-For web development, the Chrome/Firefox developer tools are quite handy. They feature a large number of tools, including:
-- Source code - Inspect the HTML/CSS/JS source code of any website.
-- Live HTML, CSS, JS modification - Change the website content, styles and behavior to test (you can see for yourself that website screenshots are not valid proofs).
-- Javascript shell - Execute commands in the JS REPL.
-- Network - Analyze the requests timeline.
-- Storage - Look into the Cookies and local application storage.
+Untuk pengembangan web, developer tools Chrome/Firefox sangat berguna. Mereka memiliki sejumlah besar alat, termasuk:
+- Source code - Memeriksa kode sumber HTML/CSS/JS dari situs web mana pun.
+- Live HTML, CSS, JS modification - Mengubah konten, gaya, dan perilaku situs web untuk pengujian (Anda bisa melihat sendiri bahwa screenshot situs web bukan bukti yang valid).
+- Javascript shell - Menjalankan perintah di JS REPL.
+- Network - Menganalisis timeline request.
+- Storage - Melihat Cookie dan penyimpanan aplikasi lokal.
 
-## Static Analysis
+## Analisis Statis
 
-For some issues you do not need to run any code.
-For example, just by carefully looking at a piece of code you could realize that your loop variable is shadowing an already existing variable or function name; or that a program reads a variable before defining it.
-Here is where [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis) tools come into play.
-Static analysis programs take source code as input and analyze it using coding rules to reason about its correctness.
+Untuk beberapa masalah, Anda tidak perlu menjalankan kode sama sekali.
+Sebagai contoh, hanya dengan melihat potongan kode secara cermat, Anda bisa menyadari bahwa variabel loop Anda shadowing variabel atau nama fungsi yang sudah ada sebelumnya; atau bahwa sebuah program membaca variabel sebelum mendefinisikannya.
+Di sinilah alat [analisis statis](https://en.wikipedia.org/wiki/Static_program_analysis) berperan.
+Program analisis statis menerima kode sumber sebagai input dan menganalisisnya menggunakan aturan pengkodean untuk menilai kebenarannya.
 
-In the following Python snippet there are several mistakes.
-First, our loop variable `foo` shadows the previous definition of the function `foo`. We also wrote `baz` instead of `bar` in the last line, so the program will crash after completing the `sleep` call (which will take one minute).
+Pada potongan Python berikut terdapat beberapa kesalahan.
+Pertama, variabel loop kita `foo` shadowing definisi sebelumnya dari fungsi `foo`. Kita juga menulis `baz` alih-alih `bar` di baris terakhir, sehingga program akan crash setelah menyelesaikan pemanggilan `sleep` (yang akan memakan waktu satu menit).
 
 ```python
 import time
@@ -186,8 +186,8 @@ time.sleep(60)
 print(baz)
 ```
 
-Static analysis tools can identify these kinds of issues. When we run [`pyflakes`](https://pypi.org/project/pyflakes) on the code we get the errors related to both bugs. [`mypy`](https://mypy-lang.org/) is another tool that can detect type checking issues. Here, `mypy` will warn us that `bar` is initially an `int` and is then casted to a `float`.
-Again, note that all these issues were detected without having to run the code.
+Alat analisis statis dapat mengidentifikasi masalah-masalah ini. Ketika kita menjalankan [`pyflakes`](https://pypi.org/project/pyflakes) pada kode tersebut, kita mendapatkan error terkait kedua bug. [`mypy`](https://mypy-lang.org/) adalah alat lain yang dapat mendeteksi masalah type checking. Di sini, `mypy` akan memperingatkan kita bahwa `bar` awalnya adalah `int` dan kemudian di-cast ke `float`.
+Sekali lagi, perhatikan bahwa semua masalah ini terdeteksi tanpa harus menjalankan kode.
 
 ```bash
 $ pyflakes foobar.py
@@ -201,29 +201,29 @@ foobar.py:11: error: Name 'baz' is not defined
 Found 3 errors in 1 file (checked 1 source file)
 ```
 
-In the shell tools lecture we covered [`shellcheck`](https://www.shellcheck.net/), which is a similar tool for shell scripts.
+Di kuliah shell tools kita telah membahas [`shellcheck`](https://www.shellcheck.net/), yang merupakan alat serupa untuk shell script.
 
-Most editors and IDEs support displaying the output of these tools within the editor itself, highlighting the locations of warnings and errors.
-This is often called **code linting** and it can also be used to display other types of issues such as stylistic violations or insecure constructs.
+Sebagian besar editor dan IDE mendukung menampilkan output dari alat-alat ini di dalam editor itu sendiri, menyoroti lokasi peringatan dan error.
+Ini sering disebut **code linting** dan juga dapat digunakan untuk menampilkan jenis masalah lain seperti pelanggaran gaya atau konstruksi yang tidak aman.
 
-In vim, the plugins [`ale`](https://vimawesome.com/plugin/ale) or [`syntastic`](https://vimawesome.com/plugin/syntastic) will let you do that.
-For Python, [`pylint`](https://github.com/PyCQA/pylint) and [`pep8`](https://pypi.org/project/pep8/) are examples of stylistic linters and [`bandit`](https://pypi.org/project/bandit/) is a tool designed to find common security issues.
-For other languages people have compiled comprehensive lists of useful static analysis tools, such as [Awesome Static Analysis](https://github.com/mre/awesome-static-analysis) (you may want to take a look at the _Writing_ section) and for linters there is [Awesome Linters](https://github.com/caramelomartins/awesome-linters).
+Di vim, plugin [`ale`](https://vimawesome.com/plugin/ale) atau [`syntastic`](https://vimawesome.com/plugin/syntastic) akan memungkinkan Anda melakukan hal itu.
+Untuk Python, [`pylint`](https://github.com/PyCQA/pylint) dan [`pep8`](https://pypi.org/project/pep8/) adalah contoh linter gaya dan [`bandit`](https://pypi.org/project/bandit/) adalah alat yang dirancang untuk menemukan masalah keamanan umum.
+Untuk bahasa lain, orang-orang telah menyusun daftar komprehensif alat analisis statis yang berguna, seperti [Awesome Static Analysis](https://github.com/mre/awesome-static-analysis) (Anda mungkin ingin melihat bagian _Writing_) dan untuk linter ada [Awesome Linters](https://github.com/caramelomartins/awesome-linters).
 
-A complementary tool to stylistic linting are code formatters such as [`black`](https://github.com/psf/black) for Python, `gofmt` for Go, `rustfmt` for Rust or [`prettier`](https://prettier.io/) for JavaScript, HTML and CSS.
-These tools autoformat your code so that it's consistent with common stylistic patterns for the given programming language.
-Although you might be unwilling to give stylistic control about your code, standardizing code format will help other people read your code and will make you better at reading other people's (stylistically standardized) code.
+Alat pelengkap untuk stylistic linting adalah code formatter seperti [`black`](https://github.com/psf/black) untuk Python, `gofmt` untuk Go, `rustfmt` untuk Rust, atau [`prettier`](https://prettier.io/) untuk JavaScript, HTML, dan CSS.
+Alat-alat ini memformat kode Anda secara otomatis sehingga konsisten dengan pola gaya umum untuk bahasa pemrograman tertentu.
+Meskipun Anda mungkin enggan menyerahkan kendali gaya tentang kode Anda, menstandarisasi format kode akan membantu orang lain membaca kode Anda dan akan membuat Anda lebih baik dalam membaca kode orang lain (yang telah distandarisasi secara gaya).
 
 # Profiling
 
-Even if your code functionally behaves as you would expect, that might not be good enough if it takes all your CPU or memory in the process.
-Algorithms classes often teach big _O_ notation but not how to find hot spots in your programs.
-Since [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), you should learn about profilers and monitoring tools. They will help you understand which parts of your program are taking most of the time and/or resources so you can focus on optimizing those parts.
+Meskipun kode Anda berperilaku fungsional seperti yang Anda harapkan, itu mungkin tidak cukup baik jika memakan semua CPU atau memori Anda dalam prosesnya.
+Kelas algoritma sering mengajarkan notasi big _O_ tetapi tidak bagaimana menemukan hot spot dalam program Anda.
+Karena [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), Anda harus mempelajari profiler dan alat monitoring. Mereka akan membantu Anda memahami bagian mana dari program Anda yang memakan waktu dan/atau sumber daya paling banyak sehingga Anda dapat fokus mengoptimalkan bagian-bagian tersebut.
 
 ## Timing
 
-Similarly to the debugging case, in many scenarios it can be enough to just print the time it took your code between two points.
-Here is an example in Python using the [`time`](https://docs.python.org/3/library/time.html) module.
+Sama seperti kasus debugging, dalam banyak skenario, cukup dengan mencetak waktu yang dibutuhkan kode Anda antara dua titik.
+Berikut contoh di Python menggunakan modul [`time`](https://docs.python.org/3/library/time.html).
 
 ```python
 import time, random
@@ -244,13 +244,13 @@ print(time.time() - start)
 # 0.5713930130004883
 ```
 
-However, wall clock time can be misleading since your computer might be running other processes at the same time or waiting for events to happen. It is common for tools to make a distinction between _Real_, _User_ and _Sys_ time. In general, _User_ + _Sys_ tells you how much time your process actually spent in the CPU (more detailed explanation [here](https://stackoverflow.com/questions/556405/what-do-real-user-and-sys-mean-in-the-output-of-time1)).
+Namun, wall clock time bisa menyesatkan karena komputer Anda mungkin menjalankan proses lain pada saat yang sama atau menunggu kejadian tertentu. Alat-alat umumnya membuat perbedaan antara waktu _Real_, _User_, dan _Sys_. Secara umum, _User_ + _Sys_ memberi tahu Anda berapa banyak waktu proses Anda sebenarnya dihabiskan di CPU (penjelasan lebih detail [di sini](https://stackoverflow.com/questions/556405/what-do-real-user-and-sys-mean-in-the-output-of-time1)).
 
-- _Real_ - Wall clock elapsed time from start to finish of the program, including the time taken by other processes and time taken while blocked (e.g. waiting for I/O or network)
-- _User_ - Amount of time spent in the CPU running user code
-- _Sys_ - Amount of time spent in the CPU running kernel code
+- _Real_ - Waktu wall clock yang berlalu dari awal hingga akhir program, termasuk waktu yang dihabiskan oleh proses lain dan waktu saat blocked (misalnya menunggu I/O atau jaringan)
+- _User_ - Jumlah waktu yang dihabiskan di CPU untuk menjalankan kode user
+- _Sys_ - Jumlah waktu yang dihabiskan di CPU untuk menjalankan kode kernel
 
-For example, try running a command that performs an HTTP request and prefixing it with [`time`](https://www.man7.org/linux/man-pages/man1/time.1.html). Under a slow connection you might get an output like the one below. Here it took over 2 seconds for the request to complete but the process only took 15ms of CPU user time and 12ms of kernel CPU time.
+Sebagai contoh, coba jalankan perintah yang melakukan HTTP request dan awali dengan [`time`](https://www.man7.org/linux/man-pages/man1/time.1.html). Pada koneksi lambat Anda mungkin mendapatkan output seperti di bawah ini. Di sini dibutuhkan lebih dari 2 detik untuk request selesai tetapi proses hanya memakan 15ms waktu CPU user dan 12ms waktu CPU kernel.
 
 ```bash
 $ time curl https://missing.csail.mit.edu &> /dev/null
@@ -259,20 +259,20 @@ user    0m0.015s
 sys     0m0.012s
 ```
 
-## Profilers
+## Profiler
 
 ### CPU
 
-Most of the time when people refer to _profilers_ they actually mean _CPU profilers_,  which are the most common.
-There are two main types of CPU profilers: _tracing_ and _sampling_ profilers.
-Tracing profilers keep a record of every function call your program makes whereas sampling profilers probe your program periodically (commonly every millisecond) and record the program's stack.
-They use these records to present aggregate statistics of what your program spent the most time doing.
-[Here](https://jvns.ca/blog/2017/12/17/how-do-ruby---python-profilers-work-) is a good intro article if you want more detail on this topic.
+Sebagian besar waktu ketika orang merujuk ke _profiler_, mereka sebenarnya berarti _CPU profiler_, yang merupakan yang paling umum.
+Ada dua jenis utama CPU profiler: profiler _tracing_ dan _sampling_.
+Tracing profiler mencatat setiap pemanggilan fungsi yang dibuat program Anda, sedangkan sampling profiler memeriksa program Anda secara berkala (biasanya setiap milidetik) dan mencatat stack program.
+Mereka menggunakan catatan ini untuk menyajikan statistik agregat tentang apa yang paling banyak dilakukan program Anda.
+[Berikut](https://jvns.ca/blog/2017/12/17/how-do-ruby---python-profilers-work-) artikel pengantar yang bagus jika Anda ingin detail lebih lanjut tentang topik ini.
 
-Most programming languages have some sort of command line profiler that you can use to analyze your code.
-They often integrate with full fledged IDEs but for this lecture we are going to focus on the command line tools themselves.
+Sebagian besar bahasa pemrograman memiliki semacam profiler baris perintah yang dapat Anda gunakan untuk menganalisis kode Anda.
+Mereka sering terintegrasi dengan IDE lengkap tetapi untuk kuliah ini kita akan fokus pada alat baris perintah itu sendiri.
 
-In Python we can use the `cProfile` module to profile time per function call. Here is a simple example that implements a rudimentary grep in Python:
+Di Python kita dapat menggunakan modul `cProfile` untuk memprofilkan waktu per pemanggilan fungsi. Berikut contoh sederhana yang mengimplementasikan grep dasar di Python:
 
 ```python
 #!/usr/bin/env python
@@ -296,7 +296,7 @@ if __name__ == '__main__':
             grep(pattern, file)
 ```
 
-We can profile this code using the following command. Analyzing the output we can see that IO is taking most of the time and that compiling the regex takes a fair amount of time as well. Since the regex only needs to be compiled once, we can factor it out of the for.
+Kita dapat memprofilkan kode ini menggunakan perintah berikut. Dengan menganalisis output, kita dapat melihat bahwa IO memakan waktu paling banyak dan bahwa kompilasi regex juga memakan waktu yang cukup. Karena regex hanya perlu dikompilasi sekali, kita dapat memfaktorkannya keluar dari for.
 
 ```
 $ python -m cProfile -s tottime grep.py 1000 '^(import|\s*def)[^,]*$' *.py
@@ -318,10 +318,10 @@ $ python -m cProfile -s tottime grep.py 1000 '^(import|\s*def)[^,]*$' *.py
 ```
 
 
-A caveat of Python's `cProfile` profiler (and many profilers for that matter) is that they display time per function call. That can become unintuitive really fast, especially if you are using third party libraries in your code since internal function calls are also accounted for.
-A more intuitive way of displaying profiling information is to include the time taken per line of code, which is what _line profilers_ do.
+Catatan tentang profiler `cProfile` Python (dan banyak profiler pada umumnya) adalah mereka menampilkan waktu per pemanggilan fungsi. Hal ini bisa menjadi sangat tidak intuitif, terutama jika Anda menggunakan pustaka pihak ketiga dalam kode Anda karena pemanggilan fungsi internal juga diperhitungkan.
+Cara yang lebih intuitif untuk menampilkan informasi profiling adalah dengan menyertakan waktu yang dihabiskan per baris kode, yang merupakan apa yang dilakukan _line profiler_.
 
-For instance, the following piece of Python code performs a request to the class website and parses the response to get all URLs in the page:
+Sebagai contoh, potongan kode Python berikut melakukan request ke situs web kelas dan mengurai respons untuk mendapatkan semua URL di halaman:
 
 ```python
 #!/usr/bin/env python
@@ -342,7 +342,7 @@ if __name__ == '__main__':
     get_urls()
 ```
 
-If we used Python's `cProfile` profiler we'd get over 2500 lines of output, and even with sorting it'd be hard to understand where the time is being spent. A quick run with [`line_profiler`](https://github.com/pyutils/line_profiler) shows the time taken per line:
+Jika kita menggunakan profiler `cProfile` Python, kita akan mendapatkan lebih dari 2500 baris output, dan bahkan dengan pengurutan, akan sulit memahami di mana waktu dihabiskan. Jalankan cepat dengan [`line_profiler`](https://github.com/pyutils/line_profiler) menunjukkan waktu yang dihabiskan per baris:
 
 ```bash
 $ kernprof -l -v a.py
@@ -364,13 +364,13 @@ Line #  Hits         Time  Per Hit   % Time  Line Contents
 11        24         33.0      1.4      0.0          urls.append(url['href'])
 ```
 
-### Memory
+### Memori
 
-In languages like C or C++ memory leaks can cause your program to never release memory that it doesn't need anymore.
-To help in the process of memory debugging you can use tools like [Valgrind](https://valgrind.org/) that will help you identify memory leaks.
+Dalam bahasa seperti C atau C++, memory leak dapat menyebabkan program Anda tidak pernah melepaskan memori yang tidak lagi dibutuhkan.
+Untuk membantu dalam proses debugging memori, Anda dapat menggunakan alat seperti [Valgrind](https://valgrind.org/) yang akan membantu Anda mengidentifikasi memory leak.
 
-In garbage collected languages like Python it is still useful to use a memory profiler because as long as you have pointers to objects in memory they won't be garbage collected.
-Here's an example program and its associated output when running it with [memory-profiler](https://pypi.org/project/memory-profiler/) (note the decorator like in `line-profiler`).
+Dalam bahasa dengan garbage collector seperti Python, tetap berguna menggunakan memory profiler karena selama Anda memiliki pointer ke objek di memori, mereka tidak akan di-garbage collect.
+Berikut contoh program dan output terkait saat menjalankannya dengan [memory-profiler](https://pypi.org/project/memory-profiler/) (perhatikan decorator seperti pada `line-profiler`).
 
 ```python
 @profile
@@ -398,58 +398,58 @@ Line #    Mem usage  Increment   Line Contents
 
 ### Event Profiling
 
-As it was the case for `strace` for debugging, you might want to ignore the specifics of the code that you are running and treat it like a black box when profiling.
-The [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) command abstracts CPU differences away and does not report time or memory, but instead it reports system events related to your programs.
-For example, `perf` can easily report poor cache locality, high amounts of page faults or livelocks. Here is an overview of the command:
+Seperti halnya `strace` untuk debugging, Anda mungkin ingin mengabaikan detail kode yang Anda jalankan dan memperlakukannya seperti black box saat melakukan profiling.
+Perintah [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) mengabstraksi perbedaan CPU dan tidak melaporkan waktu atau memori, melainkan melaporkan event sistem yang terkait dengan program Anda.
+Sebagai contoh, `perf` dapat dengan mudah melaporkan poor cache locality, page faults dalam jumlah besar, atau livelocks. Berikut ikhtisar perintahnya:
 
-- `perf list` - List the events that can be traced with perf
-- `perf stat COMMAND ARG1 ARG2` - Gets counts of different events related to a process or command
-- `perf record COMMAND ARG1 ARG2` - Records the run of a command and saves the statistical data into a file called `perf.data`
-- `perf report` - Formats and prints the data collected in `perf.data`
+- `perf list` - Mencantumkan event yang dapat ditelusuri dengan perf
+- `perf stat COMMAND ARG1 ARG2` - Mendapatkan hitungan dari berbagai event yang terkait dengan proses atau perintah
+- `perf record COMMAND ARG1 ARG2` - Merekam eksekusi perintah dan menyimpan data statistik ke file bernama `perf.data`
+- `perf report` - Memformat dan mencetak data yang dikumpulkan di `perf.data`
 
 
-### Visualization
+### Visualisasi
 
-Profiler output for real world programs will contain large amounts of information because of the inherent complexity of software projects.
-Humans are visual creatures and are quite terrible at reading large amounts of numbers and making sense of them.
-Thus there are many tools for displaying profiler's output in an easier to parse way.
+Output profiler untuk program dunia nyata akan berisi sejumlah besar informasi karena kompleksitas inheren dari proyek perangkat lunak.
+Manusia adalah makhluk visual dan cukup buruk dalam membaca sejumlah besar angka dan memahaminya.
+Oleh karena itu, ada banyak alat untuk menampilkan output profiler dengan cara yang lebih mudah dipahami.
 
-One common way to display CPU profiling information for sampling profilers is to use a [Flame Graph](https://www.brendangregg.com/flamegraphs.html), which will display a hierarchy of function calls across the Y axis and time taken proportional to the X axis. They are also interactive, letting you zoom into specific parts of the program and get their stack traces (try clicking in the image below).
+Salah satu cara umum untuk menampilkan informasi profiling CPU untuk sampling profiler adalah menggunakan [Flame Graph](https://www.brendangregg.com/flamegraphs.html), yang akan menampilkan hierarki pemanggilan fungsi pada sumbu Y dan waktu yang dihabiskan proporsional terhadap sumbu X. Mereka juga interaktif, memungkinkan Anda zoom ke bagian tertentu dari program dan mendapatkan stack trace-nya (coba klik gambar di bawah).
 
 [![FlameGraph](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)
 
-Call graphs or control flow graphs display the relationships between subroutines within a program by including functions as nodes and functions calls between them as directed edges. When coupled with profiling information such as the number of calls and time taken, call graphs can be quite useful for interpreting the flow of a program.
-In Python you can use the [`pycallgraph`](https://pycallgraph.readthedocs.io/) library to generate them.
+Call graph atau control flow graph menampilkan hubungan antar subroutine dalam suatu program dengan menyertakan fungsi sebagai node dan pemanggilan fungsi di antara mereka sebagai edge berarah. Ketika dipasangkan dengan informasi profiling seperti jumlah pemanggilan dan waktu yang dihabiskan, call graph bisa sangat berguna untuk menginterpretasikan alur program.
+Di Python Anda dapat menggunakan pustaka [`pycallgraph`](https://pycallgraph.readthedocs.io/) untuk membuatnya.
 
 ![Call Graph](https://upload.wikimedia.org/wikipedia/commons/2/2f/A_Call_Graph_generated_by_pycallgraph.png)
 
 
-## Resource Monitoring
+## Monitoring Sumber Daya
 
-Sometimes, the first step towards analyzing the performance of your program is to understand what its actual resource consumption is.
-Programs often run slowly when they are resource constrained, e.g. without enough memory or on a slow network connection.
-There are a myriad of command line tools for probing and displaying different system resources like CPU usage, memory usage, network, disk usage and so on.
+Terkadang, langkah pertama menuju analisis performa program Anda adalah memahami konsumsi sumber daya aktualnya.
+Program sering berjalan lambat ketika sumber dayanya terbatas, misalnya tanpa memori yang cukup atau pada koneksi jaringan yang lambat.
+Ada banyak sekali alat baris perintah untuk memeriksa dan menampilkan berbagai sumber daya sistem seperti penggunaan CPU, penggunaan memori, jaringan, penggunaan disk, dan sebagainya.
 
-- **General Monitoring** - Probably the most popular is [`htop`](https://htop.dev/), which is an improved version of [`top`](https://www.man7.org/linux/man-pages/man1/top.1.html).
-`htop` presents various statistics for the currently running processes on the system. `htop` has a myriad of options and keybinds, some useful ones  are: `<F6>` to sort processes, `t` to show tree hierarchy and `h` to toggle threads.
-See also [`glances`](https://nicolargo.github.io/glances/) for similar implementation with a great UI. For getting aggregate measures across all processes, [`dool`](https://github.com/scottchiefbaker/dool) is another nifty tool that computes real-time resource metrics for lots of different subsystems like I/O, networking, CPU utilization, context switches, &c.
-- **I/O operations** - [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) displays live I/O usage information and is handy to check if a process is doing heavy I/O disk operations
-- **Disk Usage** - [`df`](https://www.man7.org/linux/man-pages/man1/df.1.html) displays metrics per partitions and [`du`](https://man7.org/linux/man-pages/man1/du.1.html) displays **d**isk **u**sage per file for the current directory. In these tools the `-h` flag tells the program to print with **h**uman readable format.
-A more interactive version of `du` is [`ncdu`](https://dev.yorhel.nl/ncdu) which lets you navigate folders and delete files and folders as you navigate.
-- **Memory Usage** - [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) displays the total amount of free and used memory in the system. Memory is also displayed in tools like `htop`.
-- **Open Files** - [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html)  lists file information about files opened by processes. It can be quite useful for checking which process has opened a specific file.
-- **Network Connections and Config** - [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) lets you monitor incoming and outgoing network packets statistics as well as interface statistics. A common use case of `ss` is figuring out what process is using a given port in a machine. For displaying routing, network devices and interfaces you can use [`ip`](https://man7.org/linux/man-pages/man8/ip.8.html). Note that `netstat` and `ifconfig` have been deprecated in favor of the former tools respectively.
-- **Network Usage** -  [`nethogs`](https://github.com/raboof/nethogs) and [`iftop`](https://pdw.ex-parrot.com/iftop/) are good interactive CLI tools for monitoring network usage.
+- **Monitoring Umum** - Mungkin yang paling populer adalah [`htop`](https://htop.dev/), yang merupakan versi perbaikan dari [`top`](https://www.man7.org/linux/man-pages/man1/top.1.html).
+`htop` menyajikan berbagai statistik untuk proses yang sedang berjalan di sistem. `htop` memiliki banyak opsi dan keybind, beberapa yang berguna adalah: `<F6>` untuk mengurutkan proses, `t` untuk menampilkan hierarki tree, dan `h` untuk toggle thread.
+Lihat juga [`glances`](https://nicolargo.github.io/glances/) untuk implementasi serupa dengan UI yang hebat. Untuk mendapatkan pengukuran agregat di semua proses, [`dool`](https://github.com/scottchiefbaker/dool) adalah alat lain yang berguna yang menghitung metrik sumber daya real-time untuk banyak subsistem berbeda seperti I/O, jaringan, utilisasi CPU, context switch, &c.
+- **Operasi I/O** - [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) menampilkan informasi penggunaan I/O secara langsung dan berguna untuk memeriksa apakah suatu proses melakukan operasi disk I/O yang berat
+- **Penggunaan Disk** - [`df`](https://www.man7.org/linux/man-pages/man1/df.1.html) menampilkan metrik per partisi dan [`du`](https://man7.org/linux/man-pages/man1/du.1.html) menampilkan penggunaan **d**isk per file untuk direktori saat ini. Pada alat-alat ini, flag `-h` memberi tahu program untuk mencetak dalam format yang mudah dibaca manusia (**h**uman readable).
+Versi yang lebih interaktif dari `du` adalah [`ncdu`](https://dev.yorhel.nl/ncdu) yang memungkinkan Anda menavigasi folder dan menghapus file serta folder saat Anda menavigasi.
+- **Penggunaan Memori** - [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) menampilkan jumlah total memori bebas dan yang digunakan dalam sistem. Memori juga ditampilkan di alat seperti `htop`.
+- **File Terbuka** - [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) mencantumkan informasi file tentang file yang dibuka oleh proses. Ini bisa sangat berguna untuk memeriksa proses mana yang telah membuka file tertentu.
+- **Konfigurasi dan Koneksi Jaringan** - [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) memungkinkan Anda memantau statistik paket jaringan masuk dan keluar serta statistik antarmuka. Kasus penggunaan umum `ss` adalah mengetahui proses mana yang menggunakan port tertentu di suatu mesin. Untuk menampilkan routing, perangkat jaringan, dan antarmuka Anda dapat menggunakan [`ip`](https://man7.org/linux/man-pages/man8/ip.8.html). Perhatikan bahwa `netstat` dan `ifconfig` telah didepresiasi masing-masing demi alat-alat sebelumnya.
+- **Penggunaan Jaringan** - [`nethogs`](https://github.com/raboof/nethogs) dan [`iftop`](https://pdw.ex-parrot.com/iftop/) adalah alat CLI interaktif yang bagus untuk memantau penggunaan jaringan.
 
-If you want to test these tools you can also artificially impose loads on the machine using the [`stress`](https://linux.die.net/man/1/stress) command.
+Jika Anda ingin menguji alat-alat ini, Anda juga dapat secara buatan membebankan beban pada mesin menggunakan perintah [`stress`](https://linux.die.net/man/1/stress).
 
 
-### Specialized tools
+### Alat khusus
 
-Sometimes, black box benchmarking is all you need to determine what software to use.
-Tools like [`hyperfine`](https://github.com/sharkdp/hyperfine) let you quickly benchmark command line programs.
-For instance, in the shell tools and scripting lecture we recommended `fd` over `find`. We can use `hyperfine` to compare them in tasks we run often.
-E.g. in the example below `fd` was 20x faster than `find` in my machine.
+Terkadang, benchmarking black box adalah semua yang Anda butuhkan untuk menentukan perangkat lunak mana yang akan digunakan.
+Alat seperti [`hyperfine`](https://github.com/sharkdp/hyperfine) memungkinkan Anda dengan cepat melakukan benchmark program baris perintah.
+Sebagai contoh, di kuliah shell tools dan scripting kami merekomendasikan `fd` daripada `find`. Kita dapat menggunakan `hyperfine` untuk membandingkan mereka dalam tugas yang sering kita jalankan.
+Misalnya, pada contoh di bawah `fd` 20x lebih cepat daripada `find` di mesin saya.
 
 ```bash
 $ hyperfine --warmup 3 'fd -e jpg' 'find . -iname "*.jpg"'
@@ -466,18 +466,18 @@ Summary
    21.89 ± 2.33 times faster than 'find . -iname "*.jpg"'
 ```
 
-As it was the case for debugging, browsers also come with a fantastic set of tools for profiling webpage loading, letting you figure out where time is being spent (loading, rendering, scripting, &c).
-More info for [Firefox](https://profiler.firefox.com/docs/) and [Chrome](https://developers.google.com/web/tools/chrome-devtools/rendering-tools).
+Seperti halnya debugging, browser juga dilengkapi dengan seperangkat alat fantastis untuk memprofilkan pemuatan halaman web, memungkinkan Anda mengetahui di mana waktu dihabiskan (memuat, rendering, scripting, &c).
+Info lebih lanjut untuk [Firefox](https://profiler.firefox.com/docs/) dan [Chrome](https://developers.google.com/web/tools/chrome-devtools/rendering-tools).
 
-# Exercises
+# Latihan
 
 ## Debugging
-1. Use `journalctl` on Linux or `log show` on macOS to get the super user accesses and commands in the last day.
-If there aren't any you can execute some harmless commands such as `sudo ls` and check again.
+1. Gunakan `journalctl` di Linux atau `log show` di macOS untuk mendapatkan akses super user dan perintah di hari terakhir.
+Jika tidak ada, Anda dapat menjalankan beberapa perintah yang tidak berbahaya seperti `sudo ls` dan periksa lagi.
 
-1. Do [this](https://github.com/spiside/pdb-tutorial) hands on `pdb` tutorial to familiarize yourself with the commands. For a more in depth tutorial read [this](https://realpython.com/python-debugging-pdb).
+1. Ikuti tutorial hands-on `pdb` [ini](https://github.com/spiside/pdb-tutorial) untuk membiasakan diri dengan perintah-perintahnya. Untuk tutorial yang lebih mendalam, baca [ini](https://realpython.com/python-debugging-pdb).
 
-1. Install [`shellcheck`](https://www.shellcheck.net/) and try checking the following script. What is wrong with the code? Fix it. Install a linter plugin in your editor so you can get your warnings automatically.
+1. Instal [`shellcheck`](https://www.shellcheck.net/) dan coba periksa script berikut. Apa yang salah dengan kode tersebut? Perbaiki. Instal plugin linter di editor Anda sehingga Anda bisa mendapatkan peringatan secara otomatis.
 
    ```bash
    #!/bin/sh
@@ -489,12 +489,12 @@ If there aren't any you can execute some harmless commands such as `sudo ls` and
    done
    ```
 
-1. (Advanced) Read about [reversible debugging](https://undo.io/resources/reverse-debugging-whitepaper/) and get a simple example working using [`rr`](https://rr-project.org/) or [`RevPDB`](https://morepypy.blogspot.com/2016/07/reverse-debugging-for-python.html).
+1. (Lanjutan) Baca tentang [reversible debugging](https://undo.io/resources/reverse-debugging-whitepaper/) dan buat contoh sederhana yang berfungsi menggunakan [`rr`](https://rr-project.org/) atau [`RevPDB`](https://morepypy.blogspot.com/2016/07/reverse-debugging-for-python.html).
 ## Profiling
 
-1. [Here](/static/files/sorts.py) are some sorting algorithm implementations. Use [`cProfile`](https://docs.python.org/3/library/profile.html) and [`line_profiler`](https://github.com/pyutils/line_profiler) to compare the runtime of insertion sort and quicksort. What is the bottleneck of each algorithm? Use then `memory_profiler` to check the memory consumption, why is insertion sort better? Check now the inplace version of quicksort. Challenge: Use `perf` to look at the cycle counts and cache hits and misses of each algorithm.
+1. [Berikut](/static/files/sorts.py) beberapa implementasi algoritma pengurutan. Gunakan [`cProfile`](https://docs.python.org/3/library/profile.html) dan [`line_profiler`](https://github.com/pyutils/line_profiler) untuk membandingkan runtime insertion sort dan quicksort. Apa bottleneck masing-masing algoritma? Kemudian gunakan `memory_profiler` untuk memeriksa konsumsi memori, mengapa insertion sort lebih baik? Sekarang periksa versi inplace dari quicksort. Tantangan: Gunakan `perf` untuk melihat cycle count dan cache hits serta misses masing-masing algoritma.
 
-1. Here's some (arguably convoluted) Python code for computing Fibonacci numbers using a function for each number.
+1. Berikut kode Python (yang mungkin agak berbelit-belit) untuk menghitung bilangan Fibonacci menggunakan fungsi untuk setiap bilangan.
 
    ```python
    #!/usr/bin/env python
@@ -514,13 +514,12 @@ If there aren't any you can execute some harmless commands such as `sudo ls` and
        print(eval("fib9()"))
    ```
 
-   Put the code into a file and make it executable. Install prerequisites: [`pycallgraph`](https://lewiscowles1986.github.io/py-call-graph/) and [`graphviz`](https://graphviz.org/). (If you can run `dot`, you already have GraphViz.) Run the code as is with `pycallgraph graphviz -- ./fib.py` and check the `pycallgraph.png` file. How many times is `fib0` called?. We can do better than that by memoizing the functions. Uncomment the commented lines and regenerate the images. How many times are we calling each `fibN` function now?
+   Letakkan kode ke dalam file dan jadikan dapat dieksekusi. Instal prasyarat: [`pycallgraph`](https://lewiscowles1986.github.io/py-call-graph/) dan [`graphviz`](https://graphviz.org/). (Jika Anda bisa menjalankan `dot`, Anda sudah punya GraphViz.) Jalankan kode apa adanya dengan `pycallgraph graphviz -- ./fib.py` dan periksa file `pycallgraph.png`. Berapa kali `fib0` dipanggil?. Kita bisa melakukan lebih baik dari itu dengan memoizing fungsi-fungsi tersebut. Hapus komentar pada baris yang dikomentari dan generate ulang gambar. Berapa kali kita memanggil setiap fungsi `fibN` sekarang?
 
-1. A common issue is that a port you want to listen on is already taken by another process. Let's learn how to discover that process pid. First execute `python -m http.server 4444` to start a minimal web server listening on port `4444`. On a separate terminal run `lsof | grep LISTEN` to print all listening processes and ports. Find that process pid and terminate it by running `kill <PID>`.
+1. Masalah umum adalah port yang ingin Anda gunakan untuk listen sudah diambil oleh proses lain. Mari kita pelajari cara menemukan pid proses tersebut. Pertama jalankan `python -m http.server 4444` untuk memulai server web minimal yang listen di port `4444`. Di terminal terpisah jalankan `lsof | grep LISTEN` untuk mencetak semua proses dan port yang sedang listen. Temukan pid proses tersebut dan hentikan dengan menjalankan `kill <PID>`.
 
-1. Limiting a process's resources can be another handy tool in your toolbox.
-Try running `stress -c 3` and visualize the CPU consumption with `htop`. Now, execute `taskset --cpu-list 0,2 stress -c 3` and visualize it. Is `stress` taking three CPUs? Why not? Read [`man taskset`](https://www.man7.org/linux/man-pages/man1/taskset.1.html).
-Challenge: achieve the same using [`cgroups`](https://www.man7.org/linux/man-pages/man7/cgroups.7.html). Try limiting the memory consumption of `stress -m`.
+1. Membatasi sumber daya proses bisa menjadi alat berguna lainnya dalam kotak peralatan Anda.
+Coba jalankan `stress -c 3` dan visualisasikan konsumsi CPU dengan `htop`. Sekarang, jalankan `taskset --cpu-list 0,2 stress -c 3` dan visualisasikan. Apakah `stress` menggunakan tiga CPU? Mengapa tidak? Baca [`man taskset`](https://www.man7.org/linux/man-pages/man1/taskset.1.html).
+Tantangan: capai hal yang sama menggunakan [`cgroups`](https://www.man7.org/linux/man-pages/man7/cgroups.7.html). Coba batasi konsumsi memori `stress -m`.
 
-1. (Advanced) The command `curl ipinfo.io` performs a HTTP request and fetches information about your public IP. Open [Wireshark](https://www.wireshark.org/) and try to sniff the request and reply packets that `curl` sent and received. (Hint: Use the `http` filter to just watch HTTP packets).
-
+1. (Lanjutan) Perintah `curl ipinfo.io` melakukan HTTP request dan mengambil informasi tentang IP publik Anda. Buka [Wireshark](https://www.wireshark.org/) dan coba sniff paket request dan reply yang dikirim dan diterima `curl`. (Petunjuk: Gunakan filter `http` untuk hanya melihat paket HTTP).

--- a/_2020/debugging-profiling.md
+++ b/_2020/debugging-profiling.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Debugging and Profiling"
 description: >
-  Learn how to debug programs using logging, debuggers, and static analysis, and how to profile code for performance.
+  Pelajari cara men-debug program menggunakan logging, debugger, dan analisis statis, serta cara melakukan profiling kode untuk performa.
 thumbnail: /static/assets/thumbnails/2020/lec7.png
 date: 2020-01-23
 ready: true

--- a/_2020/editors.md
+++ b/_2020/editors.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Editors (Vim)"
+title: "Editor (Vim)"
 description: >
   Pelajari cara menggunakan Vim, editor teks yang dirancang untuk pengeditan kode yang efisien.
 thumbnail: /static/assets/thumbnails/2020/lec3.png
@@ -11,227 +11,221 @@ video:
   id: a6Q8Na575qc
 ---
 
-Writing English words and writing code are very different activities. When
-programming, you spend more time switching files, reading, navigating, and
-editing code compared to writing a long stream. It makes sense that there are
-different types of programs for writing English words versus code (e.g.
+Menulis kata-kata bahasa Inggris dan menulis kode adalah aktivitas yang sangat berbeda. Saat
+pemrograman, Anda menghabiskan lebih banyak waktu untuk berpindah file, membaca, navigasi, dan
+mengedit kode dibandingkan menulis aliran teks yang panjang. Masuk akal jika ada
+jenis program yang berbeda untuk menulis kata-kata bahasa Inggris versus kode (misalnya
 Microsoft Word versus Visual Studio Code).
 
-As programmers, we spend most of our time editing code, so it's worth investing
-time mastering an editor that fits your needs. Here's how you learn a new
-editor:
+Sebagai programmer, kita menghabiskan sebagian besar waktu untuk mengedit kode, jadi ada baiknya menginvestasikan
+waktu untuk menguasai editor yang sesuai dengan kebutuhan Anda. Berikut cara mempelajari editor baru:
 
-- Start with a tutorial (i.e. this lecture, plus resources that we point out)
-- Stick with using the editor for all your text editing needs (even if it slows
-you down initially)
-- Look things up as you go: if it seems like there should be a better way to do
-something, there probably is
+- Mulailah dengan tutorial (yaitu kuliah ini, plus sumber daya yang kami tunjukkan)
+- Tetap gunakan editor untuk semua kebutuhan pengeditan teks Anda (meskipun pada awalnya memperlambat
+Anda)
+- Cari tahu saat Anda menggunakannya: jika tampaknya ada cara yang lebih baik untuk melakukan
+sesuatu, kemungkinan besar ada
 
-If you follow the above method, fully committing to using the new program for
-all text editing purposes, the timeline for learning a sophisticated text
-editor looks like this. In an hour or two, you'll learn basic editor functions
-such as opening and editing files, save/quit, and navigating buffers. Once
-you're 20 hours in, you should be as fast as you were with your old editor.
-After that, the benefits start: you will have enough knowledge and muscle
-memory that using the new editor saves you time. Modern text editors are fancy
-and powerful tools, so the learning never stops: you'll get even faster as you
-learn more.
+Jika Anda mengikuti metode di atas, sepenuhnya berkomitmen menggunakan program baru untuk
+semua tujuan pengeditan teks, timeline untuk mempelajari editor teks yang canggih
+terlihat seperti ini. Dalam satu atau dua jam, Anda akan mempelajari fungsi-fungsi dasar editor
+seperti membuka dan mengedit file, menyimpan/keluar, dan menavigasi buffer. Setelah
+20 jam, Anda seharusnya sudah secepat saat menggunakan editor lama Anda.
+Setelah itu, manfaatnya mulai terasa: Anda akan memiliki pengetahuan dan memori otot
+yang cukup sehingga menggunakan editor baru menghemat waktu Anda. Editor teks modern adalah alat
+yang canggih dan powerful, sehingga proses belajar tidak pernah berhenti: Anda akan menjadi lebih cepat seiring
+Anda mempelajari lebih banyak hal.
 
-# Which editor to learn?
+# Editor mana yang harus dipelajari?
 
-Programmers have [strong opinions](https://en.wikipedia.org/wiki/Editor_war)
-about their text editors.
+Para programmer memiliki [opini yang kuat](https://en.wikipedia.org/wiki/Editor_war)
+tentang editor teks mereka.
 
-Which editors are popular today? See this [Stack Overflow
-survey](https://insights.stackoverflow.com/survey/2019/#development-environments-and-tools)
-(there may be some bias because Stack Overflow users may not be representative
-of programmers as a whole). [Visual Studio
-Code](https://code.visualstudio.com/) is the most popular editor.
-[Vim](https://www.vim.org/) is the most popular command-line-based editor.
+Editor mana yang populer saat ini? Lihat [survei Stack Overflow
+ini](https://insights.stackoverflow.com/survey/2019/#development-environments-and-tools)
+(mungkin ada beberapa bias karena pengguna Stack Overflow mungkin tidak mewakili
+seluruh programmer). [Visual Studio
+Code](https://code.visualstudio.com/) adalah editor yang paling populer.
+[Vim](https://www.vim.org/) adalah editor berbasis command-line yang paling populer.
 
 ## Vim
 
-All the instructors of this class use Vim as their editor. Vim has a rich
-history; it originated from the Vi editor (1976), and it's still being
-developed today. Vim has some really neat ideas behind it, and for this reason,
-lots of tools support a Vim emulation mode (for example, 1.4 million people
-have installed [Vim emulation for VS code](https://github.com/VSCodeVim/Vim)).
-Vim is probably worth learning even if you finally end up switching to some
-other text editor.
+Semua instruktur kelas ini menggunakan Vim sebagai editor mereka. Vim memiliki sejarah yang kaya;
+berasal dari editor Vi (1976), dan masih terus dikembangkan hingga saat ini. Vim memiliki
+beberapa ide yang sangat menarik di baliknya, dan karena alasan ini,
+banyak alat yang mendukung mode emulasi Vim (misalnya, 1,4 juta orang
+telah menginstal [emulasi Vim untuk VS code](https://github.com/VSCodeVim/Vim)). Vim mungkin layak dipelajari meskipun pada akhirnya Anda beralih ke editor teks lain.
 
-It's not possible to teach all of Vim's functionality in 50 minutes, so we're
-going to focus on explaining the philosophy of Vim, teaching you the basics,
-showing you some of the more advanced functionality, and giving you the
-resources to master the tool.
+Tidak mungkin mengajarkan semua fungsionalitas Vim dalam 50 menit, jadi kami
+akan fokus menjelaskan filosofi Vim, mengajarkan dasar-dasarnya,
+menunjukkan beberapa fungsionalitas yang lebih advanced, dan memberi Anda
+sumber daya untuk menguasai alat ini.
 
-# Philosophy of Vim
+# Filosofi Vim
 
-When programming, you spend most of your time reading/editing, not writing. For
-this reason, Vim is a _modal_ editor: it has different modes for inserting text
-vs manipulating text. Vim is programmable (with Vimscript and also other
-languages like Python), and Vim's interface itself is a programming language:
-keystrokes (with mnemonic names) are commands, and these commands are
-composable. Vim avoids the use of the mouse, because it's too slow; Vim even
-avoids using the arrow keys because it requires too much movement.
+Saat pemrograman, Anda menghabiskan sebagian besar waktu untuk membaca/mengedit, bukan menulis. Karena
+alasan ini, Vim adalah editor _modal_: ia memiliki mode yang berbeda untuk menyisipkan teks
+vs memanipulasi teks. Vim dapat diprogram (dengan Vimscript dan juga bahasa
+lain seperti Python), dan antarmuka Vim itu sendiri adalah bahasa pemrograman:
+tekanan tombol (dengan nama mnemonik) adalah perintah, dan perintah-perintah ini
+dapat dikomposisikan. Vim menghindari penggunaan mouse, karena terlalu lambat; Vim bahkan
+menghindari penggunaan tombol panah karena membutuhkan terlalu banyak pergerakan.
 
-The end result is an editor that can match the speed at which you think.
+Hasil akhirnya adalah editor yang dapat menyamai kecepatan berpikir Anda.
 
-# Modal editing
+# Pengeditan modal
 
-Vim's design is based on the idea that a lot of programmer time is spent
-reading, navigating, and making small edits, as opposed to writing long streams
-of text. For this reason, Vim has multiple operating modes.
+Desain Vim didasarkan pada ide bahwa banyak waktu programmer dihabiskan
+untuk membaca, navigasi, dan membuat editan kecil, bukan menulis aliran teks yang panjang. Karena alasan ini, Vim memiliki beberapa mode operasi.
 
-- **Normal**: for moving around a file and making edits
-- **Insert**: for inserting text
-- **Replace**: for replacing text
-- **Visual** (plain, line, or block): for selecting blocks of text
-- **Command-line**: for running a command
+- **Normal**: untuk berpindah dalam file dan membuat editan
+- **Insert**: untuk menyisipkan teks
+- **Replace**: untuk mengganti teks
+- **Visual** (plain, line, atau block): untuk memilih blok teks
+- **Command-line**: untuk menjalankan perintah
 
-Keystrokes have different meanings in different operating modes. For example,
-the letter `x` in Insert mode will just insert a literal character 'x', but in
-Normal mode, it will delete the character under the cursor, and in Visual mode,
-it will delete the selection.
+Tekanan tombol memiliki arti yang berbeda dalam mode operasi yang berbeda. Misalnya,
+huruf `x` dalam mode Insert hanya akan menyisipkan karakter literal 'x', tetapi dalam
+mode Normal, ia akan menghapus karakter di bawah kursor, dan dalam mode Visual,
+ia akan menghapus seleksi.
 
-In its default configuration, Vim shows the current mode in the bottom left.
-The initial/default mode is Normal mode. You'll generally spend most of your
-time between Normal mode and Insert mode.
+Dalam konfigurasi default-nya, Vim menampilkan mode saat ini di pojok kiri bawah.
+Mode awal/default adalah mode Normal. Anda umumnya akan menghabiskan sebagian besar waktu
+antara mode Normal dan mode Insert.
 
-You change modes by pressing `<ESC>` (the escape key) to switch from any mode
-back to Normal mode. From Normal mode, enter Insert mode with `i`, Replace mode
-with `R`, Visual mode with `v`, Visual Line mode with `V`, Visual Block mode
-with `<C-v>` (Ctrl-V, sometimes also written `^V`), and Command-line mode with
+Anda mengubah mode dengan menekan `<ESC>` (tombol escape) untuk beralih dari mode apa pun
+kembali ke mode Normal. Dari mode Normal, masuk ke mode Insert dengan `i`, mode Replace
+dengan `R`, mode Visual dengan `v`, mode Visual Line dengan `V`, mode Visual Block
+dengan `<C-v>` (Ctrl-V, terkadang juga ditulis `^V`), dan mode Command-line dengan
 `:`.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to
-Escape ([macOS
-instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS))
-or create an [alternative
-mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) for `<ESC>`
-with a simple key sequence.
+Anda banyak menggunakan tombol `<ESC>` saat menggunakan Vim: pertimbangkan untuk memetakan ulang Caps Lock ke
+Escape ([instruksi
+macOS](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS))
+atau buat [pemetaan
+alternatif](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) untuk `<ESC>`
+dengan urutan tombol sederhana.
 
-# Basics
+# Dasar-dasar
 
-## Inserting text
+## Menyisipkan teks
 
-From Normal mode, press `i` to enter Insert mode. Now, Vim behaves like any
-other text editor, until you press `<ESC>` to return to Normal mode. This,
-along with the basics explained above, are all you need to start editing files
-using Vim (though not particularly efficiently, if you're spending all your
-time editing from Insert mode).
+Dari mode Normal, tekan `i` untuk masuk ke mode Insert. Sekarang, Vim berperilaku seperti
+editor teks lainnya, sampai Anda menekan `<ESC>` untuk kembali ke mode Normal. Ini,
+bersama dengan dasar-dasar yang dijelaskan di atas, adalah semua yang Anda butuhkan untuk mulai mengedit file
+menggunakan Vim (meskipun tidak terlalu efisien, jika Anda menghabiskan seluruh waktu Anda
+mengedit dari mode Insert).
 
-## Buffers, tabs, and windows
+## Buffer, tab, dan window
 
-Vim maintains a set of open files, called "buffers". A Vim session has a number
-of tabs, each of which has a number of windows (split panes). Each window shows
-a single buffer. Unlike other programs you are familiar with, like web
-browsers, there is not a 1-to-1 correspondence between buffers and windows;
-windows are merely views. A given buffer may be open in _multiple_ windows,
-even within the same tab. This can be quite handy, for example, to view two
-different parts of a file at the same time.
+Vim mempertahankan sekumpulan file yang terbuka, yang disebut "buffer". Sesi Vim memiliki sejumlah
+tab, yang masing-masing memiliki sejumlah window (split pane). Setiap window menampilkan
+satu buffer. Berbeda dengan program lain yang sudah Anda kenal, seperti browser
+web, tidak ada korespondensi 1-band-1 antara buffer dan window;
+window hanyalah tampilan. Suatu buffer dapat terbuka di _beberapa_ window,
+bahkan dalam tab yang sama. Ini bisa sangat berguna, misalnya, untuk melihat dua
+bagian berbeda dari suatu file secara bersamaan.
 
-By default, Vim opens with a single tab, which contains a single window.
+Secara default, Vim terbuka dengan satu tab, yang berisi satu window.
 
 ## Command-line
 
-Command mode can be entered by typing `:` in Normal mode. Your cursor will jump
-to the command line at the bottom of the screen upon pressing `:`. This mode
-has many functionalities, including opening, saving, and closing files, and
-[quitting Vim](https://twitter.com/iamdevloper/status/435555976687923200).
+Mode command dapat dimasuki dengan mengetik `:` dalam mode Normal. Kursor Anda akan pindah
+ke baris perintah di bagian bawah layar setelah menekan `:`. Mode ini
+memiliki banyak fungsionalitas, termasuk membuka, menyimpan, dan menutup file, serta
+[keluar dari Vim](https://twitter.com/iamdevloper/status/435555976687923200).
 
-- `:q` quit (close window)
+- `:q` quit (menutup window)
 - `:w` save ("write")
-- `:wq` save and quit
-- `:e {name of file}` open file for editing
-- `:ls` show open buffers
-- `:help {topic}` open help
-    - `:help :w` opens help for the `:w` command
-    - `:help w` opens help for the `w` movement
+- `:wq` save dan quit
+- `:e {name of file}` membuka file untuk diedit
+- `:ls` menampilkan buffer yang terbuka
+- `:help {topic}` membuka bantuan
+    - `:help :w` membuka bantuan untuk perintah `:w`
+    - `:help w` membuka bantuan untuk gerakan `w`
 
-# Vim's interface is a programming language
+# Antarmuka Vim adalah bahasa pemrograman
 
-The most important idea in Vim is that Vim's interface itself is a programming
-language. Keystrokes (with mnemonic names) are commands, and these commands
-_compose_. This enables efficient movement and edits, especially once the
-commands become muscle memory.
+Ide terpenting dalam Vim adalah antarmuka Vim itu sendiri adalah bahasa pemrograman. Tekanan tombol (dengan nama mnemonik) adalah perintah, dan perintah-perintah ini
+_dapat dikomposisikan_. Ini memungkinkan pergerakan dan pengeditan yang efisien, terutama setelah
+perintah-perintah menjadi memori otot.
 
-## Movement
+## Pergerakan
 
-You should spend most of your time in Normal mode, using movement commands to
-navigate the buffer. Movements in Vim are also called "nouns", because they
-refer to chunks of text.
+Anda seharusnya menghabiskan sebagian besar waktu dalam mode Normal, menggunakan perintah pergerakan untuk
+menavigasi buffer. Pergerakan dalam Vim juga disebut "kata benda", karena merujuk pada
+bagian-bagian teks.
 
-- Basic movement: `hjkl` (left, down, up, right)
-- Words: `w` (next word), `b` (beginning of word), `e` (end of word)
-- Lines: `0` (beginning of line), `^` (first non-blank character), `$` (end of line)
-- Screen: `H` (top of screen), `M` (middle of screen), `L` (bottom of screen)
-- Scroll: `Ctrl-u` (up), `Ctrl-d` (down)
-- File: `gg` (beginning of file), `G` (end of file)
-- Line numbers: `:{number}<CR>` or `{number}G` (line {number})
-- Misc: `%` (corresponding item)
-- Find: `f{character}`, `t{character}`, `F{character}`, `T{character}`
-    - find/to forward/backward {character} on the current line
-    - `,` / `;` for navigating matches
-- Search: `/{regex}`, `n` / `N` for navigating matches
+- Pergerakan dasar: `hjkl` (kiri, bawah, atas, kanan)
+- Kata: `w` (kata berikutnya), `b` (awal kata), `e` (akhir kata)
+- Baris: `0` (awal baris), `^` (karakter non-kosong pertama), `$` (akhir baris)
+- Layar: `H` (atas layar), `M` (tengah layar), `L` (bawah layar)
+- Scroll: `Ctrl-u` (atas), `Ctrl-d` (bawah)
+- File: `gg` (awal file), `G` (akhir file)
+- Nomor baris: `:{number}<CR>` atau `{number}G` (baris ke-{number})
+- Lain-lain: `%` (item yang sesuai)
+- Cari: `f{character}`, `t{character}`, `F{character}`, `T{character}`
+    - cari/menuju maju/mundur {character} pada baris saat ini
+    - `,` / `;` untuk menavigasi hasil yang cocok
+- Pencarian: `/{regex}`, `n` / `N` untuk menavigasi hasil yang cocok
 
-## Selection
+## Seleksi
 
-Visual modes:
+Mode Visual:
 
 - Visual: `v`
 - Visual Line: `V`
 - Visual Block: `Ctrl-v`
 
-Can use movement keys to make selection.
+Dapat menggunakan tombol pergerakan untuk membuat seleksi.
 
-## Edits
+## Editan
 
-Everything that you used to do with the mouse, you now do with the keyboard
-using editing commands that compose with movement commands. Here's where Vim's
-interface starts to look like a programming language. Vim's editing commands
-are also called "verbs", because verbs act on nouns.
+Semua yang biasa Anda lakukan dengan mouse, sekarang Anda lakukan dengan keyboard
+menggunakan perintah pengeditan yang dikomposisikan dengan perintah pergerakan. Di sinilah
+antarmuka Vim mulai terlihat seperti bahasa pemrograman. Perintah pengeditan Vim
+juga disebut "kata kerja", karena kata kerja bekerja pada kata benda.
 
-- `i` enter Insert mode
-    - but for manipulating/deleting text, want to use something more than
+- `i` masuk mode Insert
+    - tetapi untuk memanipulasi/menghapus teks, ingin menggunakan sesuatu selain
     backspace
-- `o` / `O` insert line below / above
-- `d{motion}` delete {motion}
-    - e.g. `dw` is delete word, `d$` is delete to end of line, `d0` is delete
-    to beginning of line
-- `c{motion}` change {motion}
-    - e.g. `cw` is change word
-    - like `d{motion}` followed by `i`
-- `x` delete character (equal to `dl`)
-- `s` substitute character (equal to `cl`)
-- Visual mode + manipulation
-    - select text, `d` to delete it or `c` to change it
-- `u` to undo, `<C-r>` to redo
-- `y` to copy / "yank" (some other commands like `d` also copy)
-- `p` to paste
-- Lots more to learn: e.g. `~` flips the case of a character
+- `o` / `O` sisipkan baris di bawah / di atas
+- `d{motion}` hapus {motion}
+    - mis. `dw` adalah hapus kata, `d$` adalah hapus sampai akhir baris, `d0` adalah hapus
+    sampai awal baris
+- `c{motion}` ubah {motion}
+    - mis. `cw` adalah ubah kata
+    - seperti `d{motion}` diikuti oleh `i`
+- `x` hapus karakter (sama dengan `dl`)
+- `s` ganti karakter (sama dengan `cl`)
+- Mode Visual + manipulasi
+    - pilih teks, `d` untuk menghapusnya atau `c` untuk mengubahnya
+- `u` untuk undo, `<C-r>` untuk redo
+- `y` untuk menyalin / "yank" (beberapa perintah lain seperti `d` juga menyalin)
+- `p` untuk menempel
+- Masih banyak lagi yang perlu dipelajari: mis. `~` membalik huruf besar/kecil suatu karakter
 
-## Counts
+## Jumlah
 
-You can combine nouns and verbs with a count, which will perform a given action
-a number of times.
+Anda dapat menggabungkan kata benda dan kata kerja dengan jumlah, yang akan melakukan tindakan tertentu
+seberapa kali.
 
-- `3w` move 3 words forward
-- `5j` move 5 lines down
-- `7dw` delete 7 words
+- `3w` pindah 3 kata ke depan
+- `5j` pindah 5 baris ke bawah
+- `7dw` hapus 7 kata
 
-## Modifiers
+## Modifier
 
-You can use modifiers to change the meaning of a noun. Some modifiers are `i`,
-which means "inner" or "inside", and `a`, which means "around".
+Anda dapat menggunakan modifier untuk mengubah arti kata benda. Beberapa modifier adalah `i`,
+yang berarti "inner" atau "inside", dan `a`, yang berarti "around".
 
-- `ci(` change the contents inside the current pair of parentheses
-- `ci[` change the contents inside the current pair of square brackets
-- `da'` delete a single-quoted string, including the surrounding single quotes
+- `ci(` ubah konten di dalam tanda kurung saat ini
+- `ci[` ubah konten di dalam tanda kurung siku saat ini
+- `da'` hapus string kutip tunggal, termasuk tanda kutip tunggal di sekitarnya
 
 # Demo
 
-Here is a broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz)
-implementation:
+Berikut adalah implementasi [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) yang rusak:
 
 ```python
 def fizz_buzz(limit):
@@ -247,13 +241,13 @@ def main():
     fizz_buzz(10)
 ```
 
-We will fix the following issues:
+Kita akan memperbaiki masalah-masalah berikut:
 
-- Main is never called
-- Starts at 0 instead of 1
-- Prints "fizz" and "buzz" on separate lines for multiples of 15
-- Prints "fizz" for multiples of 5
-- Uses a hard-coded argument of 10 instead of taking a command-line argument
+- Main tidak pernah dipanggil
+- Dimulai dari 0, bukan 1
+- Mencetak "fizz" dan "buzz" pada baris terpisah untuk kelipatan 15
+- Mencetak "fizz" untuk kelipatan 5
+- Menggunakan argumen hard-coded 10 alih-alih menerima argumen command-line
 
 {% comment %}
 - main is never called
@@ -280,126 +274,122 @@ We will fix the following issues:
   - `ci(` to "int(sys.argv[1])"
 {% endcomment %}
 
-See the lecture video for the demonstration. Compare how the above changes are
-made using Vim to how you might make the same edits using another program.
-Notice how very few keystrokes are required in Vim, allowing you to edit at the
-speed you think.
+Lihat video kuliah untuk demonya. Bandingkan bagaimana perubahan di atas
+dibuat menggunakan Vim dengan bagaimana Anda mungkin membuat editan yang sama menggunakan program lain.
+Perhatikan betapa sedikitnya tekanan tombol yang diperlukan di Vim, memungkinkan Anda mengedit dengan
+kecepatan berpikir Anda.
 
-# Customizing Vim
+# Kustomisasi Vim
 
-Vim is customized through a plain-text configuration file in `~/.vimrc`
-(containing Vimscript commands). There are probably lots of basic settings that
-you want to turn on.
+Vim dikustomisasi melalui file konfigurasi teks biasa di `~/.vimrc`
+(berisi perintah Vimscript). Mungkin ada banyak pengaturan dasar yang
+ingin Anda aktifkan.
 
-We are providing a well-documented basic config that you can use as a starting
-point. We recommend using this because it fixes some of Vim's quirky default
-behavior. **Download our config [here](/2020/files/vimrc) and save it to
+Kami menyediakan konfigurasi dasar yang terdokumentasi dengan baik yang dapat Anda gunakan sebagai titik awal. Kami merekomendasikan untuk menggunakan ini karena memperbaiki beberapa perilaku default Vim yang aneh. **Unduh konfigurasi kami [di sini](/2020/files/vimrc) dan simpan ke
 `~/.vimrc`.**
 
-Vim is heavily customizable, and it's worth spending time exploring
-customization options. You can look at people's dotfiles on GitHub for
-inspiration, for example, your instructors' Vim configs
+Vim sangat dapat dikustomisasi, dan ada baiknya menghabiskan waktu menjelajahi
+opsi kustomisasi. Anda dapat melihat dotfiles orang-orang di GitHub untuk
+inspirasi, misalnya, konfigurasi Vim instruktur kami
 ([Anish](https://github.com/anishathalye/dotfiles/blob/master/vimrc),
-[Jon](https://github.com/jonhoo/configs/blob/master/editor/.config/nvim/init.lua) (uses [neovim](https://neovim.io/)),
-[Jose](https://github.com/JJGO/dotfiles/blob/master/vim/.vimrc)). There are
-lots of good blog posts on this topic too. Try not to copy-and-paste people's
-full configuration, but read it, understand it, and take what you need.
+[Jon](https://github.com/jonhoo/configs/blob/master/editor/.config/nvim/init.lua) (menggunakan [neovim](https://neovim.io/)),
+[Jose](https://github.com/JJGO/dotfiles/blob/master/vim/.vimrc)). Ada
+banyak postingan blog yang bagus tentang topik ini juga. Cobalah untuk tidak menyalin-tempel
+konfigurasi lengkap orang lain, tetapi bacalah, pahami, dan ambil yang Anda butuhkan.
 
-# Extending Vim
+# Memperluas Vim
 
-There are tons of plugins for extending Vim. Contrary to outdated advice that
-you might find on the internet, you do _not_ need to use a plugin manager for
-Vim (since Vim 8.0). Instead, you can use the built-in package management
-system. Simply create the directory `~/.vim/pack/vendor/start/`, and put
-plugins in there (e.g. via `git clone`).
+Ada banyak plugin untuk memperluas Vim. Bertentangan dengan saran usang yang
+mungkin Anda temukan di internet, Anda _tidak_ perlu menggunakan plugin manager untuk
+Vim (sejak Vim 8.0). Sebaliknya, Anda dapat menggunakan sistem manajemen paket bawaan. Cukup buat direktori `~/.vim/pack/vendor/start/`, dan letakkan
+plugin di sana (misalnya melalui `git clone`).
 
-Here are some of our favorite plugins:
+Berikut beberapa plugin favorit kami:
 
 - [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim): fuzzy file finder
-- [ack.vim](https://github.com/mileszs/ack.vim): code search
+- [ack.vim](https://github.com/mileszs/ack.vim): pencarian kode
 - [nerdtree](https://github.com/scrooloose/nerdtree): file explorer
 - [vim-easymotion](https://github.com/easymotion/vim-easymotion): magic motions
 
-We're trying to avoid giving an overwhelmingly long list of plugins here. You
-can check out the instructors' dotfiles
+Kami mencoba menghindari memberikan daftar plugin yang terlalu panjang di sini. Anda
+dapat memeriksa dotfiles instruktur
 ([Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
-[Jose](https://github.com/JJGO/dotfiles)) to see what other plugins we use.
-Check out [Vim Awesome](https://vimawesome.com/) for more awesome Vim plugins.
-There are also tons of blog posts on this topic: just search for "best Vim
+[Jose](https://github.com/JJGO/dotfiles)) untuk melihat plugin lain apa yang kami gunakan.
+Lihat [Vim Awesome](https://vimawesome.com/) untuk lebih banyak plugin Vim yang luar biasa.
+Ada juga banyak postingan blog tentang topik ini: cukup cari "best Vim
 plugins".
 
-# Vim-mode in other programs
+# Mode Vim di program lain
 
-Many tools support Vim emulation. The quality varies from good to great;
-depending on the tool, it may not support the fancier Vim features, but most
-cover the basics pretty well.
+Banyak alat yang mendukung emulasi Vim. Kualitasnya bervariasi dari baik hingga sangat baik;
+tergantung pada alatnya, mungkin tidak mendukung fitur Vim yang lebih canggih, tetapi sebagian besar
+mencakup dasar-dasar dengan cukup baik.
 
 ## Shell
 
-If you're a Bash user, use `set -o vi`. If you use Zsh, `bindkey -v`. For Fish,
-`fish_vi_key_bindings`. Additionally, no matter what shell you use, you can
-`export EDITOR=vim`. This is the environment variable used to decide which
-editor is launched when a program wants to start an editor. For example, `git`
-will use this editor for commit messages.
+Jika Anda pengguna Bash, gunakan `set -o vi`. Jika Anda menggunakan Zsh, `bindkey -v`. Untuk Fish,
+`fish_vi_key_bindings`. Selain itu, tidak peduli shell apa yang Anda gunakan, Anda dapat
+`export EDITOR=vim`. Ini adalah variabel lingkungan yang digunakan untuk memutuskan editor
+mana yang diluncurkan ketika suatu program ingin memulai editor. Misalnya, `git`
+akan menggunakan editor ini untuk pesan commit.
 
 ## Readline
 
-Many programs use the [GNU
-Readline](https://tiswww.case.edu/php/chet/readline/rltop.html) library for
-their command-line interface. Readline supports (basic) Vim emulation too,
-which can be enabled by adding the following line to the `~/.inputrc` file:
+Banyak program menggunakan pustaka [GNU
+Readline](https://tiswww.case.edu/php/chet/readline/rltop.html) untuk
+antarmuka command-line mereka. Readline juga mendukung emulasi Vim (dasar),
+yang dapat diaktifkan dengan menambahkan baris berikut ke file `~/.inputrc`:
 
 ```
 set editing-mode vi
 ```
 
-With this setting, for example, the Python REPL will support Vim bindings.
+Dengan pengaturan ini, misalnya, Python REPL akan mendukung binding Vim.
 
-## Others
+## Lainnya
 
-There are even vim keybinding extensions for web
-[browsers](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers) - some
-popular ones are
+Ada bahkan ekstensi keybinding vim untuk
+[browser](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers) web - beberapa
+yang populer adalah
 [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en)
-for Google Chrome and [Tridactyl](https://github.com/tridactyl/tridactyl) for
-Firefox. You can even get Vim bindings in [Jupyter
+untuk Google Chrome dan [Tridactyl](https://github.com/tridactyl/tridactyl) untuk
+Firefox. Anda bahkan bisa mendapatkan binding Vim di [Jupyter
 notebooks](https://github.com/jupyterlab-contrib/jupyterlab-vim).
-Here is a [long list](https://reversed.top/2016-08-13/big-list-of-vim-like-software) of software with vim-like keybindings.
+Berikut adalah [daftar panjang](https://reversed.top/2016-08-13/big-list-of-vim-like-software) perangkat lunak dengan keybinding mirip vim.
 
-# Advanced Vim
+# Vim Lanjutan
 
-Here are a few examples to show you the power of the editor. We can't teach you
-all of these kinds of things, but you'll learn them as you go. A good
-heuristic: whenever you're using your editor and you think "there must be a
-better way of doing this", there probably is: look it up online.
+Berikut beberapa contoh untuk menunjukkan kekuatan editor ini. Kami tidak dapat mengajarkan
+semua hal seperti ini, tetapi Anda akan mempelajarinya seiring berjalannya waktu. Heuristik yang baik: setiap kali Anda menggunakan editor dan berpikir "pasti ada
+cara yang lebih baik untuk melakukan ini", kemungkinan besar ada: cari tahu secara online.
 
-## Search and replace
+## Cari dan ganti
 
-`:s` (substitute) command ([documentation](https://vim.fandom.com/wiki/Search_and_replace)).
+Perintah `:s` (substitute) ([dokumentasi](https://vim.fandom.com/wiki/Search_and_replace)).
 
 - `%s/foo/bar/g`
-    - replace foo with bar globally in file
+    - ganti foo dengan bar secara global di file
 - `%s/\[.*\](\(.*\))/\1/g`
-    - replace named Markdown links with plain URLs
+    - ganti tautan Markdown bernama dengan URL polos
 
-## Multiple windows
+## Beberapa window
 
-- `:sp` / `:vsp` to split windows
-- Can have multiple views of the same buffer.
+- `:sp` / `:vsp` untuk membagi window
+- Dapat memiliki beberapa tampilan dari buffer yang sama.
 
-## Macros
+## Macro
 
-- `q{character}` to start recording a macro in register `{character}`
-- `q` to stop recording
-- `@{character}` replays the macro
-- Macro execution stops on error
-- `{number}@{character}` executes a macro {number} times
-- Macros can be recursive
-    - first clear the macro with `q{character}q`
-    - record the macro, with `@{character}` to invoke the macro recursively
-    (will be a no-op until recording is complete)
-- Example: convert xml to json ([file](/2020/files/example-data.xml))
+- `q{character}` untuk mulai merekam macro di register `{character}`
+- `q` untuk berhenti merekam
+- `@{character}` memutar ulang macro
+- Eksekusi macro berhenti saat terjadi error
+- `{number}@{character}` mengeksekusi macro sebanyak {number} kali
+- Macro dapat bersifat rekursif
+    - pertama bersihkan macro dengan `q{character}q`
+    - rekam macro, dengan `@{character}` untuk memanggil macro secara rekursif
+    (akan menjadi no-op sampai perekaman selesai)
+- Contoh: konversi xml ke json ([file](/2020/files/example-data.xml))
     - Array of objects with keys "name" / "email"
     - Use a Python program?
     - Use sed / regexes
@@ -422,46 +412,44 @@ better way of doing this", there probably is: look it up online.
             - `999@q`
         - Manually remove last `,` and add `[` and `]` delimiters
 
-# Resources
+# Sumber Daya
 
-- `vimtutor` is a tutorial that comes installed with Vim - if Vim is installed, you should be able to run `vimtutor` from your shell
-- [Vim Adventures](https://vim-adventures.com/) is a game to learn Vim
+- `vimtutor` adalah tutorial yang disertakan bersama Vim - jika Vim terinstal, Anda seharusnya dapat menjalankan `vimtutor` dari shell Anda
+- [Vim Adventures](https://vim-adventures.com/) adalah permainan untuk mempelajari Vim
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2019/) has various Vim tips
-- [Vim Golf](https://www.vimgolf.com/) is [code golf](https://en.wikipedia.org/wiki/Code_golf), but where the programming language is Vim's UI
+- [Vim Advent Calendar](https://vimways.org/2019/) memiliki berbagai tips Vim
+- [Vim Golf](https://www.vimgolf.com/) adalah [code golf](https://en.wikipedia.org/wiki/Code_golf), tetapi di mana bahasa pemrogramannya adalah UI Vim
 - [Vi/Vim Stack Exchange](https://vi.stackexchange.com/)
 - [Vim Screencasts](http://vimcasts.org/)
-- [Practical Vim](https://pragprog.com/titles/dnvim2/) (book)
+- [Practical Vim](https://pragprog.com/titles/dnvim2/) (buku)
 
-# Exercises
+# Latihan
 
-1. Complete `vimtutor`. Note: it looks best in a
-   [80x24](https://en.wikipedia.org/wiki/VT100) (80 columns by 24 lines)
-   terminal window.
-1. Download our [basic vimrc](/2020/files/vimrc) and save it to `~/.vimrc`. Read
-   through the well-commented file (using Vim!), and observe how Vim looks and
-   behaves slightly differently with the new config.
-1. Install and configure a plugin:
+1. Selesaikan `vimtutor`. Catatan: tampilannya paling baik di
+   jendela terminal [80x24](https://en.wikipedia.org/wiki/VT100) (80 kolom kali 24 baris).
+1. Unduh [vimrc dasar](/2020/files/vimrc) kami dan simpan ke `~/.vimrc`. Baca
+   file yang terdokumentasi dengan baik (menggunakan Vim!), dan amati bagaimana Vim terlihat dan
+   berperilaku sedikit berbeda dengan konfigurasi baru.
+1. Instal dan konfigurasikan plugin:
    [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim).
-   1. Create the plugins directory with `mkdir -p ~/.vim/pack/vendor/start`
-   1. Download the plugin: `cd ~/.vim/pack/vendor/start; git clone
-      https://github.com/ctrlpvim/ctrlp.vim`
-   1. Read the
-      [documentation](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md)
-      for the plugin. Try using CtrlP to locate a file by navigating to a
-      project directory, opening Vim, and using the Vim command-line to start
-      `:CtrlP`.
-    1. Customize CtrlP by adding
-       [configuration](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md#basic-options)
-       to your `~/.vimrc` to open CtrlP by pressing Ctrl-P.
-1. To practice using Vim, re-do the [Demo](#demo) from lecture on your own
-   machine.
-1. Use Vim for _all_ your text editing for the next month. Whenever something
-   seems inefficient, or when you think "there must be a better way", try
-   Googling it, there probably is. If you get stuck, come to office hours or
-   send us an email.
-1. Configure your other tools to use Vim bindings (see instructions above).
-1. Further customize your `~/.vimrc` and install more plugins.
-1. (Advanced) Convert XML to JSON ([example file](/2020/files/example-data.xml))
-   using Vim macros. Try to do this on your own, but you can look at the
-   [macros](#macros) section above if you get stuck.
+    1. Buat direktori plugin dengan `mkdir -p ~/.vim/pack/vendor/start`
+    1. Unduh plugin: `cd ~/.vim/pack/vendor/start; git clone
+       https://github.com/ctrlpvim/ctrlp.vim`
+    1. Baca
+       [dokumentasi](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md)
+       untuk plugin tersebut. Coba gunakan CtrlP untuk menemukan file dengan menavigasi ke
+       direktori proyek, membuka Vim, dan menggunakan command-line Vim untuk memulai
+       `:CtrlP`.
+    1. Kustomisasi CtrlP dengan menambahkan
+       [konfigurasi](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md#basic-options)
+       ke `~/.vimrc` Anda untuk membuka CtrlP dengan menekan Ctrl-P.
+1. Untuk berlatih menggunakan Vim, ulangi [Demo](#demo) dari kuliah di mesin Anda sendiri.
+1. Gunakan Vim untuk _semua_ pengeditan teks Anda selama sebulan ke depan. Setiap kali sesuatu
+   terasa tidak efisien, atau ketika Anda berpikir "pasti ada cara yang lebih baik", coba
+   Googling, kemungkinan besar ada. Jika Anda terjebak, datang ke office hours atau
+   kirimkan email kepada kami.
+1. Konfigurasikan alat-alat lain Anda untuk menggunakan binding Vim (lihat instruksi di atas).
+1. Kustomisasi lebih lanjut `~/.vimrc` Anda dan instal lebih banyak plugin.
+1. (Lanjutan) Konversi XML ke JSON ([file contoh](/2020/files/example-data.xml))
+   menggunakan macro Vim. Cobalah lakukan ini sendiri, tetapi Anda dapat melihat bagian
+   [macro](#macros) di atas jika Anda terjebak.

--- a/_2020/editors.md
+++ b/_2020/editors.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Editors (Vim)"
 description: >
-  Learn how to use Vim, a powerful text editor designed for efficient code editing.
+  Pelajari cara menggunakan Vim, editor teks yang dirancang untuk pengeditan kode yang efisien.
 thumbnail: /static/assets/thumbnails/2020/lec3.png
 date: 2020-01-15
 ready: true

--- a/_2020/editors.md
+++ b/_2020/editors.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Editors (Vim)"
+title: "Editor (Vim)"
 description: >
-  Learn how to use Vim, a powerful text editor designed for efficient code editing.
+  Pelajari cara menggunakan Vim, editor teks canggih yang dirancang untuk pengeditan kode yang efisien.
 thumbnail: /static/assets/thumbnails/2020/lec3.png
 date: 2020-01-15
 ready: true
@@ -11,116 +11,109 @@ video:
   id: a6Q8Na575qc
 ---
 
-Writing English words and writing code are very different activities. When
-programming, you spend more time switching files, reading, navigating, and
-editing code compared to writing a long stream. It makes sense that there are
-different types of programs for writing English words versus code (e.g.
+Menulis kata-kata dalam bahasa Inggris dan menulis kode adalah aktivitas yang sangat berbeda. Saat
+pemrograman, Anda menghabiskan lebih banyak waktu untuk berpindah file, membaca, navigasi, dan
+mengedit kode dibandingkan dengan menulis aliran teks yang panjang. Masuk akal jika ada
+jenis program yang berbeda untuk menulis kata-kata dalam bahasa Inggris versus kode (misalnya
 Microsoft Word versus Visual Studio Code).
 
-As programmers, we spend most of our time editing code, so it's worth investing
-time mastering an editor that fits your needs. Here's how you learn a new
-editor:
+Sebagai programmer, kita menghabiskan sebagian besar waktu untuk mengedit kode, jadi layak untuk
+menginvestasikan waktu dalam menguasai editor yang sesuai dengan kebutuhan Anda. Berikut cara Anda mempelajari editor baru:
 
-- Start with a tutorial (i.e. this lecture, plus resources that we point out)
-- Stick with using the editor for all your text editing needs (even if it slows
-you down initially)
-- Look things up as you go: if it seems like there should be a better way to do
-something, there probably is
+- Mulai dengan tutorial (yaitu kuliah ini, plus sumber daya yang kami tunjukkan)
+- Tetap gunakan editor untuk semua kebutuhan pengeditan teks Anda (meskipun pada awalnya memperlambat
+Anda)
+- Cari tahu seiring berjalannya waktu: jika sepertinya ada cara yang lebih baik untuk melakukan
+sesuatu, kemungkinan besar ada
 
-If you follow the above method, fully committing to using the new program for
-all text editing purposes, the timeline for learning a sophisticated text
-editor looks like this. In an hour or two, you'll learn basic editor functions
-such as opening and editing files, save/quit, and navigating buffers. Once
-you're 20 hours in, you should be as fast as you were with your old editor.
-After that, the benefits start: you will have enough knowledge and muscle
-memory that using the new editor saves you time. Modern text editors are fancy
-and powerful tools, so the learning never stops: you'll get even faster as you
-learn more.
+Jika Anda mengikuti metode di atas, dengan sepenuhnya berkomitmen menggunakan program baru untuk
+semua tujuan pengeditan teks, linimasa untuk mempelajari editor teks yang canggih
+terlihat seperti ini. Dalam satu atau dua jam, Anda akan mempelajari fungsi-fungsi dasar editor
+seperti membuka dan mengedit file, menyimpan/keluar, dan menavigasi buffer. Setelah
+20 jam, Anda seharusnya secepat saat menggunakan editor lama Anda.
+Setelah itu, manfaatnya mulai terasa: Anda akan memiliki pengetahuan dan memori otot
+yang cukup sehingga menggunakan editor baru menghemat waktu Anda. Editor teks modern adalah alat
+yang canggih dan kuat, sehingga proses belajar tidak pernah berhenti: Anda akan menjadi lebih cepat seiring
+Anda mempelajari lebih banyak.
 
-# Which editor to learn?
+# Editor mana yang harus dipelajari?
 
-Programmers have [strong opinions](https://en.wikipedia.org/wiki/Editor_war)
-about their text editors.
+Para programmer memiliki [pendapat yang kuat](https://en.wikipedia.org/wiki/Editor_war)
+tentang editor teks mereka.
 
-Which editors are popular today? See this [Stack Overflow
-survey](https://insights.stackoverflow.com/survey/2019/#development-environments-and-tools)
-(there may be some bias because Stack Overflow users may not be representative
-of programmers as a whole). [Visual Studio
-Code](https://code.visualstudio.com/) is the most popular editor.
-[Vim](https://www.vim.org/) is the most popular command-line-based editor.
+Editor mana yang populer saat ini? Lihat [survei Stack Overflow
+ini](https://insights.stackoverflow.com/survey/2019/#development-environments-and-tools)
+(mungkin ada beberapa bias karena pengguna Stack Overflow mungkin tidak mewakili
+seluruh programmer). [Visual Studio
+Code](https://code.visualstudio.com/) adalah editor yang paling populer.
+[Vim](https://www.vim.org/) adalah editor berbasis baris perintah yang paling populer.
 
 ## Vim
 
-All the instructors of this class use Vim as their editor. Vim has a rich
-history; it originated from the Vi editor (1976), and it's still being
-developed today. Vim has some really neat ideas behind it, and for this reason,
-lots of tools support a Vim emulation mode (for example, 1.4 million people
-have installed [Vim emulation for VS code](https://github.com/VSCodeVim/Vim)).
-Vim is probably worth learning even if you finally end up switching to some
-other text editor.
+Semua instruktur kelas ini menggunakan Vim sebagai editor mereka. Vim memiliki sejarah yang kaya;
+berasal dari editor Vi (1976), dan masih dikembangkan hingga saat ini. Vim memiliki beberapa
+ide yang sangat menarik di baliknya, dan karena alasan ini, banyak alat yang mendukung
+mode emulasi Vim (misalnya, 1,4 juta orang telah menginstal [emulasi Vim untuk VS code](https://github.com/VSCodeVim/Vim)). Vim mungkin layak dipelajari meskipun pada akhirnya Anda beralih ke editor teks lainnya.
 
-It's not possible to teach all of Vim's functionality in 50 minutes, so we're
-going to focus on explaining the philosophy of Vim, teaching you the basics,
-showing you some of the more advanced functionality, and giving you the
-resources to master the tool.
+Tidak mungkin mengajarkan semua fungsi Vim dalam 50 menit, jadi kami akan
+fokus pada penjelasan filosofi Vim, mengajari Anda dasar-dasarnya,
+menunjukkan beberapa fungsi yang lebih canggih, dan memberi Anda
+sumber daya untuk menguasai alat ini.
 
-# Philosophy of Vim
+# Filosofi Vim
 
-When programming, you spend most of your time reading/editing, not writing. For
-this reason, Vim is a _modal_ editor: it has different modes for inserting text
-vs manipulating text. Vim is programmable (with Vimscript and also other
-languages like Python), and Vim's interface itself is a programming language:
-keystrokes (with mnemonic names) are commands, and these commands are
-composable. Vim avoids the use of the mouse, because it's too slow; Vim even
-avoids using the arrow keys because it requires too much movement.
+Saat pemrograman, Anda menghabiskan sebagian besar waktu untuk membaca/mengedit, bukan menulis. Karena
+alasan ini, Vim adalah editor _modal_: ia memiliki mode yang berbeda untuk menyisipkan teks
+vs memanipulasi teks. Vim dapat diprogram (dengan Vimscript dan juga bahasa
+lain seperti Python), dan antarmuka Vim itu sendiri adalah bahasa pemrograman:
+tekanan tombol (dengan nama mnemonik) adalah perintah, dan perintah-perintah ini
+dapat dikomposisikan. Vim menghindari penggunaan mouse, karena terlalu lambat; Vim bahkan
+menghindari penggunaan tombol panah karena memerlukan terlalu banyak pergerakan.
 
-The end result is an editor that can match the speed at which you think.
+Hasil akhirnya adalah editor yang dapat menyamai kecepatan berpikir Anda.
 
-# Modal editing
+# Pengeditan modal
 
-Vim's design is based on the idea that a lot of programmer time is spent
-reading, navigating, and making small edits, as opposed to writing long streams
-of text. For this reason, Vim has multiple operating modes.
+Desain Vim didasarkan pada ide bahwa banyak waktu programmer dihabiskan
+untuk membaca, menavigasi, dan membuat editan kecil, dibandingkan dengan menulis aliran teks yang panjang. Karena alasan ini, Vim memiliki beberapa mode operasi.
 
-- **Normal**: for moving around a file and making edits
-- **Insert**: for inserting text
-- **Replace**: for replacing text
-- **Visual** (plain, line, or block): for selecting blocks of text
-- **Command-line**: for running a command
+- **Normal**: untuk berpindah-pindah dalam file dan membuat editan
+- **Insert**: untuk menyisipkan teks
+- **Replace**: untuk mengganti teks
+- **Visual** (biasa, baris, atau blok): untuk memilih blok teks
+- **Command-line**: untuk menjalankan perintah
 
-Keystrokes have different meanings in different operating modes. For example,
-the letter `x` in Insert mode will just insert a literal character 'x', but in
-Normal mode, it will delete the character under the cursor, and in Visual mode,
-it will delete the selection.
+Tekanan tombol memiliki arti yang berbeda dalam mode operasi yang berbeda. Misalnya,
+huruf `x` dalam mode Insert hanya akan menyisipkan karakter literal 'x', tetapi dalam
+mode Normal, ia akan menghapus karakter di bawah kursor, dan dalam mode Visual,
+ia akan menghapus seleksi.
 
-In its default configuration, Vim shows the current mode in the bottom left.
-The initial/default mode is Normal mode. You'll generally spend most of your
-time between Normal mode and Insert mode.
+Dalam konfigurasi default, Vim menampilkan mode saat ini di kiri bawah.
+Mode awal/default adalah mode Normal. Anda umumnya akan menghabiskan sebagian besar waktu
+antara mode Normal dan mode Insert.
 
-You change modes by pressing `<ESC>` (the escape key) to switch from any mode
-back to Normal mode. From Normal mode, enter Insert mode with `i`, Replace mode
-with `R`, Visual mode with `v`, Visual Line mode with `V`, Visual Block mode
-with `<C-v>` (Ctrl-V, sometimes also written `^V`), and Command-line mode with
+Anda berpindah mode dengan menekan `<ESC>` (tombol escape) untuk beralih dari mode apa pun
+kembali ke mode Normal. Dari mode Normal, masuk ke mode Insert dengan `i`, mode Replace
+dengan `R`, mode Visual dengan `v`, mode Visual Line dengan `V`, mode Visual Block
+dengan `<C-v>` (Ctrl-V, kadang juga ditulis `^V`), dan mode Command-line dengan
 `:`.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to
-Escape ([macOS
-instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS))
-or create an [alternative
-mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) for `<ESC>`
-with a simple key sequence.
+Anda banyak menggunakan tombol `<ESC>` saat menggunakan Vim: pertimbangkan untuk memetakan ulang Caps Lock ke
+Escape ([instruksi macOS](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS))
+atau buat [pemetaan alternatif](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) untuk `<ESC>`
+dengan urutan tombol sederhana.
 
-# Basics
+# Dasar-dasar
 
-## Inserting text
+## Menyisipkan teks
 
-From Normal mode, press `i` to enter Insert mode. Now, Vim behaves like any
-other text editor, until you press `<ESC>` to return to Normal mode. This,
-along with the basics explained above, are all you need to start editing files
-using Vim (though not particularly efficiently, if you're spending all your
-time editing from Insert mode).
+Dari mode Normal, tekan `i` untuk masuk ke mode Insert. Sekarang, Vim berperilaku seperti
+editor teks lainnya, sampai Anda menekan `<ESC>` untuk kembali ke mode Normal. Ini,
+bersama dengan dasar-dasar yang dijelaskan di atas, adalah semua yang Anda butuhkan untuk mulai mengedit file
+menggunakan Vim (meskipun tidak terlalu efisien, jika Anda menghabiskan semua waktu
+Anda mengedit dari mode Insert).
 
-## Buffers, tabs, and windows
+## Buffer, tab, dan jendela
 
 Vim maintains a set of open files, called "buffers". A Vim session has a number
 of tabs, each of which has a number of windows (split panes). Each window shows
@@ -130,14 +123,14 @@ windows are merely views. A given buffer may be open in _multiple_ windows,
 even within the same tab. This can be quite handy, for example, to view two
 different parts of a file at the same time.
 
-By default, Vim opens with a single tab, which contains a single window.
+Secara default, Vim terbuka dengan satu tab, yang berisi satu jendela.
 
-## Command-line
+## Baris perintah
 
-Command mode can be entered by typing `:` in Normal mode. Your cursor will jump
-to the command line at the bottom of the screen upon pressing `:`. This mode
-has many functionalities, including opening, saving, and closing files, and
-[quitting Vim](https://twitter.com/iamdevloper/status/435555976687923200).
+Mode perintah dapat dimasuki dengan mengetik `:` dalam mode Normal. Kursor Anda akan loncat
+ke baris perintah di bagian bawah layar setelah menekan `:`. Mode ini
+memiliki banyak fungsionalitas, termasuk membuka, menyimpan, dan menutup file, serta
+[keluar dari Vim](https://twitter.com/iamdevloper/status/435555976687923200).
 
 - `:q` quit (close window)
 - `:w` save ("write")
@@ -148,18 +141,18 @@ has many functionalities, including opening, saving, and closing files, and
     - `:help :w` opens help for the `:w` command
     - `:help w` opens help for the `w` movement
 
-# Vim's interface is a programming language
+# Antarmuka Vim adalah bahasa pemrograman
 
-The most important idea in Vim is that Vim's interface itself is a programming
-language. Keystrokes (with mnemonic names) are commands, and these commands
-_compose_. This enables efficient movement and edits, especially once the
-commands become muscle memory.
+Ide paling penting dalam Vim adalah antarmuka Vim itu sendiri adalah bahasa
+pemrograman. Tekanan tombol (dengan nama mnemonik) adalah perintah, dan perintah-perintah ini
+_dapat dikomposisikan_. Ini memungkinkan pergerakan dan editan yang efisien, terutama setelah
+perintah-perintah menjadi memori otot.
 
-## Movement
+## Pergerakan
 
-You should spend most of your time in Normal mode, using movement commands to
-navigate the buffer. Movements in Vim are also called "nouns", because they
-refer to chunks of text.
+Anda seharusnya menghabiskan sebagian besar waktu dalam mode Normal, menggunakan perintah pergerakan untuk
+menavigasi buffer. Pergerakan dalam Vim juga disebut "kata benda", karena merujuk
+pada potongan teks.
 
 - Basic movement: `hjkl` (left, down, up, right)
 - Words: `w` (next word), `b` (beginning of word), `e` (end of word)
@@ -174,22 +167,22 @@ refer to chunks of text.
     - `,` / `;` for navigating matches
 - Search: `/{regex}`, `n` / `N` for navigating matches
 
-## Selection
+## Seleksi
 
-Visual modes:
+Mode Visual:
 
 - Visual: `v`
 - Visual Line: `V`
 - Visual Block: `Ctrl-v`
 
-Can use movement keys to make selection.
+Dapat menggunakan tombol pergerakan untuk membuat seleksi.
 
-## Edits
+## Editan
 
-Everything that you used to do with the mouse, you now do with the keyboard
-using editing commands that compose with movement commands. Here's where Vim's
-interface starts to look like a programming language. Vim's editing commands
-are also called "verbs", because verbs act on nouns.
+Semua yang biasa Anda lakukan dengan mouse, sekarang Anda lakukan dengan keyboard
+menggunakan perintah editan yang dapat dikomposisikan dengan perintah pergerakan. Di sinilah
+antarmuka Vim mulai terlihat seperti bahasa pemrograman. Perintah editan Vim
+juga disebut "kata kerja", karena kata kerja bekerja pada kata benda.
 
 - `i` enter Insert mode
     - but for manipulating/deleting text, want to use something more than
@@ -210,19 +203,19 @@ are also called "verbs", because verbs act on nouns.
 - `p` to paste
 - Lots more to learn: e.g. `~` flips the case of a character
 
-## Counts
+## Jumlah
 
-You can combine nouns and verbs with a count, which will perform a given action
-a number of times.
+Anda dapat menggabungkan kata benda dan kata kerja dengan jumlah, yang akan melakukan tindakan tertentu
+sebanyak beberapa kali.
 
 - `3w` move 3 words forward
 - `5j` move 5 lines down
 - `7dw` delete 7 words
 
-## Modifiers
+## Pengubah
 
-You can use modifiers to change the meaning of a noun. Some modifiers are `i`,
-which means "inner" or "inside", and `a`, which means "around".
+Anda dapat menggunakan pengubah untuk mengubah arti dari kata benda. Beberapa pengubah adalah `i`,
+yang berarti "dalam" atau "di dalam", dan `a`, yang berarti "sekitar".
 
 - `ci(` change the contents inside the current pair of parentheses
 - `ci[` change the contents inside the current pair of square brackets
@@ -230,8 +223,7 @@ which means "inner" or "inside", and `a`, which means "around".
 
 # Demo
 
-Here is a broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz)
-implementation:
+Berikut adalah implementasi [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) yang rusak:
 
 ```python
 def fizz_buzz(limit):
@@ -247,13 +239,13 @@ def main():
     fizz_buzz(10)
 ```
 
-We will fix the following issues:
+Kami akan memperbaiki masalah-masalah berikut:
 
-- Main is never called
-- Starts at 0 instead of 1
-- Prints "fizz" and "buzz" on separate lines for multiples of 15
-- Prints "fizz" for multiples of 5
-- Uses a hard-coded argument of 10 instead of taking a command-line argument
+- Main tidak pernah dipanggil
+- Dimulai dari 0 alih-alih 1
+- Mencetak "fizz" dan "buzz" pada baris terpisah untuk kelipatan 15
+- Mencetak "fizz" untuk kelipatan 5
+- Menggunakan argumen hard-coded 10 alih-alih menerima argumen baris perintah
 
 {% comment %}
 - main is never called
@@ -280,103 +272,97 @@ We will fix the following issues:
   - `ci(` to "int(sys.argv[1])"
 {% endcomment %}
 
-See the lecture video for the demonstration. Compare how the above changes are
-made using Vim to how you might make the same edits using another program.
-Notice how very few keystrokes are required in Vim, allowing you to edit at the
-speed you think.
+Lihat video kuliah untuk demonya. Bandingkan bagaimana perubahan di atas
+dibuat menggunakan Vim dengan bagaimana Anda mungkin membuat editan yang sama menggunakan program lain.
+Perhatikan betapa sedikitnya tekanan tombol yang diperlukan dalam Vim, memungkinkan Anda mengedit dengan
+kecepatan berpikir Anda.
 
-# Customizing Vim
+# Menyesuaikan Vim
 
-Vim is customized through a plain-text configuration file in `~/.vimrc`
-(containing Vimscript commands). There are probably lots of basic settings that
-you want to turn on.
+Vim disesuaikan melalui file konfigurasi teks biasa di `~/.vimrc`
+(berisi perintah Vimscript). Mungkin ada banyak pengaturan dasar yang
+ingin Anda aktifkan.
 
-We are providing a well-documented basic config that you can use as a starting
-point. We recommend using this because it fixes some of Vim's quirky default
-behavior. **Download our config [here](/2020/files/vimrc) and save it to
+Kami menyediakan konfigurasi dasar yang terdokumentasi dengan baik yang dapat Anda gunakan sebagai titik awal. Kami merekomendasikan untuk menggunakan ini karena memperbaiki beberapa perilaku default Vim yang aneh. **Unduh konfigurasi kami [di sini](/2020/files/vimrc) dan simpan ke
 `~/.vimrc`.**
 
-Vim is heavily customizable, and it's worth spending time exploring
-customization options. You can look at people's dotfiles on GitHub for
-inspiration, for example, your instructors' Vim configs
+Vim sangat dapat disesuaikan, dan layak menghabiskan waktu untuk menjelajahi
+opsi penyesuaian. Anda dapat melihat dotfiles orang-orang di GitHub untuk
+inspirasi, misalnya, konfigurasi Vim instruktur kami
 ([Anish](https://github.com/anishathalye/dotfiles/blob/master/vimrc),
 [Jon](https://github.com/jonhoo/configs/blob/master/editor/.config/nvim/init.lua) (uses [neovim](https://neovim.io/)),
-[Jose](https://github.com/JJGO/dotfiles/blob/master/vim/.vimrc)). There are
-lots of good blog posts on this topic too. Try not to copy-and-paste people's
-full configuration, but read it, understand it, and take what you need.
+[Jose](https://github.com/JJGO/dotfiles/blob/master/vim/.vimrc)). Ada
+banyak postingan blog yang bagus tentang topik ini juga. Cobalah untuk tidak menyalin-dan-tempel
+konfigurasi lengkap orang lain, tetapi bacalah, pahami, dan ambil yang Anda butuhkan.
 
-# Extending Vim
+# Memperluas Vim
 
-There are tons of plugins for extending Vim. Contrary to outdated advice that
-you might find on the internet, you do _not_ need to use a plugin manager for
-Vim (since Vim 8.0). Instead, you can use the built-in package management
-system. Simply create the directory `~/.vim/pack/vendor/start/`, and put
-plugins in there (e.g. via `git clone`).
+Ada banyak plugin untuk memperluas Vim. Bertentangan dengan saran usang yang
+mungkin Anda temukan di internet, Anda _tidak_ perlu menggunakan pengelola plugin untuk
+Vim (sejak Vim 8.0). Sebaliknya, Anda dapat menggunakan sistem manajemen paket bawaan. Cukup buat direktori `~/.vim/pack/vendor/start/`, dan letakkan
+plugin di sana (misalnya melalui `git clone`).
 
-Here are some of our favorite plugins:
+Berikut adalah beberapa plugin favorit kami:
 
 - [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim): fuzzy file finder
 - [ack.vim](https://github.com/mileszs/ack.vim): code search
 - [nerdtree](https://github.com/scrooloose/nerdtree): file explorer
 - [vim-easymotion](https://github.com/easymotion/vim-easymotion): magic motions
 
-We're trying to avoid giving an overwhelmingly long list of plugins here. You
-can check out the instructors' dotfiles
+Kami berusaha menghindari memberikan daftar plugin yang sangat panjang di sini. Anda
+dapat melihat dotfiles instruktur
 ([Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
-[Jose](https://github.com/JJGO/dotfiles)) to see what other plugins we use.
-Check out [Vim Awesome](https://vimawesome.com/) for more awesome Vim plugins.
-There are also tons of blog posts on this topic: just search for "best Vim
+[Jose](https://github.com/JJGO/dotfiles)) untuk melihat plugin lain apa yang kami gunakan.
+Lihat [Vim Awesome](https://vimawesome.com/) untuk lebih banyak plugin Vim yang luar biasa.
+Ada juga banyak postingan blog tentang topik ini: cukup cari "best Vim
 plugins".
 
-# Vim-mode in other programs
+# Mode Vim di program lain
 
-Many tools support Vim emulation. The quality varies from good to great;
-depending on the tool, it may not support the fancier Vim features, but most
-cover the basics pretty well.
+Banyak alat yang mendukung emulasi Vim. Kualitasnya bervariasi dari baik hingga hebat;
+tergantung pada alatnya, mungkin tidak mendukung fitur Vim yang lebih mewah, tetapi sebagian besar
+mencakup dasar-dasar dengan cukup baik.
 
 ## Shell
 
-If you're a Bash user, use `set -o vi`. If you use Zsh, `bindkey -v`. For Fish,
-`fish_vi_key_bindings`. Additionally, no matter what shell you use, you can
-`export EDITOR=vim`. This is the environment variable used to decide which
-editor is launched when a program wants to start an editor. For example, `git`
-will use this editor for commit messages.
+Jika Anda pengguna Bash, gunakan `set -o vi`. Jika Anda menggunakan Zsh, `bindkey -v`. Untuk Fish,
+`fish_vi_key_bindings`. Selain itu, tidak peduli shell apa yang Anda gunakan, Anda dapat
+`export EDITOR=vim`. Ini adalah variabel environment yang digunakan untuk memutuskan editor mana yang diluncurkan ketika sebuah program ingin memulai editor. Misalnya, `git`
+akan menggunakan editor ini untuk pesan commit.
 
 ## Readline
 
-Many programs use the [GNU
-Readline](https://tiswww.case.edu/php/chet/readline/rltop.html) library for
-their command-line interface. Readline supports (basic) Vim emulation too,
-which can be enabled by adding the following line to the `~/.inputrc` file:
+Banyak program menggunakan pustaka [GNU
+Readline](https://tiswww.case.edu/php/chet/readline/rltop.html) untuk
+antarmuka baris perintah mereka. Readline juga mendukung emulasi Vim (dasar),
+yang dapat diaktifkan dengan menambahkan baris berikut ke file `~/.inputrc`:
 
 ```
 set editing-mode vi
 ```
 
-With this setting, for example, the Python REPL will support Vim bindings.
+Dengan pengaturan ini, misalnya, Python REPL akan mendukung binding Vim.
 
-## Others
+## Lainnya
 
-There are even vim keybinding extensions for web
-[browsers](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers) - some
-popular ones are
+Ada bahkan ekstensi keybinding vim untuk web
+[browser](https://vim.fandom.com/wiki/Vim_key_bindings_for_web_browsers) - beberapa
+yang populer adalah
 [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en)
-for Google Chrome and [Tridactyl](https://github.com/tridactyl/tridactyl) for
-Firefox. You can even get Vim bindings in [Jupyter
+untuk Google Chrome dan [Tridactyl](https://github.com/tridactyl/tridactyl) untuk
+Firefox. Anda bahkan bisa mendapatkan binding Vim di [Jupyter
 notebooks](https://github.com/jupyterlab-contrib/jupyterlab-vim).
-Here is a [long list](https://reversed.top/2016-08-13/big-list-of-vim-like-software) of software with vim-like keybindings.
+Berikut adalah [daftar panjang](https://reversed.top/2016-08-13/big-list-of-vim-like-software) perangkat lunak dengan keybinding mirip vim.
 
-# Advanced Vim
+# Vim Lanjutan
 
-Here are a few examples to show you the power of the editor. We can't teach you
-all of these kinds of things, but you'll learn them as you go. A good
-heuristic: whenever you're using your editor and you think "there must be a
-better way of doing this", there probably is: look it up online.
+Berikut adalah beberapa contoh untuk menunjukkan kepada Anda kekuatan editor ini. Kami tidak dapat mengajari Anda
+semua hal seperti ini, tetapi Anda akan mempelajarinya seiring berjalannya waktu. Sebuah heuristik yang baik: kapan pun Anda menggunakan editor dan Anda berpikir "pasti ada cara yang lebih baik untuk melakukan ini", kemungkinan besar ada: cari tahu secara online.
 
 ## Search and replace
 
-`:s` (substitute) command ([documentation](https://vim.fandom.com/wiki/Search_and_replace)).
+Perintah `:s` (substitute) ([dokumentasi](https://vim.fandom.com/wiki/Search_and_replace)).
 
 - `%s/foo/bar/g`
     - replace foo with bar globally in file
@@ -422,46 +408,43 @@ better way of doing this", there probably is: look it up online.
             - `999@q`
         - Manually remove last `,` and add `[` and `]` delimiters
 
-# Resources
+# Sumber Daya
 
-- `vimtutor` is a tutorial that comes installed with Vim - if Vim is installed, you should be able to run `vimtutor` from your shell
-- [Vim Adventures](https://vim-adventures.com/) is a game to learn Vim
+- `vimtutor` adalah tutorial yang disertakan bersama Vim - jika Vim terinstal, Anda seharusnya dapat menjalankan `vimtutor` dari shell Anda
+- [Vim Adventures](https://vim-adventures.com/) adalah game untuk belajar Vim
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2019/) has various Vim tips
-- [Vim Golf](https://www.vimgolf.com/) is [code golf](https://en.wikipedia.org/wiki/Code_golf), but where the programming language is Vim's UI
+- [Vim Advent Calendar](https://vimways.org/2019/) memiliki berbagai tips Vim
+- [Vim Golf](https://www.vimgolf.com/) adalah [code golf](https://en.wikipedia.org/wiki/Code_golf), tetapi di mana bahasa pemrogramannya adalah UI Vim
 - [Vi/Vim Stack Exchange](https://vi.stackexchange.com/)
 - [Vim Screencasts](http://vimcasts.org/)
 - [Practical Vim](https://pragprog.com/titles/dnvim2/) (book)
 
-# Exercises
+# Latihan
 
-1. Complete `vimtutor`. Note: it looks best in a
-   [80x24](https://en.wikipedia.org/wiki/VT100) (80 columns by 24 lines)
-   terminal window.
-1. Download our [basic vimrc](/2020/files/vimrc) and save it to `~/.vimrc`. Read
-   through the well-commented file (using Vim!), and observe how Vim looks and
-   behaves slightly differently with the new config.
-1. Install and configure a plugin:
+1. Selesaikan `vimtutor`. Catatan: terlihat paling baik di jendela
+   terminal [80x24](https://en.wikipedia.org/wiki/VT100) (80 kolom x 24 baris).
+1. Unduh [vimrc dasar](/2020/files/vimrc) kami dan simpan ke `~/.vimrc`. Baca
+   melalui file yang memiliki komentar lengkap (menggunakan Vim!), dan amati bagaimana Vim terlihat dan
+   berperilaku sedikit berbeda dengan konfigurasi baru.
+1. Instal dan konfigurasikan sebuah plugin:
    [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim).
-   1. Create the plugins directory with `mkdir -p ~/.vim/pack/vendor/start`
-   1. Download the plugin: `cd ~/.vim/pack/vendor/start; git clone
-      https://github.com/ctrlpvim/ctrlp.vim`
-   1. Read the
-      [documentation](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md)
-      for the plugin. Try using CtrlP to locate a file by navigating to a
-      project directory, opening Vim, and using the Vim command-line to start
-      `:CtrlP`.
-    1. Customize CtrlP by adding
-       [configuration](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md#basic-options)
-       to your `~/.vimrc` to open CtrlP by pressing Ctrl-P.
-1. To practice using Vim, re-do the [Demo](#demo) from lecture on your own
-   machine.
-1. Use Vim for _all_ your text editing for the next month. Whenever something
-   seems inefficient, or when you think "there must be a better way", try
-   Googling it, there probably is. If you get stuck, come to office hours or
-   send us an email.
-1. Configure your other tools to use Vim bindings (see instructions above).
-1. Further customize your `~/.vimrc` and install more plugins.
-1. (Advanced) Convert XML to JSON ([example file](/2020/files/example-data.xml))
-   using Vim macros. Try to do this on your own, but you can look at the
-   [macros](#macros) section above if you get stuck.
+    1. Buat direktori plugin dengan `mkdir -p ~/.vim/pack/vendor/start`
+    1. Unduh plugin: `cd ~/.vim/pack/vendor/start; git clone
+       https://github.com/ctrlpvim/ctrlp.vim`
+    1. Baca [dokumentasi](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md)
+       untuk plugin tersebut. Coba gunakan CtrlP untuk menemukan file dengan menavigasi ke
+       direktori proyek, membuka Vim, dan menggunakan baris perintah Vim untuk memulai
+       `:CtrlP`.
+    1. Sesuaikan CtrlP dengan menambahkan
+       [konfigurasi](https://github.com/ctrlpvim/ctrlp.vim/blob/master/readme.md#basic-options)
+       ke `~/.vimrc` Anda untuk membuka CtrlP dengan menekan Ctrl-P.
+1. Untuk berlatih menggunakan Vim, ulangi [Demo](#demo) dari kuliah di mesin Anda sendiri.
+1. Gunakan Vim untuk _semua_ pengeditan teks Anda selama bulan berikutnya. Kapan pun sesuatu
+   terasa tidak efisien, atau ketika Anda berpikir "pasti ada cara yang lebih baik", coba
+   Googling, kemungkinan besar ada. Jika Anda terjebak, datang ke jam kantor atau
+   kirimkan email kepada kami.
+1. Konfigurasikan alat-alat lain Anda untuk menggunakan binding Vim (lihat instruksi di atas).
+1. Lebih lanjut sesuaikan `~/.vimrc` Anda dan instal lebih banyak plugin.
+1. (Lanjutan) Konversi XML ke JSON ([file contoh](/2020/files/example-data.xml))
+   menggunakan macro Vim. Cobalah lakukan ini sendiri, tetapi Anda dapat melihat bagian
+   [macros](#macros) di atas jika Anda terjebak.

--- a/_2020/index.md
+++ b/_2020/index.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: "2020 Lectures"
+title: "Kuliah 2020"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2020.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2020.
 permalink: /2020/
 phony: true
 ---
@@ -29,11 +29,11 @@ phony: true
   {% endfor %}
 </ul>
 
-Video recordings of the lectures are available [on YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J).
+Rekaman video kuliah tersedia [di YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J).
 
-# Beyond MIT
+# Di Luar MIT
 
-We've also shared this class beyond MIT in the hopes that others may benefit from these resources. You can find posts and discussion on
+Kami juga telah membagikan kelas ini di luar MIT dengan harapan orang lain dapat memperoleh manfaat dari sumber daya ini. Anda dapat menemukan postingan dan diskusi di
 
  - [Hacker News](https://news.ycombinator.com/item?id=22226380)
  - [Lobsters](https://lobste.rs/s/ti1k98/missing_semester_your_cs_education_mit)
@@ -55,6 +55,6 @@ Some more URLs:
 - https://twitter.com/MIT_CSAIL/status/1581313961093484545
 {% endcomment %}
 
-# Acknowledgments
+# Ucapan Terima Kasih
 
-We thank Elaine Mello, Jim Cain, and [MIT Open Learning](https://openlearning.mit.edu/) for making it possible for us to record lecture videos; Anthony Zolnik and [MIT AeroAstro](https://aeroastro.mit.edu/) for A/V equipment; and Brandi Adams and [MIT EECS](https://www.eecs.mit.edu/) for supporting this class.
+Kami mengucapkan terima kasih kepada Elaine Mello, Jim Cain, dan [MIT Open Learning](https://openlearning.mit.edu/) yang telah memungkinkan kami merekam video kuliah; Anthony Zolnik dan [MIT AeroAstro](https://aeroastro.mit.edu/) untuk peralatan A/V; serta Brandi Adams dan [MIT EECS](https://www.eecs.mit.edu/) yang telah mendukung kelas ini.

--- a/_2020/index.md
+++ b/_2020/index.md
@@ -2,7 +2,7 @@
 layout: page
 title: "2020 Lectures"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2020.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2020.
 permalink: /2020/
 phony: true
 ---

--- a/_2020/metaprogramming.md
+++ b/_2020/metaprogramming.md
@@ -2,9 +2,9 @@
 layout: lecture
 title: "Metaprogramming"
 description: >
-  Learn about build systems, dependency management, testing, and continuous integration.
+  Pelajari tentang build system, manajemen dependensi, pengujian, dan continuous integration.
 thumbnail: /static/assets/thumbnails/2020/lec8.png
-details: build systems, dependency management, testing, CI
+details: build system, manajemen dependensi, pengujian, CI
 date: 2020-01-27
 ready: true
 video:
@@ -12,53 +12,51 @@ video:
   id: _Ms1Z4xfqv4
 ---
 
-What do we mean by "metaprogramming"? Well, it was the best collective
-term we could come up with for the set of things that are more about
-_process_ than they are about writing code or working more efficiently.
-In this lecture, we will look at systems for building and testing your
-code, and for managing dependencies. These may seem like they are of
-limited importance in your day-to-day as a student, but the moment you
-interact with a larger code base through an internship or once you enter
-the "real world", you will see this everywhere. We should note that
-"metaprogramming" can also mean "[programs that operate on
-programs](https://en.wikipedia.org/wiki/Metaprogramming)", whereas that
-is not quite the definition we are using for the purposes of this
-lecture.
+Apa yang kami maksud dengan "metaprogramming"? Itu adalah istilah kolektif terbaik
+yang bisa kami temukan untuk sekumpulan hal yang lebih berkaitan dengan
+_proses_ daripada menulis kode atau bekerja lebih efisien.
+Dalam kuliah ini, kita akan melihat sistem untuk membangun dan menguji
+kode Anda, serta untuk mengelola dependensi. Hal-hal ini mungkin tampak
+tidak terlalu penting dalam keseharian Anda sebagai mahasiswa, tetapi begitu
+Anda berinteraksi dengan codebase yang lebih besar melalui magang atau setelah
+Anda masuk ke "dunia nyata", Anda akan melihat ini di mana-mana. Perlu kami
+catat bahwa "metaprogramming" juga bisa berarti "[program yang menjalankan
+program](https://en.wikipedia.org/wiki/Metaprogramming)", sedangkan itu
+bukan definisi yang kami gunakan untuk keperluan kuliah ini.
 
-# Build systems
+# Build system
 
-If you write a paper in LaTeX, what are the commands you need to run to
-produce your paper? What about the ones used to run your benchmarks,
-plot them, and then insert that plot into your paper? Or to compile the
-code provided in the class you're taking and then running the tests?
+Jika Anda menulis makalah dengan LaTeX, perintah apa yang perlu Anda jalankan untuk
+menghasilkan makalah Anda? Bagaimana dengan perintah yang digunakan untuk menjalankan benchmark,
+membuat plot-nya, lalu menyisipkan plot tersebut ke makalah Anda? Atau untuk mengompilasi
+kode yang disediakan di kelas yang Anda ambil dan kemudian menjalankan tesnya?
 
-For most projects, whether they contain code or not, there is a "build
-process". Some sequence of operations you need to do to go from your
-inputs to your outputs. Often, that process might have many steps, and
-many branches. Run this to generate this plot, that to generate those
-results, and something else to produce the final paper. As with so many
-of the things we have seen in this class, you are not the first to
-encounter this annoyance, and luckily there exist many tools to help
-you!
+Untuk sebagian besar proyek, apakah mengandung kode atau tidak, terdapat "proses build".
+Suatu urutan operasi yang perlu Anda lakukan untuk pergi dari input ke output.
+Seringkali, proses tersebut mungkin memiliki banyak langkah, dan banyak cabang.
+Jalankan ini untuk menghasilkan plot ini, itu untuk menghasilkan hasil itu,
+dan sesuatu yang lain untuk menghasilkan makalah akhir. Seperti banyak hal yang
+telah kita lihat di kelas ini, Anda bukan yang pertama kali mengalami kesulitan ini,
+dan untungnya ada banyak alat yang bisa membantu Anda!
 
-These are usually called "build systems", and there are _many_ of them.
-Which one you use depends on the task at hand, your language of
-preference, and the size of the project. At their core, they are all
-very similar though. You define a number of _dependencies_, a number of
-_targets_, and _rules_ for going from one to the other. You tell the
-build system that you want a particular target, and its job is to find
-all the transitive dependencies of that target, and then apply the rules
-to produce intermediate targets all the way until the final target has
-been produced. Ideally, the build system does this without unnecessarily
-executing rules for targets whose dependencies haven't changed and where
-the result is available from a previous build.
+Ini biasanya disebut "build system", dan ada _banyak_ di antaranya.
+Yang Anda gunakan tergantung pada tugas yang ada, bahasa pemrograman
+favorit Anda, dan ukuran proyek. Pada intinya, semuanya sangat mirip.
+Anda mendefinisikan sejumlah _dependensi_, sejumlah _target_, dan _aturan_
+untuk beralih dari satu ke yang lain. Anda memberi tahu build system bahwa
+Anda menginginkan target tertentu, dan tugasnya adalah menemukan semua
+dependensi transitif dari target tersebut, lalu menerapkan aturan-aturan
+untuk menghasilkan target-target perantara sampai target akhir dihasilkan.
+Idealnya, build system melakukan ini tanpa menjalankan aturan secara
+tidak perlu untuk target-target yang dependensinya belum berubah dan
+hasilnya sudah tersedia dari build sebelumnya.
 
-`make` is one of the most common build systems out there, and you will
-usually find it installed on pretty much any UNIX-based computer. It has
-its warts, but works quite well for simple-to-moderate projects. When
-you run `make`, it consults a file called `Makefile` in the current
-directory. All the targets, their dependencies, and the rules are
-defined in that file. Let's take a look at one:
+`make` adalah salah satu build system yang paling umum, dan Anda biasanya
+akan menemukannya terinstal di hampir semua komputer berbasis UNIX.
+Ada beberapa kekurangannya, tetapi bekerja cukup baik untuk proyek sederhana
+hingga menengah. Saat Anda menjalankan `make`, ia membaca file bernama
+`Makefile` di direktori saat ini. Semua target, dependensi, dan aturan
+didefinisikan di file tersebut. Mari kita lihat salah satunya:
 
 ```make
 paper.pdf: paper.tex plot-data.png
@@ -68,29 +66,29 @@ plot-%.png: %.dat plot.py
 	./plot.py -i $*.dat -o $@
 ```
 
-Each directive in this file is a rule for how to produce the left-hand
-side using the right-hand side. Or, phrased differently, the things
-named on the right-hand side are dependencies, and the left-hand side is
-the target. The indented block is a sequence of programs to produce the
-target from those dependencies. In `make`, the first directive also
-defines the default goal. If you run `make` with no arguments, this is
-the target it will build. Alternatively, you can run something like
-`make plot-data.png`, and it will build that target instead.
+Setiap direktif dalam file ini adalah aturan untuk menghasilkan sisi kiri
+menggunakan sisi kanan. Atau, dengan kata lain, hal-hal yang disebutkan
+di sisi kanan adalah dependensi, dan sisi kiri adalah target. Blok yang
+diindentasi adalah urutan program untuk menghasilkan target dari
+dependensi-dependensi tersebut. Dalam `make`, direktif pertama juga
+mendefinisikan goal default. Jika Anda menjalankan `make` tanpa argumen,
+ini adalah target yang akan dibangun. Sebagai alternatif, Anda bisa
+menjalankan sesuatu seperti `make plot-data.png`, dan ia akan membangun
+target tersebut sebagai gantinya.
 
-The `%` in a rule is a "pattern", and will match the same string on the
-left and on the right. For example, if the target `plot-foo.png` is
-requested, `make` will look for the dependencies `foo.dat` and
-`plot.py`. Now let's look at what happens if we run `make` with an empty
-source directory.
+`%` dalam sebuah aturan adalah "pola", dan akan cocok dengan string yang
+sama di kiri dan di kanan. Misalnya, jika target `plot-foo.png` diminta,
+`make` akan mencari dependensi `foo.dat` dan `plot.py`. Sekarang mari kita
+lihat apa yang terjadi jika kita menjalankan `make` dengan direktori sumber kosong.
 
 ```console
 $ make
 make: *** No rule to make target 'paper.tex', needed by 'paper.pdf'.  Stop.
 ```
 
-`make` is helpfully telling us that in order to build `paper.pdf`, it
-needs `paper.tex`, and it has no rule telling it how to make that file.
-Let's try making it!
+`make` dengan ramah memberi tahu kita bahwa untuk membangun `paper.pdf`,
+ia membutuhkan `paper.tex`, dan tidak ada aturan yang memberitahu cara
+membuat file tersebut. Mari kita coba membuatnya!
 
 ```console
 $ touch paper.tex
@@ -98,10 +96,10 @@ $ make
 make: *** No rule to make target 'plot-data.png', needed by 'paper.pdf'.  Stop.
 ```
 
-Hmm, interesting, there _is_ a rule to make `plot-data.png`, but it is a
-pattern rule. Since the source files do not exist (`data.dat`), `make`
-simply states that it cannot make that file. Let's try creating all the
-files:
+Hmm, menarik, _ada_ aturan untuk membuat `plot-data.png`, tetapi itu
+adalah aturan pola. Karena file sumber tidak ada (`data.dat`), `make`
+hanya menyatakan bahwa ia tidak bisa membuat file tersebut. Mari kita
+coba membuat semua file:
 
 ```console
 $ cat paper.tex
@@ -133,7 +131,7 @@ $ cat data.dat
 5 8
 ```
 
-Now what happens if we run `make`?
+Sekarang apa yang terjadi jika kita menjalankan `make`?
 
 ```console
 $ make
@@ -142,18 +140,18 @@ pdflatex paper.tex
 ... lots of output ...
 ```
 
-And look, it made a PDF for us!
-What if we run `make` again?
+Dan lihat, ia membuat PDF untuk kita!
+Bagaimana jika kita menjalankan `make` lagi?
 
 ```console
 $ make
 make: 'paper.pdf' is up to date.
 ```
 
-It didn't do anything! Why not? Well, because it didn't need to. It
-checked that all of the previously-built targets were still up to date
-with respect to their listed dependencies. We can test this by modifying
-`paper.tex` and then re-running `make`:
+Ia tidak melakukan apa-apa! Mengapa? Karena tidak perlu. Ia memeriksa
+bahwa semua target yang sudah dibangun sebelumnya masih terbaru
+terhadap dependensi yang terdaftar. Kita bisa menguji ini dengan
+mengubah `paper.tex` lalu menjalankan ulang `make`:
 
 ```console
 $ vim paper.tex
@@ -162,168 +160,177 @@ pdflatex paper.tex
 ...
 ```
 
-Notice that `make` did _not_ re-run `plot.py` because that was not
-necessary; none of `plot-data.png`'s dependencies changed!
+Perhatikan bahwa `make` _tidak_ menjalankan ulang `plot.py` karena
+itu tidak diperlukan; tidak ada dependensi `plot-data.png` yang berubah!
 
-# Dependency management
+# Manajemen dependensi
 
-At a more macro level, your software projects are likely to have
-dependencies that are themselves projects. You might depend on installed
-programs (like `python`), system packages (like `openssl`), or libraries
-within your programming language (like `matplotlib`). These days, most
-dependencies will be available through a _repository_ that hosts a
-large number of such dependencies in a single place, and provides a
-convenient mechanism for installing them. Some examples include the
-Ubuntu package repositories for Ubuntu system packages, which you access
-through the `apt` tool, RubyGems for Ruby libraries, PyPI for Python
-libraries, or the Arch User Repository for Arch Linux user-contributed
-packages.
+Pada tingkat yang lebih makro, proyek perangkat lunak Anda kemungkinan
+besar memiliki dependensi yang merupakan proyek-proyek itu sendiri.
+Anda mungkin bergantung pada program yang terinstal (seperti `python`),
+paket sistem (seperti `openssl`), atau pustaka dalam bahasa pemrograman
+Anda (seperti `matplotlib`). Saat ini, sebagian besar dependensi akan
+tersedia melalui sebuah _repositori_ yang menampung sejumlah besar
+dependensi tersebut di satu tempat, dan menyediakan mekanisme yang
+nyaman untuk menginstalnya. Beberapa contoh termasuk repositori paket
+Ubuntu untuk paket sistem Ubuntu, yang Anda akses melalui alat `apt`,
+RubyGems untuk pustaka Ruby, PyPI untuk pustaka Python, atau Arch User
+Repository untuk paket-paket kontributor pengguna Arch Linux.
 
-Since the exact mechanisms for interacting with these repositories vary
-a lot from repository to repository and from tool to tool, we won't go
-too much into the details of any specific one in this lecture. What we
-_will_ cover is some of the common terminology they all use. The first
-among these is _versioning_. Most projects that other projects depend on
-issue a _version number_ with every release. Usually something like
-8.1.3 or 64.1.20192004. They are often, but not always, numerical.
-Version numbers serve many purposes, and one of the most important of
-them is to ensure that software keeps working. Imagine, for example,
-that I release a new version of my library where I have renamed a
-particular function. If someone tried to build some software that
-depends on my library after I release that update, the build might fail
-because it calls a function that no longer exists! Versioning attempts
-to solve this problem by letting a project say that it depends on a
-particular version, or range of versions, of some other project. That
-way, even if the underlying library changes, dependent software
-continues building by using an older version of my library.
+Karena mekanisme yang tepat untuk berinteraksi dengan repositori-repositori
+ini sangat bervariasi dari satu repositori ke repositori lain dan dari
+satu alat ke alat lain, kita tidak akan membahas terlalu detail tentang
+ada satu alat tertentu dalam kuliah ini. Yang _akan_ kita bahas adalah
+beberapa terminologi umum yang semuanya gunakan. Yang pertama adalah
+_versioning_. Sebagian besar proyek yang menjadi dependensi proyek lain
+menerbitkan _nomor versi_ dengan setiap rilis. Biasanya sesuatu seperti
+8.1.3 atau 64.1.20192004. Biasanya numerik, tetapi tidak selalu.
+Nomor versi memiliki banyak tujuan, dan salah satu yang paling penting
+adalah memastikan perangkat lunak tetap berfungsi. Bayangkan, misalnya,
+saya merilis versi baru pustaka saya di mana saya telah mengubah nama
+sebuah fungsi. Jika seseorang mencoba membangun perangkat lunak yang
+bergantung pada pustaka saya setelah saya merilis pembaruan tersebut,
+build-nya mungkin gagal karena memanggil fungsi yang tidak ada lagi!
+Versioning berusaha menyelesaikan masalah ini dengan membiarkan sebuah
+proyek menyatakan bahwa ia bergantung pada versi tertentu, atau rentang
+versi tertentu, dari proyek lain. Dengan begitu, meskipun pustaka dasar
+berubah, perangkat lunak yang bergantung tetap bisa dibangun menggunakan
+versi lama dari pustaka saya.
 
-That also isn't ideal though! What if I issue a security update which
-does _not_ change the public interface of my library (its "API"), and
-which any project that depended on the old version should immediately
-start using? This is where the different groups of numbers in a version
-come in. The exact meaning of each one varies between projects, but one
-relatively common standard is [_semantic
-versioning_](https://semver.org/). With semantic versioning, every
-version number is of the form: major.minor.patch. The rules are:
+Namun itu juga belum ideal! Bagaimana jika saya merilis pembaruan keamanan
+yang _tidak_ mengubah antarmuka publik pustaka saya (API-nya), dan
+proyek mana pun yang bergantung pada versi lama seharusnya segera
+menggunakannya? Di sinilah kelompok angka-angka berbeda dalam nomor
+versi berperan. Arti pasti masing-masing bervariasi antar proyek, tetapi
+salah satu standar yang cukup umum adalah [_semantic
+versioning_](https://semver.org/). Dengan semantic versioning, setiap
+nomor versi memiliki format: major.minor.patch. Aturannya adalah:
 
- - If a new release does not change the API, increase the patch version.
- - If you _add_ to your API in a backwards-compatible way, increase the
-   minor version.
- - If you change the API in a non-backwards-compatible way, increase the
-   major version.
+ - Jika rilis baru tidak mengubah API, naikkan versi patch.
+ - Jika Anda _menambahkan_ ke API Anda dengan cara yang kompatibel ke
+   belakang, naikkan versi minor.
+ - Jika Anda mengubah API dengan cara yang tidak kompatibel ke belakang,
+   naikkan versi major.
 
-This already provides some major advantages. Now, if my project depends
-on your project, it _should_ be safe to use the latest release with the
-same major version as the one I built against when I developed it, as
-long as its minor version is at least what it was back then. In other
-words, if I depend on your library at version `1.3.7`, then it _should_
-be fine to build it with `1.3.8`, `1.6.1`, or even `1.3.0`. Version
-`2.2.4` would probably not be okay, because the major version was
-increased. We can see an example of semantic versioning in Python's
-version numbers. Many of you are probably aware that Python 2 and Python
-3 code do not mix very well, which is why that was a _major_ version
-bump. Similarly, code written for Python 3.5 might run fine on Python
-3.7, but possibly not on 3.4.
+Ini sudah memberikan beberapa keuntungan besar. Sekarang, jika proyek saya
+bergantung pada proyek Anda, seharusnya aman menggunakan rilis terbaru
+dengan versi major yang sama dengan yang saya gunakan saat mengembangkannya,
+selama versi minor-nya setidaknya sama dengan saat itu. Dengan kata lain,
+jika saya bergantung pada pustaka Anda di versi `1.3.7`, maka seharusnya
+tidak masalah membangunnya dengan `1.3.8`, `1.6.1`, atau bahkan `1.3.0`.
+Versi `2.2.4` mungkin tidak akan cocok, karena versi major-nya naik.
+Kita bisa melihat contoh semantic versioning di nomor versi Python.
+Banyak dari Anda mungkin sudah tahu bahwa kode Python 2 dan Python 3
+tidak bisa dicampur dengan baik, itulah mengapa itu adalah _major_
+version bump. Demikian juga, kode yang ditulis untuk Python 3.5 mungkin
+berjalan baik di Python 3.7, tetapi mungkin tidak di 3.4.
 
-When working with dependency management systems, you may also come
-across the notion of _lock files_. A lock file is simply a file that
-lists the exact version you are _currently_ depending on of each
-dependency. Usually, you need to explicitly run an update program to
-upgrade to newer versions of your dependencies. There are many reasons
-for this, such as avoiding unnecessary recompiles, having reproducible
-builds, or not automatically updating to the latest version (which may
-be broken). An extreme version of this kind of dependency locking is
-_vendoring_, which is where you copy all the code of your dependencies
-into your own project. That gives you total control over any changes to
-it, and lets you introduce your own changes to it, but also means you
-have to explicitly pull in any updates from the upstream maintainers
-over time.
+Saat bekerja dengan sistem manajemen dependensi, Anda mungkin juga
+menemui konsep _lock file_. Lock file hanyalah file yang mencantumkan
+versi tepat yang saat ini Anda andalkan dari setiap dependensi.
+Biasanya, Anda perlu secara eksplisit menjalankan program pembaruan
+untuk mengupgrade ke versi dependensi yang lebih baru. Ada banyak
+alasan untuk ini, seperti menghindari recompile yang tidak perlu,
+memiliki build yang dapat direproduksi, atau tidak secara otomatis
+memperbarui ke versi terbaru (yang mungkin rusak). Versi ekstrem dari
+penguncian dependensi semacam ini adalah _vendoring_, yaitu di mana
+Anda menyalin semua kode dependensi Anda ke proyek Anda sendiri.
+Itu memberi Anda kontrol total atas setiap perubahan padanya, dan
+memungkinkan Anda memperkenalkan perubahan Anda sendiri, tetapi juga
+berarti Anda harus secara eksplisit mengambil pembaruan dari
+pemelihara upstream dari waktu ke waktu.
 
-# Continuous integration systems
+# Sistem continuous integration
 
-As you work on larger and larger projects, you'll find that there are
-often additional tasks you have to do whenever you make a change to it.
-You might have to upload a new version of the documentation, upload a
-compiled version somewhere, release the code to pypi, run your test
-suite, and all sort of other things. Maybe every time someone sends you
-a pull request on GitHub, you want their code to be style checked and
-you want some benchmarks to run? When these kinds of needs arise, it's
-time to take a look at continuous integration.
+Saat Anda mengerjakan proyek yang semakin besar, Anda akan menemukan
+bahwa sering ada tugas tambahan yang harus dilakukan setiap kali Anda
+mengubahnya. Anda mungkin harus mengunggah versi dokumentasi baru,
+mengunggah versi yang sudah dikompilasi ke suatu tempat, merilis kode
+ke pypi, menjalankan suite pengujian, dan segala macam hal lainnya.
+Mungkin setiap kali seseorang mengirim pull request di GitHub, Anda
+ingin kode mereka diperiksa gayanya dan Anda ingin beberapa benchmark
+dijalankan? Ketika kebutuhan semacam ini muncul, saatnya untuk melihat
+continuous integration.
 
-Continuous integration, or CI, is an umbrella term for "stuff that runs
-whenever your code changes", and there are many companies out there that
-provide various types of CI, often for free for open-source projects.
-Some of the big ones are Travis CI, Azure Pipelines, and GitHub Actions.
-They all work in roughly the same way: you add a file to your repository
-that describes what should happen when various things happen to that
-repository. By far the most common one is a rule like "when someone
-pushes code, run the test suite". When the event triggers, the CI
-provider spins up a virtual machines (or more), runs the commands in
-your "recipe", and then usually notes down the results somewhere. You
-might set it up so that you are notified if the test suite stops
-passing, or so that a little badge appears on your repository as long as
-the tests pass.
+Continuous integration, atau CI, adalah istilah umum untuk "hal-hal yang
+berjalan setiap kali kode Anda berubah", dan ada banyak perusahaan di luar
+sana yang menyediakan berbagai jenis CI, seringkali gratis untuk proyek
+open-source. Beberapa yang besar adalah Travis CI, Azure Pipelines, dan
+GitHub Actions. Semuanya bekerja dengan cara yang kurang lebih sama: Anda
+menambahkan file ke repositori Anda yang menjelaskan apa yang harus
+terjadi ketika berbagai hal terjadi pada repositori tersebut. Yang paling
+umum adalah aturan seperti "ketika seseorang mengirim kode, jalankan
+suite pengujian". Ketika event terpicu, penyedia CI membuat virtual
+machine (atau lebih), menjalankan perintah dalam "resep" Anda, dan
+kemudian biasanya mencatat hasilnya di suatu tempat. Anda bisa
+mengaturnya sehingga Anda diberi tahu jika suite pengujian tidak lagi
+lulus, atau sehingga sebuah badge kecil muncul di repositori Anda
+selama tes-tes lulus.
 
-As an example of a CI system, the class website is set up using GitHub
-Pages. Pages is a CI action that runs the Jekyll blog software on every
-push to `master` and makes the built site available on a particular
-GitHub domain. This makes it trivial for us to update the website! We
-just make our changes locally, commit them with git, and then push. CI
-takes care of the rest.
+Sebagai contoh sistem CI, situs web kelas ini diatur menggunakan GitHub
+Pages. Pages adalah aksi CI yang menjalankan perangkat lunak blog Jekyll
+pada setiap push ke `master` dan membuat situs yang sudah dibangun
+tersedia di domain GitHub tertentu. Ini membuat kami sangat mudah
+memperbarui situs web! Kami hanya membuat perubahan secara lokal,
+commit dengan git, lalu push. CI menangani sisanya.
 
-## A brief aside on testing
+## Sekilas tentang pengujian
 
-Most large software projects come with a "test suite". You may already
-be familiar with the general concept of testing, but we thought we'd
-quickly mention some approaches to testing and testing terminology that
-you may encounter in the wild:
+Sebagian besar proyek perangkat lunak besar dilengkapi dengan "test suite".
+Anda mungkin sudah familiar dengan konsep umum pengujian, tetapi kami
+ingin dengan cepat menyebutkan beberapa pendekatan pengujian dan
+terminologi pengujian yang mungkin Anda temui di lapangan:
 
- - Test suite: a collective term for all the tests
- - Unit test: a "micro-test" that tests a specific feature in isolation
- - Integration test: a "macro-test" that runs a larger part of the
-   system to check that different feature or components work _together_.
- - Regression test: a test that implements a particular pattern that
-   _previously_ caused a bug to ensure that the bug does not resurface.
- - Mocking: to replace a function, module, or type with a fake
-   implementation to avoid testing unrelated functionality. For example,
-   you might "mock the network" or "mock the disk".
+ - Test suite: istilah kolektif untuk semua tes
+ - Unit test: "tes mikro" yang menguji fitur spesifik secara terisolasi
+ - Integration test: "tes makro" yang menjalankan bagian yang lebih besar
+   dari sistem untuk memeriksa bahwa fitur atau komponen yang berbeda
+   bekerja _bersama-sama_.
+ - Regression test: tes yang mengimplementasikan pola tertentu yang
+   _sebelumnya_ menyebabkan bug untuk memastikan bug tersebut tidak
+   muncul kembali.
+ - Mocking: mengganti fungsi, modul, atau tipe dengan implementasi palsu
+   untuk menghindari pengujian fungsionalitas yang tidak terkait.
+   Misalnya, Anda mungkin "mock jaringan" atau "mock disk".
 
-# Exercises
+# Latihan
 
- 1. Most makefiles provide a target called `clean`. This isn't intended
-    to produce a file called `clean`, but instead to clean up any files
-    that can be re-built by make. Think of it as a way to "undo" all of
-    the build steps. Implement a `clean` target for the `paper.pdf`
-    `Makefile` above. You will have to make the target
-    [phony](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).
-    You may find the [`git
-    ls-files`](https://git-scm.com/docs/git-ls-files) subcommand useful.
-    A number of other very common make targets are listed
-    [here](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html#Standard-Targets).
- 2. Take a look at the various ways to specify version requirements for
-    dependencies in [Rust's build
-    system](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
-    Most package repositories support similar syntax. For each one
-    (caret, tilde, wildcard, comparison, and multiple), try to come up
-    with a use-case in which that particular kind of requirement makes
-    sense.
- 3. Git can act as a simple CI system all by itself. In `.git/hooks`
-    inside any git repository, you will find (currently inactive) files
-    that are run as scripts when a particular action happens. Write a
-    [`pre-commit`](https://git-scm.com/docs/githooks#_pre_commit) hook
-    that runs `make paper.pdf` and refuses the commit if the `make`
-    command fails. This should prevent any commit from having an
-    unbuildable version of the paper.
- 4. Set up a simple auto-published page using [GitHub
-    Pages](https://pages.github.com/).
-    Add a [GitHub Action](https://github.com/features/actions) to the
-    repository to run `shellcheck` on any shell files in that
-    repository (here is [one way to do
-    it](https://github.com/marketplace/actions/shellcheck)). Check that
-    it works!
- 5. [Build your
-    own](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/building-actions)
-    GitHub action to run [`proselint`](https://github.com/amperser/proselint) or
-    [`write-good`](https://github.com/btford/write-good) on all the
-    `.md` files in the repository. Enable it in your repository, and
-    check that it works by filing a pull request with a typo in it.
+  1. Sebagian besar makefile menyediakan target bernama `clean`. Ini bukan
+     dimaksudkan untuk menghasilkan file bernama `clean`, melainkan untuk
+     membersihkan file-file yang bisa di-build ulang oleh make. Anggap
+     saja sebagai cara untuk "undo" semua langkah build. Implementasikan
+     target `clean` untuk `Makefile` `paper.pdf` di atas. Anda harus
+     membuat target tersebut
+     [phony](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).
+     Anda mungkin menemukan subcommand [`git
+     ls-files`](https://git-scm.com/docs/git-ls-files) berguna. Sejumlah
+     target make umum lainnya terdaftar
+     [di sini](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html#Standard-Targets).
+  2. Lihat berbagai cara untuk menentukan persyaratan versi untuk
+     dependensi di [build system
+     Rust](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
+     Sebagian besar repositori paket mendukung sintaks yang serupa. Untuk
+     masing-masing (caret, tilde, wildcard, perbandingan, dan multiple),
+     cobalah memikirkan kasus penggunaan di mana persyaratan jenis
+     tertentu itu masuk akal.
+  3. Git bisa bertindak sebagai sistem CI sederhana secara mandiri. Di
+     `.git/hooks` di repositori git mana pun, Anda akan menemukan file
+     yang (saat ini tidak aktif) yang dijalankan sebagai skrip ketika
+     aksi tertentu terjadi. Tulis hook
+     [`pre-commit`](https://git-scm.com/docs/githooks#_pre_commit) yang
+     menjalankan `make paper.pdf` dan menolak commit jika perintah `make`
+     gagal. Ini seharusnya mencegah commit apa pun memiliki versi makalah
+     yang tidak bisa di-build.
+  4. Siapkan halaman auto-publish sederhana menggunakan [GitHub
+     Pages](https://pages.github.com/).
+     Tambahkan [GitHub Action](https://github.com/features/actions) ke
+     repositori untuk menjalankan `shellcheck` pada semua file shell di
+     repositori tersebut (ini adalah [salah satu cara untuk
+     melakukannya](https://github.com/marketplace/actions/shellcheck)).
+     Periksa bahwa itu berfungsi!
+  5. [Buat sendiri](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/building-actions)
+     GitHub action untuk menjalankan [`proselint`](https://github.com/amperser/proselint) atau
+     [`write-good`](https://github.com/btford/write-good) pada semua
+     file `.md` di repositori. Aktifkan di repositori Anda, dan
+     periksa bahwa itu berfungsi dengan mengajukan pull request yang
+     mengandung typo.

--- a/_2020/metaprogramming.md
+++ b/_2020/metaprogramming.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Metaprogramming"
 description: >
-  Learn about build systems, dependency management, testing, and continuous integration.
+  Pelajari tentang build system, manajemen dependensi, pengujian, dan continuous integration.
 thumbnail: /static/assets/thumbnails/2020/lec8.png
 details: build systems, dependency management, testing, CI
 date: 2020-01-27

--- a/_2020/potpourri.md
+++ b/_2020/potpourri.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Potpourri"
 description: >
-  Learn about a variety of useful topics including keyboard remapping, daemons, backups, APIs, and more.
+  Pelajari berbagai topik berguna termasuk keyboard remapping, daemon, backup, API, dan lainnya.
 thumbnail: /static/assets/thumbnails/2020/lec10.png
 date: 2020-01-29
 ready: true

--- a/_2020/potpourri.md
+++ b/_2020/potpourri.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Potpourri"
 description: >
-  Learn about a variety of useful topics including keyboard remapping, daemons, backups, APIs, and more.
+  Pelajari berbagai topik berguna termasuk pemetaan ulang keyboard, daemon, backup, API, dan lainnya.
 thumbnail: /static/assets/thumbnails/2020/lec10.png
 date: 2020-01-29
 ready: true
@@ -12,63 +12,63 @@ video:
 special: true
 ---
 
-## Table of Contents
+## Daftar Isi
 
-- [Keyboard remapping](#keyboard-remapping)
-- [Daemons](#daemons)
+- [Pemetaan ulang keyboard](#keyboard-remapping)
+- [Daemon](#daemons)
 - [FUSE](#fuse)
-- [Backups](#backups)
-- [APIs](#apis)
-- [Common command-line flags/patterns](#common-command-line-flagspatterns)
-- [Window managers](#window-managers)
-- [VPNs](#vpns)
+- [Backup](#backups)
+- [API](#apis)
+- [Flag/pola command-line umum](#common-command-line-flagspatterns)
+- [Window manager](#window-managers)
+- [VPN](#vpns)
 - [Markdown](#markdown)
-- [Hammerspoon (desktop automation on macOS)](#hammerspoon-desktop-automation-on-macos)
-- [Booting + Live USBs](#booting--live-usbs)
-- [Docker, Vagrant, VMs, Cloud, OpenStack](#docker-vagrant-vms-cloud-openstack)
-- [Notebook programming](#notebook-programming)
+- [Hammerspoon (otomasi desktop di macOS)](#hammerspoon-desktop-automation-on-macos)
+- [Booting + Live USB](#booting--live-usbs)
+- [Docker, Vagrant, VM, Cloud, OpenStack](#docker-vagrant-vms-cloud-openstack)
+- [Pemrograman notebook](#notebook-programming)
 - [GitHub](#github)
 
-## Keyboard remapping
+## Pemetaan ulang keyboard
 
-As a programmer, your keyboard is your main input method. As with pretty much anything in your computer, it is configurable (and worth configuring).
+Sebagai seorang programmer, keyboard Anda adalah metode input utama. Seperti hampir semua hal di komputer Anda, keyboard dapat dikonfigurasi (dan layak untuk dikonfigurasi).
 
-The most basic change is to remap keys.
-This usually involves some software that is listening and, whenever a certain key is pressed, it intercepts that event and replaces it with another event corresponding to a different key. Some examples:
-- Remap Caps Lock to Ctrl or Escape. We (the instructors) highly encourage this setting since Caps Lock has a very convenient location but is rarely used.
-- Remapping PrtSc to Play/Pause music. Most OSes have a play/pause key.
-- Swapping Ctrl and the Meta (Windows or Command) key.
+Perubahan paling dasar adalah memetakan ulang tombol.
+Ini biasanya melibatkan beberapa perangkat lunak yang mendengarkan, dan setiap kali tombol tertentu ditekan, ia mencegat peristiwa tersebut dan menggantinya dengan peristiwa lain yang sesuai dengan tombol berbeda. Beberapa contoh:
+- Memetakan ulang Caps Lock ke Ctrl atau Escape. Kami (para instruktur) sangat menyarankan pengaturan ini karena Caps Lock memiliki lokasi yang sangat nyaman tetapi jarang digunakan.
+- Memetakan ulang PrtSc ke Play/Pause musik. Sebagian besar OS memiliki tombol play/pause.
+- Menukar Ctrl dan tombol Meta (Windows atau Command).
 
-You can also map keys to arbitrary commands of your choosing. This is useful for common tasks that you perform. Here, some software listens for a specific key combination and executes some script whenever that event is detected.
-- Open a new terminal or browser window.
-- Inserting some specific text, e.g. your long email address or your MIT ID number.
-- Sleeping the computer or the displays.
+Anda juga dapat memetakan tombol ke perintah arbitrer pilihan Anda. Ini berguna untuk tugas-tugas umum yang Anda lakukan. Di sini, beberapa perangkat lunak mendengarkan kombinasi tombol tertentu dan menjalankan skrip setiap kali peristiwa tersebut terdeteksi.
+- Membuka terminal baru atau jendela browser.
+- Menyisipkan teks tertentu, misalnya alamat email panjang Anda atau nomor ID MIT Anda.
+- Menidurkan komputer atau layar.
 
-There are even more complex modifications you can configure:
-- Remapping sequences of keys, e.g. pressing shift five times toggles Caps Lock.
-- Remapping on tap vs on hold, e.g. Caps Lock key is remapped to Esc if you quickly tap it, but is remapped to Ctrl if you hold it and use it as a modifier.
-- Having remaps being keyboard or software specific.
+Ada juga modifikasi yang lebih kompleks yang dapat Anda konfigurasi:
+- Memetakan ulang urutan tombol, misalnya menekan shift lima kali mengaktifkan Caps Lock.
+- Memetakan ulang saat ditekan singkat vs ditahan, misalnya tombol Caps Lock dipetakan ulang ke Esc jika Anda menekannya dengan cepat, tetapi dipetakan ulang ke Ctrl jika Anda menahannya dan menggunakannya sebagai modifier.
+- Membuat pemetaan spesifik per keyboard atau per perangkat lunak.
 
-Some software resources to get started on the topic:
-- macOS - [karabiner-elements](https://karabiner-elements.pqrs.org/), [skhd](https://github.com/koekeishiya/skhd) or [BetterTouchTool](https://folivora.ai/)
-- Linux - [xmodmap](https://wiki.archlinux.org/index.php/Xmodmap) or [Autokey](https://github.com/autokey/autokey)
-- Windows - Builtin in Control Panel, [AutoHotkey](https://www.autohotkey.com/) or [SharpKeys](https://www.randyrants.com/category/sharpkeys/)
-- QMK - If your keyboard supports custom firmware you can use [QMK](https://docs.qmk.fm/) to configure the hardware device itself so the remaps works for any machine you use the keyboard with.
+Beberapa sumber perangkat lunak untuk memulai topik ini:
+- macOS - [karabiner-elements](https://karabiner-elements.pqrs.org/), [skhd](https://github.com/koekeishiya/skhd) atau [BetterTouchTool](https://folivora.ai/)
+- Linux - [xmodmap](https://wiki.archlinux.org/index.php/Xmodmap) atau [Autokey](https://github.com/autokey/autokey)
+- Windows - Builtin di Control Panel, [AutoHotkey](https://www.autohotkey.com/) atau [SharpKeys](https://www.randyrants.com/category/sharpkeys/)
+- QMK - Jika keyboard Anda mendukung firmware kustom, Anda dapat menggunakan [QMK](https://docs.qmk.fm/) untuk mengonfigurasi perangkat keras itu sendiri sehingga pemetaan berlaku untuk mesin mana pun yang Anda gunakan dengan keyboard tersebut.
 
-## Daemons
+## Daemon
 
-You are probably already familiar with the notion of daemons, even if the word seems new.
-Most computers have a series of processes that are always running in the background rather than waiting for a user to launch them and interact with them.
-These processes are called daemons and the programs that run as daemons often end with a `d` to indicate so.
-For example `sshd`, the SSH daemon, is the program responsible for listening to incoming SSH requests and checking that the remote user has the necessary credentials to log in.
+Anda mungkin sudah familiar dengan konsep daemon, meskipun kata tersebut terdengar baru.
+Sebagian besar komputer memiliki serangkaian proses yang selalu berjalan di latar belakang daripada menunggu pengguna untuk meluncurkannya dan berinteraksi dengannya.
+Proses-proses ini disebut daemon dan program yang berjalan sebagai daemon sering kali diakhiri dengan huruf `d` untuk menunjukkannya.
+Sebagai contoh `sshd`, daemon SSH, adalah program yang bertanggung jawab untuk mendengarkan permintaan SSH yang masuk dan memeriksa apakah pengguna jarak jauh memiliki kredensial yang diperlukan untuk masuk.
 
-In Linux, `systemd` (the system daemon) is the most common solution for running and setting up daemon processes.
-You can run `systemctl status` to list the current running daemons. Most of them might sound unfamiliar but are responsible for core parts of the system such as managing the network, solving DNS queries or displaying the graphical interface for the system.
-Systemd can be interacted with the `systemctl` command in order to `enable`, `disable`, `start`, `stop`, `restart` or check the `status` of services (those are the `systemctl` commands).
+Di Linux, `systemd` (system daemon) adalah solusi paling umum untuk menjalankan dan mengatur proses daemon.
+Anda dapat menjalankan `systemctl status` untuk melihat daftar daemon yang sedang berjalan. Sebagian besar mungkin terdengar asing tetapi bertanggung jawab atas bagian-bagian inti sistem seperti mengelola jaringan, menyelesaikan kueri DNS, atau menampilkan antarmuka grafis untuk sistem.
+Systemd dapat diinteraksi dengan perintah `systemctl` untuk `enable`, `disable`, `start`, `stop`, `restart` atau memeriksa `status` layanan (itu adalah perintah-perintah `systemctl`).
 
-More interestingly, `systemd` has a fairly accessible interface for configuring and enabling new daemons (or services).
-Below is an example of a daemon for running a simple Python app.
-We won't go in the details but as you can see most of the fields are pretty self explanatory.
+Yang lebih menarik, `systemd` memiliki antarmuka yang cukup mudah diakses untuk mengonfigurasi dan mengaktifkan daemon baru (atau layanan).
+Berikut ini adalah contoh daemon untuk menjalankan aplikasi Python sederhana.
+Kami tidak akan membahas detailnya tetapi seperti yang Anda lihat, sebagian besar field cukup jelas maknanya.
 
 ```ini
 # /etc/systemd/system/myapp.service
@@ -87,330 +87,158 @@ Restart=on-failure
 WantedBy=multi-user.target
 ```
 
-Also, if you just want to run some program with a given frequency there is no need to build a custom daemon, you can use [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html), a daemon your system already runs to perform scheduled tasks.
+Juga, jika Anda hanya ingin menjalankan beberapa program dengan frekuensi tertentu, tidak perlu membuat daemon kustom, Anda dapat menggunakan [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html), daemon yang sudah dijalankan sistem Anda untuk melakukan tugas terjadwal.
 
 ## FUSE
 
-Modern software systems are usually composed of smaller building blocks that are composed together.
-Your operating system supports using different filesystem backends because there is a common language of what operations a filesystem supports.
-For instance, when you run `touch` to create a file, `touch` performs a system call to the kernel to create the file and the kernel performs the appropriate filesystem call to create the given file.
-A caveat is that UNIX filesystems are traditionally implemented as kernel modules and only the kernel is allowed to perform filesystem calls.
+Sistem perangkat lunak modern biasanya terdiri dari blok-blok bangunan kecil yang disusun bersama.
+Sistem operasi Anda mendukung penggunaan berbagai backend filesystem karena ada bahasa umum tentang operasi apa yang didukung oleh sebuah filesystem.
+Sebagai contoh, ketika Anda menjalankan `touch` untuk membuat file, `touch` melakukan system call ke kernel untuk membuat file dan kernel melakukan panggilan filesystem yang sesuai untuk membuat file tersebut.
+Masalahnya adalah filesystem UNIX secara tradisional diimplementasikan sebagai modul kernel dan hanya kernel yang diizinkan melakukan panggilan filesystem.
 
-[FUSE](https://en.wikipedia.org/wiki/Filesystem_in_Userspace) (Filesystem in User Space) allows filesystems to be implemented by a user program. FUSE lets users run user space code for filesystem calls and then bridges the necessary calls to the kernel interfaces.
-In practice, this means that users can implement arbitrary functionality for filesystem calls.
+[FUSE](https://en.wikipedia.org/wiki/Filesystem_in_Userspace) (Filesystem in User Space) memungkinkan filesystem diimplementasikan oleh program pengguna. FUSE memungkinkan pengguna menjalankan kode user space untuk panggilan filesystem dan kemudian menjembatani panggilan-panggilan yang diperlukan ke antarmuka kernel.
+Dalam praktiknya, ini berarti pengguna dapat mengimplementasikan fungsionalitas arbitrer untuk panggilan filesystem.
 
-For example, FUSE can be used so whenever you perform an operation in a virtual filesystem, that operation is forwarded through SSH to a remote machine, performed there, and the output is returned back to you.
-This way, local programs can see the file as if it was in your computer while in reality it's in a remote server.
-This is effectively what `sshfs` does.
+Sebagai contoh, FUSE dapat digunakan sehingga setiap kali Anda melakukan operasi di filesystem virtual, operasi tersebut diteruskan melalui SSH ke mesin jarak jauh, dilakukan di sana, dan outputnya dikembalikan kepada Anda.
+Dengan cara ini, program lokal dapat melihat file seolah-olah ada di komputer Anda padahal sebenarnya ada di server jarak jauh.
+Ini secara efektif adalah apa yang dilakukan `sshfs`.
 
-Some interesting examples of FUSE filesystems are:
-- [sshfs](https://github.com/libfuse/sshfs) - Open locally remote files/folder through an SSH connection.
-- [rclone](https://rclone.org/commands/rclone_mount/) - Mount cloud storage services like Dropbox, GDrive, Amazon S3 or Google Cloud Storage and open data locally.
-- [gocryptfs](https://nuetzlich.net/gocryptfs/) - Encrypted overlay system. Files are stored encrypted but once the FS is mounted they appear as plaintext in the mountpoint.
-- [kbfs](https://keybase.io/docs/kbfs) - Distributed filesystem with end-to-end encryption. You can have private, shared and public folders.
-- [borgbackup](https://borgbackup.readthedocs.io/en/stable/usage/mount.html) - Mount your deduplicated, compressed and encrypted backups for ease of browsing.
+Beberapa contoh menarik filesystem FUSE adalah:
+- [sshfs](https://github.com/libfuse/sshfs) - Membuka file/folder jarak jauh secara lokal melalui koneksi SSH.
+- [rclone](https://rclone.org/commands/rclone_mount/) - Mount layanan penyimpanan cloud seperti Dropbox, GDrive, Amazon S3 atau Google Cloud Storage dan buka data secara lokal.
+- [gocryptfs](https://nuetzlich.net/gocryptfs/) - Sistem overlay terenkripsi. File disimpan secara terenkripsi tetapi setelah FS di-mount, mereka muncul sebagai plaintext di mountpoint.
+- [kbfs](https://keybase.io/docs/kbfs) - Filesystem terdistribusi dengan enkripsi end-to-end. Anda dapat memiliki folder pribadi, bersama, dan publik.
+- [borgbackup](https://borgbackup.readthedocs.io/en/stable/usage/mount.html) - Mount backup Anda yang telah dideduplikasi, dikompresi, dan dienkripsi untuk kemudahan browsing.
 
-## Backups
+## Backup
 
-Any data that you haven’t backed up is data that could be gone at any moment, forever.
-It's easy to copy data around, it's hard to reliably backup data.
-Here are some good backup basics and the pitfalls of some approaches.
+Data apa pun yang belum Anda backup adalah data yang bisa hilang kapan saja, selamanya.
+Mudah untuk menyalin data, tetapi sulit untuk melakukan backup data secara andal.
+Berikut adalah beberapa dasar backup yang baik dan jebakan dari beberapa pendekatan.
 
-First, a copy of the data in the same disk is not a backup, because the disk is the single point of failure for all the data. Similarly, an external drive in your home is also a weak backup solution since it could be lost in a fire/robbery/&c. Instead, having an off-site backup is a recommended practice.
+Pertama, salinan data di disk yang sama bukanlah backup, karena disk adalah titik kegagalan tunggal untuk semua data. Demikian pula, drive eksternal di rumah Anda juga merupakan solusi backup yang lemah karena bisa hilang dalam kebakaran/pencurian/dll. Sebaliknya, memiliki backup di lokasi terpisah adalah praktik yang direkomendasikan.
 
-Synchronization solutions are not backups. For instance, Dropbox/GDrive are convenient solutions, but when data is erased or corrupted they propagate the change. For the same reason, disk mirroring solutions like RAID are not backups. They don't help if data gets deleted, corrupted or encrypted by ransomware.
+Solusi sinkronisasi bukanlah backup. Misalnya, Dropbox/GDrive adalah solusi yang nyaman, tetapi ketika data dihapus atau rusak, mereka menyebarkan perubahan tersebut. Untuk alasan yang sama, solusi disk mirroring seperti RAID bukanlah backup. Mereka tidak membantu jika data dihapus, rusak, atau dienkripsi oleh ransomware.
 
-Some core features of good backups solutions are versioning, deduplication and security.
-Versioning backups ensure that you can access your history of changes and efficiently recover files.
-Efficient backup solutions use data deduplication to only store incremental changes and reduce the storage overhead.
-Regarding security, you should ask yourself what someone would need to know/have in order to read your data and, more importantly, to delete all your data and associated backups.
-Lastly, blindly trusting backups is a terrible idea and you should verify regularly that you can use them to recover data.
+Beberapa fitur inti dari solusi backup yang baik adalah versioning, deduplication, dan keamanan.
+Backup versioning memastikan Anda dapat mengakses riwayat perubahan dan memulihkan file secara efisien.
+Solusi backup yang efisien menggunakan deduplication data untuk hanya menyimpan perubahan inkremental dan mengurangi overhead penyimpanan.
+Terkait keamanan, Anda harus menanyakan apa yang perlu diketahui/dimiliki seseorang untuk membaca data Anda dan, yang lebih penting, untuk menghapus semua data Anda dan backup terkait.
+Terakhir, mempercayai backup secara membabi-buta adalah ide yang buruk dan Anda harus secara teratur memverifikasi bahwa Anda dapat menggunakannya untuk memulihkan data.
 
-Backups go beyond local files in your computer.
-Given the significant growth of web applications, large amounts of your data are only stored in the cloud.
-For instance, your webmail, social media photos, music playlists in streaming services or online docs are gone if you lose access to the corresponding accounts.
-Having an offline copy of this information is the way to go, and you can find online tools that people have built to fetch the data and save it.
+Backup tidak hanya berlaku untuk file lokal di komputer Anda.
+Mengingat pertumbuhan signifikan aplikasi web, sebagian besar data Anda hanya disimpan di cloud.
+Misalnya, webmail Anda, foto media sosial, playlist musik di layanan streaming, atau dokumen online akan hilang jika Anda kehilangan akses ke akun terkait.
+Memiliki salinan offline dari informasi ini adalah cara yang tepat, dan Anda dapat menemukan alat online yang telah dibuat orang untuk mengambil data dan menyimpannya.
 
-For a more detailed explanation, see 2019's lecture notes on [Backups](/2019/backups).
-
-
-## APIs
-
-We've talked a lot in this class about using your computer more
-efficiently to accomplish _local_ tasks, but you will find that many of
-these lessons also extend to the wider internet. Most services online
-will have "APIs" that let you programmatically access their data. For
-example, the US government has an API that lets you get weather
-forecasts, which you could use to easily get a weather forecast in your
-shell.
-
-Most of these APIs have a similar format. They are structured URLs,
-often rooted at `api.service.com`, where the path and query parameters
-indicate what data you want to read or what action you want to perform.
-For the US weather data for example, to get the forecast for a
-particular location, you issue GET request (with `curl` for example) to
-https://api.weather.gov/points/42.3604,-71.094. The response itself
-contains a bunch of other URLs that let you get specific forecasts for
-that region. Usually, the responses are formatted as JSON, which you can
-then pipe through a tool like [`jq`](https://stedolan.github.io/jq/) to
-massage into what you care about.
-
-Some APIs require authentication, and this usually takes the form of
-some sort of secret _token_ that you need to include with the request.
-You should read the documentation for the API to see what the particular
-service you are looking for uses, but "[OAuth](https://www.oauth.com/)"
-is a protocol you will often see used. At its heart, OAuth is a way to
-give you tokens that can "act as you" on a given service, and can only
-be used for particular purposes. Keep in mind that these tokens are
-_secret_, and anyone who gains access to your token can do whatever the
-token allows under _your_ account!
-
-[IFTTT](https://ifttt.com/) is a website and service centered around the
-idea of APIs — it provides integrations with tons of services, and lets
-you chain events from them in nearly arbitrary ways. Give it a look!
-
-## Common command-line flags/patterns
-
-Command-line tools vary a lot, and you will often want to check out
-their `man` pages before using them. They often share some common
-features though that can be good to be aware of:
-
- - Most tools support some kind of `--help` flag to display brief usage
-   instructions for the tool.
- - Many tools that can cause irrevocable change support the notion of a
-   "dry run" in which they only print what they _would have done_, but
-   do not actually perform the change. Similarly, they often have an
-   "interactive" flag that will prompt you for each destructive action.
- - You can usually use `--version` or `-V` to have the program print its
-   own version (handy for reporting bugs!).
- - Almost all tools have a `--verbose` or `-v` flag to produce more
-   verbose output. You can usually include the flag multiple times
-   (`-vvv`) to get _more_ verbose output, which can be handy for
-   debugging. Similarly, many tools have a `--quiet` flag for making it
-   only print something on error.
- - In many tools, `-` in place of a file name means "standard input" or
-   "standard output", depending on the argument.
- - Possibly destructive tools are generally not recursive by default,
-   but support a "recursive" flag (often `-r`) to make them recurse.
- - Sometimes, you want to pass something that _looks_ like a flag as a
-   normal argument. For example, imagine you wanted to remove a file
-   called `-r`. Or you want to run one program "through" another, like
-   `ssh machine foo`, and you want to pass a flag to the "inner" program
-   (`foo`). The special argument `--` makes a program _stop_ processing
-   flags and options (things starting with `-`) in what follows, letting
-   you pass things that look like flags without them being interpreted
-   as such: `rm -- -r` or `ssh machine --for-ssh -- foo --for-foo`.
-
-## Window managers
-
-Most of you are used to using a "drag and drop" window manager, like
-what comes with Windows, macOS, and Ubuntu by default. There are windows
-that just sort of hang there on screen, and you can drag them around,
-resize them, and have them overlap one another. But these are only one
-_type_ of window manager, often referred to as a "floating" window
-manager. There are many others, especially on Linux. A particularly
-common alternative is a "tiling" window manager. In a tiling window
-manager, windows never overlap, and are instead arranged as tiles on
-your screen, sort of like panes in tmux. With a tiling window manager,
-the screen is always filled by whatever windows are open, arranged
-according to some _layout_. If you have just one window, it takes up the
-full screen. If you then open another, the original window shrinks to
-make room for it (often something like 2/3 and 1/3). If you open a
-third, the other windows will again shrink to accommodate the new
-window. Just like with tmux panes, you can navigate around these tiled
-windows with your keyboard, and you can resize them and move them
-around, all without touching the mouse. They are worth looking into!
+Untuk penjelasan yang lebih detail, lihat catatan kuliah tahun 2019 tentang [Backups](/2019/backups).
 
 
-## VPNs
+## API
 
-VPNs are all the rage these days, but it's not clear that's for [any
-good reason](https://web.archive.org/web/20230710155258/https://gist.github.com/joepie91/5a9909939e6ce7d09e29). You
-should be aware of what a VPN does and does not get you. A VPN, in the
-best case, is _really_ just a way for you to change your internet
-service provider as far as the internet is concerned. All your traffic
-will look like it's coming from the VPN provider instead of your "real"
-location, and the network you are connected to will only see encrypted
-traffic.
+Kita telah banyak berbicara di kelas ini tentang menggunakan komputer Anda secara lebih efisien untuk menyelesaikan tugas _lokal_, tetapi Anda akan menemukan bahwa banyak pelajaran ini juga berlaku untuk internet yang lebih luas. Sebagian besar layanan online memiliki "API" yang memungkinkan Anda mengakses data mereka secara terprogram. Sebagai contoh, pemerintah AS memiliki API yang memungkinkan Anda mendapatkan prakiraan cuaca, yang bisa Anda gunakan untuk dengan mudah mendapatkan prakiraan cuaca di shell Anda.
 
-While that may seem attractive, keep in mind that when you use a VPN,
-all you are really doing is shifting your trust from you current ISP to
-the VPN hosting company. Whatever your ISP _could_ see, the VPN provider
-now sees _instead_. If you trust them _more_ than your ISP, that is a
-win, but otherwise, it is not clear that you have gained much. If you
-are sitting on some dodgy unencrypted public Wi-Fi at an airport, then
-maybe you don't trust the connection much, but at home, the trade-off is
-not quite as clear.
+Sebagian besar API ini memiliki format yang serupa. Mereka adalah URL terstruktur, sering kali berakar di `api.service.com`, di mana path dan parameter query menunjukkan data apa yang ingin Anda baca atau tindakan apa yang ingin Anda lakukan. Untuk data cuaca AS misalnya, untuk mendapatkan prakiraan untuk lokasi tertentu, Anda mengirim permintaan GET (dengan `curl` misalnya) ke https://api.weather.gov/points/42.3604,-71.094. Respons itu sendiri berisi banyak URL lain yang memungkinkan Anda mendapatkan prakiraan spesifik untuk wilayah tersebut. Biasanya, respons diformat sebagai JSON, yang kemudian dapat Anda pipe melalui alat seperti [`jq`](https://stedolan.github.io/jq/) untuk mengolahnya sesuai kebutuhan Anda.
 
-You should also know that these days, much of your traffic, at least of
-a sensitive nature, is _already_ encrypted through HTTPS or TLS more
-generally. In that case, it usually matters little whether you are on
-a "bad" network or not -- the network operator will only learn what
-servers you talk to, but not anything about the data that is exchanged.
+Beberapa API memerlukan autentikasi, dan ini biasanya berupa _token_ rahasia yang perlu Anda sertakan dengan permintaan. Anda harus membaca dokumentasi API untuk melihat apa yang digunakan oleh layanan tertentu yang Anda cari, tetapi "[OAuth](https://www.oauth.com/)" adalah protokol yang sering Anda lihat digunakan. Pada intinya, OAuth adalah cara untuk memberikan token yang dapat "bertindak sebagai Anda" pada layanan tertentu, dan hanya dapat digunakan untuk tujuan tertentu. Ingatlah bahwa token ini _rahasia_, dan siapa pun yang mendapatkan akses ke token Anda dapat melakukan apa pun yang diizinkan token tersebut di bawah akun _Anda_!
 
-Notice that I said "in the best case" above. It is not unheard of for
-VPN providers to accidentally misconfigure their software such that the
-encryption is either weak or entirely disabled. Some VPN providers are
-malicious (or at the very least opportunist), and will log all your
-traffic, and possibly sell information about it to third parties.
-Choosing a bad VPN provider is often worse than not using one in the
-first place.
+[IFTTT](https://ifttt.com/) adalah situs web dan layanan yang berpusat pada ide API — layanan ini menyediakan integrasi dengan banyak layanan, dan memungkinkan Anda merangkai peristiwa dari mereka dengan cara yang hampir arbitrer. Coba lihat!
 
-In a pinch, MIT [runs a VPN](https://ist.mit.edu/vpn) for its students,
-so that may be worth taking a look at. Also, if you're going to roll
-your own, give [WireGuard](https://www.wireguard.com/) a look.
+## Flag/pola command-line umum
+
+Alat command-line sangat bervariasi, dan Anda sering kali ingin memeriksa halaman `man` mereka sebelum menggunakannya. Namun mereka sering berbagi beberapa fitur umum yang baik untuk diketahui:
+
+ - Sebagian besar alat mendukung semacam flag `--help` untuk menampilkan instruksi penggunaan singkat untuk alat tersebut.
+ - Banyak alat yang dapat menyebabkan perubahan yang tidak dapat dibatalkan mendukung konsep "dry run" di mana mereka hanya mencetak apa yang _akan mereka lakukan_, tetapi tidak benar-benar melakukan perubahan. Demikian pula, mereka sering memiliki flag "interactive" yang akan meminta konfirmasi Anda untuk setiap tindakan destruktif.
+ - Anda biasanya dapat menggunakan `--version` atau `-V` untuk membuat program mencetak versinya (berguna untuk melaporkan bug!).
+ - Hampir semua alat memiliki flag `--verbose` atau `-v` untuk menghasilkan output yang lebih detail. Anda biasanya dapat menyertakan flag beberapa kali (`-vvv`) untuk mendapatkan output yang _lebih_ detail, yang dapat berguna untuk debugging. Demikian pula, banyak alat memiliki flag `--quiet` untuk membuatnya hanya mencetak sesuatu saat terjadi error.
+ - Di banyak alat, `-` sebagai ganti nama file berarti "standard input" atau "standard output", tergantung pada argumen.
+ - Alat yang berpotensi destruktif umumnya tidak rekursif secara default, tetapi mendukung flag "recursive" (sering `-r`) untuk membuatnya rekursif.
+ - Terkadang, Anda ingin melewati sesuatu yang _terlihat_ seperti flag sebagai argumen normal. Misalnya, bayangkan Anda ingin menghapus file bernama `-r`. Atau Anda ingin menjalankan satu program "melalui" program lain, seperti `ssh machine foo`, dan Anda ingin melewati flag ke program "dalam" (`foo`). Argumen khusus `--` membuat program _berhenti_ memproses flag dan opsi (hal-hal yang dimulai dengan `-`) dalam apa yang mengikuti, memungkinkan Anda melewati hal-hal yang terlihat seperti flag tanpa ditafsirkan sebagai flag: `rm -- -r` atau `ssh machine --for-ssh -- foo --for-foo`.
+
+## Window manager
+
+Sebagian besar dari Anda terbiasa menggunakan window manager "drag and drop", seperti yang tersedia di Windows, macOS, dan Ubuntu secara default. Ada jendela-jendela yang begitu saja tergantung di layar, dan Anda dapat menyeretnya, mengubah ukurannya, dan membiarkan mereka saling tumpang tindih. Tetapi ini hanyalah satu _jenis_ window manager, sering disebut sebagai window manager "floating". Ada banyak lainnya, terutama di Linux. Alternatif yang sangat umum adalah window manager "tiling". Di window manager tiling, jendela tidak pernah tumpang tindih, dan sebaliknya diatur sebagai ubin di layar Anda, mirip dengan pane di tmux. Dengan window manager tiling, layar selalu diisi oleh jendela apa pun yang terbuka, diatur menurut _layout_ tertentu. Jika Anda hanya memiliki satu jendela, ia memenuhi seluruh layar. Jika Anda kemudian membuka yang lain, jendela asli mengecil untuk memberinya tempat (sering kali sesuatu seperti 2/3 dan 1/3). Jika Anda membuka yang ketiga, jendela-jendela lain akan kembali mengecil untuk mengakomodasi jendela baru. Sama seperti pane tmux, Anda dapat bernavigasi di antara jendela-jendela ubin ini dengan keyboard Anda, dan Anda dapat mengubah ukurannya serta memindahkannya, semuanya tanpa menyentuh mouse. Ini layak untuk ditelusuri!
+
+
+## VPN
+
+VPN sedang sangat populer akhir-akhir ini, tetapi tidak jelas apakah itu karena [alasan yang baik](https://web.archive.org/web/20230710155258/https://gist.github.com/joepie91/5a9909939e6ce7d09e29). Anda harus menyadari apa yang VPN berikan dan tidak berikan. VPN, dalam kasus terbaik, _sebenarnya_ hanyalah cara bagi Anda untuk mengubah penyedia layanan internet Anda sejauh yang internet perhatikan. Semua lalu lintas Anda akan terlihat berasal dari penyedia VPN daripada lokasi "asli" Anda, dan jaringan yang Anda hubungkan hanya akan melihat lalu lintas terenkripsi.
+
+Meskipun itu mungkin terlihat menarik, perlu diingat bahwa ketika Anda menggunakan VPN, yang sebenarnya Anda lakukan hanyalah menggeser kepercayaan Anda dari ISP saat ini ke perusahaan hosting VPN. Apa pun yang _bisa_ dilihat oleh ISP Anda, sekarang dilihat oleh penyedia VPN _sebagai gantinya_. Jika Anda mempercayai mereka _lebih_ dari ISP Anda, itu adalah kemenangan, tetapi jika tidak, tidak jelas bahwa Anda telah mendapatkan banyak hal. Jika Anda berada di Wi-Fi publik tidak terenkripsi yang mencurigakan di bandara, mungkin Anda tidak terlalu mempercayai koneksi tersebut, tetapi di rumah, pertukarannya tidak terlalu jelas.
+
+Anda juga harus tahu bahwa saat ini, sebagian besar lalu lintas Anda, setidaknya yang bersifat sensitif, _sudah_ terenkripsi melalui HTTPS atau TLS secara umum. Dalam hal ini, biasanya tidak terlalu penting apakah Anda berada di jaringan yang "buruk" atau tidak -- operator jaringan hanya akan mengetahui server apa yang Anda hubungi, tetapi tidak ada informasi tentang data yang dipertukarkan.
+
+Perhatikan bahwa saya mengatakan "dalam kasus terbaik" di atas. Bukan tidak pernah terjadi penyedia VPN secara tidak sengaja salah mengonfigurasi perangkat lunak mereka sehingga enkripsi lemah atau sepenuhnya dinonaktifkan. Beberapa penyedia VPN bersifat jahat (atau setidaknya oportunistik), dan akan mencatat semua lalu lintas Anda, dan mungkin menjual informasi tentangnya kepada pihak ketiga. Memilih penyedia VPN yang buruk sering kali lebih buruk daripada tidak menggunakannya sama sekali.
+
+Dalam keadaan darurat, MIT [mengoperasikan VPN](https://ist.mit.edu/vpn) untuk mahasiswanya, jadi itu mungkin layak untuk dilihat. Juga, jika Anda ingin membuat sendiri, coba lihat [WireGuard](https://www.wireguard.com/).
 
 ## Markdown
 
-There is a high chance that you will write some text over the course of
-your career. And often, you will want to mark up that text in simple
-ways. You want some text to be bold or italic, or you want to add
-headers, links, and code fragments. Instead of pulling out a heavy tool
-like Word or LaTeX, you may want to consider using the lightweight
-markup language [Markdown](https://commonmark.org/help/).
+Ada kemungkinan besar Anda akan menulis beberapa teks selama karier Anda. Dan sering kali, Anda akan ingin menandai teks tersebut dengan cara-cara sederhana. Anda ingin beberapa teks menjadi tebal atau miring, atau Anda ingin menambahkan header, tautan, dan fragmen kode. Alih-alih menggunakan alat berat seperti Word atau LaTeX, Anda mungkin ingin mempertimbangkan menggunakan bahasa markup ringan [Markdown](https://commonmark.org/help/).
 
-You have probably seen Markdown already, or at least some variant of it.
-Subsets of it are used and supported almost everywhere, even if it's not
-under the name Markdown. At its core, Markdown is an attempt to codify
-the way that people already often mark up text when they are writing
-plain text documents. Emphasis (*italics*) is added by surrounding a
-word with `*`. Strong emphasis (**bold**) is added using `**`. Lines
-starting with `#` are headings (and the number of `#`s is the subheading
-level). Any line starting with `-` is a bullet list item, and any line
-starting with a number + `.` is a numbered list item. Backtick is used
-to show words in `code font`, and a code block can be entered by
-indenting a line with four spaces or surrounding it with
-triple-backticks:
+Anda mungkin sudah pernah melihat Markdown, atau setidaknya beberapa variannya. Subset dari Markdown digunakan dan didukung hampir di mana-mana, meskipun tidak dengan nama Markdown. Pada intinya, Markdown adalah upaya untuk membakukan cara orang sudah sering menandai teks ketika mereka menulis dokumen teks biasa. Penekanan (*miring*) ditambahkan dengan mengelilingi kata dengan `*`. Penekanan kuat (**tebal**) ditambahkan menggunakan `**`. Baris yang dimulai dengan `#` adalah heading (dan jumlah `#` adalah tingkat subheading). Baris yang dimulai dengan `-` adalah item daftar bullet, dan baris yang dimulai dengan angka + `.` adalah item daftar bernomor. Backtick digunakan untuk menampilkan kata dalam `font kode`, dan blok kode dapat dimasukkan dengan memberi indentasi empat spasi atau mengelilinginya dengan triple-backtick:
 
     ```
     code goes here
     ```
 
-To add a link, place the _text_ for the link in square brackets,
-and the URL immediately following that in parentheses: `[name](url)`.
-Markdown is easy to get started with, and you can use it nearly
-everywhere. In fact, the lecture notes for this lecture, and all the
-others, are written in Markdown, and you can see the raw Markdown
-[here](https://raw.githubusercontent.com/missing-semester/missing-semester/master/_2020/potpourri.md).
+Untuk menambahkan tautan, tempatkan _teks_ untuk tautan dalam kurung siku, dan URL segera setelahnya dalam kurung: `[name](url)`. Markdown mudah untuk dimulai, dan Anda dapat menggunakannya hampir di mana-mana. Faktanya, catatan kuliah untuk kuliah ini, dan semua kuliah lainnya, ditulis dalam Markdown, dan Anda dapat melihat Markdown mentahnya [di sini](https://raw.githubusercontent.com/missing-semester/missing-semester/master/_2020/potpourri.md).
 
 
 
-## Hammerspoon (desktop automation on macOS)
+## Hammerspoon (otomasi desktop di macOS)
 
-[Hammerspoon](https://www.hammerspoon.org/) is a desktop automation framework
-for macOS. It lets you write Lua scripts that hook into operating system
-functionality, allowing you to interact with the keyboard/mouse, windows,
-displays, filesystem, and much more.
+[Hammerspoon](https://www.hammerspoon.org/) adalah framework otomasi desktop untuk macOS. Ini memungkinkan Anda menulis skrip Lua yang terhubung ke fungsionalitas sistem operasi, memungkinkan Anda berinteraksi dengan keyboard/mouse, jendela, layar, filesystem, dan banyak lagi.
 
-Some examples of things you can do with Hammerspoon:
+Beberapa contoh hal yang dapat Anda lakukan dengan Hammerspoon:
 
-- Bind hotkeys to move windows to specific locations
-- Create a menu bar button that automatically lays out windows in a specific layout
-- Mute your speaker when you arrive in lab (by detecting the Wi-Fi network)
-- Show you a warning if you've accidentally taken your friend's power supply
+- Mengikat hotkey untuk memindahkan jendela ke lokasi tertentu
+- Membuat tombol menu bar yang secara otomatis menata jendela dalam layout tertentu
+- Membisukan speaker Anda ketika Anda tiba di lab (dengan mendeteksi jaringan Wi-Fi)
+- Menampilkan peringatan jika Anda tidak sengaja mengambil power supply teman Anda
 
-At a high level, Hammerspoon lets you run arbitrary Lua code, bound to menu
-buttons, key presses, or events, and Hammerspoon provides an extensive library
-for interacting with the system, so there's basically no limit to what you can
-do with it. Many people have made their Hammerspoon configurations public, so
-you can generally find what you need by searching the internet, but you can
-always write your own code from scratch.
+Pada tingkat tinggi, Hammerspoon memungkinkan Anda menjalankan kode Lua arbitrer, yang diikat ke tombol menu, tekanan tombol, atau peristiwa, dan Hammerspoon menyediakan pustaka yang luas untuk berinteraksi dengan sistem, sehingga pada dasarnya tidak ada batasan untuk apa yang dapat Anda lakukan. Banyak orang telah membuat konfigurasi Hammerspoon mereka publik, jadi Anda biasanya dapat menemukan apa yang Anda butuhkan dengan mencari di internet, tetapi Anda selalu dapat menulis kode Anda sendiri dari awal.
 
-### Resources
+### Sumber Daya
 
 - [Getting Started with Hammerspoon](https://www.hammerspoon.org/go/)
 - [Sample configurations](https://github.com/Hammerspoon/hammerspoon/wiki/Sample-Configurations)
 - [Anish's Hammerspoon config](https://github.com/anishathalye/dotfiles-local/tree/mac/hammerspoon)
 
-## Booting + Live USBs
+## Booting + Live USB
 
-When your machine boots up, before the operating system is loaded, the
-[BIOS](https://en.wikipedia.org/wiki/BIOS)/[UEFI](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface)
-initializes the system. During this process, you can press a specific key
-combination to configure this layer of software. For example, your computer may
-say something like "Press F9 to configure BIOS. Press F12 to enter boot menu."
-during the boot process. You can configure all sorts of hardware-related
-settings in the BIOS menu. You can also enter the boot menu to boot from an
-alternate device instead of your hard drive.
+Ketika mesin Anda boot, sebelum sistem operasi dimuat, [BIOS](https://en.wikipedia.org/wiki/BIOS)/[UEFI](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface) menginisialisasi sistem. Selama proses ini, Anda dapat menekan kombinasi tombol tertentu untuk mengonfigurasi lapisan perangkat lunak ini. Misalnya, komputer Anda mungkin menampilkan sesuatu seperti "Press F9 to configure BIOS. Press F12 to enter boot menu." selama proses boot. Anda dapat mengonfigurasi berbagai pengaturan terkait perangkat keras di menu BIOS. Anda juga dapat masuk ke menu boot untuk boot dari perangkat alternatif selain hard drive Anda.
 
-[Live USBs](https://en.wikipedia.org/wiki/Live_USB) are USB flash drives
-containing an operating system. You can create one of these by downloading an
-operating system (e.g. a Linux distribution) and burning it to the flash drive.
-This process is a little bit more complicated than simply copying a `.iso` file
-to the disk. There are tools like [UNetbootin](https://unetbootin.github.io/)
-to help you create live USBs.
+[Live USB](https://en.wikipedia.org/wiki/Live_USB) adalah USB flash drive yang berisi sistem operasi. Anda dapat membuatnya dengan mengunduh sistem operasi (misalnya distribusi Linux) dan membakarnya ke flash drive. Proses ini sedikit lebih rumit daripada hanya menyalin file `.iso` ke disk. Ada alat seperti [UNetbootin](https://unetbootin.github.io/) untuk membantu Anda membuat live USB.
 
-Live USBs are useful for all sorts of purposes. Among other things, if you
-break your existing operating system installation so that it no longer boots,
-you can use a live USB to recover data or fix the operating system.
+Live USB berguna untuk berbagai tujuan. Antara lain, jika Anda merusak instalasi sistem operasi yang ada sehingga tidak lagi boot, Anda dapat menggunakan live USB untuk memulihkan data atau memperbaiki sistem operasi.
 
-## Docker, Vagrant, VMs, Cloud, OpenStack
+## Docker, Vagrant, VM, Cloud, OpenStack
 
-[Virtual machines](https://en.wikipedia.org/wiki/Virtual_machine) and similar
-tools like containers let you emulate a whole computer system, including the
-operating system. This can be useful for creating an isolated environment for
-testing, development, or exploration (e.g. running potentially malicious code).
+[Virtual machine](https://en.wikipedia.org/wiki/Virtual_machine) dan alat serupa seperti container memungkinkan Anda mengemulasi seluruh sistem komputer, termasuk sistem operasi. Ini dapat berguna untuk membuat lingkungan terisolasi untuk pengujian, pengembangan, atau eksplorasi (misalnya menjalankan kode yang berpotensi berbahaya).
 
-[Vagrant](https://www.vagrantup.com/) is a tool that lets you describe machine
-configurations (operating system, services, packages, etc.) in code, and then
-instantiate VMs with a simple `vagrant up`. [Docker](https://www.docker.com/)
-is conceptually similar but it uses containers instead.
+[Vagrant](https://www.vagrantup.com/) adalah alat yang memungkinkan Anda mendeskripsikan konfigurasi mesin (sistem operasi, layanan, paket, dll.) dalam kode, dan kemudian menginisialisasi VM dengan `vagrant up` yang sederhana. [Docker](https://www.docker.com/) secara konsep serupa tetapi menggunakan container sebagai gantinya.
 
-You can also rent virtual machines on the cloud, and it's a nice way to get instant
-access to:
+Anda juga dapat menyewa virtual machine di cloud, dan itu adalah cara yang bagus untuk mendapatkan akses instan ke:
 
-- A cheap always-on machine that has a public IP address, used to host services
-- A machine with a lot of CPU, disk, RAM, and/or GPU
-- Many more machines than you physically have access to (billing is often by
-the second, so if you want a lot of computing for a short amount of time, it's
-feasible to rent 1000 computers for a couple of minutes)
+- Mesin always-on yang murah yang memiliki alamat IP publik, digunakan untuk menghosting layanan
+- Mesin dengan banyak CPU, disk, RAM, dan/atau GPU
+- Lebih banyak mesin daripada yang Anda miliki secara fisik (penagihan sering per detik, jadi jika Anda ingin banyak komputasi dalam waktu singkat, layak untuk menyewa 1000 komputer selama beberapa menit)
 
-Popular services include [Amazon AWS](https://aws.amazon.com/), [Google
-Cloud](https://cloud.google.com/),[ Microsoft Azure](https://azure.microsoft.com/),
-[DigitalOcean](https://www.digitalocean.com/).
+Layanan populer termasuk [Amazon AWS](https://aws.amazon.com/), [Google Cloud](https://cloud.google.com/), [Microsoft Azure](https://azure.microsoft.com/), [DigitalOcean](https://www.digitalocean.com/).
 
-If you're a member of MIT CSAIL, you can get free VMs for research purposes
-through the [CSAIL OpenStack
-instance](https://tig.csail.mit.edu/shared-computing/open-stack/).
+Jika Anda anggota MIT CSAIL, Anda bisa mendapatkan VM gratis untuk tujuan penelitian melalui [CSAIL OpenStack instance](https://tig.csail.mit.edu/shared-computing/open-stack/).
 
-## Notebook programming
+## Pemrograman notebook
 
-[Notebook programming
-environments](https://en.wikipedia.org/wiki/Notebook_interface) can be really
-handy for doing certain types of interactive or exploratory development.
-Perhaps the most popular notebook programming environment today is
-[Jupyter](https://jupyter.org/), for Python (and several other languages).
-[Wolfram Mathematica](https://www.wolfram.com/mathematica/) is another notebook
-programming environment that's great for doing math-oriented programming.
+[Lingkungan pemrograman notebook](https://en.wikipedia.org/wiki/Notebook_interface) bisa sangat berguna untuk melakukan jenis pengembangan interaktif atau eksploratif tertentu. Mungkin lingkungan pemrograman notebook paling populer saat ini adalah [Jupyter](https://jupyter.org/), untuk Python (dan beberapa bahasa lainnya). [Wolfram Mathematica](https://www.wolfram.com/mathematica/) adalah lingkungan pemrograman notebook lain yang hebat untuk pemrograman berorientasi matematika.
 
 ## GitHub
 
-[GitHub](https://github.com/) is one of the most popular platforms for
-open-source software development. Many of the tools we've talked about in this
-class, from [vim](https://github.com/vim/vim) to
-[Hammerspoon](https://github.com/Hammerspoon/hammerspoon), are hosted on
-GitHub. It's easy to get started contributing to open-source to help improve
-the tools that you use every day.
+[GitHub](https://github.com/) adalah salah satu platform paling populer untuk pengembangan perangkat lunak open-source. Banyak alat yang kita bahas di kelas ini, dari [vim](https://github.com/vim/vim) hingga [Hammerspoon](https://github.com/Hammerspoon/hammerspoon), dihosting di GitHub. Mudah untuk mulai berkontribusi pada open-source untuk membantu meningkatkan alat yang Anda gunakan setiap hari.
 
-There are two primary ways in which people contribute to projects on GitHub:
+Ada dua cara utama orang berkontribusi pada proyek di GitHub:
 
-- Creating an
-[issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue).
-This can be used to report bugs or request a new feature. Neither of these
-involves reading or writing code, so it can be pretty lightweight to do.
-High-quality bug reports can be extremely valuable to developers. Commenting on
-existing discussions can be helpful too.
-- Contribute code through a [pull
-request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
-This is generally more involved than creating an issue. You can
-[fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
-a repository on GitHub, clone your fork, create a new branch, make some changes
-(e.g. fix a bug or implement a feature), push the branch, and then [create a
-pull
-request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
-After this, there will generally be some back-and-forth with the project
-maintainers, who will give you feedback on your patch. Finally, if all goes
-well, your patch will be merged into the upstream repository. Often times,
-larger projects will have a contributing guide, tag beginner-friendly issues,
-and some even have mentorship programs to help first-time contributors become
-familiar with the project.
+- Membuat [issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue). Ini dapat digunakan untuk melaporkan bug atau meminta fitur baru. Keduanya tidak melibatkan membaca atau menulis kode, jadi bisa cukup ringan untuk dilakukan. Laporan bug berkualitas tinggi bisa sangat berharga bagi pengembang. Mengomentari diskusi yang ada juga bisa membantu.
+- Berkontribusi kode melalui [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). Ini umumnya lebih terlibat daripada membuat issue. Anda dapat [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) sebuah repository di GitHub, clone fork Anda, membuat branch baru, melakukan beberapa perubahan (misalnya memperbaiki bug atau mengimplementasikan fitur), push branch tersebut, dan kemudian [membuat pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request). Setelah itu, biasanya akan ada beberapa diskusi dengan maintainer proyek, yang akan memberikan umpan balik pada patch Anda. Akhirnya, jika semuanya berjalan baik, patch Anda akan digabungkan ke repository upstream. Sering kali, proyek yang lebih besar akan memiliki panduan kontribusi, menandai issue yang ramah pemula, dan beberapa bahkan memiliki program mentorship untuk membantu kontributor pertama kali menjadi familiar dengan proyek.

--- a/_2020/qa.md
+++ b/_2020/qa.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Q&A"
 description: >
-  Answers to student questions on topics like operating systems, shell scripting, tool recommendations, and more.
+  Jawaban atas pertanyaan mahasiswa tentang topik seperti sistem operasi, shell scripting, rekomendasi tools, dan lainnya.
 thumbnail: /static/assets/thumbnails/2020/lec11.png
 date: 2020-01-30
 ready: true

--- a/_2020/qa.md
+++ b/_2020/qa.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Q&A"
+title: "Tanya Jawab"
 description: >
-  Answers to student questions on topics like operating systems, shell scripting, tool recommendations, and more.
+  Jawaban atas pertanyaan mahasiswa seputar topik seperti sistem operasi, shell scripting, rekomendasi tools, dan lainnya.
 thumbnail: /static/assets/thumbnails/2020/lec11.png
 date: 2020-01-30
 ready: true
@@ -12,176 +12,176 @@ video:
 special: true
 ---
 
-For the last lecture, we answered questions that the students submitted:
+Untuk kuliah terakhir, kami menjawab pertanyaan-pertanyaan yang diajukan oleh para mahasiswa:
 
-- [Any recommendations on learning Operating Systems related topics like processes, virtual memory, interrupts, memory management, etc ](#any-recommendations-on-learning-operating-systems-related-topics-like-processes-virtual-memory-interrupts-memory-management-etc)
-- [What are some of the tools you'd prioritize learning first?](#what-are-some-of-the-tools-youd-prioritize-learning-first)
-- [When do I use Python versus a Bash scripts versus some other language?](#when-do-i-use-python-versus-a-bash-scripts-versus-some-other-language)
-- [What is the difference between `source script.sh` and `./script.sh`](#what-is-the-difference-between-source-scriptsh-and-scriptsh)
-- [What are the places where various packages and tools are stored and how does referencing them work? What even is `/bin` or `/lib`?](#what-are-the-places-where-various-packages-and-tools-are-stored-and-how-does-referencing-them-work-what-even-is-bin-or-lib)
-- [Should I `apt-get install` a python-whatever, or `pip install` whatever package?](#should-i-apt-get-install-a-python-whatever-or-pip-install-whatever-package)
-- [What's the easiest and best profiling tools to use to improve performance of my code?](#whats-the-easiest-and-best-profiling-tools-to-use-to-improve-performance-of-my-code)
-- [What browser plugins do you use?](#what-browser-plugins-do-you-use)
-- [What are other useful data wrangling tools?](#what-are-other-useful-data-wrangling-tools)
-- [What is the difference between Docker and a Virtual Machine?](#what-is-the-difference-between-docker-and-a-virtual-machine)
-- [What are the advantages and disadvantages of each OS and how can we choose between them (e.g. choosing the best Linux distribution for our purposes)?](#what-are-the-advantages-and-disadvantages-of-each-os-and-how-can-we-choose-between-them-eg-choosing-the-best-linux-distribution-for-our-purposes)
+- [Ada rekomendasi untuk mempelajari topik terkait Sistem Operasi seperti proses, memori virtual, interrupt, manajemen memori, dll?](#any-recommendations-on-learning-operating-systems-related-topics-like-processes-virtual-memory-interrupts-memory-management-etc)
+- [Tools apa saja yang sebaiknya diprioritaskan untuk dipelajari pertama kali?](#what-are-some-of-the-tools-youd-prioritize-learning-first)
+- [Kapan saya harus menggunakan Python versus skrip Bash versus bahasa lainnya?](#when-do-i-use-python-versus-a-bash-scripts-versus-some-other-language)
+- [Apa perbedaan antara `source script.sh` dan `./script.sh`?](#what-is-the-difference-between-source-scriptsh-and-scriptsh)
+- [Di mana berbagai paket dan tools disimpan dan bagaimana cara mereferensikannya? Apa sebenarnya `/bin` atau `/lib`?](#what-are-the-places-where-various-packages-and-tools-are-stored-and-how-does-referencing-them-work-what-even-is-bin-or-lib)
+- [Haruskah saya `apt-get install` python-whatever, atau `pip install` whatever package?](#should-i-apt-get-install-a-python-whatever-or-pip-install-whatever-package)
+- [Apa tools profiling yang paling mudah dan terbaik untuk meningkatkan performa kode saya?](#whats-the-easiest-and-best-profiling-tools-to-use-to-improve-performance-of-my-code)
+- [Plugin browser apa saja yang Anda gunakan?](#what-browser-plugins-do-you-use)
+- [Apa saja tools data wrangling lainnya yang berguna?](#what-are-other-useful-data-wrangling-tools)
+- [Apa perbedaan antara Docker dan Virtual Machine?](#what-is-the-difference-between-docker-and-a-virtual-machine)
+- [Apa kelebihan dan kekurangan masing-masing OS dan bagaimana cara memilih di antaranya (misalnya memilih distribusi Linux terbaik untuk keperluan kita)?](#what-are-the-advantages-and-disadvantages-of-each-os-and-how-can-we-choose-between-them-eg-choosing-the-best-linux-distribution-for-our-purposes)
 - [Vim vs Emacs?](#vim-vs-emacs)
-- [Any tips or tricks for Machine Learning applications?](#any-tips-or-tricks-for-machine-learning-applications)
-- [Any more Vim tips?](#any-more-vim-tips)
-- [What is 2FA and why should I use it?](#what-is-2fa-and-why-should-i-use-it)
-- [Any comments on differences between web browsers?](#any-comments-on-differences-between-web-browsers)
+- [Ada tips atau trik untuk aplikasi Machine Learning?](#any-tips-or-tricks-for-machine-learning-applications)
+- [Ada tips Vim lainnya?](#any-more-vim-tips)
+- [Apa itu 2FA dan mengapa saya harus menggunakannya?](#what-is-2fa-and-why-should-i-use-it)
+- [Ada komentar tentang perbedaan antar web browser?](#any-comments-on-differences-between-web-browsers)
 
-## Any recommendations on learning Operating Systems related topics like processes, virtual memory, interrupts, memory management, etc
+## Ada rekomendasi untuk mempelajari topik terkait Sistem Operasi seperti proses, memori virtual, interrupt, manajemen memori, dll?
 
-First, it is unclear whether you actually need to be very familiar with all of these topics since they are very low level topics.
-They will matter as you start writing more low level code like implementing or modifying a kernel. Otherwise, most topics will not be relevant, with the exception of processes and signals that were briefly covered in other lectures.
+Pertama, belum jelas apakah Anda benar-benar perlu sangat familiar dengan semua topik ini karena semuanya adalah topik tingkat rendah.
+Topik-topik ini akan relevan ketika Anda mulai menulis kode tingkat rendah seperti mengimplementasikan atau memodifikasi kernel. Jika tidak, sebagian besar topik tidak akan relevan, kecuali proses dan sinyal yang telah dibahas secara singkat di kuliah-kuliah lainnya.
 
-Some good resources to learn about this topic:
+Beberapa sumber belajar yang bagus tentang topik ini:
 
-- [MIT's 6.828 class](https://pdos.csail.mit.edu/6.828/) - Graduate level class on Operating System Engineering. Class materials are publicly available.
-- Modern Operating Systems (4th ed) - by Andrew S. Tanenbaum is a good overview of many of the mentioned concepts.
-- The Design and Implementation of the FreeBSD Operating System - A good resource about the FreeBSD OS (note that this is not Linux).
-- Other guides like [Writing an OS in Rust](https://os.phil-opp.com/) where people implement a kernel step by step in various languages, mostly for teaching purposes.
-
-
-## What are some of the tools you'd prioritize learning first?
-
-Some topics worth prioritizing:
-
-- Learning how to use your keyboard more and your mouse less. This can be through keyboard shortcuts, changing interfaces, &c.
-- Learning your editor well. As a programmer most of your time is spent editing files so it really pays off to learn this skill well.
-- Learning how to automate and/or simplify repetitive tasks in your workflow because the time savings will be enormous...
-- Learning about version control tools like Git and how to use it in conjunction with GitHub to collaborate in modern software projects.
-
-## When do I use Python versus a Bash scripts versus some other language?
-
-In general, bash scripts are useful for short and simple one-off scripts when you just want to run a specific series of commands. bash has a set of oddities that make it hard to work with for larger programs or scripts:
-
-- bash is easy to get right for a simple use case but it can be really hard to get right for all possible inputs. For example, spaces in script arguments have led to countless bugs in bash scripts.
-- bash is not amenable to code reuse so it can be hard to reuse components of previous programs you have written. More generally, there is no concept of software libraries in bash.
-- bash relies on many magic strings like `$?` or `$@` to refer to specific values, whereas other languages refer to them explicitly, like `exitCode` or `sys.args` respectively.
-
-Therefore, for larger and/or more complex scripts we recommend using more mature scripting languages like Python or Ruby.
-You can find online countless libraries that people have already written to solve common problems in these languages.
-If you find a library that implements the specific functionality you care about in some language, usually the best thing to do is to just use that language.
-
-## What is the difference between `source script.sh` and `./script.sh`
-
-In both cases the `script.sh` will be read and executed in a bash session, the difference lies in which session is running the commands.
-For `source` the commands are executed in your current bash session and thus any changes made to the current environment, like changing directories or defining functions will persist in the current session once the `source` command finishes executing.
-When running the script standalone like `./script.sh`, your current bash session starts a new instance of bash that will run the commands in `script.sh`.
-Thus, if `script.sh` changes directories, the new bash instance will change directories but once it exits and returns control to the parent bash session, the parent session will remain in the same place.
-Similarly, if `script.sh` defines a function that you want to access in your terminal, you need to `source` it for it to be defined in your current bash session. Otherwise, if you run it, the new bash process will be the one to process the function definition instead of your current shell.
-
-## What are the places where various packages and tools are stored and how does referencing them work? What even is `/bin` or `/lib`?
-
-Regarding programs that you execute in your terminal, they are all found in the directories listed in your `PATH` environment variable and you can use the `which` command (or the `type` command) to check where your shell is finding a specific program.
-In general, there are some conventions about where specific types of files live. Here are some of the ones we talked about, check the [Filesystem, Hierarchy Standard](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for a more comprehensive list.
-
-- `/bin` - Essential command binaries
-- `/sbin` - Essential system binaries, usually to be run by root
-- `/dev` - Device files, special files that often are interfaces to hardware devices
-- `/etc` - Host-specific system-wide configuration files
-- `/home` - Home directories for users in the system
-- `/lib` - Common libraries for system programs
-- `/opt` - Optional application software
-- `/sys` - Contains information and configuration for the system (covered in the [first lecture](/2020/course-shell/))
-- `/tmp` - Temporary files (also `/var/tmp`). Usually deleted between reboots.
-- `/usr/` - Read only user data
-  + `/usr/bin` - Non-essential command binaries
-  + `/usr/sbin` - Non-essential system binaries, usually to be run by root
-  + `/usr/local/bin` - Binaries for user compiled programs
-- `/var` - Variable files like logs or caches
-
-## Should I `apt-get install` a python-whatever, or `pip install` whatever package?
-
-There's no universal answer to this question. It's related to the more general question of whether you should use your system's package manager or a language-specific package manager to install software. A few things to take into account:
-
-- Common packages will be available through both, but less popular ones or more recent ones might not be available in your system package manager. In this case, using the language-specific tool is the better choice.
-- Similarly, language-specific package managers usually have more up to date versions of packages than system package managers.
-- When using your system package manager, libraries will be installed system wide. This means that if you need different versions of a library for development purposes, the system package manager might not suffice. For this scenario, most programming languages provide some sort of isolated or virtual environment so you can install different versions of libraries without running into conflicts. For Python, there's virtualenv, and for Ruby, there's RVM.
-- Depending on the operating system and the hardware architecture, some of these packages might come with binaries or might need to be compiled. For instance, in ARM computers like the Raspberry Pi, using the system package manager can be better than the language specific one if the former comes in form of binaries and the latter needs to be compiled. This is highly dependent on your specific setup.
-
-You should try to use one solution or the other and not both since that can lead to conflicts that are hard to debug. Our recommendation is to use the language-specific package manager whenever possible, and to use isolated environments (like Python's virtualenv) to avoid polluting the global environment.
-
-## What's the easiest and best profiling tools to use to improve performance of my code?
-
-The easiest tool that is quite useful for profiling purposes is [print timing](/2020/debugging-profiling/#timing).
-You just manually compute the time taken between different parts of your code. By repeatedly doing this, you can effectively do a binary search over your code and find the segment of code that took the longest.
-
-For more advanced tools, Valgrind's [Callgrind](https://valgrind.org/docs/manual/cl-manual.html) lets you run your program and measure how long everything takes and all the call stacks, namely which function called which other function. It then produces an annotated version of your program's source code with the time taken per line. However, it slows down your program by an order of magnitude and does not support threads. For other cases, the [`perf`](https://www.brendangregg.com/perf.html) tool and other language specific sampling profilers can output useful data pretty quickly. [Flamegraphs](https://www.brendangregg.com/flamegraphs.html) are a good visualization tool for the output of said sampling profilers. You should also try to use specific tools for the programming language or task you are working with. For example, for web development, the dev tools built into Chrome and Firefox have fantastic profilers.
-
-Sometimes the slow part of your code will be because your system is waiting for an event like a disk read or a network packet. In those cases, it is worth checking that back-of-the-envelope calculations about the theoretical speed in terms of hardware capabilities do not deviate from the actual readings. There are also specialized tools to analyze the wait times in system calls. These include tools like [eBPF](https://www.brendangregg.com/blog/2019-01-01/learn-ebpf-tracing.html) that perform kernel tracing of user programs. In particular [`bpftrace`](https://github.com/iovisor/bpftrace) is worth checking out if you need to perform this sort of low level profiling.
+- [MIT's 6.828 class](https://pdos.csail.mit.edu/6.828/) - Kelas tingkat pascasarjana tentang Operating System Engineering. Materi kelas tersedia secara publik.
+- Modern Operating Systems (4th ed) - oleh Andrew S. Tanenbaum adalah gambaran umum yang bagus tentang banyak konsep yang disebutkan.
+- The Design and Implementation of the FreeBSD Operating System - Sumber bagus tentang OS FreeBSD (perhatikan bahwa ini bukan Linux).
+- Panduan lain seperti [Writing an OS in Rust](https://os.phil-opp.com/) di mana orang-orang mengimplementasikan kernel langkah demi langkah dalam berbagai bahasa, sebagian besar untuk tujuan pengajaran.
 
 
-## What browser plugins do you use?
+## Tools apa saja yang sebaiknya diprioritaskan untuk dipelajari pertama kali?
 
-Some of our favorites, mostly related to security and usability:
+Beberapa topik yang sebaiknya diprioritaskan:
 
-- [uBlock Origin](https://github.com/gorhill/uBlock) - It is a [wide-spectrum](https://github.com/gorhill/uBlock/wiki/Blocking-mode) blocker that doesn’t just stop ads, but all sorts of third-party communication a page may try to do. This also covers inline scripts and other types of resource loading. If you’re willing to spend some time on configuration to make things work, go to [medium mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-medium-mode) or even [hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode). Those will make some sites not work until you’ve fiddled with the settings enough, but will also significantly improve your online security. Otherwise, the [easy mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-easy-mode) is already a good default that blocks most ads and tracking. You can also define your own rules about what website objects to block.
-- [Stylus](https://github.com/openstyles/stylus/) - a fork of Stylish (don't use Stylish, it was shown to [steal users' browsing history](https://www.theregister.co.uk/2018/07/05/browsers_pull_stylish_but_invasive_browser_extension/)), allows you to sideload custom CSS stylesheets to websites. With Stylus you can easily customize and modify the appearance of websites. This can be removing a sidebar, changing the background color or even the text size or font choice. This is fantastic for making websites that you visit frequently more readable. Moreover, Stylus can find styles written by other users and published in [userstyles.org](https://userstyles.org/). Most common websites have one or several dark theme stylesheets for instance.
-- Full Page Screen Capture - [Built into Firefox](https://screenshots.firefox.com/) and [Chrome extension](https://chrome.google.com/webstore/detail/full-page-screen-capture/fdpohaocaechififmbbbbbknoalclacl?hl=en). Lets you take a screenshot of a full website, often much better than printing for reference purposes.
-- [Multi Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/) - lets you separate cookies into "containers", allowing you to browse the web with different identities and/or ensuring that websites are unable to share information between them.
-- Password Manager Integration - Most password managers have browser extensions that make inputting your credentials into websites not only more convenient but also more secure. Compared to simply copy-pasting your user and password, these tools will first check that the website domain matches the one listed for the entry, preventing phishing attacks that impersonate popular websites to steal credentials.
-- [Vimium](https://github.com/philc/vimium) - A browser extension that provides keyboard-based navigation and control of the web in the spirit of the Vim editor.
+- Belajar menggunakan keyboard lebih banyak dan mouse lebih sedikit. Ini bisa melalui shortcut keyboard, mengubah antarmuka, &c.
+- Menguasai editor Anda dengan baik. Sebagai programmer, sebagian besar waktu Anda dihabiskan untuk mengedit file jadi sangat bermanfaat untuk mempelajari keterampilan ini dengan baik.
+- Belajar cara mengotomatisasi dan/atau menyederhanakan tugas-tugas berulang dalam workflow Anda karena penghematan waktunya akan sangat besar...
+- Belajar tentang tools version control seperti Git dan cara menggunakannya bersama GitHub untuk berkolaborasi dalam proyek perangkat lunak modern.
 
-## What are other useful data wrangling tools?
+## Kapan saya harus menggunakan Python versus skrip Bash versus bahasa lainnya?
 
-Some of the data wrangling tools we did not have time to cover during the data wrangling lecture include `jq` or `pup` which are specialized parsers for JSON and HTML data respectively. The Perl programming language is another good tool for more advanced data wrangling pipelines. Another trick is the `column -t` command that can be used to convert whitespace text (not necessarily aligned) into properly column aligned text.
+Secara umum, skrip bash berguna untuk skrip singkat dan sederhana yang bersifat sekali pakai ketika Anda hanya ingin menjalankan serangkaian perintah tertentu. bash memiliki sejumlah keanehan yang membuatnya sulit digunakan untuk program atau skrip yang lebih besar:
 
-More generally a couple of more unconventional data wrangling tools are vim and Python. For some complex and multi-line transformations, vim macros can be a quite invaluable tool to use. You can just record a series of actions and repeat them as many times as you want, for instance in the editors [lecture notes](/2020/editors/#macros) (and last year's [video](/2019/editors/)) there is an example of converting an XML-formatted file into JSON just using vim macros.
+- bash mudah digunakan untuk kasus sederhana tetapi bisa sangat sulit untuk menangani semua kemungkinan input. Contohnya, spasi pada argumen skrip telah menyebabkan banyak bug dalam skrip bash.
+- bash tidak mendukung penggunaan ulang kode sehingga sulit untuk menggunakan kembali komponen dari program yang pernah Anda tulis. Secara lebih umum, tidak ada konsep pustaka perangkat lunak dalam bash.
+- bash bergantung pada banyak string ajaib seperti `$?` atau `$@` untuk merujuk pada nilai-nilai tertentu, sedangkan bahasa lain merujuknya secara eksplisit, seperti `exitCode` atau `sys.args`.
 
-For tabular data, often presented in CSVs, the [pandas](https://pandas.pydata.org/) Python library is a great tool. Not only because it makes it quite easy to define complex operations like group by, join or filters; but also makes it quite easy to plot different properties of your data. It also supports exporting to many table formats including XLS, HTML or LaTeX. Alternatively the R programming language (an arguably [bad](https://arrgh.tim-smith.us/) programming language) has lots of functionality for computing statistics over data and can be quite useful as the last step of your pipeline. [ggplot2](https://ggplot2.tidyverse.org/) is a great plotting library in R.
+Oleh karena itu, untuk skrip yang lebih besar dan/atau lebih kompleks, kami merekomendasikan menggunakan bahasa scripting yang lebih matang seperti Python atau Ruby.
+Anda bisa menemukan banyak pustaka online yang telah ditulis orang lain untuk menyelesaikan masalah umum dalam bahasa-bahasa ini.
+Jika Anda menemukan pustaka yang mengimplementasikan fungsionalitas spesifik yang Anda butuhkan dalam suatu bahasa, biasanya yang terbaik adalah langsung menggunakan bahasa tersebut.
 
-## What is the difference between Docker and a Virtual Machine?
+## Apa perbedaan antara `source script.sh` dan `./script.sh`?
 
-Docker is based on a more general concept called containers. The main difference between containers and virtual machines is that virtual machines will execute an entire OS stack, including the kernel, even if the kernel is the same as the host machine. Unlike VMs, containers avoid running another instance of the kernel and instead share the kernel with the host. In Linux, this is achieved through a mechanism called LXC, and it makes use of a series of isolation mechanisms to spin up a program that thinks it's running on its own hardware but it's actually sharing the hardware and kernel with the host. Thus, containers have a lower overhead than a full VM.
-On the flip side, containers have a weaker isolation and only work if the host runs the same kernel. For instance if you run Docker on macOS, Docker needs to spin up a Linux virtual machine to get an initial Linux kernel and thus the overhead is still significant. Lastly, Docker is a specific implementation of containers and it is tailored for software deployment. Because of this, it has some quirks: for example, Docker containers will not persist any form of storage between reboots by default.
+Dalam kedua kasus, `script.sh` akan dibaca dan dieksekusi dalam sesi bash, perbedaannya terletak pada sesi mana yang menjalankan perintah tersebut.
+Untuk `source`, perintah dijalankan di sesi bash Anda saat ini sehingga setiap perubahan yang dibuat pada environment saat ini, seperti mengubah direktori atau mendefinisikan fungsi, akan tetap ada di sesi saat ini setelah perintah `source` selesai dieksekusi.
+Ketika menjalankan skrip secara mandiri seperti `./script.sh`, sesi bash Anda saat ini memulai instance bash baru yang akan menjalankan perintah di `script.sh`.
+Jadi, jika `script.sh` mengubah direktori, instance bash baru akan mengubah direktori, tetapi setelah keluar dan mengembalikan kontrol ke sesi bash induk, sesi induk akan tetap di tempat yang sama.
+Demikian pula, jika `script.sh` mendefinisikan fungsi yang ingin Anda akses di terminal, Anda perlu melakukan `source` agar fungsi tersebut terdefinisi di sesi bash Anda saat ini. Jika tidak, saat Anda menjalankannya, proses bash baru yang akan memproses definisi fungsi tersebut, bukan shell Anda saat ini.
 
-## What are the advantages and disadvantages of each OS and how can we choose between them (e.g. choosing the best Linux distribution for our purposes)?
+## Di mana berbagai paket dan tools disimpan dan bagaimana cara mereferensikannya? Apa sebenarnya `/bin` atau `/lib`?
 
-Regarding Linux distros, even though there are many, many distros, most of them will behave fairly identically for most use cases.
-Most of Linux and UNIX features and inner workings can be learned in any distro.
-A fundamental difference between distros is how they deal with package updates.
-Some distros, like Arch Linux, use a rolling update policy where things are bleeding-edge but things might break every so often. On the other hand, some distros like Debian, CentOS or Ubuntu LTS releases are much more conservative with releasing updates in their repositories so things are usually more stable at the expense of sacrificing newer features.
-Our recommendation for an easy and stable experience with both desktops and servers is to use Debian or Ubuntu.
+Terkait program yang Anda jalankan di terminal, semuanya ditemukan di direktori yang terdaftar di variabel environment `PATH` Anda dan Anda bisa menggunakan perintah `which` (atau perintah `type`) untuk mengecek di mana shell Anda menemukan program tertentu.
+Secara umum, ada beberapa konvensi tentang di mana jenis file tertentu berada. Berikut beberapa yang telah kita bahas, silakan cek [Filesystem, Hierarchy Standard](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) untuk daftar yang lebih lengkap.
 
-Mac OS is a good middle point between Windows and Linux that has a nicely polished interface. However, Mac OS is based on BSD rather than Linux, so some parts of the system and commands are different.
-An alternative worth checking is FreeBSD. Even though some programs will not run on FreeBSD, the BSD ecosystem is much less fragmented and better documented than Linux.
-We discourage Windows for anything but for developing Windows applications or if there is some deal breaker feature that you need, like good driver support for gaming.
+- `/bin` - Binary perintah esensial
+- `/sbin` - Binary sistem esensial, biasanya dijalankan oleh root
+- `/dev` - File perangkat, file khusus yang seringkali merupakan antarmuka ke perangkat keras
+- `/etc` - File konfigurasi sistem spesifik host untuk seluruh sistem
+- `/home` - Direktori home untuk pengguna dalam sistem
+- `/lib` - Pustaka umum untuk program sistem
+- `/opt` - Perangkat lunak aplikasi opsional
+- `/sys` - Berisi informasi dan konfigurasi untuk sistem (dibahas di [kuliah pertama](/2020/course-shell/))
+- `/tmp` - File sementara (juga `/var/tmp`). Biasanya dihapus antara reboot.
+- `/usr/` - Data pengguna yang hanya bisa dibaca
+  + `/usr/bin` - Binary perintah non-esensial
+  + `/usr/sbin` - Binary sistem non-esensial, biasanya dijalankan oleh root
+  + `/usr/local/bin` - Binary untuk program yang dikompilasi pengguna
+- `/var` - File variabel seperti log atau cache
 
-For dual boot systems, we think that the most working implementation is macOS' bootcamp and that any other combination can be problematic  on the long run, specially if you combine it with other features like disk encryption.
+## Haruskah saya `apt-get install` python-whatever, atau `pip install` whatever package?
+
+Tidak ada jawaban universal untuk pertanyaan ini. Ini terkait dengan pertanyaan yang lebih umum apakah Anda harus menggunakan package manager sistem atau package manager spesifik bahasa untuk menginstal perangkat lunak. Beberapa hal yang perlu diperhatikan:
+
+- Paket umum akan tersedia melalui keduanya, tetapi paket yang kurang populer atau yang lebih baru mungkin tidak tersedia di package manager sistem Anda. Dalam kasus ini, menggunakan tools spesifik bahasa adalah pilihan yang lebih baik.
+- Demikian pula, package manager spesifik bahasa biasanya memiliki versi paket yang lebih terbaru dibandingkan package manager sistem.
+- Saat menggunakan package manager sistem, pustaka akan diinstal secara sistem-wide. Ini berarti jika Anda memerlukan versi pustaka yang berbeda untuk tujuan pengembangan, package manager sistem mungkin tidak memadai. Untuk skenario ini, sebagian besar bahasa pemrograman menyediakan semacam isolated atau virtual environment sehingga Anda bisa menginstal versi pustaka yang berbeda tanpa mengalami konflik. Untuk Python, ada virtualenv, dan untuk Ruby, ada RVM.
+- Tergantung pada sistem operasi dan arsitektur perangkat keras, beberapa paket ini mungkin sudah disertai binary atau perlu dikompilasi. Misalnya, pada komputer ARM seperti Raspberry Pi, menggunakan package manager sistem bisa lebih baik daripada yang spesifik bahasa jika yang pertama tersedia dalam bentuk binary dan yang kedua perlu dikompilasi. Ini sangat tergantung pada setup spesifik Anda.
+
+Anda sebaiknya mencoba menggunakan satu solusi atau yang lain, bukan keduanya, karena hal itu dapat menyebabkan konflik yang sulit di-debug. Rekomendasi kami adalah menggunakan package manager spesifik bahasa bila memungkinkan, dan menggunakan isolated environment (seperti virtualenv Python) untuk menghindari polusi pada environment global.
+
+## Apa tools profiling yang paling mudah dan terbaik untuk meningkatkan performa kode saya?
+
+Tools paling mudah yang cukup berguna untuk tujuan profiling adalah [print timing](/2020/debugging-profiling/#timing).
+Anda cukup menghitung secara manual waktu yang dibutuhkan antar bagian kode Anda. Dengan melakukan ini berulang kali, Anda secara efektif bisa melakukan binary search pada kode Anda dan menemukan segmen kode yang memakan waktu paling lama.
+
+Untuk tools yang lebih canggih, Valgrind's [Callgrind](https://valgrind.org/docs/manual/cl-manual.html) memungkinkan Anda menjalankan program dan mengukur berapa lama setiap bagian berjalan serta semua call stack, yaitu fungsi mana yang memanggil fungsi lainnya. Kemudian menghasilkan versi anotasi dari source code program Anda dengan waktu yang dibutuhkan per baris. Namun, ini memperlambat program Anda hingga satu orde magnitudo dan tidak mendukung thread. Untuk kasus lain, tool [`perf`](https://www.brendangregg.com/perf.html) dan profiler sampling spesifik bahasa lainnya dapat menghasilkan data yang berguna dengan cukup cepat. [Flamegraphs](https://www.brendangregg.com/flamegraphs.html) adalah tools visualisasi yang bagus untuk output dari profiler sampling tersebut. Anda juga sebaiknya menggunakan tools khusus untuk bahasa pemrograman atau tugas yang sedang Anda kerjakan. Misalnya, untuk pengembangan web, dev tools bawaan Chrome dan Firefox memiliki profiler yang fantastis.
+
+Terkadang bagian kode yang lambat disebabkan karena sistem Anda sedang menunggu event seperti pembacaan disk atau paket jaringan. Dalam kasus tersebut, ada baiknya memeriksa bahwa perhitungan kasar tentang kecepatan teoretis berdasarkan kemampuan perangkat keras tidak menyimpang dari pembacaan aktual. Ada juga tools khusus untuk menganalisis waktu tunggu dalam system call. Ini termasuk tools seperti [eBPF](https://www.brendangregg.com/blog/2019-01-01/learn-ebpf-tracing.html) yang melakukan kernel tracing pada program user. Khususnya [`bpftrace`](https://github.com/iovisor/bpftrace) patut dicoba jika Anda perlu melakukan profiling tingkat rendah semacam ini.
+
+
+## Plugin browser apa saja yang Anda gunakan?
+
+Beberapa favorit kami, sebagian besar terkait keamanan dan kegunaan:
+
+- [uBlock Origin](https://github.com/gorhill/uBlock) - Ini adalah blocker [wide-spectrum](https://github.com/gorhill/uBlock/wiki/Blocking-mode) yang tidak hanya menghentikan iklan, tetapi juga semua jenis komunikasi pihak ketiga yang mungkin dicoba oleh suatu halaman. Ini juga mencakup skrip inline dan jenis pemuatan sumber daya lainnya. Jika Anda bersedia meluangkan waktu untuk konfigurasi agar mọi sesuatu berfungsi, beralihlah ke [medium mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-medium-mode) atau bahkan [hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode). Itu akan membuat beberapa situs tidak berfungsi sampai Anda cukup mengutak-atik pengaturannya, tetapi juga akan secara signifikan meningkatkan keamanan online Anda. Jika tidak, [easy mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-easy-mode) sudah menjadi default yang bagus yang memblokir sebagian besar iklan dan pelacakan. Anda juga bisa menentukan aturan Anda sendiri tentang objek situs web mana yang akan diblokir.
+- [Stylus](https://github.com/openstyles/stylus/) - fork dari Stylish (jangan gunakan Stylish, terbukti [mencuri riwayat browsing pengguna](https://www.theregister.co.uk/2018/07/05/browsers_pull_stylish_but_invasive_browser_extension/)), memungkinkan Anda memuat stylesheet CSS kustom ke situs web. Dengan Stylus, Anda bisa dengan mudah mengkustomisasi dan mengubah tampilan situs web. Ini bisa berupa menghapus sidebar, mengubah warna latar belakang, atau bahkan ukuran teks atau pilihan font. Ini sangat bagus untuk membuat situs web yang sering Anda kunjungi menjadi lebih mudah dibaca. Selain itu, Stylus bisa menemukan gaya yang ditulis oleh pengguna lain dan dipublikasikan di [userstyles.org](https://userstyles.org/). Sebagian besar situs web umum memiliki satu atau beberapa stylesheet tema gelap, misalnya.
+- Full Page Screen Capture - [Built into Firefox](https://screenshots.firefox.com/) dan [Chrome extension](https://chrome.google.com/webstore/detail/full-page-screen-capture/fdpohaocaechififmbbbbbknoalclacl?hl=en). Memungkinkan Anda mengambil screenshot dari seluruh situs web, seringkali jauh lebih baik daripada mencetak untuk tujuan referensi.
+- [Multi Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/) - memungkinkan Anda memisahkan cookie ke dalam "container", memungkinkan Anda menjelajahi web dengan identitas berbeda dan/atau memastikan bahwa situs web tidak dapat berbagi informasi di antara mereka.
+- Password Manager Integration - Sebagian besar password manager memiliki ekstensi browser yang membuat memasukkan kredensial Anda ke situs web tidak hanya lebih nyaman tetapi juga lebih aman. Dibandingkan dengan hanya copy-paste user dan password Anda, tools ini pertama-tama akan memeriksa bahwa domain situs web cocok dengan yang terdaftar untuk entri tersebut, mencegah serangan phishing yang meniru situs web populer untuk mencuri kredensial.
+- [Vimium](https://github.com/philc/vimium) - Ekstensi browser yang menyediakan navigasi dan kontrol web berbasis keyboard dalam semangat editor Vim.
+
+## Apa saja tools data wrangling lainnya yang berguna?
+
+Beberapa tools data wrangling yang tidak sempat kita bahas selama kuliah data wrangling meliputi `jq` atau `pup` yang merupakan parser khusus untuk data JSON dan HTML. Bahasa pemrograman Perl juga merupakan tools bagus untuk pipeline data wrangling yang lebih canggih. Trik lainnya adalah perintah `column -t` yang bisa digunakan untuk mengonversi teks whitespace (belum tentu rata) menjadi teks yang rata kolom dengan benar.
+
+Secara lebih umum, beberapa tools data wrangling yang lebih tidak konvensional adalah vim dan Python. Untuk transformasi yang kompleks dan multi-baris, macro vim bisa menjadi tools yang sangat berharga. Anda cukup merekam serangkaian tindakan dan mengulanginya sebanyak yang Anda inginkan, misalnya di [catatan kuliah](/2020/editors/#macros) editor (dan [video](/2019/editors/) tahun lalu) ada contoh mengonversi file berformat XML menjadi JSON hanya menggunakan macro vim.
+
+Untuk data tabular, yang sering disajikan dalam CSV, pustaka Python [pandas](https://pandas.pydata.org/) adalah tools yang hebat. Tidak hanya karena memudahkan untuk mendefinisikan operasi kompleks seperti group by, join, atau filter; tetapi juga memudahkan untuk memplot berbagai properti data Anda. Ini juga mendukung ekspor ke banyak format tabel termasuk XLS, HTML, atau LaTeX. Sebagai alternatif, bahasa pemrograman R (bahasa pemrograman yang bisa dibilang [buruk](https://arrgh.tim-smith.us/)) memiliki banyak fungsionalitas untuk menghitung statistik atas data dan bisa sangat berguna sebagai langkah terakhir dalam pipeline Anda. [ggplot2](https://ggplot2.tidyverse.org/) adalah pustaka plotting yang hebat di R.
+
+## Apa perbedaan antara Docker dan Virtual Machine?
+
+Docker didasarkan pada konsep yang lebih umum yang disebut container. Perbedaan utama antara container dan virtual machine adalah bahwa virtual machine akan menjalankan seluruh stack OS, termasuk kernel, meskipun kernelnya sama dengan mesin host. Berbeda dengan VM, container menghindari menjalankan instance kernel lain dan sebaliknya berbagi kernel dengan host. Di Linux, ini dicapai melalui mekanisme yang disebut LXC, dan memanfaatkan serangkaian mekanisme isolasi untuk menjalankan program yang berpikir berjalan di perangkat kerasnya sendiri tetapi sebenarnya berbagi perangkat keras dan kernel dengan host. Jadi, container memiliki overhead yang lebih rendah daripada VM penuh.
+Di sisi lain, container memiliki isolasi yang lebih lemah dan hanya berfungsi jika host menjalankan kernel yang sama. Misalnya jika Anda menjalankan Docker di macOS, Docker perlu menjalankan virtual machine Linux untuk mendapatkan kernel Linux awal sehingga overheadnya tetap signifikan. Terakhir, Docker adalah implementasi spesifik dari container dan disesuaikan untuk deployment perangkat lunak. Karena itu, ada beberapa keanehan: misalnya, container Docker tidak akan menyimpan penyimpanan apapun secara default antara reboot.
+
+## Apa kelebihan dan kekurangan masing-masing OS dan bagaimana cara memilih di antaranya (misalnya memilih distribusi Linux terbaik untuk keperluan kita)?
+
+Terkait distro Linux, meskipun ada banyak sekali distro, sebagian besar akan berperilaku cukup identik untuk sebagian besar kasus penggunaan.
+Sebagian besar fitur dan cara kerja internal Linux dan UNIX dapat dipelajari di distro mana pun.
+Perbedaan mendasar antar distro adalah bagaimana mereka menangani pembaruan paket.
+Beberapa distro, seperti Arch Linux, menggunakan kebijakan rolling update di mana semuanya terbaru tetapi hal-hal bisa rusak setiap saat. Di sisi lain, beberapa distro seperti Debian, CentOS, atau rilis LTS Ubuntu jauh lebih konservatif dalam merilis pembaruan di repositori mereka sehingga semuanya biasanya lebih stabil dengan mengorbankan fitur-fitur baru.
+Rekomendasi kami untuk pengalaman yang mudah dan stabil baik untuk desktop maupun server adalah menggunakan Debian atau Ubuntu.
+
+Mac OS adalah titik tengah yang bagus antara Windows dan Linux yang memiliki antarmuka yang dipoles dengan baik. Namun, Mac OS didasarkan pada BSD daripada Linux, sehingga beberapa bagian sistem dan perintahnya berbeda.
+Alternatif yang patut dicoba adalah FreeBSD. Meskipun beberapa program tidak akan berjalan di FreeBSD, ekosistem BSD jauh tidak terfragmentasi dan lebih terdokumentasi dengan baik daripada Linux.
+Kami tidak merekomendasikan Windows untuk apa pun kecuali untuk mengembangkan aplikasi Windows atau jika ada fitur deal breaker yang Anda butuhkan, seperti dukungan driver yang baik untuk gaming.
+
+Untuk sistem dual boot, kami pikir implementasi yang paling berfungsi adalah bootcamp macOS dan bahwa kombinasi lainnya bisa bermasalah dalam jangka panjang, terutama jika Anda menggabungkannya dengan fitur lain seperti enkripsi disk.
 
 ## Vim vs Emacs?
 
-The three of us use vim as our primary editor but Emacs is also a good alternative and it's worth trying both to see which works better for you. Emacs does not follow vim's modal editing, but this can be enabled through Emacs plugins like [Evil](https://github.com/emacs-evil/evil) or [Doom Emacs](https://github.com/hlissner/doom-emacs).
-An advantage of using Emacs is that extensions can be implemented in Lisp, a better scripting language than vimscript, Vim's default scripting language.
+Kami bertiga menggunakan vim sebagai editor utama kami, tetapi Emacs juga merupakan alternatif yang bagus dan patut dicoba keduanya untuk melihat mana yang lebih cocok untuk Anda. Emacs tidak mengikuti pengeditan modal vim, tetapi ini bisa diaktifkan melalui plugin Emacs seperti [Evil](https://github.com/emacs-evil/evil) atau [Doom Emacs](https://github.com/hlissner/doom-emacs).
+Keuntungan menggunakan Emacs adalah ekstensi dapat diimplementasikan dalam Lisp, bahasa scripting yang lebih baik daripada vimscript, bahasa scripting default Vim.
 
-## Any tips or tricks for Machine Learning applications?
+## Ada tips atau trik untuk aplikasi Machine Learning?
 
-Some of the lessons and takeaways from this class can directly be applied to ML applications.
-As it is the case with many science disciplines, in ML you often perform a series of experiments and want to check what things worked and what didn't.
-You can use shell tools to easily and quickly search through these experiments and aggregate the results in a sensible way. This could mean subselecting all experiments in a given time frame or that use a specific dataset. By using a simple JSON file to log all relevant parameters of the experiments, this can be incredibly simple with the tools we covered in this class.
-Lastly, if you do not work with some sort of cluster where you submit your GPU jobs, you should look into how to automate this process since it can be a quite time consuming task that also eats away your mental energy.
+Beberapa pelajaran dan takeaway dari kelas ini dapat langsung diterapkan ke aplikasi ML.
+Seperti halnya banyak disiplin ilmu, di ML Anda sering melakukan serangkaian eksperimen dan ingin memeriksa hal-hal mana yang berhasil dan mana yang tidak.
+Anda bisa menggunakan tools shell untuk mencari melalui eksperimen-eksperimen ini dengan mudah dan cepat serta menggabungkan hasilnya dengan cara yang masuk akal. Ini bisa berarti memilih semua eksperimen dalam jangka waktu tertentu atau yang menggunakan dataset tertentu. Dengan menggunakan file JSON sederhana untuk mencatat semua parameter relevan dari eksperimen, ini bisa menjadi sangat sederhana dengan tools yang kita bahas di kelas ini.
+Terakhir, jika Anda tidak bekerja dengan semacam cluster tempat Anda mengirim pekerjaan GPU, Anda sebaiknya mencari cara untuk mengotomatisasi proses ini karena ini bisa menjadi tugas yang sangat memakan waktu dan juga menguras energi mental Anda.
 
-## Any more Vim tips?
+## Ada tips Vim lainnya?
 
-A few more tips:
+Beberapa tips tambahan:
 
-- Plugins - Take your time and explore the plugin landscape. There are a lot of great plugins that address some of vim's shortcomings or add new functionality that composes well with existing vim workflows. For this, good resources are [VimAwesome](https://vimawesome.com/) and other programmers' dotfiles.
-- Marks - In vim, you can set a mark doing `m<X>` for some letter `X`. You can then go back to that mark doing `'<X>`. This lets you quickly navigate to specific locations within a file or even across files.
-- Navigation - `Ctrl+O` and `Ctrl+I` move you backward and forward respectively through your recently visited locations.
-- Undo Tree - Vim has a quite fancy mechanism for keeping track of changes. Unlike other editors, vim stores a tree of changes so even if you undo and then make a different change you can still go back to the original state by navigating the undo tree. Some plugins like [gundo.vim](https://github.com/sjl/gundo.vim) and [undotree](https://github.com/mbbill/undotree) expose this tree in a graphical way.
-- Undo with time - The `:earlier` and `:later` commands will let you navigate the files using time references instead of one change at a time.
-- [Persistent undo](https://vim.fandom.com/wiki/Using_undo_branches#Persistent_undo) is an amazing built-in feature of vim that is disabled by default. It persists undo history between vim invocations. By setting `undofile` and `undodir` in your `.vimrc`, vim will store a per-file history of changes.
-- Leader Key - The leader key is a special key that is often left to the user to be configured for custom commands. The pattern is usually to press and release this key (often the space key) and then some other key to execute a certain command. Often, plugins will use this key to add their own functionality, for instance the UndoTree plugin uses `<Leader> U` to open the undo tree.
-- Advanced Text Objects - Text objects like searches can also be composed with vim commands. E.g. `d/<pattern>` will delete to the next match of said pattern or `cgn` will change the next occurrence of the last searched string.
+- Plugin - Luangkan waktu Anda dan jelajahi lanskap plugin. Ada banyak plugin hebat yang mengatasi beberapa kekurangan vim atau menambahkan fungsionalitas baru yang berpadu dengan baik dengan workflow vim yang ada. Untuk ini, sumber daya yang bagus adalah [VimAwesome](https://vimawesome.com/) dan dotfiles para programmer lainnya.
+- Marks - Di vim, Anda bisa men-set mark dengan melakukan `m<X>` untuk huruf `X` tertentu. Anda kemudian bisa kembali ke mark tersebut dengan melakukan `'<X>`. Ini memungkinkan Anda berpindah dengan cepat ke lokasi spesifik dalam file atau bahkan antar file.
+- Navigasi - `Ctrl+O` dan `Ctrl+I` memindahkan Anda mundur dan maju masing-masing melalui lokasi yang baru-baru ini dikunjungi.
+- Undo Tree - Vim memiliki mekanisme yang cukup canggih untuk melacak perubahan. Berbeda dengan editor lain, vim menyimpan pohon perubahan sehingga meskipun Anda undo dan kemudian membuat perubahan berbeda, Anda masih bisa kembali ke keadaan semula dengan menavigasi pohon undo. Beberapa plugin seperti [gundo.vim](https://github.com/sjl/gundo.vim) dan [undotree](https://github.com/mbbill/undotree) menampilkan pohon ini secara grafis.
+- Undo dengan waktu - Perintah `:earlier` dan `:later` akan memungkinkan Anda menavigasi file menggunakan referensi waktu alih-alih satu perubahan pada satu waktu.
+- [Persistent undo](https://vim.fandom.com/wiki/Using_undo_branches#Persistent_undo) adalah fitur bawaan vim yang luar biasa yang dinonaktifkan secara default. Ini mempertahankan riwayat undo antar pemanggilan vim. Dengan men-set `undofile` dan `undodir` di `.vimrc` Anda, vim akan menyimpan riwayat perubahan per file.
+- Leader Key - Leader key adalah kunci khusus yang sering dibiarkan untuk dikonfigurasi pengguna untuk perintah kustom. Polanya biasanya adalah menekan dan melepaskan kunci ini (seringkali kunci spasi) lalu menekan kunci lainnya untuk menjalankan perintah tertentu. Seringkali, plugin akan menggunakan kunci ini untuk menambahkan fungsionalitas mereka sendiri, misalnya plugin UndoTree menggunakan `<Leader> U` untuk membuka pohon undo.
+- Advanced Text Objects - Text objects seperti pencarian juga bisa dikomposisikan dengan perintah vim. Misalnya `d/<pattern>` akan menghapus hingga ke match berikutnya dari pola tersebut atau `cgn` akan mengubah kemunculan berikutnya dari string yang terakhir dicari.
 
-## What is 2FA and why should I use it?
+## Apa itu 2FA dan mengapa saya harus menggunakannya?
 
-Two Factor Authentication (2FA) adds an extra layer of protection to your accounts on top of passwords. In order to login, you not only have to know some password, but you also have to "prove" in some way you have access to some hardware device. In the most simple case, this can be achieved by receiving an SMS on your phone, although there are [known issues](https://www.kaspersky.com/blog/2fa-practical-guide/24219/) with SMS 2FA. A better alternative we endorse is to use a [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) solution like [YubiKey](https://www.yubico.com/).
+Two Factor Authentication (2FA) menambahkan lapisan perlindungan ekstra ke akun Anda di atas password. Untuk login, Anda tidak hanya harus mengetahui password, tetapi Anda juga harus "membuktikan" dengan cara tertentu bahwa Anda memiliki akses ke suatu perangkat perangkat keras. Dalam kasus paling sederhana, ini dapat dicapai dengan menerima SMS di ponsel Anda, meskipun ada [masalah yang diketahui](https://www.kaspersky.com/blog/2fa-practical-guide/24219/) dengan SMS 2FA. Alternatif yang lebih baik yang kami dukung adalah menggunakan solusi [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) seperti [YubiKey](https://www.yubico.com/).
 
-## Any comments on differences between web browsers?
+## Ada komentar tentang perbedaan antar web browser?
 
-The current landscape of browsers as of 2020 is that most of them are like Chrome because they use the same engine (Blink). This means that Microsoft Edge which is also based on Blink, and Safari, which is based on WebKit, a similar engine to Blink, are just worse versions of Chrome. Chrome is a reasonably good browser both in terms of performance and usability. Should you want an alternative, Firefox is our recommendation. It is comparable to Chrome in pretty much every regard and it excels for privacy reasons.
-Another browser called [Flow](https://www.ekioh.com/flow-browser/) is not user ready yet, but it is implementing a new rendering engine that promises to be faster than the current ones.
+Lanskap browser saat ini pada tahun 2020 adalah bahwa sebagian besar dari mereka seperti Chrome karena menggunakan engine yang sama (Blink). Ini berarti bahwa Microsoft Edge yang juga berbasis Blink, dan Safari, yang berbasis WebKit, engine yang mirip dengan Blink, hanyalah versi Chrome yang lebih buruk. Chrome adalah browser yang cukup baik baik dari segi performa maupun kegunaan. Jika Anda menginginkan alternatif, Firefox adalah rekomendasi kami. Ini sebanding dengan Chrome dalam hampir segala hal dan unggul dalam hal privasi.
+Browser lain bernama [Flow](https://www.ekioh.com/flow-browser/) belum siap untuk pengguna, tetapi sedang mengimplementasikan rendering engine baru yang menjanjikan lebih cepat daripada yang saat ini.

--- a/_2020/security.md
+++ b/_2020/security.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Security and Cryptography"
 description: >
-  Learn about cryptographic primitives like hashes and key derivation functions, and understand how tools like Git and SSH use them.
+  Pelajari primitif kriptografi seperti hash dan key derivation functions, serta pahami bagaimana tools seperti Git dan SSH menggunakannya.
 thumbnail: /static/assets/thumbnails/2020/lec9.png
 date: 2020-01-28
 ready: true

--- a/_2020/security.md
+++ b/_2020/security.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Security and Cryptography"
+title: "Keamanan dan Kriptografi"
 description: >
   Pelajari primitif kriptografi seperti hash dan key derivation functions, serta pahami bagaimana tools seperti Git dan SSH menggunakannya.
 thumbnail: /static/assets/thumbnails/2020/lec9.png
@@ -12,68 +12,35 @@ video:
 special: true
 ---
 
-Last year's [security and privacy lecture](/2019/security/) focused on how you
-can be more secure as a computer _user_. This year, we will focus on security
-and cryptography concepts that are relevant in understanding tools covered
-earlier in this class, such as the use of hash functions in Git or key
-derivation functions and symmetric/asymmetric cryptosystems in SSH.
+[Ceramah keamanan dan privasi tahun lalu](/2019/security/) berfokus pada bagaimana Anda bisa lebih aman sebagai _pengguna_ komputer. Tahun ini, kita akan berfokus pada konsep keamanan dan kriptografi yang relevan untuk memahami tools yang telah dibahas sebelumnya di kelas ini, seperti penggunaan hash functions di Git atau key derivation functions dan symmetric/asymmetric cryptosystems di SSH.
 
-This lecture is not a substitute for a more rigorous and complete course on
-computer systems security ([6.858](https://css.csail.mit.edu/6.858/)) or
-cryptography ([6.857](https://courses.csail.mit.edu/6.857/) and 6.875). Don't
-do security work without formal training in security. Unless you're an expert,
-don't [roll your own
-crypto](https://www.schneier.com/blog/archives/2015/05/amateurs_produc.html).
-The same principle applies to systems security.
+Ceramah ini bukan pengganti untuk kursus yang lebih ketat dan lengkap tentang keamanan sistem komputer ([6.858](https://css.csail.mit.edu/6.858/)) atau kriptografi ([6.857](https://courses.csail.mit.edu/6.857/) dan 6.875). Jangan melakukan pekerjaan keamanan tanpa pelatihan formal di bidang keamanan. Kecuali Anda seorang ahli, jangan [membuat kriptografi sendiri](https://www.schneier.com/blog/archives/2015/05/amateurs_produc.html). Prinsip yang sama berlaku untuk keamanan sistem.
 
-This lecture has a very informal (but we think practical) treatment of basic
-cryptography concepts. This lecture won't be enough to teach you how to
-_design_ secure systems or cryptographic protocols, but we hope it will be
-enough to give you a general understanding of the programs and protocols you
-already use.
+Ceramah ini memberikan perlakuan yang sangat informal (tetapi menurut kami praktis) terhadap konsep-konsep dasar kriptografi. Ceramah ini tidak akan cukup untuk mengajari Anda cara _merancang_ sistem yang aman atau protokol kriptografi, tetapi kami harap ini akan cukup untuk memberi Anda pemahaman umum tentang program dan protokol yang sudah Anda gunakan.
 
 # Entropy
 
-[Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) is a
-measure of randomness. This is useful, for example, when determining the
-strength of a password.
+[Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) adalah ukuran keacakan. Ini berguna, misalnya, saat menentukan kekuatan sebuah password.
 
 ![XKCD 936: Password Strength](https://imgs.xkcd.com/comics/password_strength.png)
 
-As the above [XKCD comic](https://xkcd.com/936/) illustrates, a password like
-"correcthorsebatterystaple" is more secure than one like "Tr0ub4dor&3". But how
-do you quantify something like this?
+Seperti yang diilustrasikan oleh [komik XKCD](https://xkcd.com/936/) di atas, password seperti "correcthorsebatterystaple" lebih aman daripada yang seperti "Tr0ub4dor&3". Tetapi bagaimana Anda mengukur sesuatu seperti ini?
 
-Entropy is measured in _bits_, and when selecting uniformly at random from a
-set of possible outcomes, the entropy is equal to `log_2(# of possibilities)`.
-A fair coin flip gives 1 bit of entropy. A dice roll (of a 6-sided die) has
-\~2.58 bits of entropy.
+Entropy diukur dalam _bit_, dan saat memilih secara seragam dan acak dari sekumpulan kemungkinan hasil, entropy sama dengan `log_2(# of possibilities)`. Lemparan koin yang adil menghasilkan 1 bit entropy. Lemparan dadu (dadu 6 sisi) memiliki \~2.58 bit entropy.
 
-You should consider that the attacker knows the _model_ of the password, but
-not the randomness (e.g. from [dice
-rolls](https://en.wikipedia.org/wiki/Diceware)) used to select a particular
-password.
+Anda harus menganggap bahwa penyerang mengetahui _model_ dari password tersebut, tetapi bukan keacakannya (misalnya dari [lemparan dadu](https://en.wikipedia.org/wiki/Diceware)) yang digunakan untuk memilih password tertentu.
 
-How many bits of entropy is enough? It depends on your threat model. For online
-guessing, as the XKCD comic points out, \~40 bits of entropy is pretty good. To
-be resistant to offline guessing, a stronger password would be necessary (e.g.
-80 bits, or more).
+Berapa banyak bit entropy yang cukup? Tergantung pada model ancaman Anda. Untuk penebakan online, seperti yang ditunjukkan oleh komik XKCD, \~40 bit entropy sudah cukup bagus. Untuk tahan terhadap penebakan offline, password yang lebih kuat akan diperlukan (misalnya 80 bit, atau lebih).
 
 # Hash functions
 
-A [cryptographic hash
-function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) maps data
-of arbitrary size to a fixed size, and has some special properties. A rough
-specification of a hash function is as follows:
+Sebuah [cryptographic hash function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) memetakan data berukuran sembarang ke ukuran yang tetap, dan memiliki beberapa properti khusus. Spesifikasi kasar dari sebuah hash function adalah sebagai berikut:
 
 ```
 hash(value: array<byte>) -> vector<byte, N>  (for some fixed N)
 ```
 
-An example of a hash function is [SHA1](https://en.wikipedia.org/wiki/SHA-1),
-which is used in Git. It maps arbitrary-sized inputs to 160-bit outputs (which
-can be represented as 40 hexadecimal characters). We can try out the SHA1 hash
-on an input using the `sha1sum` command:
+Contoh dari hash function adalah [SHA1](https://en.wikipedia.org/wiki/SHA-1), yang digunakan di Git. Ia memetakan input berukuran sembarang ke output 160-bit (yang dapat direpresentasikan sebagai 40 karakter heksadesimal). Kita bisa mencoba hash SHA1 pada sebuah input menggunakan perintah `sha1sum`:
 
 ```console
 $ printf 'hello' | sha1sum
@@ -84,71 +51,33 @@ $ printf 'Hello' | sha1sum
 f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0
 ```
 
-At a high level, a hash function can be thought of as a hard-to-invert
-random-looking (but deterministic) function (and this is the [ideal model of a
-hash function](https://en.wikipedia.org/wiki/Random_oracle)). A hash function
-has the following properties:
+Pada tingkat tinggi, sebuah hash function dapat dianggap sebagai fungsi yang sulit dibalik, terlihat acak (tetapi deterministik) (dan ini adalah [model ideal dari hash function](https://en.wikipedia.org/wiki/Random_oracle)). Sebuah hash function memiliki properti-properti berikut:
 
-- Deterministic: the same input always generates the same output.
-- Non-invertible: it is hard to find an input `m` such that `hash(m) = h` for
-some desired output `h`.
-- Target collision resistant: given an input `m_1`, it's hard to find a
-different input `m_2` such that `hash(m_1) = hash(m_2)`.
-- Collision resistant: it's hard to find two inputs `m_1` and `m_2` such that
-`hash(m_1) = hash(m_2)` (note that this is a strictly stronger property than
-target collision resistance).
+- Deterministik: input yang sama selalu menghasilkan output yang sama.
+- Non-invertible: sulit untuk menemukan sebuah input `m` sedemikian sehingga `hash(m) = h` untuk output yang diinginkan `h`.
+- Target collision resistant: diberikan sebuah input `m_1`, sulit untuk menemukan input yang berbeda `m_2` sedemikian sehingga `hash(m_1) = hash(m_2)`.
+- Collision resistant: sulit untuk menemukan dua input `m_1` dan `m_2` sedemikian sehingga `hash(m_1) = hash(m_2)` (perhatikan bahwa ini adalah properti yang secara ketat lebih kuat daripada target collision resistance).
 
-Note: while it may work for certain purposes, SHA-1 is [no
-longer](https://web.archive.org/web/20260207211148/https://shattered.io/) considered a strong cryptographic hash function.
-You might find this table of [lifetimes of cryptographic hash
-functions](https://valerieaurora.org/hash.html) interesting. However, note that
-recommending specific hash functions is beyond the scope of this lecture. If you
-are doing work where this matters, you need formal training in
-security/cryptography.
+Catatan: meskipun mungkin berfungsi untuk tujuan tertentu, SHA-1 [tidak lagi](https://web.archive.org/web/20260207211148/https://shattered.io/) dianggap sebagai cryptographic hash function yang kuat. Anda mungkin menemukan tabel [umur dari cryptographic hash functions](https://valerieaurora.org/hash.html) ini menarik. Namun, perhatikan bahwa merekomendasikan hash function tertentu berada di luar cakupan ceramah ini. Jika Anda melakukan pekerjaan di mana hal ini penting, Anda memerlukan pelatihan formal di bidang keamanan/kriptografi.
 
-## Applications
+## Aplikasi
 
-- Git, for content-addressed storage. The idea of a [hash
-function](https://en.wikipedia.org/wiki/Hash_function) is a more general
-concept (there are non-cryptographic hash functions). Why does Git use a
-cryptographic hash function?
-- A short summary of the contents of a file. Software can often be downloaded
-from (potentially less trustworthy) mirrors, e.g. Linux ISOs, and it would be
-nice to not have to trust them. The official sites usually post hashes
-alongside the download links (that point to third-party mirrors), so that the
-hash can be checked after downloading a file.
-- [Commitment schemes](https://en.wikipedia.org/wiki/Commitment_scheme).
-Suppose you want to commit to a particular value, but reveal the value itself
-later. For example, I want to do a fair coin toss "in my head", without a
-trusted shared coin that two parties can see. I could choose a value `r =
-random()`, and then share `h = sha256(r)`. Then, you could call heads or tails
-(we'll agree that even `r` means heads, and odd `r` means tails). After you
-call, I can reveal my value `r`, and you can confirm that I haven't cheated by
-checking `sha256(r)` matches the hash I shared earlier.
+- Git, untuk penyimpanan yang di-address oleh konten. Gagasan dari sebuah [hash function](https://en.wikipedia.org/wiki/Hash_function) adalah konsep yang lebih umum (ada hash functions yang non-kriptografis). Mengapa Git menggunakan cryptographic hash function?
+- Ringkasan singkat dari isi sebuah file. Perangkat lunak sering kali dapat diunduh dari mirror (yang mungkin kurang tepercaya), misalnya ISO Linux, dan akan sangat bagus jika tidak perlu mempercayai mereka. Situs-situs resmi biasanya memposting hash di samping tautan unduhan (yang menunjuk ke mirror pihak ketiga), sehingga hash dapat diperiksa setelah mengunduh sebuah file.
+- [Commitment schemes](https://en.wikipedia.org/wiki/Commitment_scheme). Misalkan Anda ingin melakukan commitment pada nilai tertentu, tetapi mengungkapkan nilai itu sendiri nanti. Misalnya, saya ingin melakukan lemparan koin yang adil "di kepala saya", tanpa koin bersama yang tepercaya yang dapat dilihat oleh dua pihak. Saya bisa memilih sebuah nilai `r = random()`, dan kemudian membagikan `h = sha256(r)`. Kemudian, Anda bisa memilih heads atau tails (kita sepakat bahwa `r` genap berarti heads, dan `r` ganjil berarti tails). Setelah Anda memilih, saya bisa mengungkapkan nilai saya `r`, dan Anda bisa memastikan bahwa saya tidak curang dengan memeriksa `sha256(r)` cocok dengan hash yang saya bagikan sebelumnya.
 
 # Key derivation functions
 
-A related concept to cryptographic hashes, [key derivation
-functions](https://en.wikipedia.org/wiki/Key_derivation_function) (KDFs) are
-used for a number of applications, including producing fixed-length output for
-use as keys in other cryptographic algorithms. Usually, KDFs are deliberately
-slow, in order to slow down offline brute-force attacks.
+Konsep yang terkait dengan cryptographic hashes, [key derivation functions](https://en.wikipedia.org/wiki/Key_derivation_function) (KDFs) digunakan untuk sejumlah aplikasi, termasuk menghasilkan output dengan panjang tetap untuk digunakan sebagai key di algoritma kriptografi lainnya. Biasanya, KDFs sengaja dibuat lambat, untuk memperlambat serangan brute-force secara offline.
 
-## Applications
+## Aplikasi
 
-- Producing keys from passphrases for use in other cryptographic algorithms
-(e.g. symmetric cryptography, see below).
-- Storing login credentials. Storing plaintext passwords is bad; the right
-approach is to generate and store a random
-[salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) `salt = random()` for
-each user, store `KDF(password + salt)`, and verify login attempts by
-re-computing the KDF given the entered password and the stored salt.
+- Menghasilkan key dari passphrase untuk digunakan di algoritma kriptografi lainnya (misalnya symmetric cryptography, lihat di bawah).
+- Menyimpan kredensial login. Menyimpan password dalam plaintext sangat buruk; pendekatan yang benar adalah menghasilkan dan menyimpan [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) acak `salt = random()` untuk setiap pengguna, menyimpan `KDF(password + salt)`, dan memverifikasi upaya login dengan menghitung ulang KDF berdasarkan password yang dimasukkan dan salt yang disimpan.
 
 # Symmetric cryptography
 
-Hiding message contents is probably the first concept you think about when you
-think about cryptography. Symmetric cryptography accomplishes this with the
-following set of functionality:
+Menyembunyikan isi pesan mungkin adalah konsep pertama yang Anda pikirkan ketika memikirkan kriptografi. Symmetric cryptography mencapai ini dengan kumpulan fungsionalitas berikut:
 
 ```
 keygen() -> key  (this function is randomized)
@@ -157,26 +86,17 @@ encrypt(plaintext: array<byte>, key) -> array<byte>  (the ciphertext)
 decrypt(ciphertext: array<byte>, key) -> array<byte>  (the plaintext)
 ```
 
-The encrypt function has the property that given the output (ciphertext), it's
-hard to determine the input (plaintext) without the key. The decrypt function
-has the obvious correctness property, that `decrypt(encrypt(m, k), k) = m`.
+Fungsi encrypt memiliki properti bahwa diberikan output (ciphertext), sulit untuk menentukan input (plaintext) tanpa key. Fungsi decrypt memiliki properti kebenaran yang jelas, yaitu `decrypt(encrypt(m, k), k) = m`.
 
-An example of a symmetric cryptosystem in wide use today is
-[AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard).
+Contoh dari symmetric cryptosystem yang banyak digunakan saat ini adalah [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard).
 
-## Applications
+## Aplikasi
 
-- Encrypting files for storage in an untrusted cloud service. This can be
-combined with KDFs, so you can encrypt a file with a passphrase. Generate `key
-= KDF(passphrase)`, and then store `encrypt(file, key)`.
+- Mengenkripsi file untuk penyimpanan di layanan cloud yang tidak tepercaya. Ini dapat dikombinasikan dengan KDFs, sehingga Anda dapat mengenkripsi file dengan passphrase. Hasilkan `key = KDF(passphrase)`, dan kemudian simpan `encrypt(file, key)`.
 
 # Asymmetric cryptography
 
-The term "asymmetric" refers to there being two keys, with two different roles.
-A private key, as its name implies, is meant to be kept private, while the
-public key can be publicly shared and it won't affect security (unlike sharing
-the key in a symmetric cryptosystem). Asymmetric cryptosystems provide the
-following set of functionality, to encrypt/decrypt and to sign/verify:
+Istilah "asymmetric" mengacu pada adanya dua key, dengan dua peran yang berbeda. Private key, sesuai namanya, dimaksudkan untuk dijaga kerahasiaannya, sedangkan public key dapat dibagikan secara publik dan tidak akan memengaruhi keamanan (berbeda dengan berbagi key dalam symmetric cryptosystem). Asymmetric cryptosystems menyediakan kumpulan fungsionalitas berikut, untuk mengenkripsi/dekripsi dan menandatangani/memverifikasi:
 
 ```
 keygen() -> (public key, private key)  (this function is randomized)
@@ -188,118 +108,49 @@ sign(message: array<byte>, private key) -> array<byte>  (the signature)
 verify(message: array<byte>, signature: array<byte>, public key) -> bool  (whether or not the signature is valid)
 ```
 
-The encrypt/decrypt functions have properties similar to their analogs from
-symmetric cryptosystems. A message can be encrypted using the _public_ key.
-Given the output (ciphertext), it's hard to determine the input (plaintext)
-without the _private_ key. The decrypt function has the obvious correctness
-property, that `decrypt(encrypt(m, public key), private key) = m`.
+Fungsi encrypt/decrypt memiliki properti yang mirip dengan analognya dari symmetric cryptosystems. Sebuah pesan dapat dienkripsi menggunakan _public_ key. Diberikan output (ciphertext), sulit untuk menentukan input (plaintext) tanpa _private_ key. Fungsi decrypt memiliki properti kebenaran yang jelas, yaitu `decrypt(encrypt(m, public key), private key) = m`.
 
-Symmetric and asymmetric encryption can be compared to physical locks. A
-symmetric cryptosystem is like a door lock: anyone with the key can lock and
-unlock it. Asymmetric encryption is like a padlock with a key. You could give
-the unlocked lock to someone (the public key), they could put a message in a
-box and then put the lock on, and after that, only you could open the lock
-because you kept the key (the private key).
+Symmetric dan asymmetric encryption dapat dibandingkan dengan kunci fisik. Sebuah symmetric cryptosystem seperti kunci pintu: siapa pun yang memiliki key dapat mengunci dan membukanya. Asymmetric encryption seperti gembok dengan kunci. Anda bisa memberikan gembok yang tidak terkunci kepada seseorang (public key), mereka bisa menaruh pesan di dalam kotak dan kemudian memasang gemboknya, dan setelah itu, hanya Anda yang bisa membuka gembok tersebut karena Anda menyimpan kuncinya (private key).
 
-The sign/verify functions have the same properties that you would hope physical
-signatures would have, in that it's hard to forge a signature. No matter the
-message, without the _private_ key, it's hard to produce a signature such that
-`verify(message, signature, public key)` returns true. And of course, the
-verify function has the obvious correctness property that `verify(message,
-sign(message, private key), public key) = true`.
+Fungsi sign/verify memiliki properti yang sama yang Anda harapkan dari tanda tangan fisik, yaitu sulit untuk memalsukan tanda tangan. Tidak peduli pesannya, tanpa _private_ key, sulit untuk menghasilkan tanda tangan sedemikian sehingga `verify(message, signature, public key)` mengembalikan true. Dan tentu saja, fungsi verify memiliki properti kebenaran yang jelas yaitu `verify(message, sign(message, private key), public key) = true`.
 
-## Applications
+## Aplikasi
 
-- [PGP email encryption](https://en.wikipedia.org/wiki/Pretty_Good_Privacy).
-People can have their public keys posted online (e.g. in a PGP keyserver, or on
-[Keybase](https://keybase.io/)). Anyone can send them encrypted email.
-- Private messaging. Apps like [Signal](https://signal.org/) and
-[Keybase](https://keybase.io/) use asymmetric keys to establish private
-communication channels.
-- Signing software. Git can have GPG-signed commits and tags. With a posted
-public key, anyone can verify the authenticity of downloaded software.
+- [Enkripsi email PGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy). Orang-orang dapat memposting public key mereka secara online (misalnya di PGP keyserver, atau di [Keybase](https://keybase.io/)). Siapa pun dapat mengirimi mereka email terenkripsi.
+- Pesan pribadi. Aplikasi seperti [Signal](https://signal.org/) dan [Keybase](https://keybase.io/) menggunakan asymmetric keys untuk mendirikan saluran komunikasi pribadi.
+- Menandatangani perangkat lunak. Git dapat memiliki commit dan tag yang ditandatangani GPG. Dengan public key yang diposting, siapa pun dapat memverifikasi keaslian perangkat lunak yang diunduh.
 
-## Key distribution
+## Distribusi key
 
-Asymmetric-key cryptography is wonderful, but it has a big challenge of
-distributing public keys / mapping public keys to real-world identities. There
-are many solutions to this problem. Signal has one simple solution: trust on
-first use, and support out-of-band public key exchange (you verify your
-friends' "safety numbers" in person). PGP has a different solution, which is
-[web of trust](https://en.wikipedia.org/wiki/Web_of_trust). Keybase has yet
-another solution of [social
-proof](https://keybase.io/blog/chat-apps-softer-than-tofu) (along with other
-neat ideas). Each model has its merits; we (the instructors) like Keybase's
-model.
+Asymmetric-key cryptography sangat luar biasa, tetapi memiliki tantangan besar dalam mendistribusikan public key / memetakan public key ke identitas dunia nyata. Ada banyak solusi untuk masalah ini. Signal memiliki satu solusi sederhana: trust on first use, dan mendukung pertukaran public key secara out-of-band (Anda memverifikasi "safety numbers" teman-teman Anda secara langsung). PGP memiliki solusi yang berbeda, yaitu [web of trust](https://en.wikipedia.org/wiki/Web_of_trust). Keybase memiliki solusi lain lagi yaitu [social proof](https://keybase.io/blog/chat-apps-softer-than-tofu) (bersama dengan ide-ide menarik lainnya). Setiap model memiliki kelebihannya masing-masing; kami (para instruktur) menyukai model Keybase.
 
-# Case studies
+# Studi kasus
 
-## Password managers
+## Password manager
 
-This is an essential tool that everyone should try to use (e.g.
-[KeePassXC](https://keepassxc.org/), [pass](https://git.zx2c4.com/password-store/about/),
-and [1Password](https://1password.com)). Password managers make it convenient to use unique,
-randomly generated high-entropy passwords for all your logins, and they save
-all your passwords in one place, encrypted with a symmetric cipher with a key
-produced from a passphrase using a KDF.
+Ini adalah tool esensial yang seharusnya dicoba digunakan oleh semua orang (misalnya [KeePassXC](https://keepassxc.org/), [pass](https://git.zx2c4.com/password-store/about/), dan [1Password](https://1password.com)). Password manager memudahkan penggunaan password yang unik, dihasilkan secara acak dengan entropy tinggi untuk semua login Anda, dan mereka menyimpan semua password Anda di satu tempat, dienkripsi dengan symmetric cipher dengan key yang dihasilkan dari passphrase menggunakan KDF.
 
-Using a password manager lets you avoid password reuse (so you're less impacted
-when websites get compromised), use high-entropy passwords (so you're less likely to
-get compromised), and only need to remember a single high-entropy password.
+Menggunakan password manager memungkinkan Anda menghindari penggunaan ulang password (sehingga Anda lebih tidak terdampak ketika situs web diretas), menggunakan password dengan entropy tinggi (sehingga Anda lebih kecil kemungkinannya untuk diretas), dan hanya perlu mengingat satu password dengan entropy tinggi.
 
-## Two-factor authentication
+## Autentikasi dua faktor
 
-[Two-factor
-authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication)
-(2FA) requires you to use a passphrase ("something you know") along with a 2FA
-authenticator (like a [YubiKey](https://www.yubico.com/), "something you have")
-in order to protect against stolen passwords and
-[phishing](https://en.wikipedia.org/wiki/Phishing) attacks.
+[Two-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) (2FA) mengharuskan Anda menggunakan passphrase ("something you know") bersama dengan authenticator 2FA (seperti [YubiKey](https://www.yubico.com/), "something you have") untuk melindungi dari pencurian password dan serangan [phishing](https://en.wikipedia.org/wiki/Phishing).
 
-## Full disk encryption
+## Enkripsi disk penuh
 
-Keeping your laptop's entire disk encrypted is an easy way to protect your data
-in the case that your laptop is stolen. You can use [cryptsetup +
-LUKS](https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system)
-on Linux,
-[BitLocker](https://fossbytes.com/enable-full-disk-encryption-windows-10/) on
-Windows, or [FileVault](https://support.apple.com/en-us/HT204837) on macOS.
-This encrypts the entire disk with a symmetric cipher, with a key protected by
-a passphrase.
+Menjaga seluruh disk laptop Anda terenkripsi adalah cara mudah untuk melindungi data Anda jika laptop Anda dicuri. Anda dapat menggunakan [cryptsetup + LUKS](https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system) di Linux, [BitLocker](https://fossbytes.com/enable-full-disk-encryption-windows-10/) di Windows, atau [FileVault](https://support.apple.com/en-us/HT204837) di macOS. Ini mengenkripsi seluruh disk dengan symmetric cipher, dengan key yang dilindungi oleh passphrase.
 
-## Private messaging
+## Pesan pribadi
 
-Use [Signal](https://signal.org/) or [Keybase](https://keybase.io/). End-to-end
-security is bootstrapped from asymmetric-key encryption. Obtaining your
-contacts' public keys is the critical step here. If you want good security, you
-need to authenticate public keys out-of-band (with Signal or Keybase), or trust
-social proofs (with Keybase).
+Gunakan [Signal](https://signal.org/) atau [Keybase](https://keybase.io/). Keamanan end-to-end dimulai dari asymmetric-key encryption. Mendapatkan public key kontak Anda adalah langkah kritis di sini. Jika Anda menginginkan keamanan yang baik, Anda perlu mengautentikasi public key secara out-of-band (dengan Signal atau Keybase), atau mempercayai social proofs (dengan Keybase).
 
 ## SSH
 
-We've covered the use of SSH and SSH keys in an [earlier
-lecture](/2020/command-line/#remote-machines). Let's look at the cryptography
-aspects of this.
+Kita telah membahas penggunaan SSH dan SSH keys di [ceramah sebelumnya](/2020/command-line/#remote-machines). Mari kita lihat aspek kriptografi dari hal ini.
 
-When you run `ssh-keygen`, it generates an asymmetric key pair, `public_key,
-private_key`. This is generated randomly, using entropy provided by the
-operating system (collected from hardware events, etc.). The public key is
-stored as-is (it's public, so keeping it a secret is not important), but at
-rest, the private key should be encrypted on disk. The `ssh-keygen` program
-prompts the user for a passphrase, and this is fed through a key derivation
-function to produce a key, which is then used to encrypt the private key with a
-symmetric cipher.
+Ketika Anda menjalankan `ssh-keygen`, ia menghasilkan asymmetric key pair, `public_key, private_key`. Ini dihasilkan secara acak, menggunakan entropy yang disediakan oleh sistem operasi (dikumpulkan dari event hardware, dll.). Public key disimpan apa adanya (ini publik, jadi menjaganya tetap rahasia tidak penting), tetapi saat disimpan, private key harus dienkripsi di disk. Program `ssh-keygen` meminta passphrase kepada pengguna, dan ini dimasukkan melalui key derivation function untuk menghasilkan key, yang kemudian digunakan untuk mengenkripsi private key dengan symmetric cipher.
 
-In use, once the server knows the client's public key (stored in the
-`.ssh/authorized_keys` file), a connecting client can prove its identity using
-asymmetric signatures. This is done through
-[challenge-response](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication).
-At a high level, the server picks a random number and sends it to the client.
-The client then signs this message and sends the signature back to the server,
-which checks the signature against the public key on record. This effectively
-proves that the client is in possession of the private key corresponding to the
-public key that's in the server's `.ssh/authorized_keys` file, so the server
-can allow the client to log in.
+Dalam penggunaan, setelah server mengetahui public key klien (disimpan di file `.ssh/authorized_keys`), klien yang terhubung dapat membuktikan identitasnya menggunakan asymmetric signatures. Ini dilakukan melalui [challenge-response](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication). Pada tingkat tinggi, server memilih angka acak dan mengirimkannya ke klien. Klien kemudian menandatangani pesan ini dan mengirim tanda tangan kembali ke server, yang memeriksa tanda tangan terhadap public key yang tercatat. Ini secara efektif membuktikan bahwa klien memiliki private key yang sesuai dengan public key yang ada di file `.ssh/authorized_keys` server, sehingga server dapat mengizinkan klien untuk login.
 
 {% comment %}
 extra topics, if there's time
@@ -309,48 +160,22 @@ security concepts, tips
 - HTTPS
 {% endcomment %}
 
-# Resources
+# Sumber daya
 
-- [Last year's notes](/2019/security/): from when this lecture was more focused on security and privacy as a computer user
-- [Cryptographic Right Answers](https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html): answers "what crypto should I use for X?" for many common X.
+- [Catatan tahun lalu](/2019/security/): dari ketika ceramah ini lebih berfokus pada keamanan dan privasi sebagai pengguna komputer
+- [Cryptographic Right Answers](https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html): menjawab "kriptografi apa yang harus saya gunakan untuk X?" untuk banyak X yang umum.
 
-# Exercises
+# Latihan
 
 1. **Entropy.**
-    1. Suppose a password is chosen as a concatenation of four lower-case
-       dictionary words, where each word is selected uniformly at random from a
-       dictionary of size 100,000. An example of such a password is
-       `correcthorsebatterystaple`. How many bits of entropy does this have?
-    1. Consider an alternative scheme where a password is chosen as a sequence
-       of 8 random alphanumeric characters (including both lower-case and
-       upper-case letters). An example is `rg8Ql34g`. How many bits of entropy
-       does this have?
-    1. Which is the stronger password?
-    1. Suppose an attacker can try guessing 10,000 passwords per second. On
-       average, how long will it take to break each of the passwords?
-1. **Cryptographic hash functions.** Download a Debian image from a
-   [mirror](https://www.debian.org/CD/http-ftp/) (e.g. [from this Argentinean
-   mirror](http://debian.xfree.com.ar/debian-cd/current/amd64/iso-cd/)).
-   Cross-check the hash (e.g. using the `sha256sum` command) with the hash
-   retrieved from the official Debian site (e.g. [this
-   file](https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS)
-   hosted at `debian.org`, if you've downloaded the linked file from the
-   Argentinean mirror).
-1. **Symmetric cryptography.** Encrypt a file with AES encryption, using
-   [OpenSSL](https://www.openssl.org/): `openssl aes-256-cbc -salt -in {input
-   filename} -out {output filename}`. Look at the contents using `cat` or
-   `hexdump`. Decrypt it with `openssl aes-256-cbc -d -in {input filename} -out
-   {output filename}` and confirm that the contents match the original using
-   `cmp`.
+    1. Misalkan sebuah password dipilih sebagai gabungan dari empat kata kamus huruf kecil, di mana setiap kata dipilih secara seragam dan acak dari kamus berukuran 100.000. Contoh password seperti ini adalah `correcthorsebatterystaple`. Berapa banyak bit entropy yang dimilikinya?
+    1. Pertimbangkan skema alternatif di mana password dipilih sebagai urutan 8 karakter alfanumerik acak (termasuk huruf kecil dan huruf besar). Contohnya adalah `rg8Ql34g`. Berapa banyak bit entropy yang dimilikinya?
+    1. Mana yang merupakan password lebih kuat?
+    1. Misalkan seorang penyerang dapat mencoba menebak 10.000 password per detik. Secara rata-rata, berapa lama waktu yang dibutuhkan untuk memecahkan masing-masing password?
+1. **Cryptographic hash functions.** Unduh sebuah image Debian dari [mirror](https://www.debian.org/CD/http-ftp/) (misalnya [dari mirror Argentina ini](http://debian.xfree.com.ar/debian-cd/current/amd64/iso-cd/)). Periksa silang hash-nya (misalnya menggunakan perintah `sha256sum`) dengan hash yang diambil dari situs resmi Debian (misalnya [file ini](https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS) yang di-host di `debian.org`, jika Anda telah mengunduh file yang ditautkan dari mirror Argentina).
+1. **Symmetric cryptography.** Enkripsi sebuah file dengan enkripsi AES, menggunakan [OpenSSL](https://www.openssl.org/): `openssl aes-256-cbc -salt -in {input filename} -out {output filename}`. Lihat isinya menggunakan `cat` atau `hexdump`. Dekripsi dengan `openssl aes-256-cbc -d -in {input filename} -out {output filename}` dan konfirmasi bahwa isinya cocok dengan yang asli menggunakan `cmp`.
 1. **Asymmetric cryptography.**
-    1. Set up [SSH
-       keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2)
-       on a computer you have access to (not Athena, because Kerberos interacts
-       weirdly with SSH keys). Make sure
-       your private key is encrypted with a passphrase, so it is protected at
-       rest.
-    1. [Set up GPG](https://www.digitalocean.com/community/tutorials/how-to-use-gpg-to-encrypt-and-sign-messages)
-    1. Send Anish an encrypted email ([public key](https://keybase.io/anish)).
-    1. Sign a Git commit with `git commit -S` or create a signed Git tag with
-       `git tag -s`. Verify the signature on the commit with `git show
-       --show-signature` or on the tag with `git tag -v`.
+    1. Siapkan [SSH keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2) pada komputer yang Anda miliki aksesnya (bukan Athena, karena Kerberos berinteraksi secara aneh dengan SSH keys). Pastikan private key Anda dienkripsi dengan passphrase, sehingga terlindungi saat disimpan.
+    1. [Siapkan GPG](https://www.digitalocean.com/community/tutorials/how-to-use-gpg-to-encrypt-and-sign-messages)
+    1. Kirim email terenkripsi ke Anish ([public key](https://keybase.io/anish)).
+    1. Tandatangani sebuah Git commit dengan `git commit -S` atau buat Git tag yang ditandatangani dengan `git tag -s`. Verifikasi tanda tangan pada commit dengan `git show --show-signature` atau pada tag dengan `git tag -v`.

--- a/_2020/security.md
+++ b/_2020/security.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Security and Cryptography"
+title: "Keamanan dan Kriptografi"
 description: >
-  Learn about cryptographic primitives like hashes and key derivation functions, and understand how tools like Git and SSH use them.
+  Pelajari primitif kriptografi seperti fungsi hash dan fungsi turunan kunci, serta pahami bagaimana alat-alat seperti Git dan SSH menggunakannya.
 thumbnail: /static/assets/thumbnails/2020/lec9.png
 date: 2020-01-28
 ready: true
@@ -12,68 +12,67 @@ video:
 special: true
 ---
 
-Last year's [security and privacy lecture](/2019/security/) focused on how you
-can be more secure as a computer _user_. This year, we will focus on security
-and cryptography concepts that are relevant in understanding tools covered
-earlier in this class, such as the use of hash functions in Git or key
-derivation functions and symmetric/asymmetric cryptosystems in SSH.
+[Ceramah keamanan dan privasi](/2019/security/) tahun lalu berfokus pada bagaimana Anda
+bisa lebih aman sebagai _pengguna_ komputer. Tahun ini, kita akan fokus pada konsep
+keamanan dan kriptografi yang relevan untuk memahami alat-alat yang telah dibahas
+sebelumnya di kelas ini, seperti penggunaan fungsi hash di Git atau fungsi turunan
+kunci dan sistem kriptografi simetris/asimetris di SSH.
 
-This lecture is not a substitute for a more rigorous and complete course on
-computer systems security ([6.858](https://css.csail.mit.edu/6.858/)) or
-cryptography ([6.857](https://courses.csail.mit.edu/6.857/) and 6.875). Don't
-do security work without formal training in security. Unless you're an expert,
-don't [roll your own
-crypto](https://www.schneier.com/blog/archives/2015/05/amateurs_produc.html).
-The same principle applies to systems security.
+Ceramah ini bukan pengganti untuk kursus yang lebih ketat dan lengkap tentang
+keamanan sistem komputer ([6.858](https://css.csail.mit.edu/6.858/)) atau
+kriptografi ([6.857](https://courses.csail.mit.edu/6.857/) dan 6.875). Jangan
+melakukan pekerjaan keamanan tanpa pelatihan formal di bidang keamanan. Kecuali
+Anda seorang ahli, jangan [membuat kriptografi sendiri
+](https://www.schneier.com/blog/archives/2015/05/amateurs_produc.html). Prinsip
+yang sama berlaku untuk keamanan sistem.
 
-This lecture has a very informal (but we think practical) treatment of basic
-cryptography concepts. This lecture won't be enough to teach you how to
-_design_ secure systems or cryptographic protocols, but we hope it will be
-enough to give you a general understanding of the programs and protocols you
-already use.
+Ceramah ini memberikan perlakuan yang sangat informal (tetapi menurut kami praktis)
+terhadap konsep-konsep dasar kriptografi. Ceramah ini tidak akan cukup untuk
+mengajari Anda cara _merancang_ sistem yang aman atau protokol kriptografi, tetapi
+kami harap ini akan cukup untuk memberi Anda pemahaman umum tentang program dan
+protokol yang sudah Anda gunakan.
 
-# Entropy
+# Entropi
 
-[Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) is a
-measure of randomness. This is useful, for example, when determining the
-strength of a password.
+[Entropi](https://en.wikipedia.org/wiki/Entropy_(information_theory)) adalah
+ukuran keacakan. Ini berguna, misalnya, saat menentukan kekuatan sebuah kata sandi.
 
 ![XKCD 936: Password Strength](https://imgs.xkcd.com/comics/password_strength.png)
 
-As the above [XKCD comic](https://xkcd.com/936/) illustrates, a password like
-"correcthorsebatterystaple" is more secure than one like "Tr0ub4dor&3". But how
-do you quantify something like this?
+Seperti yang diilustrasikan oleh [komik XKCD](https://xkcd.com/936/) di atas, kata
+sandi seperti "correcthorsebatterystaple" lebih aman daripada yang seperti
+"Tr0ub4dor&3". Tetapi bagaimana Anda mengukur sesuatu seperti ini?
 
-Entropy is measured in _bits_, and when selecting uniformly at random from a
-set of possible outcomes, the entropy is equal to `log_2(# of possibilities)`.
-A fair coin flip gives 1 bit of entropy. A dice roll (of a 6-sided die) has
-\~2.58 bits of entropy.
+Entropi diukur dalam _bit_, dan saat memilih secara seragam dan acak dari
+sekumpulan kemungkinan hasil, entropi sama dengan `log_2(# of possibilities)`.
+Lemparan koin yang adil memberikan 1 bit entropi. Lemparan dadu (dadu 6 sisi)
+memiliki entropi ~2.58 bit.
 
-You should consider that the attacker knows the _model_ of the password, but
-not the randomness (e.g. from [dice
-rolls](https://en.wikipedia.org/wiki/Diceware)) used to select a particular
-password.
+Anda harus mempertimbangkan bahwa penyerang mengetahui _model_ kata sandi, tetapi
+tidak mengetahui keacakan (misalnya dari [lemparan
+dadu](https://en.wikipedia.org/wiki/Diceware)) yang digunakan untuk memilih kata
+sandi tertentu.
 
-How many bits of entropy is enough? It depends on your threat model. For online
-guessing, as the XKCD comic points out, \~40 bits of entropy is pretty good. To
-be resistant to offline guessing, a stronger password would be necessary (e.g.
-80 bits, or more).
+Berapa banyak bit entropi yang cukup? Tergantung pada model ancaman Anda. Untuk
+penebakan online, seperti yang ditunjukkan oleh komik XKCD, ~40 bit entropi sudah
+cukup baik. Untuk tahan terhadap penebakan offline, kata sandi yang lebih kuat
+diperlukan (misalnya 80 bit, atau lebih).
 
-# Hash functions
+# Fungsi hash
 
-A [cryptographic hash
-function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) maps data
-of arbitrary size to a fixed size, and has some special properties. A rough
-specification of a hash function is as follows:
+[Fungsi hash
+kriptografi](https://en.wikipedia.org/wiki/Cryptographic_hash_function) memetakan
+data berukuran sewenang-wenang ke ukuran tetap, dan memiliki beberapa properti
+khusus. Spesifikasi kasar dari fungsi hash adalah sebagai berikut:
 
 ```
 hash(value: array<byte>) -> vector<byte, N>  (for some fixed N)
 ```
 
-An example of a hash function is [SHA1](https://en.wikipedia.org/wiki/SHA-1),
-which is used in Git. It maps arbitrary-sized inputs to 160-bit outputs (which
-can be represented as 40 hexadecimal characters). We can try out the SHA1 hash
-on an input using the `sha1sum` command:
+Contoh fungsi hash adalah [SHA1](https://en.wikipedia.org/wiki/SHA-1), yang
+digunakan di Git. Fungsi ini memetakan input berukuran sewenang-wenang ke output
+160-bit (yang dapat direpresentasikan sebagai 40 karakter heksadesimal). Kita bisa
+mencoba hash SHA1 pada sebuah input menggunakan perintah `sha1sum`:
 
 ```console
 $ printf 'hello' | sha1sum
@@ -84,71 +83,74 @@ $ printf 'Hello' | sha1sum
 f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0
 ```
 
-At a high level, a hash function can be thought of as a hard-to-invert
-random-looking (but deterministic) function (and this is the [ideal model of a
-hash function](https://en.wikipedia.org/wiki/Random_oracle)). A hash function
-has the following properties:
+Pada tingkat tinggi, fungsi hash dapat dianggap sebagai fungsi yang sulit
+dibalikkan, terlihat acak (tetapi deterministik) (dan ini adalah [model ideal dari
+fungsi hash](https://en.wikipedia.org/wiki/Random_oracle)). Fungsi hash memiliki
+properti berikut:
 
-- Deterministic: the same input always generates the same output.
-- Non-invertible: it is hard to find an input `m` such that `hash(m) = h` for
-some desired output `h`.
-- Target collision resistant: given an input `m_1`, it's hard to find a
-different input `m_2` such that `hash(m_1) = hash(m_2)`.
-- Collision resistant: it's hard to find two inputs `m_1` and `m_2` such that
-`hash(m_1) = hash(m_2)` (note that this is a strictly stronger property than
-target collision resistance).
+- Deterministik: input yang sama selalu menghasilkan output yang sama.
+- Tidak dapat dibalik: sulit untuk menemukan input `m` sedemikian rupa sehingga
+  `hash(m) = h` untuk output `h` yang diinginkan.
+- Tahan terhadap tabrakan target: diberikan input `m_1`, sulit untuk menemukan
+  input berbeda `m_2` sedemikian rupa sehingga `hash(m_1) = hash(m_2)`.
+- Tahan terhadap tabrakan: sulit untuk menemukan dua input `m_1` dan `m_2`
+  sedemikian rupa sehingga `hash(m_1) = hash(m_2)` (perhatikan bahwa ini adalah
+  properti yang secara ketat lebih kuat daripada tahan terhadap tabrakan target).
 
-Note: while it may work for certain purposes, SHA-1 is [no
-longer](https://web.archive.org/web/20260207211148/https://shattered.io/) considered a strong cryptographic hash function.
-You might find this table of [lifetimes of cryptographic hash
-functions](https://valerieaurora.org/hash.html) interesting. However, note that
-recommending specific hash functions is beyond the scope of this lecture. If you
-are doing work where this matters, you need formal training in
-security/cryptography.
+Catatan: meskipun mungkin berfungsi untuk tujuan tertentu, SHA-1 [tidak
+lagi](https://web.archive.org/web/20260207211148/https://shattered.io/) dianggap
+sebagai fungsi hash kriptografi yang kuat. Anda mungkin tertarik dengan tabel
+[masa pakai fungsi hash
+kriptografi](https://valerieaurora.org/hash.html) ini. Namun, perhatikan bahwa
+merekomendasikan fungsi hash tertentu berada di luar ruang lingkup ceramah ini.
+Jika Anda melakukan pekerjaan di mana hal ini penting, Anda memerlukan pelatihan
+formal di bidang keamanan/kriptografi.
 
-## Applications
+## Aplikasi
 
-- Git, for content-addressed storage. The idea of a [hash
-function](https://en.wikipedia.org/wiki/Hash_function) is a more general
-concept (there are non-cryptographic hash functions). Why does Git use a
-cryptographic hash function?
-- A short summary of the contents of a file. Software can often be downloaded
-from (potentially less trustworthy) mirrors, e.g. Linux ISOs, and it would be
-nice to not have to trust them. The official sites usually post hashes
-alongside the download links (that point to third-party mirrors), so that the
-hash can be checked after downloading a file.
-- [Commitment schemes](https://en.wikipedia.org/wiki/Commitment_scheme).
-Suppose you want to commit to a particular value, but reveal the value itself
-later. For example, I want to do a fair coin toss "in my head", without a
-trusted shared coin that two parties can see. I could choose a value `r =
-random()`, and then share `h = sha256(r)`. Then, you could call heads or tails
-(we'll agree that even `r` means heads, and odd `r` means tails). After you
-call, I can reveal my value `r`, and you can confirm that I haven't cheated by
-checking `sha256(r)` matches the hash I shared earlier.
+- Git, untuk penyimpanan berbasis konten. Gagasan tentang [fungsi
+  hash](https://en.wikipedia.org/wiki/Hash_function) adalah konsep yang lebih umum
+  (ada fungsi hash non-kriptografi). Mengapa Git menggunakan fungsi hash
+  kriptografi?
+- Ringkasan singkat dari isi sebuah file. Perangkat lunak sering dapat diunduh
+  dari mirror (yang mungkin kurang tepercaya), misalnya ISO Linux, dan akan sangat
+  bagus jika tidak perlu mempercayai mereka. Situs-situs resmi biasanya memposting
+  hash di samping tautan unduhan (yang menunjuk ke mirror pihak ketiga), sehingga
+  hash dapat diperiksa setelah mengunduh file.
+- [Skema komitmen](https://en.wikipedia.org/wiki/Commitment_scheme). Misalkan Anda
+  ingin berkomitmen pada nilai tertentu, tetapi mengungkapkan nilai itu sendiri
+  nanti. Misalnya, saya ingin melakukan lemparan koin yang adil "di kepala saya",
+  tanpa koin bersama yang tepercaya yang dapat dilihat oleh dua pihak. Saya bisa
+  memilih nilai `r = random()`, dan kemudian membagikan `h = sha256(r)`. Kemudian,
+  Anda bisa memilih heads atau tails (kita akan sepakat bahwa `r` genap berarti
+  heads, dan `r` ganjil berarti tails). Setelah Anda memilih, saya bisa
+  mengungkapkan nilai `r` saya, dan Anda bisa memastikan bahwa saya tidak curang
+  dengan memeriksa `sha256(r)` cocok dengan hash yang saya bagikan sebelumnya.
 
-# Key derivation functions
+# Fungsi turunan kunci
 
-A related concept to cryptographic hashes, [key derivation
-functions](https://en.wikipedia.org/wiki/Key_derivation_function) (KDFs) are
-used for a number of applications, including producing fixed-length output for
-use as keys in other cryptographic algorithms. Usually, KDFs are deliberately
-slow, in order to slow down offline brute-force attacks.
+Konsep yang terkait dengan fungsi hash kriptografi, [fungsi turunan
+key](https://en.wikipedia.org/wiki/Key_derivation_function) (KDF) digunakan untuk
+sejumlah aplikasi, termasuk menghasilkan output dengan panjang tetap untuk
+digunakan sebagai kunci di algoritma kriptografi lainnya. Biasanya, KDF sengaja
+dibuat lambat, untuk memperlambat serangan brute-force offline.
 
-## Applications
+## Aplikasi
 
-- Producing keys from passphrases for use in other cryptographic algorithms
-(e.g. symmetric cryptography, see below).
-- Storing login credentials. Storing plaintext passwords is bad; the right
-approach is to generate and store a random
-[salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) `salt = random()` for
-each user, store `KDF(password + salt)`, and verify login attempts by
-re-computing the KDF given the entered password and the stored salt.
+- Menghasilkan kunci dari frasa sandi untuk digunakan di algoritma kriptografi
+  lainnya (misalnya kriptografi simetris, lihat di bawah).
+- Menyimpan kredensial login. Menyimpan kata sandi dalam bentuk teks biasa adalah
+  hal yang buruk; pendekatan yang tepat adalah menghasilkan dan menyimpan
+  [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) acak `salt = random()`
+  untuk setiap pengguna, menyimpan `KDF(password + salt)`, dan memverifikasi upaya
+  login dengan menghitung ulang KDF berdasarkan kata sandi yang dimasukkan dan salt
+  yang disimpan.
 
-# Symmetric cryptography
+# Kriptografi simetris
 
-Hiding message contents is probably the first concept you think about when you
-think about cryptography. Symmetric cryptography accomplishes this with the
-following set of functionality:
+Menyembunyikan isi pesan mungkin adalah konsep pertama yang Anda pikirkan ketika
+berpikir tentang kriptografi. Kriptografi simetris mencapai ini dengan
+fungsionalitas berikut:
 
 ```
 keygen() -> key  (this function is randomized)
@@ -157,26 +159,28 @@ encrypt(plaintext: array<byte>, key) -> array<byte>  (the ciphertext)
 decrypt(ciphertext: array<byte>, key) -> array<byte>  (the plaintext)
 ```
 
-The encrypt function has the property that given the output (ciphertext), it's
-hard to determine the input (plaintext) without the key. The decrypt function
-has the obvious correctness property, that `decrypt(encrypt(m, k), k) = m`.
+Fungsi encrypt memiliki properti bahwa diberikan output (ciphertext), sulit untuk
+menentukan input (plaintext) tanpa kunci. Fungsi decrypt memiliki properti
+kebenaran yang jelas, yaitu `decrypt(encrypt(m, k), k) = m`.
 
-An example of a symmetric cryptosystem in wide use today is
+Contoh sistem kriptografi simetris yang banyak digunakan saat ini adalah
 [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard).
 
-## Applications
+## Aplikasi
 
-- Encrypting files for storage in an untrusted cloud service. This can be
-combined with KDFs, so you can encrypt a file with a passphrase. Generate `key
-= KDF(passphrase)`, and then store `encrypt(file, key)`.
+- Mengenkripsi file untuk disimpan di layanan cloud yang tidak tepercaya. Ini
+  dapat dikombinasikan dengan KDF, sehingga Anda dapat mengenkripsi file dengan
+  frasa sandi. Hasilkan `key = KDF(passphrase)`, dan kemudian simpan
+  `encrypt(file, key)`.
 
-# Asymmetric cryptography
+# Kriptografi asimetris
 
-The term "asymmetric" refers to there being two keys, with two different roles.
-A private key, as its name implies, is meant to be kept private, while the
-public key can be publicly shared and it won't affect security (unlike sharing
-the key in a symmetric cryptosystem). Asymmetric cryptosystems provide the
-following set of functionality, to encrypt/decrypt and to sign/verify:
+Istilah "asimetris" mengacu pada adanya dua kunci, dengan dua peran berbeda. Kunci
+pribadi, sesuai namanya, dimaksudkan untuk dirahasiakan, sementara kunci publik
+dapat dibagikan secara publik dan tidak akan memengaruhi keamanan (berbeda dengan
+berbagi kunci di sistem kriptografi simetris). Sistem kriptografi asimetris
+menyediakan fungsionalitas berikut, untuk mengenkripsi/deskripsi dan
+menandatangani/memverifikasi:
 
 ```
 keygen() -> (public key, private key)  (this function is randomized)
@@ -188,118 +192,125 @@ sign(message: array<byte>, private key) -> array<byte>  (the signature)
 verify(message: array<byte>, signature: array<byte>, public key) -> bool  (whether or not the signature is valid)
 ```
 
-The encrypt/decrypt functions have properties similar to their analogs from
-symmetric cryptosystems. A message can be encrypted using the _public_ key.
-Given the output (ciphertext), it's hard to determine the input (plaintext)
-without the _private_ key. The decrypt function has the obvious correctness
-property, that `decrypt(encrypt(m, public key), private key) = m`.
+Fungsi encrypt/decrypt memiliki properti yang mirip dengan analog mereka dari
+sistem kriptografi simetris. Sebuah pesan dapat dienkripsi menggunakan kunci
+_publik_. Diberikan output (ciphertext), sulit untuk menentukan input (plaintext)
+tanpa kunci _pribadi_. Fungsi decrypt memiliki properti kebenaran yang jelas, yaitu
+`decrypt(encrypt(m, public key), private key) = m`.
 
-Symmetric and asymmetric encryption can be compared to physical locks. A
-symmetric cryptosystem is like a door lock: anyone with the key can lock and
-unlock it. Asymmetric encryption is like a padlock with a key. You could give
-the unlocked lock to someone (the public key), they could put a message in a
-box and then put the lock on, and after that, only you could open the lock
-because you kept the key (the private key).
+Enkripsi simetris dan asimetris dapat dibandingkan dengan kunci fisik. Sistem
+kriptografi simetris seperti kunci pintu: siapa pun dengan kunci dapat mengunci
+dan membukanya. Enkripsi asimetris seperti gembok dengan kunci. Anda bisa
+memberikan gembok yang tidak terkunci kepada seseorang (kunci publik), mereka bisa
+menaruh pesan di dalam kotak dan kemudian memasang gemboknya, dan setelah itu,
+hanya Anda yang bisa membuka gemboknya karena Anda menyimpan kuncinya (kunci
+pribadi).
 
-The sign/verify functions have the same properties that you would hope physical
-signatures would have, in that it's hard to forge a signature. No matter the
-message, without the _private_ key, it's hard to produce a signature such that
-`verify(message, signature, public key)` returns true. And of course, the
-verify function has the obvious correctness property that `verify(message,
-sign(message, private key), public key) = true`.
+Fungsi sign/verify memiliki properti yang sama dengan yang Anda harapkan dari
+tanda tangan fisik, yaitu sulit untuk memalsukan tanda tangan. Tidak peduli
+pesannya, tanpa kunci _pribadi_, sulit untuk menghasilkan tanda tangan sedemikian
+rupa sehingga `verify(message, signature, public key)` mengembalikan true. Dan
+tentu saja, fungsi verify memiliki properti kebenaran yang jelas yaitu
+`verify(message, sign(message, private key), public key) = true`.
 
-## Applications
+## Aplikasi
 
-- [PGP email encryption](https://en.wikipedia.org/wiki/Pretty_Good_Privacy).
-People can have their public keys posted online (e.g. in a PGP keyserver, or on
-[Keybase](https://keybase.io/)). Anyone can send them encrypted email.
-- Private messaging. Apps like [Signal](https://signal.org/) and
-[Keybase](https://keybase.io/) use asymmetric keys to establish private
-communication channels.
-- Signing software. Git can have GPG-signed commits and tags. With a posted
-public key, anyone can verify the authenticity of downloaded software.
+- [Enkripsi email PGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy). Orang
+  dapat memposting kunci publik mereka secara online (misalnya di PGP keyserver,
+  atau di [Keybase](https://keybase.io/)). Siapa pun dapat mengirimi mereka email
+  terenkripsi.
+- Pesan pribadi. Aplikasi seperti [Signal](https://signal.org/) dan
+  [Keybase](https://keybase.io/) menggunakan kunci asimetris untuk membentuk
+  saluran komunikasi pribadi.
+- Menandatangani perangkat lunak. Git dapat memiliki commit dan tag yang
+  ditandatangani GPG. Dengan kunci publik yang diposting, siapa pun dapat
+  memverifikasi keaslian perangkat lunak yang diunduh.
 
-## Key distribution
+## Distribusi kunci
 
-Asymmetric-key cryptography is wonderful, but it has a big challenge of
-distributing public keys / mapping public keys to real-world identities. There
-are many solutions to this problem. Signal has one simple solution: trust on
-first use, and support out-of-band public key exchange (you verify your
-friends' "safety numbers" in person). PGP has a different solution, which is
-[web of trust](https://en.wikipedia.org/wiki/Web_of_trust). Keybase has yet
-another solution of [social
-proof](https://keybase.io/blog/chat-apps-softer-than-tofu) (along with other
-neat ideas). Each model has its merits; we (the instructors) like Keybase's
-model.
+Kriptografi kunci asimetris sangat luar biasa, tetapi memiliki tantangan besar
+dalam mendistribusikan kunci publik / memetakan kunci publik ke identitas dunia
+nyata. Ada banyak solusi untuk masalah ini. Signal memiliki satu solusi sederhana:
+trust on first use, dan mendukung pertukaran kunci publik di luar saluran (Anda
+memverifikasi "safety numbers" teman-teman Anda secara langsung). PGP memiliki
+solusi berbeda, yaitu [web of
+trust](https://en.wikipedia.org/wiki/Web_of_trust). Keybase memiliki solusi lain
+lagi yaitu [social
+proof](https://keybase.io/blog/chat-apps-softer-than-tofu) (bersama dengan ide-ide
+menarik lainnya). Setiap model memiliki kelebihannya masing-masing; kami (para
+instruktur) menyukai model Keybase.
 
-# Case studies
+# Studi kasus
 
-## Password managers
+## Pengelola kata sandi
 
-This is an essential tool that everyone should try to use (e.g.
-[KeePassXC](https://keepassxc.org/), [pass](https://git.zx2c4.com/password-store/about/),
-and [1Password](https://1password.com)). Password managers make it convenient to use unique,
-randomly generated high-entropy passwords for all your logins, and they save
-all your passwords in one place, encrypted with a symmetric cipher with a key
-produced from a passphrase using a KDF.
+Ini adalah alat penting yang harus dicoba digunakan oleh semua orang (misalnya
+[KeePassXC](https://keepassxc.org/),
+[pass](https://git.zx2c4.com/password-store/about/), dan
+[1Password](https://1password.com)). Pengelola kata sandi memudahkan penggunaan
+kata sandi unik yang dihasilkan secara acak dengan entropi tinggi untuk semua login
+Anda, dan mereka menyimpan semua kata sandi Anda di satu tempat, dienkripsi dengan
+cipher simetris dengan kunci yang dihasilkan dari frasa sandi menggunakan KDF.
 
-Using a password manager lets you avoid password reuse (so you're less impacted
-when websites get compromised), use high-entropy passwords (so you're less likely to
-get compromised), and only need to remember a single high-entropy password.
+Menggunakan pengelola kata sandi memungkinkan Anda menghindari penggunaan ulang
+kata sandi (sehingga Anda lebih tidak terdampak ketika situs web diretas),
+menggunakan kata sandi dengan entropi tinggi (sehingga Anda lebih kecil
+kemungkinannya untuk diretas), dan hanya perlu mengingat satu kata sandi dengan
+entropi tinggi.
 
-## Two-factor authentication
+## Autentikasi dua faktor
 
-[Two-factor
-authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication)
-(2FA) requires you to use a passphrase ("something you know") along with a 2FA
-authenticator (like a [YubiKey](https://www.yubico.com/), "something you have")
-in order to protect against stolen passwords and
-[phishing](https://en.wikipedia.org/wiki/Phishing) attacks.
+[Autentikasi dua
+faktor](https://en.wikipedia.org/wiki/Multi-factor_authentication) (2FA)
+mewajibkan Anda menggunakan frasa sandi ("something you know") bersama dengan
+autentikator 2FA (seperti [YubiKey](https://www.yubico.com/), "something you have")
+untuk melindungi dari kata sandi yang dicuri dan serangan
+[phishing](https://en.wikipedia.org/wiki/Phishing).
 
-## Full disk encryption
+## Enkripsi disk penuh
 
-Keeping your laptop's entire disk encrypted is an easy way to protect your data
-in the case that your laptop is stolen. You can use [cryptsetup +
+Menjaga seluruh disk laptop Anda terenkripsi adalah cara mudah untuk melindungi
+data Anda jika laptop Anda dicuri. Anda dapat menggunakan [cryptsetup +
 LUKS](https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system)
-on Linux,
-[BitLocker](https://fossbytes.com/enable-full-disk-encryption-windows-10/) on
-Windows, or [FileVault](https://support.apple.com/en-us/HT204837) on macOS.
-This encrypts the entire disk with a symmetric cipher, with a key protected by
-a passphrase.
+di Linux,
+[BitLocker](https://fossbytes.com/enable-full-disk-encryption-windows-10/) di
+Windows, atau [FileVault](https://support.apple.com/en-us/HT204837) di macOS. Ini
+mengenkripsi seluruh disk dengan cipher simetris, dengan kunci yang dilindungi
+oleh frasa sandi.
 
-## Private messaging
+## Pesan pribadi
 
-Use [Signal](https://signal.org/) or [Keybase](https://keybase.io/). End-to-end
-security is bootstrapped from asymmetric-key encryption. Obtaining your
-contacts' public keys is the critical step here. If you want good security, you
-need to authenticate public keys out-of-band (with Signal or Keybase), or trust
-social proofs (with Keybase).
+Gunakan [Signal](https://signal.org/) atau [Keybase](https://keybase.io/).
+Keamanan end-to-end di-bootstrap dari enkripsi kunci asimetris. Mendapatkan kunci
+publik kontak Anda adalah langkah kritis di sini. Jika Anda ingin keamanan yang
+baik, Anda perlu mengautentikasi kunci publik di luar saluran (dengan Signal atau
+Keybase), atau mempercayai social proofs (dengan Keybase).
 
 ## SSH
 
-We've covered the use of SSH and SSH keys in an [earlier
-lecture](/2020/command-line/#remote-machines). Let's look at the cryptography
-aspects of this.
+Kita telah membahas penggunaan SSH dan kunci SSH di [ceramah
+sebelumnya](/2020/command-line/#remote-machines). Mari kita lihat aspek
+kriptografi dari hal ini.
 
-When you run `ssh-keygen`, it generates an asymmetric key pair, `public_key,
-private_key`. This is generated randomly, using entropy provided by the
-operating system (collected from hardware events, etc.). The public key is
-stored as-is (it's public, so keeping it a secret is not important), but at
-rest, the private key should be encrypted on disk. The `ssh-keygen` program
-prompts the user for a passphrase, and this is fed through a key derivation
-function to produce a key, which is then used to encrypt the private key with a
-symmetric cipher.
+Ketika Anda menjalankan `ssh-keygen`, ini menghasilkan pasangan kunci asimetris,
+`public_key, private_key`. Ini dihasilkan secara acak, menggunakan entropi yang
+disediakan oleh sistem operasi (dikumpulkan dari event perangkat keras, dll.).
+Kunci publik disimpan apa adanya (ini publik, jadi menjaganya tetap rahasia bukan
+hal yang penting), tetapi saat diam, kunci pribadi harus dienkripsi di disk.
+Program `ssh-keygen` meminta pengguna untuk memasukkan frasa sandi, dan ini
+dimasukkan melalui fungsi turunan kunci untuk menghasilkan kunci, yang kemudian
+digunakan untuk mengenkripsi kunci pribadi dengan cipher simetris.
 
-In use, once the server knows the client's public key (stored in the
-`.ssh/authorized_keys` file), a connecting client can prove its identity using
-asymmetric signatures. This is done through
+Dalam penggunaan, setelah server mengetahui kunci publik klien (disimpan di file
+`.ssh/authorized_keys`), klien yang terhubung dapat membuktikan identitasnya
+menggunakan tanda tangan asimetris. Ini dilakukan melalui
 [challenge-response](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication).
-At a high level, the server picks a random number and sends it to the client.
-The client then signs this message and sends the signature back to the server,
-which checks the signature against the public key on record. This effectively
-proves that the client is in possession of the private key corresponding to the
-public key that's in the server's `.ssh/authorized_keys` file, so the server
-can allow the client to log in.
+Pada tingkat tinggi, server memilih angka acak dan mengirimkannya ke klien. Klien
+kemudian menandatangani pesan ini dan mengirim tanda tangan kembali ke server, yang
+memeriksa tanda tangan terhadap kunci publik yang tercatat. Ini secara efektif
+membuktikan bahwa klien memiliki kunci pribadi yang sesuai dengan kunci publik yang
+ada di file `.ssh/authorized_keys` server, sehingga server dapat mengizinkan klien
+untuk login.
 
 {% comment %}
 extra topics, if there's time
@@ -309,48 +320,52 @@ security concepts, tips
 - HTTPS
 {% endcomment %}
 
-# Resources
+# Sumber daya
 
-- [Last year's notes](/2019/security/): from when this lecture was more focused on security and privacy as a computer user
-- [Cryptographic Right Answers](https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html): answers "what crypto should I use for X?" for many common X.
+- [Catatan tahun lalu](/2019/security/): dari ketika ceramah ini lebih berfokus
+  pada keamanan dan privasi sebagai pengguna komputer
+- [Cryptographic Right
+  Answers](https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html):
+  menjawab "kriptografi apa yang harus saya gunakan untuk X?" untuk banyak X yang
+  umum.
 
-# Exercises
+# Latihan
 
-1. **Entropy.**
-    1. Suppose a password is chosen as a concatenation of four lower-case
-       dictionary words, where each word is selected uniformly at random from a
-       dictionary of size 100,000. An example of such a password is
-       `correcthorsebatterystaple`. How many bits of entropy does this have?
-    1. Consider an alternative scheme where a password is chosen as a sequence
-       of 8 random alphanumeric characters (including both lower-case and
-       upper-case letters). An example is `rg8Ql34g`. How many bits of entropy
-       does this have?
-    1. Which is the stronger password?
-    1. Suppose an attacker can try guessing 10,000 passwords per second. On
-       average, how long will it take to break each of the passwords?
-1. **Cryptographic hash functions.** Download a Debian image from a
-   [mirror](https://www.debian.org/CD/http-ftp/) (e.g. [from this Argentinean
-   mirror](http://debian.xfree.com.ar/debian-cd/current/amd64/iso-cd/)).
-   Cross-check the hash (e.g. using the `sha256sum` command) with the hash
-   retrieved from the official Debian site (e.g. [this
-   file](https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS)
-   hosted at `debian.org`, if you've downloaded the linked file from the
-   Argentinean mirror).
-1. **Symmetric cryptography.** Encrypt a file with AES encryption, using
+1. **Entropi.**
+    1. Misalkan sebuah kata sandi dipilih sebagai gabungan dari empat kata kamus
+       huruf kecil, di mana setiap kata dipilih secara seragam dan acak dari kamus
+       berukuran 100.000. Contoh kata sandi seperti ini adalah
+       `correcthorsebatterystaple`. Berapa banyak bit entropi yang dimilikinya?
+    1. Pertimbangkan skema alternatif di mana kata sandi dipilih sebagai urutan 8
+       karakter alfanumerik acak (termasuk huruf kecil dan huruf besar). Contoh:
+       `rg8Ql34g`. Berapa banyak bit entropi yang dimilikinya?
+    1. Mana yang merupakan kata sandi yang lebih kuat?
+    1. Misalkan seorang penyerang dapat mencoba menebak 10.000 kata sandi per
+       detik. Secara rata-rata, berapa lama waktu yang dibutuhkan untuk memecahkan
+       masing-masing kata sandi?
+1. **Fungsi hash kriptografi.** Unduh image Debian dari
+   [mirror](https://www.debian.org/CD/http-ftp/) (misalnya [dari mirror Argentina
+   ini](http://debian.xfree.com.ar/debian-cd/current/amd64/iso-cd/)).
+   Periksa silang hash (misalnya menggunakan perintah `sha256sum`) dengan hash
+   yang diambil dari situs Debian resmi (misalnya [file
+   ini](https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS)
+   yang di-host di `debian.org`, jika Anda telah mengunduh file yang ditautkan
+   dari mirror Argentina).
+1. **Kriptografi simetris.** Enkripsi sebuah file dengan enkripsi AES, menggunakan
    [OpenSSL](https://www.openssl.org/): `openssl aes-256-cbc -salt -in {input
-   filename} -out {output filename}`. Look at the contents using `cat` or
-   `hexdump`. Decrypt it with `openssl aes-256-cbc -d -in {input filename} -out
-   {output filename}` and confirm that the contents match the original using
+   filename} -out {output filename}`. Lihat isinya menggunakan `cat` atau
+   `hexdump`. Dekripsi dengan `openssl aes-256-cbc -d -in {input filename} -out
+   {output filename}` dan konfirmasi bahwa isinya cocok dengan aslinya menggunakan
    `cmp`.
-1. **Asymmetric cryptography.**
-    1. Set up [SSH
-       keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2)
-       on a computer you have access to (not Athena, because Kerberos interacts
-       weirdly with SSH keys). Make sure
-       your private key is encrypted with a passphrase, so it is protected at
-       rest.
-    1. [Set up GPG](https://www.digitalocean.com/community/tutorials/how-to-use-gpg-to-encrypt-and-sign-messages)
-    1. Send Anish an encrypted email ([public key](https://keybase.io/anish)).
-    1. Sign a Git commit with `git commit -S` or create a signed Git tag with
-       `git tag -s`. Verify the signature on the commit with `git show
-       --show-signature` or on the tag with `git tag -v`.
+1. **Kriptografi asimetris.**
+    1. Siapkan [kunci
+       SSH](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2)
+       di komputer yang Anda miliki aksesnya (bukan Athena, karena Kerberos
+       berinteraksi secara aneh dengan kunci SSH). Pastikan kunci pribadi Anda
+       dienkripsi dengan frasa sandi, sehingga terlindungi saat diam.
+    1. [Siapkan GPG](https://www.digitalocean.com/community/tutorials/how-to-use-gpg-to-encrypt-and-sign-messages)
+    1. Kirim email terenkripsi ke Anish ([kunci
+       publik](https://keybase.io/anish)).
+    1. Tandatangani commit Git dengan `git commit -S` atau buat tag Git yang
+       ditandatangani dengan `git tag -s`. Verifikasi tanda tangan pada commit
+       dengan `git show --show-signature` atau pada tag dengan `git tag -v`.

--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Shell Tools and Scripting"
+title: "Tools Shell dan Scripting"
 description: >
   Pelajari cara menulis shell script dan menggunakan tools command-line yang powerful.
 thumbnail: /static/assets/thumbnails/2020/lec2.png
@@ -11,25 +11,25 @@ video:
   id: kgII-YWo3Zw
 ---
 
-In this lecture, we will present some of the basics of using bash as a scripting language along with a number of shell tools that cover several of the most common tasks that you will be constantly performing in the command line.
+Pada kuliah ini, kita akan membahas beberapa dasar penggunaan bash sebagai bahasa scripting beserta sejumlah tools shell yang mencakup beberapa tugas paling umum yang akan terus Anda lakukan di command line.
 
-# Shell Scripting
+# Scripting Shell
 
-So far we have seen how to execute commands in the shell and pipe them together.
-However, in many scenarios you will want to perform a series of commands and make use of control flow expressions like conditionals or loops.
+Sejauh ini kita telah melihat cara menjalankan perintah di shell dan menggabungkannya dengan pipe.
+Namun, dalam banyak skenario Anda ingin melakukan serangkaian perintah dan menggunakan ekspresi control flow seperti kondisional atau perulangan.
 
-Shell scripts are the next step in complexity.
-Most shells have their own scripting language with variables, control flow and its own syntax.
-What makes shell scripting different from other scripting programming languages is that it is optimized for performing shell-related tasks.
-Thus, creating command pipelines, saving results into files, and reading from standard input are primitives in shell scripting, which makes it easier to use than general purpose scripting languages.
-For this section we will focus on bash scripting since it is the most common.
+Shell script adalah langkah berikutnya dalam hal kompleksitas.
+Kebanyakan shell memiliki bahasa scripting sendiri dengan variabel, control flow, dan sintaksisnya sendiri.
+Yang membedakan shell scripting dari bahasa scripting lainnya adalah ia dioptimalkan untuk melakukan tugas-tugas terkait shell.
+Dengan demikian, membuat pipeline perintah, menyimpan hasil ke file, dan membaca dari standard input adalah primitif dalam shell scripting, sehingga lebih mudah digunakan daripada bahasa scripting serbaguna.
+Untuk bagian ini kita akan fokus pada bash scripting karena merupakan yang paling umum.
 
-To assign variables in bash, use the syntax `foo=bar` and access the value of the variable with `$foo`.
-Note that `foo = bar` will not work since it is interpreted as calling the `foo` program with arguments `=` and `bar`.
-In general, in shell scripts the space character will perform argument splitting. This behavior can be confusing to use at first, so always check for that.
+Untuk menetapkan variabel di bash, gunakan sintaks `foo=bar` dan akses nilai variabel dengan `$foo`.
+Perhatikan bahwa `foo = bar` tidak akan berhasil karena diinterpretasikan sebagai pemanggilan program `foo` dengan argumen `=` dan `bar`.
+Secara umum, di shell script karakter spasi akan melakukan pemisahan argumen. Perilaku ini bisa membingungkan pada awalnya, jadi selalu periksa hal tersebut.
 
-Strings in bash can be defined with `'` and `"` delimiters, but they are not equivalent.
-Strings delimited with `'` are literal strings and will not substitute variable values whereas `"` delimited strings will.
+String di bash dapat didefinisikan dengan delimiter `'` dan `"`, tetapi keduanya tidak ekuivalen.
+String yang dibatasi dengan `'` adalah string literal dan tidak akan mensubstitusi nilai variabel, sedangkan string yang dibatasi dengan `"` akan melakukannya.
 
 ```bash
 foo=bar
@@ -39,8 +39,8 @@ echo '$foo'
 # prints $foo
 ```
 
-As with most programming languages, bash supports control flow techniques including `if`, `case`, `while` and `for`.
-Similarly, `bash` has functions that take arguments and can operate with them. Here is an example of a function that creates a directory and `cd`s into it.
+Seperti kebanyakan bahasa pemrograman, bash mendukung teknik-teknik control flow termasuk `if`, `case`, `while`, dan `for`.
+Demikian pula, `bash` memiliki fungsi yang menerima argumen dan dapat beroperasi dengan argumen tersebut. Berikut adalah contoh fungsi yang membuat direktori dan melakukan `cd` ke dalamnya.
 
 
 ```bash
@@ -50,24 +50,24 @@ mcd () {
 }
 ```
 
-Here `$1` is the first argument to the script/function.
-Unlike other scripting languages, bash uses a variety of special variables to refer to arguments, error codes, and other relevant variables. Below is a list of some of them. A more comprehensive list can be found [here](https://tldp.org/LDP/abs/html/special-chars.html).
-- `$0` - Name of the script
-- `$1` to `$9` - Arguments to the script. `$1` is the first argument and so on.
-- `$@` - All the arguments
-- `$#` - Number of arguments
-- `$?` - Return code of the previous command
-- `$$` - Process identification number (PID) for the current script
-- `!!` - Entire last command, including arguments. A common pattern is to execute a command only for it to fail due to missing permissions; you can quickly re-execute the command with sudo by doing `sudo !!`
-- `$_` - Last argument from the last command. If you are in an interactive shell, you can also quickly get this value by typing `Esc` followed by `.` or `Alt+.`
+Di sini `$1` adalah argumen pertama untuk script/fungsi.
+Berbeda dengan bahasa scripting lainnya, bash menggunakan berbagai variabel khusus untuk merujuk pada argumen, kode error, dan variabel relevan lainnya. Berikut adalah daftar beberapa di antaranya. Daftar yang lebih lengkap dapat ditemukan [di sini](https://tldp.org/LDP/abs/html/special-chars.html).
+- `$0` - Nama script
+- `$1` hingga `$9` - Argumen untuk script. `$1` adalah argumen pertama dan seterusnya.
+- `$@` - Semua argumen
+- `$#` - Jumlah argumen
+- `$?` - Return code dari perintah sebelumnya
+- `$$` - Nomor identifikasi proses (PID) untuk script saat ini
+- `!!` - Seluruh perintah terakhir, termasuk argumen. Pola yang umum adalah menjalankan perintah yang kemudian gagal karena izin yang kurang; Anda dapat dengan cepat menjalankan ulang perintah tersebut dengan sudo menggunakan `sudo !!`
+- `$_` - Argumen terakhir dari perintah terakhir. Jika Anda berada di shell interaktif, Anda juga dapat dengan cepat mendapatkan nilai ini dengan mengetik `Esc` diikuti oleh `.` atau `Alt+.`
 
-Commands will often return output using `STDOUT`, errors through `STDERR`, and a Return Code to report errors in a more script-friendly manner.
-The return code or exit status is the way scripts/commands have to communicate how execution went.
-A value of 0 usually means everything went OK; anything different from 0 means an error occurred.
+Perintah sering kali mengembalikan output menggunakan `STDOUT`, error melalui `STDERR`, dan Return Code untuk melaporkan error dengan cara yang lebih ramah terhadap script.
+Return code atau exit status adalah cara script/perintah melaporkan bagaimana eksekusi berjalan.
+Nilai 0 biasanya berarti semuanya berjalan dengan baik; nilai selain 0 berarti terjadi error.
 
-Exit codes can be used to conditionally execute commands using `&&` (and operator) and `||` (or operator), both of which are [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators. Commands can also be separated within the same line using a semicolon `;`.
-The `true` program will always have a 0 return code and the `false` command will always have a 1 return code.
-Let's see some examples
+Exit code dapat digunakan untuk mengeksekusi perintah secara kondisional menggunakan `&&` (operator and) dan `||` (operator or), yang keduanya merupakan operator [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation). Perintah juga dapat dipisahkan dalam satu baris menggunakan titik koma `;`.
+Program `true` akan selalu memiliki return code 0 dan perintah `false` akan selalu memiliki return code 1.
+Mari kita lihat beberapa contoh.
 
 ```bash
 false || echo "Oops, fail"
@@ -89,13 +89,13 @@ false ; echo "This will always run"
 # This will always run
 ```
 
-Another common pattern is wanting to get the output of a command as a variable. This can be done with _command substitution_.
-Whenever you place `$( CMD )` it will execute `CMD`, get the output of the command and substitute it in place.
-For example, if you do `for file in $(ls)`, the shell will first call `ls` and then iterate over those values.
-A lesser known similar feature is _process substitution_, `<( CMD )` will execute `CMD` and place the output in a temporary file and substitute the `<()` with that file's name. This is useful when commands expect values to be passed by file instead of by STDIN. For example, `diff <(ls foo) <(ls bar)` will show differences between files in dirs  `foo` and `bar`.
+Pola umum lainnya adalah ingin mendapatkan output dari sebuah perintah sebagai variabel. Hal ini dapat dilakukan dengan _command substitution_.
+Kapan pun Anda menempatkan `$( CMD )`, ia akan mengeksekusi `CMD`, mendapatkan output perintah tersebut, dan mensubstitusikannya di tempat.
+Sebagai contoh, jika Anda melakukan `for file in $(ls)`, shell pertama-tama akan memanggil `ls` dan kemudian mengiterasi nilai-nilai tersebut.
+Fitur serupa yang kurang dikenal adalah _process substitution_, `<( CMD )` akan mengeksekusi `CMD` dan menempatkan outputnya di file sementara serta mensubstitusi `<()` dengan nama file tersebut. Ini berguna ketika perintah mengharapkan nilai dikirim melalui file, bukan melalui STDIN. Sebagai contoh, `diff <(ls foo) <(ls bar)` akan menunjukkan perbedaan antara file-file di direktori `foo` dan `bar`.
 
 
-Since that was a huge information dump, let's see an example that showcases some of these features. It will iterate through the arguments we provide, `grep` for the string `foobar`, and append it to the file as a comment if it's not found.
+Karena tadi sudah banyak sekali informasi yang disampaikan, mari kita lihat sebuah contoh yang memperlihatkan beberapa fitur tersebut. Contoh ini akan mengiterasi argumen yang kita berikan, melakukan `grep` untuk string `foobar`, dan menambahkannya ke file sebagai komentar jika tidak ditemukan.
 
 ```bash
 #!/bin/bash
@@ -115,13 +115,13 @@ for file in "$@"; do
 done
 ```
 
-In the comparison we tested whether `$?` was not equal to 0.
-Bash implements many comparisons of this sort - you can find a detailed list in the manpage for [`test`](https://www.man7.org/linux/man-pages/man1/test.1.html).
-When performing comparisons in bash, try to use double brackets `[[ ]]` in favor of simple brackets `[ ]`. Chances of making mistakes are lower although it won't be portable to `sh`. A more detailed explanation can be found [here](https://mywiki.wooledge.org/BashFAQ/031).
+Dalam perbandingan tersebut kita menguji apakah `$?` tidak sama dengan 0.
+Bash mengimplementasikan banyak perbandingan semacam ini - Anda dapat menemukan daftar lengkapnya di manpage untuk [`test`](https://www.man7.org/linux/man-pages/man1/test.1.html).
+Saat melakukan perbandingan di bash, usahakan menggunakan kurung siku ganda `[[ ]]` daripada kurung siku tunggal `[ ]`. Kemungkinan kesalahan lebih kecil meskipun tidak akan portabel ke `sh`. Penjelasan lebih lengkap dapat ditemukan [di sini](https://mywiki.wooledge.org/BashFAQ/031).
 
-When launching scripts, you will often want to provide arguments that are similar. Bash has ways of making this easier, expanding expressions by carrying out filename expansion. These techniques are often referred to as shell _globbing_.
-- Wildcards - Whenever you want to perform some sort of wildcard matching, you can use `?` and `*` to match one or any amount of characters respectively. For instance, given files `foo`, `foo1`, `foo2`, `foo10` and `bar`, the command `rm foo?` will delete `foo1` and `foo2` whereas `rm foo*` will delete all but `bar`.
-- Curly braces `{}` - Whenever you have a common substring in a series of commands, you can use curly braces for bash to expand this automatically. This comes in very handy when moving or converting files.
+Saat menjalankan script, Anda sering kali ingin memberikan argumen yang serupa. Bash memiliki cara untuk mempermudah hal ini, yaitu dengan memperluas ekspresi melalui filename expansion. Teknik-teknik ini sering disebut sebagai shell _globbing_.
+- Wildcard - Kapan pun Anda ingin melakukan pencocokan wildcard, Anda dapat menggunakan `?` dan `*` untuk mencocokkan satu karakter atau sejumlah karakter. Sebagai contoh, dengan file `foo`, `foo1`, `foo2`, `foo10`, dan `bar`, perintah `rm foo?` akan menghapus `foo1` dan `foo2` sedangkan `rm foo*` akan menghapus semuanya kecuali `bar`.
+- Kurung kurawal `{}` - Kapan pun Anda memiliki substring yang sama dalam serangkaian perintah, Anda dapat menggunakan kurung kurawal agar bash mengembangkannya secara otomatis. Ini sangat berguna saat memindahkan atau mengonversi file.
 
 ```bash
 convert image.{png,jpg}
@@ -151,9 +151,9 @@ diff <(ls foo) <(ls bar)
 
 <!-- Lastly, pipes `|` are a core feature of scripting. Pipes connect one program's output to the next program's input. We will cover them more in detail in the data wrangling lecture. -->
 
-Writing `bash` scripts can be tricky and unintuitive. There are tools like [shellcheck](https://github.com/koalaman/shellcheck) that will help you find errors in your sh/bash scripts.
+Menulis script `bash` bisa jadi rumit dan tidak intuitif. Ada tools seperti [shellcheck](https://github.com/koalaman/shellcheck) yang dapat membantu Anda menemukan error di script sh/bash Anda.
 
-Note that scripts need not necessarily be written in bash to be called from the terminal. For instance, here's a simple Python script that outputs its arguments in reversed order:
+Perhatikan bahwa script tidak harus selalu ditulis dalam bash untuk dapat dipanggil dari terminal. Sebagai contoh, berikut adalah script Python sederhana yang mengeluarkan argumennya dalam urutan terbalik:
 
 ```python
 #!/usr/local/bin/python
@@ -162,40 +162,40 @@ for arg in reversed(sys.argv[1:]):
     print(arg)
 ```
 
-The kernel knows to execute this script with a python interpreter instead of a shell command because we included a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line at the top of the script.
-It is good practice to write shebang lines using the [`env`](https://www.man7.org/linux/man-pages/man1/env.1.html) command that will resolve to wherever the command lives in the system, increasing the portability of your scripts. To resolve the location, `env` will make use of the `PATH` environment variable we introduced in the first lecture.
-For this example the shebang line would look like `#!/usr/bin/env python`.
+Kernel tahu bahwa script ini harus dieksekusi dengan interpreter Python, bukan perintah shell, karena kita menyertakan baris [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) di bagian atas script.
+Merupakan praktik yang baik untuk menulis baris shebang menggunakan perintah [`env`](https://www.man7.org/linux/man-pages/man1/env.1.html) yang akan meresolve ke lokasi perintah tersebut di sistem, sehingga meningkatkan portabilitas script Anda. Untuk meresolve lokasi, `env` akan menggunakan variabel lingkungan `PATH` yang telah kita bahas di kuliah pertama.
+Untuk contoh ini, baris shebang-nya akan terlihat seperti `#!/usr/bin/env python`.
 
-Some differences between shell functions and scripts that you should keep in mind are:
-- Functions have to be in the same language as the shell, while scripts can be written in any language. This is why including a shebang for scripts is important.
-- Functions are loaded once when their definition is read. Scripts are loaded every time they are executed. This makes functions slightly faster to load, but whenever you change them you will have to reload their definition.
-- Functions are executed in the current shell environment whereas scripts execute in their own process. Thus, functions can modify environment variables, e.g. change your current directory, whereas scripts can't. Environment variables which have been exported using [`export`](https://www.man7.org/linux/man-pages/man1/export.1p.html) are passed by value to scripts.
-- As with any programming language, functions are a powerful construct to achieve modularity, code reuse, and clarity of shell code. Often shell scripts will include their own function definitions.
+Beberapa perbedaan antara fungsi shell dan script yang perlu Anda ingat adalah:
+- Fungsi harus ditulis dalam bahasa yang sama dengan shell, sedangkan script dapat ditulis dalam bahasa apa pun. Itulah mengapa menyertakan shebang untuk script itu penting.
+- Fungsi dimuat sekali saat definisinya dibaca. Script dimuat setiap kali dieksekusi. Ini membuat fungsi sedikit lebih cepat untuk dimuat, tetapi setiap kali Anda mengubahnya, Anda harus memuat ulang definisinya.
+- Fungsi dijalankan di environment shell saat ini, sedangkan script dijalankan di prosesnya sendiri. Oleh karena itu, fungsi dapat memodifikasi variabel lingkungan, misalnya mengubah direktori kerja Anda saat ini, sedangkan script tidak bisa. Variabel lingkungan yang telah diekspor menggunakan [`export`](https://www.man7.org/linux/man-pages/man1/export.1p.html) diteruskan secara nilai ke script.
+- Seperti bahasa pemrograman lainnya, fungsi adalah konstruksi yang powerful untuk mencapai modularitas, penggunaan ulang kode, dan kejelasan kode shell. Script shell sering kali akan menyertakan definisi fungsi mereka sendiri.
 
 # Shell Tools
 
-## Finding how to use commands
+## Mencari cara menggunakan perintah
 
-At this point, you might be wondering how to find the flags for the commands in the aliasing section such as `ls -l`, `mv -i` and `mkdir -p`.
-More generally, given a command, how do you go about finding out what it does and its different options?
-You could always start googling, but since UNIX predates StackOverflow, there are built-in ways of getting this information.
+Pada titik ini, Anda mungkin bertanya-tanya bagaimana cara mencari flag untuk perintah-perintah di bagian aliasing seperti `ls -l`, `mv -i`, dan `mkdir -p`.
+Secara lebih umum, diberikan sebuah perintah, bagaimana cara Anda mengetahui apa yang dilakukannya dan opsi-opsi yang tersedia?
+Anda selalu bisa mulai mencari di Google, tetapi karena UNIX lebih tua dari StackOverflow, ada cara bawaan untuk mendapatkan informasi ini.
 
-As we saw in the shell lecture, the first-order approach is to call said command with the `-h` or `--help` flags. A more detailed approach is to use the `man` command.
-Short for manual, [`man`](https://www.man7.org/linux/man-pages/man1/man.1.html) provides a manual page (called manpage) for a command you specify.
-For example, `man rm` will output the behavior of the `rm` command along with the flags that it takes, including the `-i` flag we showed earlier.
-In fact, what I have been linking so far for every command is the online version of the Linux manpages for the commands.
-Even non-native commands that you install will have manpage entries if the developer wrote them and included them as part of the installation process.
-For interactive tools such as the ones based on ncurses, help for the commands can often be accessed within the program using the `:help` command or typing `?`.
+Seperti yang kita lihat di kuliah shell, pendekatan pertama adalah memanggil perintah tersebut dengan flag `-h` atau `--help`. Pendekatan yang lebih detail adalah menggunakan perintah `man`.
+Singkatan dari manual, [`man`](https://www.man7.org/linux/man-pages/man1/man.1.html) menyediakan halaman manual (disebut manpage) untuk perintah yang Anda tentukan.
+Sebagai contoh, `man rm` akan menampilkan perilaku perintah `rm` beserta flag-flag yang diterimanya, termasuk flag `-i` yang kita tunjukkan sebelumnya.
+Sebenarnya, yang telah saya tautkan sejauh ini untuk setiap perintah adalah versi online dari manpage Linux untuk perintah-perintah tersebut.
+Bahkan perintah non-bawaan yang Anda instal akan memiliki entri manpage jika developernya menulisnya dan menyertakannya sebagai bagian dari proses instalasi.
+Untuk tool interaktif seperti yang berbasis ncurses, bantuan untuk perintah sering kali dapat diakses di dalam program menggunakan perintah `:help` atau mengetik `?`.
 
-Sometimes manpages can provide overly detailed descriptions of the commands, making it hard to decipher what flags/syntax to use for common use cases.
-[TLDR pages](https://tldr.sh/) are a nifty complementary solution that focuses on giving example use cases of a command so you can quickly figure out which options to use.
-For instance, I find myself referring back to the tldr pages for [`tar`](https://tldr.inbrowser.app/pages/common/tar) and [`ffmpeg`](https://tldr.inbrowser.app/pages/common/ffmpeg) way more often than the manpages.
+Terkadang manpage dapat memberikan deskripsi yang terlalu detail tentang perintah, sehingga sulit untuk menentukan flag/sintaks yang digunakan untuk kasus umum.
+[Halaman TLDR](https://tldr.sh/) adalah solusi pelengkap yang berguna yang berfokus pada memberikan contoh penggunaan perintah sehingga Anda dapat dengan cepat mengetahui opsi mana yang harus digunakan.
+Sebagai contoh, saya sering merujuk ke halaman tldr untuk [`tar`](https://tldr.inbrowser.app/pages/common/tar) dan [`ffmpeg`](https://tldr.inbrowser.app/pages/common/ffmpeg) jauh lebih sering daripada manpage-nya.
 
 
-## Finding files
+## Mencari file
 
-One of the most common repetitive tasks that every programmer faces is finding files or directories.
-All UNIX-like systems come packaged with [`find`](https://www.man7.org/linux/man-pages/man1/find.1.html), a great shell tool to find files. `find` will recursively search for files matching some criteria. Some examples:
+Salah satu tugas repetitif paling umum yang dihadapi setiap programmer adalah mencari file atau direktori.
+Semua sistem berbasis UNIX dilengkapi dengan [`find`](https://www.man7.org/linux/man-pages/man1/find.1.html), tool shell yang hebat untuk mencari file. `find` akan mencari file secara rekursif berdasarkan kriteria tertentu. Beberapa contoh:
 
 ```bash
 # Find all directories named src
@@ -207,8 +207,8 @@ find . -mtime -1
 # Find all zip files with size in range 500k to 10M
 find . -size +500k -size -10M -name '*.tar.gz'
 ```
-Beyond listing files, find can also perform actions over files that match your query.
-This property can be incredibly helpful to simplify what could be fairly monotonous tasks.
+Selain mendaftar file, find juga dapat melakukan aksi terhadap file yang cocok dengan pencarian Anda.
+Sifat ini bisa sangat membantu untuk menyederhanakan tugas yang bisa jadi cukup monoton.
 ```bash
 # Delete all files with .tmp extension
 find . -name '*.tmp' -exec rm {} \;
@@ -217,37 +217,37 @@ find . -name '*.tmp' -exec rm {} \;
 find . -name '*.png' -exec magick {} {}.jpg \;
 ```
 
-Despite `find`'s ubiquitousness, its syntax can sometimes be tricky to remember.
-For instance, to simply find files that match some pattern `PATTERN` you have to execute `find -name '*PATTERN*'` (or `-iname` if you want the pattern matching to be case insensitive).
-You could start building aliases for those scenarios, but part of the shell philosophy is that it is good to explore alternatives.
-Remember, one of the best properties of the shell is that you are just calling programs, so you can find (or even write yourself) replacements for some.
-For instance, [`fd`](https://github.com/sharkdp/fd) is a simple, fast, and user-friendly alternative to `find`.
-It offers some nice defaults like colorized output, default regex matching, and Unicode support. It also has, in my opinion, a more intuitive syntax.
-For example, the syntax to find a pattern `PATTERN` is `fd PATTERN`.
+Meskipun `find` sangat umum digunakan, sintaksnya terkadang sulit diingat.
+Sebagai contoh, untuk mencari file yang cocok dengan pola `PATTERN`, Anda harus menjalankan `find -name '*PATTERN*'` (atau `-iname` jika Anda ingin pencocokan pola yang tidak case-sensitive).
+Anda bisa mulai membuat alias untuk skenario-skenario tersebut, tetapi bagian dari filosofi shell adalah baik untuk menjelajahi alternatif.
+Ingat, salah satu keunggulan terbaik dari shell adalah Anda hanya memanggil program, sehingga Anda dapat mencari (atau bahkan menulis sendiri) pengganti untuk beberapa di antaranya.
+Sebagai contoh, [`fd`](https://github.com/sharkdp/fd) adalah alternatif `find` yang sederhana, cepat, dan mudah digunakan.
+Ia menawarkan beberapa fitur default yang bagus seperti output berwarna, pencocokan regex default, dan dukungan Unicode. Selain itu, menurut saya, sintaksnya lebih intuitif.
+Sebagai contoh, sintaks untuk mencari pola `PATTERN` adalah `fd PATTERN`.
 
-Most would agree that `find` and `fd` are good, but some of you might be wondering about the efficiency of looking for files every time versus compiling some sort of index or database for quickly searching.
-That is what [`locate`](https://www.man7.org/linux/man-pages/man1/locate.1.html) is for.
-`locate` uses a database that is updated using [`updatedb`](https://www.man7.org/linux/man-pages/man1/updatedb.1.html).
-In most systems, `updatedb` is updated daily via [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html).
-Therefore one trade-off between the two is speed vs freshness.
-Moreover `find` and similar tools can also find files using attributes such as file size, modification time, or file permissions, while `locate` just uses the file name.
-A more in-depth comparison can be found [here](https://unix.stackexchange.com/questions/60205/locate-vs-find-usage-pros-and-cons-of-each-other).
+Kebanyakan orang akan setuju bahwa `find` dan `fd` sudah bagus, tetapi beberapa dari Anda mungkin bertanya-tanya tentang efisiensi mencari file setiap saat dibandingkan dengan mengompilasi semacam indeks atau database untuk pencarian cepat.
+Itulah fungsi dari [`locate`](https://www.man7.org/linux/man-pages/man1/locate.1.html).
+`locate` menggunakan database yang diperbarui menggunakan [`updatedb`](https://www.man7.org/linux/man-pages/man1/updatedb.1.html).
+Di sebagian besar sistem, `updatedb` diperbarui setiap hari melalui [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html).
+Oleh karena itu, trade-off antara keduanya adalah kecepatan vs kesegaran data.
+Selain itu, `find` dan tool sejenis juga dapat mencari file menggunakan atribut seperti ukuran file, waktu modifikasi, atau izin file, sedangkan `locate` hanya menggunakan nama file.
+Perbandingan yang lebih mendalam dapat ditemukan [di sini](https://unix.stackexchange.com/questions/60205/locate-vs-find-usage-pros-and-cons-of-each-other).
 
-## Finding code
+## Mencari kode
 
-Finding files by name is useful, but quite often you want to search based on file *content*.
-A common scenario is wanting to search for all files that contain some pattern, along with where in those files said pattern occurs.
-To achieve this, most UNIX-like systems provide [`grep`](https://www.man7.org/linux/man-pages/man1/grep.1.html), a generic tool for matching patterns from the input text.
-`grep` is an incredibly valuable shell tool that we will cover in greater detail during the data wrangling lecture.
+Mencari file berdasarkan nama memang berguna, tetapi cukup sering Anda ingin mencari berdasarkan *konten* file.
+Skenario umum adalah ingin mencari semua file yang mengandung pola tertentu, beserta lokasi pola tersebut dalam file-file itu.
+Untuk mencapai hal ini, sebagian besar sistem berbasis UNIX menyediakan [`grep`](https://www.man7.org/linux/man-pages/man1/grep.1.html), tool umum untuk mencocokkan pola dari teks input.
+`grep` adalah tool shell yang sangat berharga yang akan kita bahas lebih detail pada kuliah data wrangling.
 
-For now, know that `grep` has many flags that make it a very versatile tool.
-Some I frequently use are `-C` for getting **C**ontext around the matching line and `-v` for in**v**erting the match, i.e. print all lines that do **not** match the pattern. For example, `grep -C 5` will print 5 lines before and after the match.
-When it comes to quickly searching through many files, you want to use `-R` since it will **R**ecursively go into directories and look for files for the matching string.
+Untuk saat ini, ketahuilah bahwa `grep` memiliki banyak flag yang membuatnya sangat serbaguna.
+Beberapa yang sering saya gunakan adalah `-C` untuk mendapatkan **C**ontext di sekitar baris yang cocok dan `-v` untuk in**v**ersi pencocokan, yaitu mencetak semua baris yang **tidak** cocok dengan pola. Sebagai contoh, `grep -C 5` akan mencetak 5 baris sebelum dan sesudah pencocokan.
+Untuk pencarian cepat di banyak file, Anda ingin menggunakan `-R` karena akan secara **R**ekursif masuk ke direktori dan mencari file untuk string yang cocok.
 
-But `grep -R` can be improved in many ways, such as ignoring `.git` folders, using multi CPU support, &c.
-Many `grep` alternatives have been developed, including [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher) and [rg](https://github.com/BurntSushi/ripgrep).
-All of them are fantastic and pretty much provide the same functionality.
-For now I am sticking with ripgrep (`rg`), given how fast and intuitive it is. Some examples:
+Tetapi `grep -R` dapat ditingkatkan dalam banyak hal, seperti mengabaikan folder `.git`, menggunakan dukungan multi-CPU, dan lain-lain.
+Banyak alternatif `grep` telah dikembangkan, termasuk [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher), dan [rg](https://github.com/BurntSushi/ripgrep).
+Semuanya fantastis dan kurang lebih menyediakan fungsionalitas yang sama.
+Untuk saat ini saya tetap menggunakan ripgrep (`rg`), mengingat kecepatannya dan intuitifnya. Beberapa contoh:
 ```bash
 # Find all python files where I used the requests library
 rg -t py 'import requests'
@@ -259,56 +259,56 @@ rg foo -A 5
 rg --stats PATTERN
 ```
 
-Note that as with `find`/`fd`, it is important that you know that these problems can be quickly solved using one of these tools, while the specific tools you use are not as important.
+Perhatikan bahwa seperti `find`/`fd`, penting bagi Anda untuk mengetahui bahwa masalah ini dapat diselesaikan dengan cepat menggunakan salah satu tool ini, sedangkan tool spesifik yang Anda gunakan tidak terlalu penting.
 
-## Finding shell commands
+## Mencari perintah shell
 
-So far we have seen how to find files and code, but as you start spending more time in the shell, you may want to find specific commands you typed at some point.
-The first thing to know is that typing the up arrow will give you back your last command, and if you keep pressing it you will slowly go through your shell history.
+Sejauh ini kita telah melihat cara mencari file dan kode, tetapi seiring Anda semakin banyak menghabiskan waktu di shell, Anda mungkin ingin mencari perintah tertentu yang pernah Anda ketik.
+Hal pertama yang perlu diketahui adalah menekan tombol panah atas akan menampilkan perintah terakhir Anda, dan jika Anda terus menekannya, Anda akan menelusuri riwayat shell Anda secara perlahan.
 
-The `history` command will let you access your shell history programmatically.
-It will print your shell history to the standard output.
-If we want to search there we can pipe that output to `grep` and search for patterns.
-`history | grep find` will print commands that contain the substring "find".
+Perintah `history` akan memungkinkan Anda mengakses riwayat shell Anda secara terprogram.
+Ia akan mencetak riwayat shell Anda ke standard output.
+Jika kita ingin mencari di sana, kita dapat mem-pipe output tersebut ke `grep` dan mencari pola.
+`history | grep find` akan mencetak perintah yang mengandung substring "find".
 
-In most shells, you can make use of `Ctrl+R` to perform backwards search through your history.
-After pressing `Ctrl+R`, you can type a substring you want to match for commands in your history.
-As you keep pressing it, you will cycle through the matches in your history.
-This can also be enabled with the UP/DOWN arrows in [zsh](https://github.com/zsh-users/zsh-history-substring-search).
-A nice addition on top of `Ctrl+R` comes with using [fzf](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings#ctrl-r) bindings.
-`fzf` is a general-purpose fuzzy finder that can be used with many commands.
-Here it is used to fuzzily match through your history and present results in a convenient and visually pleasing manner.
+Di sebagian besar shell, Anda dapat menggunakan `Ctrl+R` untuk melakukan pencarian mundur melalui riwayat Anda.
+Setelah menekan `Ctrl+R`, Anda dapat mengetik substring yang ingin dicocokkan dengan perintah di riwayat Anda.
+Saat Anda terus menekannya, Anda akan berpindah dari satu pencocokan ke pencocokan berikutnya di riwayat Anda.
+Ini juga dapat diaktifkan dengan tombol panah ATAS/BAWAH di [zsh](https://github.com/zsh-users/zsh-history-substring-search).
+Tambahan yang bagus untuk `Ctrl+R` adalah dengan menggunakan binding [fzf](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings#ctrl-r).
+`fzf` adalah fuzzy finder serbaguna yang dapat digunakan dengan banyak perintah.
+Di sini ia digunakan untuk mencocokkan riwayat Anda secara fuzzy dan menampilkan hasil dengan cara yang nyaman dan menarik secara visual.
 
-Another cool history-related trick I really enjoy is **history-based autosuggestions**.
-First introduced by the [fish](https://fishshell.com/) shell, this feature dynamically autocompletes your current shell command with the most recent command that you typed that shares a common prefix with it.
-It can be enabled in [zsh](https://github.com/zsh-users/zsh-autosuggestions) and it is a great quality of life trick for your shell.
+Trik lain terkait riwayat yang sangat saya nikmati adalah **autosuggestions berbasis riwayat**.
+Pertama kali diperkenalkan oleh shell [fish](https://fishshell.com/), fitur ini secara dinamis melengkapi perintah shell Anda saat ini dengan perintah terbaru yang Anda ketik yang memiliki awalan yang sama.
+Fitur ini dapat diaktifkan di [zsh](https://github.com/zsh-users/zsh-autosuggestions) dan merupakan trik kualitas hidup yang hebat untuk shell Anda.
 
-You can modify your shell's history behavior, like preventing commands with a leading space from being included. This comes in handy when you are typing commands with passwords or other bits of sensitive information.
-To do this, add `HISTCONTROL=ignorespace` to your `.bashrc` or `setopt HIST_IGNORE_SPACE` to your `.zshrc`.
-If you make the mistake of not adding the leading space, you can always manually remove the entry by editing your `.bash_history` or `.zsh_history`.
+Anda dapat memodifikasi perilaku riwayat shell Anda, seperti mencegah perintah dengan spasi di awal agar tidak disertakan. Ini berguna saat Anda mengetik perintah dengan password atau informasi sensitif lainnya.
+Untuk melakukannya, tambahkan `HISTCONTROL=ignorespace` ke `.bashrc` Anda atau `setopt HIST_IGNORE_SPACE` ke `.zshrc` Anda.
+Jika Anda terlanjur tidak menambahkan spasi di awal, Anda selalu dapat menghapus entri tersebut secara manual dengan mengedit `.bash_history` atau `.zsh_history` Anda.
 
-## Directory Navigation
+## Navigasi Direktori
 
-So far, we have assumed that you are already where you need to be to perform these actions. But how do you go about quickly navigating directories?
-There are many simple ways that you could do this, such as writing shell aliases or creating symlinks with [ln -s](https://www.man7.org/linux/man-pages/man1/ln.1.html), but the truth is that developers have figured out quite clever and sophisticated solutions by now.
+Sejauh ini, kita berasumsi bahwa Anda sudah berada di tempat yang tepat untuk melakukan tindakan-tindakan tersebut. Tetapi bagaimana cara Anda dengan cepat berpindah antar direktori?
+Ada banyak cara sederhana yang bisa Anda lakukan, seperti menulis alias shell atau membuat symlink dengan [ln -s](https://www.man7.org/linux/man-pages/man1/ln.1.html), tetapi kenyataannya para developer telah menemukan solusi yang cukup cerdas dan canggih.
 
-As with the theme of this course, you often want to optimize for the common case.
-Finding frequent and/or recent files and directories can be done through tools like [`fasd`](https://github.com/clvv/fasd) and [`autojump`](https://github.com/wting/autojump).
-Fasd ranks files and directories by [_frecency_](https://web.archive.org/web/20210421120120/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm), that is, by both _frequency_ and _recency_.
-By default, `fasd` adds a `z` command that you can use to quickly `cd` using a substring of a _frecent_ directory. For example, if you often go to `/home/user/files/cool_project` you can simply use `z cool` to jump there. Using autojump, this same change of directory could be accomplished using `j cool`.
+Seperti tema kursus ini, Anda sering kali ingin mengoptimalkan untuk kasus yang paling umum.
+Mencari file dan direktori yang sering atau baru-baru ini diakses dapat dilakukan melalui tool seperti [`fasd`](https://github.com/clvv/fasd) dan [`autojump`](https://github.com/wting/autojump).
+Fasd memberi peringkat pada file dan direktori berdasarkan [_frecency_](https://web.archive.org/web/20210421120120/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm), yaitu berdasarkan _frekuensi_ dan _recency_ (kedekatan waktu).
+Secara default, `fasd` menambahkan perintah `z` yang dapat Anda gunakan untuk melakukan `cd` dengan cepat menggunakan substring dari direktori yang _frecent_. Sebagai contoh, jika Anda sering pergi ke `/home/user/files/cool_project`, Anda cukup menggunakan `z cool` untuk langsung ke sana. Menggunakan autojump, perubahan direktori yang sama dapat dilakukan dengan `j cool`.
 
-More complex tools exist to quickly get an overview of a directory structure: [`tree`](https://linux.die.net/man/1/tree), [`broot`](https://github.com/Canop/broot) or even full fledged file managers like [`nnn`](https://github.com/jarun/nnn) or [`ranger`](https://github.com/ranger/ranger).
+Tool yang lebih kompleks tersedia untuk mendapatkan gambaran cepat tentang struktur direktori: [`tree`](https://linux.die.net/man/1/tree), [`broot`](https://github.com/Canop/broot), atau bahkan file manager lengkap seperti [`nnn`](https://github.com/jarun/nnn) atau [`ranger`](https://github.com/ranger/ranger).
 
-# Exercises
+# Latihan
 
-1. Read [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) and write an `ls` command that lists files in the following manner
+1. Baca [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) dan tulis perintah `ls` yang menampilkan file dengan cara berikut
 
-    - Includes all files, including hidden files
-    - Sizes are listed in human readable format (e.g. 454M instead of 454279954)
-    - Files are ordered by recency
-    - Output is colorized
+    - Mencakup semua file, termasuk file tersembunyi
+    - Ukuran ditampilkan dalam format yang mudah dibaca manusia (misalnya 454M, bukan 454279954)
+    - File diurutkan berdasarkan recency (terbaru)
+    - Output diberi warna
 
-    A sample output would look like this
+    Contoh outputnya akan terlihat seperti ini
 
     ```
     -rw-r--r--   1 user group 1.1M Jan 14 09:53 baz
@@ -322,9 +322,9 @@ More complex tools exist to quickly get an overview of a directory structure: [`
 ls -lath --color=auto
 {% endcomment %}
 
-1. Write bash functions  `marco` and `polo` that do the following.
-Whenever you execute `marco` the current working directory should be saved in some manner, then when you execute `polo`, no matter what directory you are in, `polo` should `cd` you back to the directory where you executed `marco`.
-For ease of debugging you can write the code in a file `marco.sh` and (re)load the definitions to your shell by executing `source marco.sh`.
+1. Tulis fungsi bash `marco` dan `polo` yang melakukan hal berikut.
+Setiap kali Anda menjalankan `marco`, direktori kerja saat ini harus disimpan dengan cara tertentu, kemudian ketika Anda menjalankan `polo`, tidak peduli di direktori mana Anda berada, `polo` harus melakukan `cd` kembali ke direktori tempat Anda menjalankan `marco`.
+Untuk kemudahan debugging, Anda dapat menulis kode dalam file `marco.sh` dan memuat ulang definisinya ke shell dengan menjalankan `source marco.sh`.
 
 {% comment %}
 marco() {
@@ -336,9 +336,9 @@ polo() {
 }
 {% endcomment %}
 
-1. Say you have a command that fails rarely. In order to debug it you need to capture its output but it can be time consuming to get a failure run.
-Write a bash script that runs the following script until it fails and captures its standard output and error streams to files and prints everything at the end.
-Bonus points if you can also report how many runs it took for the script to fail.
+1. Misalkan Anda memiliki perintah yang jarang gagal. Untuk melakukan debugging, Anda perlu menangkap outputnya tetapi bisa memakan waktu lama untuk mendapatkan run yang gagal.
+Tulis script bash yang menjalankan script berikut hingga gagal dan menangkap standard output serta error stream-nya ke file, lalu mencetak semuanya di akhir.
+Poin bonus jika Anda juga dapat melaporkan berapa kali run yang diperlukan hingga script tersebut gagal.
 
     ```bash
     #!/usr/bin/env bash
@@ -368,18 +368,18 @@ echo "found error after $count runs"
 cat out.txt
 {% endcomment %}
 
-1. As we covered in the lecture `find`'s `-exec` can be very powerful for performing operations over the files we are searching for.
-However, what if we want to do something with **all** the files, like creating a zip file?
-As you have seen so far commands will take input from both arguments and STDIN.
-When piping commands, we are connecting STDOUT to STDIN, but some commands like `tar` take inputs from arguments.
-To bridge this disconnect there's the [`xargs`](https://www.man7.org/linux/man-pages/man1/xargs.1.html) command which will execute a command using STDIN as arguments.
-For example `ls | xargs rm` will delete the files in the current directory.
+1. Seperti yang kita bahas di kuliah, `-exec` milik `find` bisa sangat powerful untuk melakukan operasi pada file yang kita cari.
+Namun, bagaimana jika kita ingin melakukan sesuatu dengan **semua** file, seperti membuat file zip?
+Seperti yang telah Anda lihat sejauh ini, perintah akan menerima input baik dari argumen maupun STDIN.
+Saat mem-pipe perintah, kita menghubungkan STDOUT ke STDIN, tetapi beberapa perintah seperti `tar` menerima input dari argumen.
+Untuk menjembatani kesenjangan ini, ada perintah [`xargs`](https://www.man7.org/linux/man-pages/man1/xargs.1.html) yang akan mengeksekusi perintah menggunakan STDIN sebagai argumen.
+Sebagai contoh, `ls | xargs rm` akan menghapus file-file di direktori saat ini.
 
-    Your task is to write a command that recursively finds all HTML files in the folder and makes a zip with them. Note that your command should work even if the files have spaces (hint: check `-d` flag for `xargs`).
+    Tugas Anda adalah menulis perintah yang secara rekursif mencari semua file HTML di folder dan membuat zip dari file-file tersebut. Perhatikan bahwa perintah Anda harus bekerja meskipun file memiliki spasi (petunjuk: periksa flag `-d` untuk `xargs`).
     {% comment %}
     find . -type f -name "*.html" | xargs -d '\n'  tar -cvzf archive.tar.gz
     {% endcomment %}
 
-    If you're on macOS, note that the default BSD `find` is different from the one included in [GNU coreutils](https://en.wikipedia.org/wiki/List_of_GNU_Core_Utilities_commands). You can use `-print0` on `find` and the `-0` flag on `xargs`. As a macOS user, you should be aware that command-line utilities shipped with macOS may differ from the GNU counterparts; you can install the GNU versions if you like by [using brew](https://formulae.brew.sh/formula/coreutils).
+    Jika Anda menggunakan macOS, perhatikan bahwa `find` BSD default berbeda dari yang disertakan dalam [GNU coreutils](https://en.wikipedia.org/wiki/List_of_GNU_Core_Utilities_commands). Anda dapat menggunakan `-print0` pada `find` dan flag `-0` pada `xargs`. Sebagai pengguna macOS, Anda perlu menyadari bahwa utilitas command-line yang disertakan dengan macOS mungkin berbeda dari versi GNU; Anda dapat menginstal versi GNU jika mau dengan [menggunakan brew](https://formulae.brew.sh/formula/coreutils).
 
-1. (Advanced) Write a command or script to recursively find the most recently modified file in a directory. More generally, can you list all files by recency?
+1. (Lanjutan) Tulis perintah atau script untuk secara rekursif menemukan file yang paling baru diubah di sebuah direktori. Secara lebih umum, dapatkah Anda menampilkan semua file berdasarkan recency?

--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Shell Tools and Scripting"
 description: >
-  Learn how to write shell scripts and use powerful command-line tools.
+  Pelajari cara menulis shell script dan menggunakan tools command-line yang powerful.
 thumbnail: /static/assets/thumbnails/2020/lec2.png
 date: 2020-01-14
 ready: true

--- a/_2020/shell-tools.md
+++ b/_2020/shell-tools.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Shell Tools and Scripting"
+title: "Alat dan Scripting Shell"
 description: >
-  Learn how to write shell scripts and use powerful command-line tools.
+  Pelajari cara menulis skrip shell dan menggunakan alat baris perintah yang powerful.
 thumbnail: /static/assets/thumbnails/2020/lec2.png
 date: 2020-01-14
 ready: true
@@ -11,25 +11,25 @@ video:
   id: kgII-YWo3Zw
 ---
 
-In this lecture, we will present some of the basics of using bash as a scripting language along with a number of shell tools that cover several of the most common tasks that you will be constantly performing in the command line.
+Pada kuliah ini, kami akan menyajikan beberapa dasar penggunaan bash sebagai bahasa scripting beserta sejumlah alat shell yang mencakup beberapa tugas paling umum yang akan terus-menerus Anda lakukan di baris perintah.
 
 # Shell Scripting
 
-So far we have seen how to execute commands in the shell and pipe them together.
-However, in many scenarios you will want to perform a series of commands and make use of control flow expressions like conditionals or loops.
+Sejauh ini kita telah melihat cara menjalankan perintah di shell dan menggabungkannya dengan pipe.
+Namun, dalam banyak skenario Anda ingin melakukan serangkaian perintah dan menggunakan ekspresi control flow seperti kondisional atau perulangan.
 
-Shell scripts are the next step in complexity.
-Most shells have their own scripting language with variables, control flow and its own syntax.
-What makes shell scripting different from other scripting programming languages is that it is optimized for performing shell-related tasks.
-Thus, creating command pipelines, saving results into files, and reading from standard input are primitives in shell scripting, which makes it easier to use than general purpose scripting languages.
-For this section we will focus on bash scripting since it is the most common.
+Shell script adalah langkah berikutnya dalam hal kompleksitas.
+Sebagian besar shell memiliki bahasa scripting sendiri dengan variabel, control flow, dan sintaksisnya sendiri.
+Yang membedakan shell scripting dari bahasa scripting lainnya adalah bahwa ia dioptimalkan untuk melakukan tugas-tugas terkait shell.
+Dengan demikian, membuat pipeline perintah, menyimpan hasil ke dalam file, dan membaca dari standard input adalah primitif dalam shell scripting, sehingga lebih mudah digunakan dibandingkan bahasa scripting umum.
+Untuk bagian ini kita akan fokus pada bash scripting karena merupakan yang paling umum.
 
-To assign variables in bash, use the syntax `foo=bar` and access the value of the variable with `$foo`.
-Note that `foo = bar` will not work since it is interpreted as calling the `foo` program with arguments `=` and `bar`.
-In general, in shell scripts the space character will perform argument splitting. This behavior can be confusing to use at first, so always check for that.
+Untuk menetapkan variabel dalam bash, gunakan sintaks `foo=bar` dan akses nilai variabel dengan `$foo`.
+Perhatikan bahwa `foo = bar` tidak akan berhasil karena diinterpretasikan sebagai pemanggilan program `foo` dengan argumen `=` dan `bar`.
+Secara umum, dalam shell script karakter spasi akan melakukan pemisahan argumen. Perilaku ini bisa membingungkan pada awalnya, jadi selalu periksa hal tersebut.
 
-Strings in bash can be defined with `'` and `"` delimiters, but they are not equivalent.
-Strings delimited with `'` are literal strings and will not substitute variable values whereas `"` delimited strings will.
+String dalam bash dapat didefinisikan dengan delimiter `'` dan `"`, tetapi keduanya tidak ekuivalen.
+String yang dibatasi dengan `'` adalah string literal dan tidak akan mensubstitusi nilai variabel, sedangkan string yang dibatasi dengan `"` akan mensubstitusi nilai variabel.
 
 ```bash
 foo=bar
@@ -39,8 +39,8 @@ echo '$foo'
 # prints $foo
 ```
 
-As with most programming languages, bash supports control flow techniques including `if`, `case`, `while` and `for`.
-Similarly, `bash` has functions that take arguments and can operate with them. Here is an example of a function that creates a directory and `cd`s into it.
+Seperti kebanyakan bahasa pemrograman, bash mendukung teknik control flow termasuk `if`, `case`, `while`, dan `for`.
+Demikian pula, `bash` memiliki fungsi yang menerima argumen dan dapat beroperasi dengannya. Berikut adalah contoh fungsi yang membuat direktori dan melakukan `cd` ke dalamnya.
 
 
 ```bash
@@ -50,24 +50,24 @@ mcd () {
 }
 ```
 
-Here `$1` is the first argument to the script/function.
-Unlike other scripting languages, bash uses a variety of special variables to refer to arguments, error codes, and other relevant variables. Below is a list of some of them. A more comprehensive list can be found [here](https://tldp.org/LDP/abs/html/special-chars.html).
-- `$0` - Name of the script
-- `$1` to `$9` - Arguments to the script. `$1` is the first argument and so on.
-- `$@` - All the arguments
-- `$#` - Number of arguments
-- `$?` - Return code of the previous command
-- `$$` - Process identification number (PID) for the current script
-- `!!` - Entire last command, including arguments. A common pattern is to execute a command only for it to fail due to missing permissions; you can quickly re-execute the command with sudo by doing `sudo !!`
-- `$_` - Last argument from the last command. If you are in an interactive shell, you can also quickly get this value by typing `Esc` followed by `.` or `Alt+.`
+Di sini `$1` adalah argumen pertama untuk skrip/fungsi.
+Berbeda dengan bahasa scripting lainnya, bash menggunakan berbagai variabel khusus untuk merujuk pada argumen, kode error, dan variabel relevan lainnya. Berikut adalah daftar beberapa di antaranya. Daftar yang lebih lengkap dapat ditemukan [di sini](https://tldp.org/LDP/abs/html/special-chars.html).
+- `$0` - Nama skrip
+- `$1` hingga `$9` - Argumen untuk skrip. `$1` adalah argumen pertama dan seterusnya.
+- `$@` - Semua argumen
+- `$#` - Jumlah argumen
+- `$?` - Return code dari perintah sebelumnya
+- `$$` - Nomor identifikasi proses (PID) untuk skrip saat ini
+- `!!` - Seluruh perintah terakhir, termasuk argumen. Pola yang umum adalah menjalankan perintah yang kemudian gagal karena izin yang kurang; Anda dapat dengan cepat menjalankan ulang perintah tersebut dengan sudo menggunakan `sudo !!`
+- `$_` - Argumen terakhir dari perintah terakhir. Jika Anda berada di shell interaktif, Anda juga dapat dengan cepat mendapatkan nilai ini dengan mengetik `Esc` diikuti oleh `.` atau `Alt+.`
 
-Commands will often return output using `STDOUT`, errors through `STDERR`, and a Return Code to report errors in a more script-friendly manner.
-The return code or exit status is the way scripts/commands have to communicate how execution went.
-A value of 0 usually means everything went OK; anything different from 0 means an error occurred.
+Perintah sering kali mengembalikan output menggunakan `STDOUT`, error melalui `STDERR`, dan Return Code untuk melaporkan error dengan cara yang lebih ramah skrip.
+Return code atau exit status adalah cara skrip/perintah untuk mengkomunikasikan bagaimana eksekusi berjalan.
+Nilai 0 biasanya berarti semuanya berjalan dengan baik; nilai selain 0 berarti ada error yang terjadi.
 
-Exit codes can be used to conditionally execute commands using `&&` (and operator) and `||` (or operator), both of which are [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators. Commands can also be separated within the same line using a semicolon `;`.
-The `true` program will always have a 0 return code and the `false` command will always have a 1 return code.
-Let's see some examples
+Exit code dapat digunakan untuk mengeksekusi perintah secara kondisional menggunakan `&&` (operator and) dan `||` (operator or), yang keduanya merupakan operator [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation). Perintah juga dapat dipisahkan dalam satu baris menggunakan titik koma `;`.
+Program `true` akan selalu memiliki return code 0 dan perintah `false` akan selalu memiliki return code 1.
+Mari kita lihat beberapa contoh.
 
 ```bash
 false || echo "Oops, fail"
@@ -89,13 +89,13 @@ false ; echo "This will always run"
 # This will always run
 ```
 
-Another common pattern is wanting to get the output of a command as a variable. This can be done with _command substitution_.
-Whenever you place `$( CMD )` it will execute `CMD`, get the output of the command and substitute it in place.
-For example, if you do `for file in $(ls)`, the shell will first call `ls` and then iterate over those values.
-A lesser known similar feature is _process substitution_, `<( CMD )` will execute `CMD` and place the output in a temporary file and substitute the `<()` with that file's name. This is useful when commands expect values to be passed by file instead of by STDIN. For example, `diff <(ls foo) <(ls bar)` will show differences between files in dirs  `foo` and `bar`.
+Pola umum lainnya adalah ingin mendapatkan output dari sebuah perintah sebagai variabel. Ini dapat dilakukan dengan _command substitution_.
+Setiap kali Anda menempatkan `$( CMD )`, ini akan mengeksekusi `CMD`, mendapatkan output dari perintah tersebut dan menggantikannya di tempat.
+Sebagai contoh, jika Anda melakukan `for file in $(ls)`, shell akan memanggil `ls` terlebih dahulu dan kemudian melakukan iterasi atas nilai-nilai tersebut.
+Fitur serupa yang kurang dikenal adalah _process substitution_, `<( CMD )` akan mengeksekusi `CMD` dan menempatkan output dalam file sementara serta mengganti `<()` dengan nama file tersebut. Ini berguna ketika perintah mengharapkan nilai diberikan melalui file daripada melalui STDIN. Sebagai contoh, `diff <(ls foo) <(ls bar)` akan menunjukkan perbedaan antara file-file dalam direktori `foo` dan `bar`.
 
 
-Since that was a huge information dump, let's see an example that showcases some of these features. It will iterate through the arguments we provide, `grep` for the string `foobar`, and append it to the file as a comment if it's not found.
+Karena itu adalah banyak sekali informasi, mari kita lihat contoh yang memperlihatkan beberapa fitur ini. Contoh ini akan melakukan iterasi melalui argumen yang kita berikan, melakukan `grep` untuk string `foobar`, dan menambahkannya ke file sebagai komentar jika tidak ditemukan.
 
 ```bash
 #!/bin/bash
@@ -115,13 +115,13 @@ for file in "$@"; do
 done
 ```
 
-In the comparison we tested whether `$?` was not equal to 0.
-Bash implements many comparisons of this sort - you can find a detailed list in the manpage for [`test`](https://www.man7.org/linux/man-pages/man1/test.1.html).
-When performing comparisons in bash, try to use double brackets `[[ ]]` in favor of simple brackets `[ ]`. Chances of making mistakes are lower although it won't be portable to `sh`. A more detailed explanation can be found [here](https://mywiki.wooledge.org/BashFAQ/031).
+Dalam perbandingan tersebut kita menguji apakah `$?` tidak sama dengan 0.
+Bash mengimplementasikan banyak perbandingan semacam ini - Anda dapat menemukan daftar lengkapnya di manpage untuk [`test`](https://www.man7.org/linux/man-pages/man1/test.1.html).
+Saat melakukan perbandingan dalam bash, cobalah gunakan double bracket `[[ ]]` daripada single bracket `[ ]`. Kemungkinan kesalahan lebih rendah meskipun tidak akan portable ke `sh`. Penjelasan lebih lengkap dapat ditemukan [di sini](https://mywiki.wooledge.org/BashFAQ/031).
 
-When launching scripts, you will often want to provide arguments that are similar. Bash has ways of making this easier, expanding expressions by carrying out filename expansion. These techniques are often referred to as shell _globbing_.
-- Wildcards - Whenever you want to perform some sort of wildcard matching, you can use `?` and `*` to match one or any amount of characters respectively. For instance, given files `foo`, `foo1`, `foo2`, `foo10` and `bar`, the command `rm foo?` will delete `foo1` and `foo2` whereas `rm foo*` will delete all but `bar`.
-- Curly braces `{}` - Whenever you have a common substring in a series of commands, you can use curly braces for bash to expand this automatically. This comes in very handy when moving or converting files.
+Saat menjalankan skrip, Anda sering kali ingin memberikan argumen yang serupa. Bash memiliki cara untuk mempermudah hal ini, yaitu dengan melakukan ekspansi nama file. Teknik-teknik ini sering disebut sebagai shell _globbing_.
+- Wildcard - Setiap kali Anda ingin melakukan pencocokan wildcard, Anda dapat menggunakan `?` dan `*` untuk mencocokkan satu karakter atau sejumlah karakter. Misalnya, dengan file `foo`, `foo1`, `foo2`, `foo10` dan `bar`, perintah `rm foo?` akan menghapus `foo1` dan `foo2` sedangkan `rm foo*` akan menghapus semua kecuali `bar`.
+- Curly braces `{}` - Setiap kali Anda memiliki substring yang sama dalam serangkaian perintah, Anda dapat menggunakan curly braces agar bash mengekspansinya secara otomatis. Ini sangat berguna saat memindahkan atau mengonversi file.
 
 ```bash
 convert image.{png,jpg}
@@ -151,9 +151,9 @@ diff <(ls foo) <(ls bar)
 
 <!-- Lastly, pipes `|` are a core feature of scripting. Pipes connect one program's output to the next program's input. We will cover them more in detail in the data wrangling lecture. -->
 
-Writing `bash` scripts can be tricky and unintuitive. There are tools like [shellcheck](https://github.com/koalaman/shellcheck) that will help you find errors in your sh/bash scripts.
+Menulis skrip `bash` bisa jadi rumit dan tidak intuitif. Ada alat seperti [shellcheck](https://github.com/koalaman/shellcheck) yang akan membantu Anda menemukan error dalam skrip sh/bash Anda.
 
-Note that scripts need not necessarily be written in bash to be called from the terminal. For instance, here's a simple Python script that outputs its arguments in reversed order:
+Perhatikan bahwa skrip tidak harus ditulis dalam bash untuk dipanggil dari terminal. Misalnya, berikut adalah skrip Python sederhana yang menghasilkan argumennya dalam urutan terbalik:
 
 ```python
 #!/usr/local/bin/python
@@ -162,40 +162,40 @@ for arg in reversed(sys.argv[1:]):
     print(arg)
 ```
 
-The kernel knows to execute this script with a python interpreter instead of a shell command because we included a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line at the top of the script.
-It is good practice to write shebang lines using the [`env`](https://www.man7.org/linux/man-pages/man1/env.1.html) command that will resolve to wherever the command lives in the system, increasing the portability of your scripts. To resolve the location, `env` will make use of the `PATH` environment variable we introduced in the first lecture.
-For this example the shebang line would look like `#!/usr/bin/env python`.
+Kernel mengetahui cara mengeksekusi skrip ini dengan interpreter python alih-alih perintah shell karena kita menyertakan baris [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) di bagian atas skrip.
+Merupakan praktik yang baik untuk menulis baris shebang menggunakan perintah [`env`](https://www.man7.org/linux/man-pages/man1/env.1.html) yang akan menemukan di mana perintah tersebut berada di sistem, sehingga meningkatkan portabilitas skrip Anda. Untuk menemukan lokasi tersebut, `env` akan menggunakan variabel lingkungan `PATH` yang telah kita bahas di kuliah pertama.
+Untuk contoh ini, baris shebang akan terlihat seperti `#!/usr/bin/env python`.
 
-Some differences between shell functions and scripts that you should keep in mind are:
-- Functions have to be in the same language as the shell, while scripts can be written in any language. This is why including a shebang for scripts is important.
-- Functions are loaded once when their definition is read. Scripts are loaded every time they are executed. This makes functions slightly faster to load, but whenever you change them you will have to reload their definition.
-- Functions are executed in the current shell environment whereas scripts execute in their own process. Thus, functions can modify environment variables, e.g. change your current directory, whereas scripts can't. Environment variables which have been exported using [`export`](https://www.man7.org/linux/man-pages/man1/export.1p.html) are passed by value to scripts.
-- As with any programming language, functions are a powerful construct to achieve modularity, code reuse, and clarity of shell code. Often shell scripts will include their own function definitions.
+Beberapa perbedaan antara fungsi shell dan skrip yang perlu Anda ingat adalah:
+- Fungsi harus ditulis dalam bahasa yang sama dengan shell, sedangkan skrip dapat ditulis dalam bahasa apa pun. Inilah mengapa menyertakan shebang untuk skrip itu penting.
+- Fungsi dimuat sekali saat definisinya dibaca. Skrip dimuat setiap kali dieksekusi. Ini membuat fungsi sedikit lebih cepat untuk dimuat, tetapi setiap kali Anda mengubahnya, Anda harus memuat ulang definisinya.
+- Fungsi dijalankan di environment shell saat ini sedangkan skrip dijalankan di prosesnya sendiri. Dengan demikian, fungsi dapat memodifikasi variabel lingkungan, misalnya mengubah direktori kerja Anda saat ini, sedangkan skrip tidak bisa. Variabel lingkungan yang telah diekspor menggunakan [`export`](https://www.man7.org/linux/man-pages/man1/export.1p.html) diteruskan sebagai nilai ke skrip.
+- Seperti dalam bahasa pemrograman apa pun, fungsi adalah konstruksi yang powerful untuk mencapai modularitas, penggunaan ulang kode, dan kejelasan kode shell. Seringkali skrip shell akan menyertakan definisi fungsinya sendiri.
 
-# Shell Tools
+# Alat Shell
 
-## Finding how to use commands
+## Menemukan cara menggunakan perintah
 
-At this point, you might be wondering how to find the flags for the commands in the aliasing section such as `ls -l`, `mv -i` and `mkdir -p`.
-More generally, given a command, how do you go about finding out what it does and its different options?
-You could always start googling, but since UNIX predates StackOverflow, there are built-in ways of getting this information.
+Pada titik ini, Anda mungkin bertanya-tanya bagaimana cara menemukan flag untuk perintah-perintah di bagian alias seperti `ls -l`, `mv -i`, dan `mkdir -p`.
+Secara lebih umum, diberikan sebuah perintah, bagaimana Anda mencari tahu apa yang dilakukannya dan opsi-opsi yang berbeda?
+Anda bisa saja mulai mencari di Google, tetapi karena UNIX lebih tua dari StackOverflow, ada cara bawaan untuk mendapatkan informasi ini.
 
-As we saw in the shell lecture, the first-order approach is to call said command with the `-h` or `--help` flags. A more detailed approach is to use the `man` command.
-Short for manual, [`man`](https://www.man7.org/linux/man-pages/man1/man.1.html) provides a manual page (called manpage) for a command you specify.
-For example, `man rm` will output the behavior of the `rm` command along with the flags that it takes, including the `-i` flag we showed earlier.
-In fact, what I have been linking so far for every command is the online version of the Linux manpages for the commands.
-Even non-native commands that you install will have manpage entries if the developer wrote them and included them as part of the installation process.
-For interactive tools such as the ones based on ncurses, help for the commands can often be accessed within the program using the `:help` command or typing `?`.
+Seperti yang kita lihat di kuliah shell, pendekatan pertama adalah memanggil perintah tersebut dengan flag `-h` atau `--help`. Pendekatan yang lebih detail adalah menggunakan perintah `man`.
+Singkatan dari manual, [`man`](https://www.man7.org/linux/man-pages/man1/man.1.html) menyediakan halaman manual (disebut manpage) untuk perintah yang Anda tentukan.
+Sebagai contoh, `man rm` akan menampilkan perilaku perintah `rm` beserta flag-flag yang diterimanya, termasuk flag `-i` yang kita tunjukkan sebelumnya.
+Sebenarnya, apa yang telah saya tautkan sejauh ini untuk setiap perintah adalah versi online dari manpage Linux untuk perintah-perintah tersebut.
+Bahkan perintah non-bawaan yang Anda instal akan memiliki entri manpage jika pengembang menulisnya dan menyertakannya sebagai bagian dari proses instalasi.
+Untuk alat interaktif seperti yang berbasis ncurses, bantuan untuk perintah sering kali dapat diakses di dalam program menggunakan perintah `:help` atau mengetik `?`.
 
-Sometimes manpages can provide overly detailed descriptions of the commands, making it hard to decipher what flags/syntax to use for common use cases.
-[TLDR pages](https://tldr.sh/) are a nifty complementary solution that focuses on giving example use cases of a command so you can quickly figure out which options to use.
-For instance, I find myself referring back to the tldr pages for [`tar`](https://tldr.inbrowser.app/pages/common/tar) and [`ffmpeg`](https://tldr.inbrowser.app/pages/common/ffmpeg) way more often than the manpages.
+Terkadang manpage dapat memberikan deskripsi yang terlalu detail tentang perintah, sehingga sulit untuk memahami flag/sintaks apa yang harus digunakan untuk kasus penggunaan umum.
+[Halaman TLDR](https://tldr.sh/) adalah solusi pelengkap yang berguna yang berfokus pada memberikan contoh penggunaan perintah sehingga Anda dapat dengan cepat mengetahui opsi mana yang harus digunakan.
+Sebagai contoh, saya sering merujuk ke halaman tldr untuk [`tar`](https://tldr.inbrowser.app/pages/common/tar) dan [`ffmpeg`](https://tldr.inbrowser.app/pages/common/ffmpeg) lebih sering daripada manpage.
 
 
-## Finding files
+## Mencari file
 
-One of the most common repetitive tasks that every programmer faces is finding files or directories.
-All UNIX-like systems come packaged with [`find`](https://www.man7.org/linux/man-pages/man1/find.1.html), a great shell tool to find files. `find` will recursively search for files matching some criteria. Some examples:
+Salah satu tugas repetitif paling umum yang dihadapi setiap programmer adalah mencari file atau direktori.
+Semua sistem berbasis UNIX dilengkapi dengan [`find`](https://www.man7.org/linux/man-pages/man1/find.1.html), alat shell yang hebat untuk mencari file. `find` akan mencari file secara rekursif berdasarkan kriteria tertentu. Beberapa contoh:
 
 ```bash
 # Find all directories named src
@@ -207,8 +207,8 @@ find . -mtime -1
 # Find all zip files with size in range 500k to 10M
 find . -size +500k -size -10M -name '*.tar.gz'
 ```
-Beyond listing files, find can also perform actions over files that match your query.
-This property can be incredibly helpful to simplify what could be fairly monotonous tasks.
+Selain menampilkan daftar file, find juga dapat melakukan aksi terhadap file yang cocok dengan pencarian Anda.
+Properti ini bisa sangat membantu untuk menyederhanakan tugas yang bisa jadi cukup monoton.
 ```bash
 # Delete all files with .tmp extension
 find . -name '*.tmp' -exec rm {} \;
@@ -217,37 +217,37 @@ find . -name '*.tmp' -exec rm {} \;
 find . -name '*.png' -exec magick {} {}.jpg \;
 ```
 
-Despite `find`'s ubiquitousness, its syntax can sometimes be tricky to remember.
-For instance, to simply find files that match some pattern `PATTERN` you have to execute `find -name '*PATTERN*'` (or `-iname` if you want the pattern matching to be case insensitive).
-You could start building aliases for those scenarios, but part of the shell philosophy is that it is good to explore alternatives.
-Remember, one of the best properties of the shell is that you are just calling programs, so you can find (or even write yourself) replacements for some.
-For instance, [`fd`](https://github.com/sharkdp/fd) is a simple, fast, and user-friendly alternative to `find`.
-It offers some nice defaults like colorized output, default regex matching, and Unicode support. It also has, in my opinion, a more intuitive syntax.
-For example, the syntax to find a pattern `PATTERN` is `fd PATTERN`.
+Meskipun `find` sangat umum digunakan, sintaksnya terkadang sulit diingat.
+Misalnya, untuk mencari file yang cocok dengan pola `PATTERN`, Anda harus menjalankan `find -name '*PATTERN*'` (atau `-iname` jika Anda ingin pencocokan pola yang tidak case-sensitive).
+Anda bisa mulai membuat alias untuk skenario-skenario tersebut, tetapi bagian dari filosofi shell adalah bahwa baik untuk menjelajahi alternatif.
+Ingat, salah satu properti terbaik dari shell adalah Anda hanya memanggil program, sehingga Anda dapat menemukan (atau bahkan menulis sendiri) pengganti untuk beberapa di antaranya.
+Misalnya, [`fd`](https://github.com/sharkdp/fd) adalah alternatif yang sederhana, cepat, dan user-friendly untuk `find`.
+Alat ini menawarkan beberapa default yang bagus seperti output berwarna, pencocokan regex default, dan dukungan Unicode. Alat ini juga memiliki, menurut saya, sintaks yang lebih intuitif.
+Sebagai contoh, sintaks untuk mencari pola `PATTERN` adalah `fd PATTERN`.
 
-Most would agree that `find` and `fd` are good, but some of you might be wondering about the efficiency of looking for files every time versus compiling some sort of index or database for quickly searching.
-That is what [`locate`](https://www.man7.org/linux/man-pages/man1/locate.1.html) is for.
-`locate` uses a database that is updated using [`updatedb`](https://www.man7.org/linux/man-pages/man1/updatedb.1.html).
-In most systems, `updatedb` is updated daily via [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html).
-Therefore one trade-off between the two is speed vs freshness.
-Moreover `find` and similar tools can also find files using attributes such as file size, modification time, or file permissions, while `locate` just uses the file name.
-A more in-depth comparison can be found [here](https://unix.stackexchange.com/questions/60205/locate-vs-find-usage-pros-and-cons-of-each-other).
+Sebagian besar akan setuju bahwa `find` dan `fd` adalah alat yang bagus, tetapi beberapa dari Anda mungkin bertanya-tanya tentang efisiensi mencari file setiap kali versus mengompilasi semacam indeks atau database untuk pencarian cepat.
+Itulah fungsi dari [`locate`](https://www.man7.org/linux/man-pages/man1/locate.1.html).
+`locate` menggunakan database yang diperbarui menggunakan [`updatedb`](https://www.man7.org/linux/man-pages/man1/updatedb.1.html).
+Di sebagian besar sistem, `updatedb` diperbarui setiap hari melalui [`cron`](https://www.man7.org/linux/man-pages/man8/cron.8.html).
+Oleh karena itu, trade-off antara keduanya adalah kecepatan vs kesegaran data.
+Selain itu, `find` dan alat serupa juga dapat mencari file menggunakan atribut seperti ukuran file, waktu modifikasi, atau izin file, sedangkan `locate` hanya menggunakan nama file.
+Perbandingan yang lebih mendalam dapat ditemukan [di sini](https://unix.stackexchange.com/questions/60205/locate-vs-find-usage-pros-and-cons-of-each-other).
 
-## Finding code
+## Mencari kode
 
-Finding files by name is useful, but quite often you want to search based on file *content*.
-A common scenario is wanting to search for all files that contain some pattern, along with where in those files said pattern occurs.
-To achieve this, most UNIX-like systems provide [`grep`](https://www.man7.org/linux/man-pages/man1/grep.1.html), a generic tool for matching patterns from the input text.
-`grep` is an incredibly valuable shell tool that we will cover in greater detail during the data wrangling lecture.
+Mencari file berdasarkan nama memang berguna, tetapi cukup sering Anda ingin mencari berdasarkan *konten* file.
+Skenario yang umum adalah ingin mencari semua file yang mengandung pola tertentu, beserta lokasi pola tersebut dalam file-file itu.
+Untuk mencapai ini, sebagian besar sistem berbasis UNIX menyediakan [`grep`](https://www.man7.org/linux/man-pages/man1/grep.1.html), alat generik untuk mencocokkan pola dari teks input.
+`grep` adalah alat shell yang sangat berharga yang akan kita bahas lebih detail selama kuliah data wrangling.
 
-For now, know that `grep` has many flags that make it a very versatile tool.
-Some I frequently use are `-C` for getting **C**ontext around the matching line and `-v` for in**v**erting the match, i.e. print all lines that do **not** match the pattern. For example, `grep -C 5` will print 5 lines before and after the match.
-When it comes to quickly searching through many files, you want to use `-R` since it will **R**ecursively go into directories and look for files for the matching string.
+Untuk saat ini, ketahuilah bahwa `grep` memiliki banyak flag yang membuatnya menjadi alat yang sangat serbaguna.
+Beberapa yang sering saya gunakan adalah `-C` untuk mendapatkan **C**ontext di sekitar baris yang cocok dan `-v` untuk in**v**erting pencocokan, yaitu mencetak semua baris yang **tidak** cocok dengan pola. Misalnya, `grep -C 5` akan mencetak 5 baris sebelum dan setelah pencocokan.
+Saat mencari dengan cepat di banyak file, Anda ingin menggunakan `-R` karena akan secara **R**ekursif masuk ke direktori dan mencari file untuk string yang cocok.
 
-But `grep -R` can be improved in many ways, such as ignoring `.git` folders, using multi CPU support, &c.
-Many `grep` alternatives have been developed, including [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher) and [rg](https://github.com/BurntSushi/ripgrep).
-All of them are fantastic and pretty much provide the same functionality.
-For now I am sticking with ripgrep (`rg`), given how fast and intuitive it is. Some examples:
+Tetapi `grep -R` dapat ditingkatkan dalam banyak hal, seperti mengabaikan folder `.git`, menggunakan dukungan multi CPU, dll.
+Banyak alternatif `grep` telah dikembangkan, termasuk [ack](https://github.com/beyondgrep/ack3), [ag](https://github.com/ggreer/the_silver_searcher), dan [rg](https://github.com/BurntSushi/ripgrep).
+Semuanya fantastis dan kurang lebih menyediakan fungsionalitas yang sama.
+Untuk saat ini saya tetap menggunakan ripgrep (`rg`), mengingat kecepatannya yang tinggi dan intuitif. Beberapa contoh:
 ```bash
 # Find all python files where I used the requests library
 rg -t py 'import requests'
@@ -259,56 +259,56 @@ rg foo -A 5
 rg --stats PATTERN
 ```
 
-Note that as with `find`/`fd`, it is important that you know that these problems can be quickly solved using one of these tools, while the specific tools you use are not as important.
+Perhatikan bahwa seperti `find`/`fd`, penting bagi Anda untuk mengetahui bahwa masalah ini dapat dengan cepat dipecahkan menggunakan salah satu dari alat-alat ini, sedangkan alat spesifik yang Anda gunakan tidak terlalu penting.
 
-## Finding shell commands
+## Mencari perintah shell
 
-So far we have seen how to find files and code, but as you start spending more time in the shell, you may want to find specific commands you typed at some point.
-The first thing to know is that typing the up arrow will give you back your last command, and if you keep pressing it you will slowly go through your shell history.
+Sejauh ini kita telah melihat cara mencari file dan kode, tetapi seiring Anda menghabiskan lebih banyak waktu di shell, Anda mungkin ingin mencari perintah tertentu yang pernah Anda ketik.
+Hal pertama yang perlu diketahui adalah menekan tombol panah atas akan menampilkan perintah terakhir Anda, dan jika Anda terus menekannya, Anda akan menelusuri riwayat shell Anda secara perlahan.
 
-The `history` command will let you access your shell history programmatically.
-It will print your shell history to the standard output.
-If we want to search there we can pipe that output to `grep` and search for patterns.
-`history | grep find` will print commands that contain the substring "find".
+Perintah `history` akan memberi Anda akses ke riwayat shell secara terprogram.
+Perintah ini akan mencetak riwayat shell Anda ke standard output.
+Jika kita ingin mencari di sana, kita dapat mem-pipe output tersebut ke `grep` dan mencari pola.
+`history | grep find` akan mencetak perintah yang mengandung substring "find".
 
-In most shells, you can make use of `Ctrl+R` to perform backwards search through your history.
-After pressing `Ctrl+R`, you can type a substring you want to match for commands in your history.
-As you keep pressing it, you will cycle through the matches in your history.
-This can also be enabled with the UP/DOWN arrows in [zsh](https://github.com/zsh-users/zsh-history-substring-search).
-A nice addition on top of `Ctrl+R` comes with using [fzf](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings#ctrl-r) bindings.
-`fzf` is a general-purpose fuzzy finder that can be used with many commands.
-Here it is used to fuzzily match through your history and present results in a convenient and visually pleasing manner.
+Di sebagian besar shell, Anda dapat menggunakan `Ctrl+R` untuk melakukan pencarian mundur melalui riwayat Anda.
+Setelah menekan `Ctrl+R`, Anda dapat mengetik substring yang ingin dicocokkan dengan perintah dalam riwayat Anda.
+Saat Anda terus menekannya, Anda akan berpindah melalui pencocokan dalam riwayat Anda.
+Ini juga dapat diaktifkan dengan tombol panah ATAS/BAWAH di [zsh](https://github.com/zsh-users/zsh-history-substring-search).
+Tambahan yang bagus untuk `Ctrl+R` datang dengan menggunakan binding [fzf](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings#ctrl-r).
+`fzf` adalah fuzzy finder serbaguna yang dapat digunakan dengan banyak perintah.
+Di sini ia digunakan untuk mencocokkan secara fuzzy melalui riwayat Anda dan menyajikan hasil dengan cara yang nyaman dan menarik secara visual.
 
-Another cool history-related trick I really enjoy is **history-based autosuggestions**.
-First introduced by the [fish](https://fishshell.com/) shell, this feature dynamically autocompletes your current shell command with the most recent command that you typed that shares a common prefix with it.
-It can be enabled in [zsh](https://github.com/zsh-users/zsh-autosuggestions) and it is a great quality of life trick for your shell.
+Trik menarik lainnya terkait riwayat yang sangat saya nikmati adalah **autosuggestions berbasis riwayat**.
+Pertama kali diperkenalkan oleh shell [fish](https://fishshell.com/), fitur ini secara dinamis melengkapi perintah shell Anda saat ini dengan perintah terbaru yang Anda ketik yang memiliki prefix yang sama.
+Fitur ini dapat diaktifkan di [zsh](https://github.com/zsh-users/zsh-autosuggestions) dan merupakan trik quality of life yang hebat untuk shell Anda.
 
-You can modify your shell's history behavior, like preventing commands with a leading space from being included. This comes in handy when you are typing commands with passwords or other bits of sensitive information.
-To do this, add `HISTCONTROL=ignorespace` to your `.bashrc` or `setopt HIST_IGNORE_SPACE` to your `.zshrc`.
-If you make the mistake of not adding the leading space, you can always manually remove the entry by editing your `.bash_history` or `.zsh_history`.
+Anda dapat memodifikasi perilaku riwayat shell Anda, seperti mencegah perintah dengan spasi di awal agar tidak disertakan. Ini berguna saat Anda mengetik perintah dengan password atau informasi sensitif lainnya.
+Untuk melakukan ini, tambahkan `HISTCONTROL=ignorespace` ke `.bashrc` Anda atau `setopt HIST_IGNORE_SPACE` ke `.zshrc` Anda.
+Jika Anda tidak sengaja tidak menambahkan spasi di awal, Anda selalu dapat menghapus entri tersebut secara manual dengan mengedit `.bash_history` atau `.zsh_history` Anda.
 
-## Directory Navigation
+## Navigasi Direktori
 
-So far, we have assumed that you are already where you need to be to perform these actions. But how do you go about quickly navigating directories?
-There are many simple ways that you could do this, such as writing shell aliases or creating symlinks with [ln -s](https://www.man7.org/linux/man-pages/man1/ln.1.html), but the truth is that developers have figured out quite clever and sophisticated solutions by now.
+Sejauh ini, kita berasumsi bahwa Anda sudah berada di tempat yang Anda butuhkan untuk melakukan tindakan-tindakan ini. Tetapi bagaimana cara Anda menavigasi direktori dengan cepat?
+Ada banyak cara sederhana yang bisa Anda lakukan, seperti menulis alias shell atau membuat symlink dengan [ln -s](https://www.man7.org/linux/man-pages/man1/ln.1.html), tetapi kenyataannya adalah para pengembang telah menemukan solusi yang cukup cerdas dan canggih sampai saat ini.
 
-As with the theme of this course, you often want to optimize for the common case.
-Finding frequent and/or recent files and directories can be done through tools like [`fasd`](https://github.com/clvv/fasd) and [`autojump`](https://github.com/wting/autojump).
-Fasd ranks files and directories by [_frecency_](https://web.archive.org/web/20210421120120/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm), that is, by both _frequency_ and _recency_.
-By default, `fasd` adds a `z` command that you can use to quickly `cd` using a substring of a _frecent_ directory. For example, if you often go to `/home/user/files/cool_project` you can simply use `z cool` to jump there. Using autojump, this same change of directory could be accomplished using `j cool`.
+Seperti tema kursus ini, Anda sering ingin mengoptimalkan untuk kasus yang paling umum.
+Mencari file dan direktori yang sering atau baru-baru ini diakses dapat dilakukan melalui alat seperti [`fasd`](https://github.com/clvv/fasd) dan [`autojump`](https://github.com/wting/autojump).
+Fasd memberi peringkat pada file dan direktori berdasarkan [_frecency_](https://web.archive.org/web/20210421120120/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm), yaitu berdasarkan _frekuensi_ dan _recency_.
+Secara default, `fasd` menambahkan perintah `z` yang dapat Anda gunakan untuk `cd` dengan cepat menggunakan substring dari direktori yang _frecent_. Misalnya, jika Anda sering pergi ke `/home/user/files/cool_project`, Anda cukup menggunakan `z cool` untuk melompat ke sana. Menggunakan autojump, perubahan direktori yang sama dapat dilakukan dengan `j cool`.
 
-More complex tools exist to quickly get an overview of a directory structure: [`tree`](https://linux.die.net/man/1/tree), [`broot`](https://github.com/Canop/broot) or even full fledged file managers like [`nnn`](https://github.com/jarun/nnn) or [`ranger`](https://github.com/ranger/ranger).
+Alat yang lebih kompleks tersedia untuk mendapatkan gambaran cepat tentang struktur direktori: [`tree`](https://linux.die.net/man/1/tree), [`broot`](https://github.com/Canop/broot), atau bahkan file manager lengkap seperti [`nnn`](https://github.com/jarun/nnn) atau [`ranger`](https://github.com/ranger/ranger).
 
-# Exercises
+# Latihan
 
-1. Read [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) and write an `ls` command that lists files in the following manner
+1. Baca [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) dan tulis perintah `ls` yang menampilkan daftar file dengan cara berikut
 
-    - Includes all files, including hidden files
-    - Sizes are listed in human readable format (e.g. 454M instead of 454279954)
-    - Files are ordered by recency
-    - Output is colorized
+    - Mencakup semua file, termasuk file tersembunyi
+    - Ukuran ditampilkan dalam format yang mudah dibaca manusia (misalnya 454M alih-alih 454279954)
+    - File diurutkan berdasarkan recency
+    - Output diberi warna
 
-    A sample output would look like this
+    Contoh output akan terlihat seperti ini
 
     ```
     -rw-r--r--   1 user group 1.1M Jan 14 09:53 baz
@@ -322,9 +322,9 @@ More complex tools exist to quickly get an overview of a directory structure: [`
 ls -lath --color=auto
 {% endcomment %}
 
-1. Write bash functions  `marco` and `polo` that do the following.
-Whenever you execute `marco` the current working directory should be saved in some manner, then when you execute `polo`, no matter what directory you are in, `polo` should `cd` you back to the directory where you executed `marco`.
-For ease of debugging you can write the code in a file `marco.sh` and (re)load the definitions to your shell by executing `source marco.sh`.
+1. Tulis fungsi bash `marco` dan `polo` yang melakukan hal berikut.
+Setiap kali Anda menjalankan `marco`, direktori kerja saat ini harus disimpan dengan cara tertentu, kemudian ketika Anda menjalankan `polo`, tidak peduli di direktori mana Anda berada, `polo` harus melakukan `cd` kembali ke direktori tempat Anda menjalankan `marco`.
+Untuk kemudahan debugging, Anda dapat menulis kode dalam file `marco.sh` dan memuat ulang definisi ke shell Anda dengan menjalankan `source marco.sh`.
 
 {% comment %}
 marco() {
@@ -336,9 +336,9 @@ polo() {
 }
 {% endcomment %}
 
-1. Say you have a command that fails rarely. In order to debug it you need to capture its output but it can be time consuming to get a failure run.
-Write a bash script that runs the following script until it fails and captures its standard output and error streams to files and prints everything at the end.
-Bonus points if you can also report how many runs it took for the script to fail.
+1. Katakan Anda memiliki perintah yang jarang gagal. Untuk melakukan debugging, Anda perlu menangkap outputnya tetapi bisa memakan waktu lama untuk mendapatkan hasil yang gagal.
+Tulis skrip bash yang menjalankan skrip berikut sampai ia gagal dan menangkap standard output serta error stream ke file dan mencetak semuanya di akhir.
+Poin bonus jika Anda juga dapat melaporkan berapa kali percobaan yang diperlukan hingga skrip gagal.
 
     ```bash
     #!/usr/bin/env bash
@@ -368,18 +368,18 @@ echo "found error after $count runs"
 cat out.txt
 {% endcomment %}
 
-1. As we covered in the lecture `find`'s `-exec` can be very powerful for performing operations over the files we are searching for.
-However, what if we want to do something with **all** the files, like creating a zip file?
-As you have seen so far commands will take input from both arguments and STDIN.
-When piping commands, we are connecting STDOUT to STDIN, but some commands like `tar` take inputs from arguments.
-To bridge this disconnect there's the [`xargs`](https://www.man7.org/linux/man-pages/man1/xargs.1.html) command which will execute a command using STDIN as arguments.
-For example `ls | xargs rm` will delete the files in the current directory.
+1. Seperti yang kita bahas di kuliah, `-exec` milik `find` bisa sangat powerful untuk melakukan operasi pada file yang kita cari.
+Namun, bagaimana jika kita ingin melakukan sesuatu dengan **semua** file, seperti membuat file zip?
+Seperti yang telah Anda lihat sejauh ini, perintah menerima input baik dari argumen maupun STDIN.
+Saat mem-pipe perintah, kita menghubungkan STDOUT ke STDIN, tetapi beberapa perintah seperti `tar` menerima input dari argumen.
+Untuk menjembatani ketidaksesuaian ini, ada perintah [`xargs`](https://www.man7.org/linux/man-pages/man1/xargs.1.html) yang akan menjalankan perintah menggunakan STDIN sebagai argumen.
+Misalnya `ls | xargs rm` akan menghapus file-file di direktori saat ini.
 
-    Your task is to write a command that recursively finds all HTML files in the folder and makes a zip with them. Note that your command should work even if the files have spaces (hint: check `-d` flag for `xargs`).
+    Tugas Anda adalah menulis perintah yang secara rekursif mencari semua file HTML dalam folder dan membuat zip dari file-file tersebut. Perhatikan bahwa perintah Anda harus berfungsi meskipun file memiliki spasi (petunjuk: periksa flag `-d` untuk `xargs`).
     {% comment %}
     find . -type f -name "*.html" | xargs -d '\n'  tar -cvzf archive.tar.gz
     {% endcomment %}
 
-    If you're on macOS, note that the default BSD `find` is different from the one included in [GNU coreutils](https://en.wikipedia.org/wiki/List_of_GNU_Core_Utilities_commands). You can use `-print0` on `find` and the `-0` flag on `xargs`. As a macOS user, you should be aware that command-line utilities shipped with macOS may differ from the GNU counterparts; you can install the GNU versions if you like by [using brew](https://formulae.brew.sh/formula/coreutils).
+    Jika Anda menggunakan macOS, perhatikan bahwa `find` BSD default berbeda dari yang disertakan dalam [GNU coreutils](https://en.wikipedia.org/wiki/List_of_GNU_Core_Utilities_commands). Anda dapat menggunakan `-print0` pada `find` dan flag `-0` pada `xargs`. Sebagai pengguna macOS, Anda harus menyadari bahwa utilitas baris perintah yang disertakan dengan macOS mungkin berbeda dari versi GNU; Anda dapat menginstal versi GNU jika Anda mau dengan [menggunakan brew](https://formulae.brew.sh/formula/coreutils).
 
-1. (Advanced) Write a command or script to recursively find the most recently modified file in a directory. More generally, can you list all files by recency?
+1. (Lanjutan) Tulis perintah atau skrip untuk secara rekursif menemukan file yang paling baru diubah dalam sebuah direktori. Secara lebih umum, dapatkah Anda menampilkan semua file berdasarkan recency?

--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Version Control (Git)"
 description: >
-  Learn Git's data model and how to use Git for version control and collaboration.
+  Pelajari model data Git dan cara menggunakan Git untuk version control dan kolaborasi.
 thumbnail: /static/assets/thumbnails/2020/lec6.png
 date: 2020-01-22
 ready: true
@@ -11,61 +11,60 @@ video:
   id: 2sjqTHE0zok
 ---
 
-Version control systems (VCSs) are tools used to track changes to source code
-(or other collections of files and folders). As the name implies, these tools
-help maintain a history of changes; furthermore, they facilitate collaboration.
-VCSs track changes to a folder and its contents in a series of snapshots, where
-each snapshot encapsulates the entire state of files/folders within a top-level
-directory. VCSs also maintain metadata like who created each snapshot, messages
-associated with each snapshot, and so on.
+Sistem version control (VCS) adalah alat yang digunakan untuk melacak perubahan pada kode sumber
+(atau koleksi file dan folder lainnya). Sesuai namanya, alat-alat ini
+membantu mempertahankan riwayat perubahan; selain itu, mereka memfasilitasi kolaborasi.
+VCS melacak perubahan pada sebuah folder dan isinya dalam serangkaian snapshot, di mana
+setiap snapshot mencakup seluruh keadaan file/folder dalam sebuah direktori
+tingkat atas. VCS juga mempertahankan metadata seperti siapa yang membuat setiap snapshot, pesan
+yang terkait dengan setiap snapshot, dan sebagainya.
 
-Why is version control useful? Even when you're working by yourself, it can let
-you look at old snapshots of a project, keep a log of why certain changes were
-made, work on parallel branches of development, and much more. When working
-with others, it's an invaluable tool for seeing what other people have changed,
-as well as resolving conflicts in concurrent development.
+Mengapa version control berguna? Bahkan ketika Anda bekerja sendiri, version control memungkinkan Anda
+melihat snapshot lama dari sebuah proyek, menyimpan log mengapa perubahan tertentu dibuat,
+bekerja pada cabang pengembangan yang paralel, dan banyak lagi. Ketika bekerja
+dengan orang lain, ini adalah alat yang sangat berharga untuk melihat apa yang telah diubah orang lain,
+serta menyelesaikan konflik dalam pengembangan yang bersamaan.
 
-Modern VCSs also let you easily (and often automatically) answer questions
-like:
+VCS modern juga memungkinkan Anda untuk dengan mudah (dan sering kali secara otomatis) menjawab pertanyaan
+seperti:
 
-- Who wrote this module?
-- When was this particular line of this particular file edited? By whom? Why
-  was it edited?
-- Over the last 1000 revisions, when/why did a particular unit test stop
-working?
+- Siapa yang menulis modul ini?
+- Kapan baris tertentu dari file tertentu ini diedit? Oleh siapa? Mengapa
+  diedit?
+- Dalam 1000 revisi terakhir, kapan/mengapa unit test tertentu berhenti
+  berfungsi?
 
-While other VCSs exist, **Git** is the de facto standard for version control.
-This [XKCD comic](https://xkcd.com/1597/) captures Git's reputation:
+Meskipun ada VCS lain, **Git** adalah standar de facto untuk version control.
+[Komik XKCD](https://xkcd.com/1597/) ini menggambarkan reputasi Git:
 
 ![xkcd 1597](https://imgs.xkcd.com/comics/git.png)
 
-Because Git's interface is a leaky abstraction, learning Git top-down (starting
-with its interface / command-line interface) can lead to a lot of confusion.
-It's possible to memorize a handful of commands and think of them as magic
-incantations, and follow the approach in the comic above whenever anything goes
-wrong.
+Karena antarmuka Git adalah abstraksi yang bocor, mempelajari Git dari atas ke bawah (dimulai
+dari antarmuka / command-line interface) dapat menyebabkan banyak kebingungan.
+Anda mungkin bisa menghafal beberapa perintah dan menganggapnya sebagai mantra sihir,
+dan mengikuti pendekatan dalam komik di atas setiap kali ada yang salah.
 
-While Git admittedly has an ugly interface, its underlying design and ideas are
-beautiful. While an ugly interface has to be _memorized_, a beautiful design
-can be _understood_. For this reason, we give a bottom-up explanation of Git,
-starting with its data model and later covering the command-line interface.
-Once the data model is understood, the commands can be better understood in
-terms of how they manipulate the underlying data model.
+Meskipun antarmuka Git memang memiliki antarmuka yang kurang menarik, desain dan ide di baliknya
+sangat indah. Meskipun antarmuka yang kurang menarik harus _dihafal_, desain yang indah
+dapat _dipahami_. Karena alasan ini, kami memberikan penjelasan Git dari bawah ke atas,
+dimulai dari model datanya dan kemudian membahas command-line interface.
+Setelah model data dipahami, perintah-perintah dapat dipahami dengan lebih baik dalam
+hal bagaimana mereka memanipulasi model data yang mendasarinya.
 
-# Git's data model
+# Model data Git
 
-There are many ad-hoc approaches you could take to version control. Git has a
-well-thought-out model that enables all the nice features of version control,
-like maintaining history, supporting branches, and enabling collaboration.
+Ada banyak pendekatan ad-hoc yang bisa Anda ambil untuk version control. Git memiliki
+model yang dirancang dengan baik yang memungkinkan semua fitur bagus dari version control,
+seperti mempertahankan riwayat, mendukung cabang, dan memfasilitasi kolaborasi.
 
-## Snapshots
+## Snapshot
 
-Git models the history of a collection of files and folders within some
-top-level directory as a series of snapshots. In Git terminology, a file is
-called a "blob", and it's just a bunch of bytes. A directory is called a
-"tree", and it maps names to blobs or trees (so directories can contain other
-directories). A snapshot is the top-level tree that is being tracked. For
-example, we might have a tree as follows:
+Git memodelkan riwayat koleksi file dan folder dalam sebuah
+direktori tingkat atas sebagai serangkaian snapshot. Dalam terminologi Git, sebuah file disebut
+"blob", dan isinya hanyalah sekumpulan byte. Sebuah direktori disebut
+"tree", dan ia memetakan nama ke blob atau tree (sehingga direktori dapat berisi direktori
+lain). Sebuah snapshot adalah tree tingkat atas yang sedang dilacak. Sebagai
+contoh, kita mungkin memiliki tree sebagai berikut:
 
 ```
 <root> (tree)
@@ -77,24 +76,24 @@ example, we might have a tree as follows:
 +- baz.txt (blob, contents = "git is wonderful")
 ```
 
-The top-level tree contains two elements, a tree "foo" (that itself contains
-one element, a blob "bar.txt"), and a blob "baz.txt".
+Tree tingkat atas berisi dua elemen, sebuah tree "foo" (yang berisi
+satu elemen, sebuah blob "bar.txt"), dan sebuah blob "baz.txt".
 
-## Modeling history: relating snapshots
+## Memodelkan riwayat: menghubungkan snapshot
 
-How should a version control system relate snapshots? One simple model would be
-to have a linear history. A history would be a list of snapshots in time-order.
-For many reasons, Git doesn't use a simple model like this.
+Bagaimana seharusnya sistem version control menghubungkan snapshot? Satu model sederhana adalah
+memiliki riwayat linear. Sebuah riwayat akan menjadi daftar snapshot dalam urutan waktu.
+Karena banyak alasan, Git tidak menggunakan model sederhana seperti ini.
 
-In Git, a history is a directed acyclic graph (DAG) of snapshots. That may
-sound like a fancy math word, but don't be intimidated. All this means is that
-each snapshot in Git refers to a set of "parents", the snapshots that preceded
-it. It's a set of parents rather than a single parent (as would be the case in
-a linear history) because a snapshot might descend from multiple parents, for
-example, due to combining (merging) two parallel branches of development.
+Dalam Git, sebuah riwayat adalah directed acyclic graph (DAG) dari snapshot. Itu mungkin
+terdengar seperti istilah matematika yang rumit, tetapi jangan terintimidasi. Yang dimaksud adalah
+setiap snapshot dalam Git merujuk pada sekumpulan "parent", yaitu snapshot yang mendahuluinya.
+Ini adalah sekumpulan parent daripada satu parent (seperti yang terjadi dalam
+riwayat linear) karena sebuah snapshot mungkin berasal dari beberapa parent, misalnya,
+karena penggabungan (merge) dua cabang pengembangan yang paralel.
 
-Git calls these snapshots "commit"s. Visualizing a commit history might look
-something like this:
+Git menyebut snapshot ini sebagai "commit". Memvisualisasikan riwayat commit mungkin terlihat
+seperti ini:
 
 ```
 o <-- o <-- o <-- o
@@ -103,14 +102,14 @@ o <-- o <-- o <-- o
               --- o <-- o
 ```
 
-In the ASCII art above, the `o`s correspond to individual commits (snapshots).
-The arrows point to the parent of each commit (it's a "comes before" relation,
-not "comes after"). After the third commit, the history branches into two
-separate branches. This might correspond to, for example, two separate features
-being developed in parallel, independently from each other. In the future,
-these branches may be merged to create a new snapshot that incorporates both of
-the features, producing a new history that looks like this, with the newly
-created merge commit shown in bold:
+Dalam gambar ASCII di atas, `o` mewakili commit individual (snapshot).
+Panah menunjuk ke parent dari setiap commit (ini adalah relasi "mendahului",
+bukan "mengikuti"). Setelah commit ketiga, riwayat bercabang menjadi dua
+cabang yang terpisah. Ini mungkin sesuai dengan, misalnya, dua fitur terpisah
+yang dikembangkan secara paralel, secara independen satu sama lain. Di masa depan,
+cabang-cabang ini dapat digabungkan untuk membuat snapshot baru yang menggabungkan kedua
+fitur tersebut, menghasilkan riwayat baru yang terlihat seperti ini, dengan commit merge
+yang baru dibuat ditampilkan dalam huruf tebal:
 
 <pre class="highlight">
 <code>
@@ -121,14 +120,14 @@ o <-- o <-- o <-- o <---- <strong>o</strong>
 </code>
 </pre>
 
-Commits in Git are immutable. This doesn't mean that mistakes can't be
-corrected, however; it's just that "edits" to the commit history are actually
-creating entirely new commits, and references (see below) are updated to point
-to the new ones.
+Commit dalam Git bersifat immutable. Ini bukan berarti kesalahan tidak bisa
+diperbaiki; hanya saja "edit" pada riwayat commit sebenarnya
+membuat commit yang sepenuhnya baru, dan referensi (lihat di bawah) diperbarui untuk menunjuk
+ke yang baru.
 
-## Data model, as pseudocode
+## Model data, sebagai pseudocode
 
-It may be instructive to see Git's data model written down in pseudocode:
+Mungkin berguna untuk melihat model data Git dituliskan dalam pseudocode:
 
 ```
 // a file is a bunch of bytes
@@ -146,18 +145,17 @@ type commit = struct {
 }
 ```
 
-It's a clean, simple model of history.
+Ini adalah model riwayat yang bersih dan sederhana.
 
-## Objects and content-addressing
+## Object dan content-addressing
 
-An "object" is a blob, tree, or commit:
+Sebuah "object" adalah blob, tree, atau commit:
 
 ```
 type object = blob | tree | commit
 ```
 
-In Git data store, all objects are content-addressed by their [SHA-1
-hash](https://en.wikipedia.org/wiki/SHA-1).
+Dalam penyimpanan data Git, semua object di-address berdasarkan [hash SHA-1](https://en.wikipedia.org/wiki/SHA-1) mereka.
 
 ```
 objects = map<string, object>
@@ -170,23 +168,23 @@ def load(id):
     return objects[id]
 ```
 
-Blobs, trees, and commits are unified in this way: they are all objects. When
-they reference other objects, they don't actually _contain_ them in their
-on-disk representation, but have a reference to them by their hash.
+Blob, tree, dan commit disatukan dengan cara ini: semuanya adalah object. Ketika
+mereka merujuk ke object lain, mereka sebenarnya tidak _berisi_ object tersebut dalam
+representasi di disk mereka, tetapi memiliki referensi ke object tersebut berdasarkan hash-nya.
 
-For example, the tree for the example directory structure [above](#snapshots)
-(visualized using `git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d`),
-looks like this:
+Sebagai contoh, tree untuk struktur direktori contoh [di atas](#snapshots)
+(divisualisasikan menggunakan `git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d`),
+terlihat seperti ini:
 
 ```
 100644 blob 4448adbf7ecd394f42ae135bbeed9676e894af85    baz.txt
 040000 tree c68d233a33c5c06e0340e4c224f0afca87c8ce87    foo
 ```
 
-The tree itself contains pointers to its contents, `baz.txt` (a blob) and `foo`
-(a tree). If we look at the contents addressed by the hash corresponding to
-baz.txt with `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85`, we get
-the following:
+Tree itu sendiri berisi pointer ke isinya, `baz.txt` (sebuah blob) dan `foo`
+(sebuah tree). Jika kita melihat isi yang di-address oleh hash yang sesuai dengan
+baz.txt menggunakan `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85`, kita mendapatkan
+hasil berikut:
 
 ```
 git is wonderful
@@ -194,14 +192,14 @@ git is wonderful
 
 ## References
 
-Now, all snapshots can be identified by their SHA-1 hashes. That's inconvenient,
-because humans aren't good at remembering strings of 40 hexadecimal characters.
+Sekarang, semua snapshot dapat diidentifikasi berdasarkan hash SHA-1 mereka. Itu tidak praktis,
+karena manusia tidak pandai mengingat string yang terdiri dari 40 karakter heksadesimal.
 
-Git's solution to this problem is human-readable names for SHA-1 hashes, called
-"references". References are pointers to commits. Unlike objects, which are
-immutable, references are mutable (can be updated to point to a new commit).
-For example, the `master` reference usually points to the latest commit in the
-main branch of development.
+Solusi Git untuk masalah ini adalah nama yang mudah dibaca manusia untuk hash SHA-1, yang disebut
+"references". References adalah pointer ke commit. Berbeda dengan object yang bersifat
+immutable, references bersifat mutable (dapat diperbarui untuk menunjuk ke commit baru).
+Sebagai contoh, reference `master` biasanya menunjuk ke commit terbaru di
+cabang pengembangan utama.
 
 ```
 references = map<string, string>
@@ -219,57 +217,57 @@ def load_reference(name_or_id):
         return load(name_or_id)
 ```
 
-With this, Git can use human-readable names like "master" to refer to a
-particular snapshot in the history, instead of a long hexadecimal string.
+Dengan ini, Git dapat menggunakan nama yang mudah dibaca manusia seperti "master" untuk merujuk ke
+snapshot tertentu dalam riwayat, alih-alih string heksadesimal yang panjang.
 
-One detail is that we often want a notion of "where we currently are" in the
-history, so that when we take a new snapshot, we know what it is relative to
-(how we set the `parents` field of the commit). In Git, that "where we
-currently are" is a special reference called "HEAD".
+Satu detail adalah bahwa kita sering kali membutuhkan konsep "di mana kita saat ini" dalam
+riwayat, sehingga ketika kita mengambil snapshot baru, kita tahu snapshot itu relatif terhadap apa
+(bagaimana kita mengatur field `parents` dari commit). Dalam Git, "di mana kita
+saat ini" adalah reference khusus yang disebut "HEAD".
 
 ## Repositories
 
-Finally, we can define what (roughly) is a Git _repository_: it is the data
-`objects` and `references`.
+Terakhir, kita dapat mendefinisikan apa (secara kasar) sebuah _repository_ Git: yaitu data
+`objects` dan `references`.
 
-On disk, all Git stores are objects and references: that's all there is to Git's
-data model. All `git` commands map to some manipulation of the commit DAG by
-adding objects and adding/updating references.
+Di disk, semua penyimpanan Git adalah object dan referensi: hanya itu yang ada dalam
+model data Git. Semua perintah `git` memetakan ke beberapa manipulasi pada DAG commit dengan
+menambahkan object dan menambahkan/memperbarui references.
 
-Whenever you're typing in any command, think about what manipulation the
-command is making to the underlying graph data structure. Conversely, if you're
-trying to make a particular kind of change to the commit DAG, e.g. "discard
-uncommitted changes and make the 'master' ref point to commit `5d83f9e`", there's
-probably a command to do it (e.g. in this case, `git checkout master; git reset
+Setiap kali Anda mengetik perintah apa pun, pikirkan manipulasi apa yang
+dibuat perintah tersebut pada struktur data graf yang mendasarinya. Sebaliknya, jika Anda
+mencoba membuat jenis perubahan tertentu pada DAG commit, misalnya "buang
+perubahan yang belum di-commit dan buat ref 'master' menunjuk ke commit `5d83f9e`", ada
+kemungkinan ada perintah untuk melakukannya (misalnya dalam kasus ini, `git checkout master; git reset
 --hard 5d83f9e`).
 
 # Staging area
 
-This is another concept that's orthogonal to the data model, but it's a part of
-the interface to create commits.
+Ini adalah konsep lain yang ortogonal terhadap model data, tetapi ini adalah bagian dari
+antarmuka untuk membuat commit.
 
-One way you might imagine implementing snapshotting as described above is to have
-a "create snapshot" command that creates a new snapshot based on the _current
-state_ of the working directory. Some version control tools work like this, but
-not Git. We want clean snapshots, and it might not always be ideal to make a
-snapshot from the current state. For example, imagine a scenario where you've
-implemented two separate features, and you want to create two separate commits,
-where the first introduces the first feature, and the next introduces the
-second feature. Or imagine a scenario where you have debugging print statements
-added all over your code, along with a bugfix; you want to commit the bugfix
-while discarding all the print statements.
+Salah satu cara yang bisa Anda bayangkan untuk mengimplementasikan snapshot seperti yang dijelaskan di atas adalah
+dengan memiliki perintah "create snapshot" yang membuat snapshot baru berdasarkan _keadaan
+saat ini_ dari direktori kerja. Beberapa alat version control bekerja seperti ini, tetapi
+bukan Git. Kita menginginkan snapshot yang bersih, dan mungkin tidak selalu ideal untuk membuat
+snapshot dari keadaan saat ini. Misalnya, bayangkan skenario di mana Anda telah
+mengimplementasikan dua fitur terpisah, dan Anda ingin membuat dua commit terpisah,
+di mana yang pertama memperkenalkan fitur pertama, dan yang berikutnya memperkenalkan
+fitur kedua. Atau bayangkan skenario di mana Anda memiliki pernyataan print debugging
+yang ditambahkan di seluruh kode Anda, bersama dengan perbaikan bug; Anda ingin meng-commit perbaikan bug
+tersebut sambil membuang semua pernyataan print.
 
-Git accommodates such scenarios by allowing you to specify which modifications
-should be included in the next snapshot through a mechanism called the "staging
+Git mengakomodasi skenario seperti ini dengan memungkinkan Anda menentukan modifikasi mana
+yang harus disertakan dalam snapshot berikutnya melalui mekanisme yang disebut "staging
 area".
 
-# Git command-line interface
+# Command-line interface Git
 
-To avoid duplicating information, we're not going to explain the commands below
-in detail. See the highly recommended [Pro Git](https://git-scm.com/book/en/v2)
-for more information, or watch the lecture video.
+Untuk menghindari duplikasi informasi, kami tidak akan menjelaskan perintah-perintah di bawah ini
+secara detail. Lihat [Pro Git](https://git-scm.com/book/en/v2) yang sangat direkomendasikan
+untuk informasi lebih lanjut, atau tonton video kuliah.
 
-## Basics
+## Dasar-dasar
 
 {% comment %}
 
@@ -424,20 +422,20 @@ index 94bab17..f0013b2 100644
 
 {% endcomment %}
 
-- `git help <command>`: get help for a git command
-- `git init`: creates a new git repo, with data stored in the `.git` directory
-- `git status`: tells you what's going on
-- `git add <filename>`: adds files to staging area
-- `git commit`: creates a new commit
-    - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)!
-    - Even more reasons to write [good commit messages](https://chris.beams.io/posts/git-commit/)!
-- `git log`: shows a flattened log of history
-- `git log --all --graph --decorate`: visualizes history as a DAG
-- `git diff <filename>`: show changes you made relative to the staging area
-- `git diff <revision> <filename>`: shows differences in a file between snapshots
-- `git checkout <revision>`: updates HEAD (and current branch if checking out a branch)
+- `git help <command>`: mendapatkan bantuan untuk perintah git
+- `git init`: membuat repo git baru, dengan data disimpan di direktori `.git`
+- `git status`: memberi tahu Anda apa yang sedang terjadi
+- `git add <filename>`: menambahkan file ke staging area
+- `git commit`: membuat commit baru
+    - Tulis [pesan commit yang baik](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)!
+    - Lebih banyak alasan untuk menulis [pesan commit yang baik](https://chris.beams.io/posts/git-commit/)!
+- `git log`: menampilkan log riwayat yang diratakan
+- `git log --all --graph --decorate`: memvisualisasikan riwayat sebagai DAG
+- `git diff <filename>`: menampilkan perubahan yang Anda buat relatif terhadap staging area
+- `git diff <revision> <filename>`: menampilkan perbedaan dalam sebuah file antar snapshot
+- `git checkout <revision>`: memperbarui HEAD (dan cabang saat ini jika melakukan checkout sebuah cabang)
 
-## Branching and merging
+## Branching dan merging
 
 {% comment %}
 
@@ -452,124 +450,124 @@ command is used for merging.
 
 {% endcomment %}
 
-- `git branch`: shows branches
-- `git branch <name>`: creates a branch
-- `git checkout -b <name>`: creates a branch and switches to it
-    - same as `git branch <name>; git checkout <name>`
-- `git merge <revision>`: merges into current branch
-- `git mergetool`: use a fancy tool to help resolve merge conflicts
-- `git rebase`: rebase set of patches onto a new base
+- `git branch`: menampilkan cabang-cabang
+- `git branch <name>`: membuat sebuah cabang
+- `git checkout -b <name>`: membuat sebuah cabang dan beralih ke cabang tersebut
+    - sama dengan `git branch <name>; git checkout <name>`
+- `git merge <revision>`: menggabungkan ke cabang saat ini
+- `git mergetool`: menggunakan alat yang canggih untuk membantu menyelesaikan konflik merge
+- `git rebase`: memindahkan sekumpulan patch ke basis baru
 
 ## Remotes
 
-- `git remote`: list remotes
-- `git remote add <name> <url>`: add a remote
-- `git push <remote> <local branch>:<remote branch>`: send objects to remote, and update remote reference
-- `git branch --set-upstream-to=<remote>/<remote branch>`: set up correspondence between local and remote branch
-- `git fetch`: retrieve objects/references from a remote
-- `git pull`: same as `git fetch; git merge`
-- `git clone`: download repository from remote
+- `git remote`: daftar remotes
+- `git remote add <name> <url>`: menambahkan sebuah remote
+- `git push <remote> <local branch>:<remote branch>`: mengirim object ke remote, dan memperbarui referensi remote
+- `git branch --set-upstream-to=<remote>/<remote branch>`: mengatur korespondensi antara cabang lokal dan remote
+- `git fetch`: mengambil object/referensi dari sebuah remote
+- `git pull`: sama dengan `git fetch; git merge`
+- `git clone`: mengunduh repository dari remote
 
 ## Undo
 
-- `git commit --amend`: edit a commit's contents/message
-- `git reset HEAD <file>`: unstage a file
-- `git checkout -- <file>`: discard changes
+- `git commit --amend`: mengedit isi/pesan sebuah commit
+- `git reset HEAD <file>`: menghapus file dari staging area
+- `git checkout -- <file>`: membatalkan perubahan
 
-# Advanced Git
+# Git Lanjutan
 
-- `git config`: Git is [highly customizable](https://git-scm.com/docs/git-config)
-- `git clone --depth=1`: shallow clone, without entire version history
-- `git add -p`: interactive staging
-- `git rebase -i`: interactive rebasing
-- `git blame`: show who last edited which line
-- `git stash`: temporarily remove modifications to working directory
-- `git bisect`: binary search history (e.g. for regressions)
-- `.gitignore`: [specify](https://git-scm.com/docs/gitignore) intentionally untracked files to ignore
+- `git config`: Git [sangat dapat dikustomisasi](https://git-scm.com/docs/git-config)
+- `git clone --depth=1`: clone dangkal, tanpa seluruh riwayat versi
+- `git add -p`: staging interaktif
+- `git rebase -i`: rebasing interaktif
+- `git blame`: menampilkan siapa yang terakhir mengedit baris mana
+- `git stash`: sementara menghapus modifikasi pada direktori kerja
+- `git bisect`: pencarian biner pada riwayat (misalnya untuk regresi)
+- `.gitignore`: [menentukan](https://git-scm.com/docs/gitignore) file yang tidak terlacak yang sengaja diabaikan
 
-# Miscellaneous
+# Lain-lain
 
-- **GUIs**: there are many [GUI clients](https://git-scm.com/downloads/guis)
-out there for Git. We personally don't use them and use the command-line
-interface instead.
-- **Shell integration**: it's super handy to have a Git status as part of your
-shell prompt ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
-[bash](https://github.com/magicmonty/bash-git-prompt)). Often included in
-frameworks like [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
-- **Editor integration**: similarly to the above, handy integrations with many
-features. [fugitive.vim](https://github.com/tpope/vim-fugitive) is the standard
-one for Vim.
-- **Workflows**: we taught you the data model, plus some basic commands; we
-didn't tell you what practices to follow when working on big projects (and
-there are [many](https://nvie.com/posts/a-successful-git-branching-model/)
-[different](https://www.endoflineblog.com/gitflow-considered-harmful)
-[approaches](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)).
-- **GitHub**: Git is not GitHub. GitHub has a specific way of contributing code
-to other projects, called [pull
-requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
-- **Other Git providers**: GitHub is not special: there are many Git repository
-hosts, like [GitLab](https://about.gitlab.com/) and
-[BitBucket](https://bitbucket.org/).
+- **GUI**: ada banyak [klien GUI](https://git-scm.com/downloads/guis)
+  untuk Git. Kami secara pribadi tidak menggunakannya dan lebih memilih menggunakan
+  command-line interface.
+- **Integrasi shell**: sangat berguna memiliki status Git sebagai bagian dari
+  prompt shell Anda ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
+  [bash](https://github.com/magicmonty/bash-git-prompt)). Sering kali sudah termasuk dalam
+  framework seperti [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
+- **Integrasi editor**: serupa dengan di atas, integrasi yang berguna dengan banyak
+  fitur. [fugitive.vim](https://github.com/tpope/vim-fugitive) adalah standar
+  untuk Vim.
+- **Workflow**: kami telah mengajari Anda model data, ditambah beberapa perintah dasar; kami
+  tidak memberitahu Anda praktik apa yang harus diikuti ketika bekerja pada proyek besar (dan
+  ada [banyak](https://nvie.com/posts/a-successful-git-branching-model/)
+  [berbeda](https://www.endoflineblog.com/gitflow-considered-harmful)
+  [pendekatan](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)).
+- **GitHub**: Git bukan GitHub. GitHub memiliki cara khusus untuk berkontribusi kode
+  ke proyek lain, yang disebut [pull
+  requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+- **Penyedia Git lainnya**: GitHub bukan satu-satunya: ada banyak host repository Git,
+  seperti [GitLab](https://about.gitlab.com/) dan
+  [BitBucket](https://bitbucket.org/).
 
-# Resources
+# Sumber Daya
 
-- [Pro Git](https://git-scm.com/book/en/v2) is **highly recommended reading**.
-Going through Chapters 1--5 should teach you most of what you need to use Git
-proficiently, now that you understand the data model. The later chapters have
-some interesting, advanced material.
-- [Oh Shit, Git!?!](https://ohshitgit.com/) is a short guide on how to recover
-from some common Git mistakes.
+- [Pro Git](https://git-scm.com/book/en/v2) adalah **bacaan yang sangat direkomendasikan**.
+  Membaca Bab 1--5 seharusnya mengajari Anda sebagian besar yang perlu Anda ketahui untuk menggunakan Git
+  dengan mahir, sekarang Anda sudah memahami model datanya. Bab-bab selanjutnya memiliki
+  beberapa materi lanjutan yang menarik.
+- [Oh Shit, Git!?!](https://ohshitgit.com/) adalah panduan singkat tentang cara memulihkan
+  dari beberapa kesalahan umum Git.
 - [Git for Computer
-Scientists](https://eagain.net/articles/git-for-computer-scientists/) is a
-short explanation of Git's data model, with less pseudocode and more fancy
-diagrams than these lecture notes.
+  Scientists](https://eagain.net/articles/git-for-computer-scientists/) adalah
+  penjelasan singkat tentang model data Git, dengan lebih sedikit pseudocode dan lebih banyak diagram
+  yang menarik daripada catatan kuliah ini.
 - [Git from the Bottom Up](https://jwiegley.github.io/git-from-the-bottom-up/)
-is a detailed explanation of Git's implementation details beyond just the data
-model, for the curious.
+  adalah penjelasan detail tentang detail implementasi Git di luar hanya model
+  data, untuk yang penasaran.
 - [How to explain git in simple
-words](https://smusamashah.github.io/blog/2017/10/14/explain-git-in-simple-words)
-- [Learn Git Branching](https://learngitbranching.js.org/) is a browser-based
-game that teaches you Git.
+  words](https://smusamashah.github.io/blog/2017/10/14/explain-git-in-simple-words)
+- [Learn Git Branching](https://learngitbranching.js.org/) adalah permainan
+  berbasis browser yang mengajari Anda Git.
 
-# Exercises
+# Latihan
 
-1. If you don't have any past experience with Git, either try reading the first
-   couple chapters of [Pro Git](https://git-scm.com/book/en/v2) or go through a
-   tutorial like [Learn Git Branching](https://learngitbranching.js.org/). As
-   you're working through it, relate Git commands to the data model.
-1. Clone the [repository for the
-class website](https://github.com/missing-semester/missing-semester).
-    1. Explore the version history by visualizing it as a graph.
-    1. Who was the last person to modify `README.md`? (Hint: use `git log` with
-       an argument).
-    1. What was the commit message associated with the last modification to the
-       `collections:` line of `_config.yml`? (Hint: use `git blame` and `git
+1. Jika Anda tidak memiliki pengalaman sebelumnya dengan Git, cobalah membaca beberapa
+   bab pertama [Pro Git](https://git-scm.com/book/en/v2) atau ikuti
+   tutorial seperti [Learn Git Branching](https://learngitbranching.js.org/). Saat
+   Anda mengerjakannya, hubungkan perintah Git dengan model data.
+1. Clone [repository untuk
+   situs web kelas](https://github.com/missing-semester/missing-semester).
+    1. Jelajahi riwayat versi dengan memvisualisasikannya sebagai graf.
+    1. Siapa orang terakhir yang memodifikasi `README.md`? (Petunjuk: gunakan `git log` dengan
+       sebuah argumen).
+    1. Apa pesan commit yang terkait dengan modifikasi terakhir pada
+       baris `collections:` di `_config.yml`? (Petunjuk: gunakan `git blame` dan `git
        show`).
-1. One common mistake when learning Git is to commit large files that should
-   not be managed by Git or adding sensitive information. Try adding a file to
-   a repository, making some commits and then deleting that file from history
-   (you may want to look at
-   [this](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)).
-1. Clone some repository from GitHub, and modify one of its existing files.
-   What happens when you do `git stash`? What do you see when running `git log
-   --all --oneline`? Run `git stash pop` to undo what you did with `git stash`.
-   In what scenario might this be useful?
-1. Like many command line tools, Git provides a configuration file (or dotfile)
-   called `~/.gitconfig`. Create an alias in `~/.gitconfig` so that when you
-   run `git graph`, you get the output of `git log --all --graph --decorate
-   --oneline`. You can do this by directly
-   [editing](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias)
-   the `~/.gitconfig` file, or you can use the `git config` command to add the
-   alias. Information about git aliases can be found
-   [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
-1. You can define global ignore patterns in` ~/.gitignore_global` after running
-   `git config --global core.excludesfile ~/.gitignore_global`. This sets the
-   location of the global ignore file that Git will use, but you still need to
-   manually create the file at that path. Set up your global gitignore file to
-   ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
-1. Fork the [repository for the class
-   website](https://github.com/missing-semester/missing-semester), find a typo
-   or some other improvement you can make, and submit a pull request on GitHub
-   (you may want to look at [this](https://github.com/firstcontributions/first-contributions)).
-   Please only submit PRs that are useful (don't spam us, please!). If you
-   can't find an improvement to make, you can skip this exercise.
+1. Kesalahan umum saat belajar Git adalah meng-commit file besar yang seharusnya
+   tidak dikelola oleh Git atau menambahkan informasi sensitif. Cobalah menambahkan sebuah file ke
+   repository, membuat beberapa commit dan kemudian menghapus file tersebut dari riwayat
+   (Anda mungkin ingin melihat
+   [ini](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)).
+1. Clone beberapa repository dari GitHub, dan modifikasi salah satu file yang ada.
+   Apa yang terjadi ketika Anda melakukan `git stash`? Apa yang Anda lihat ketika menjalankan `git log
+   --all --oneline`? Jalankan `git stash pop` untuk membatalkan apa yang Anda lakukan dengan `git stash`.
+   Dalam skenario apa ini mungkin berguna?
+1. Seperti banyak alat command line, Git menyediakan file konfigurasi (atau dotfile)
+   yang disebut `~/.gitconfig`. Buat sebuah alias di `~/.gitconfig` sehingga ketika Anda
+   menjalankan `git graph`, Anda mendapatkan output dari `git log --all --graph --decorate
+   --oneline`. Anda dapat melakukannya dengan secara langsung
+   [mengedit](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias)
+   file `~/.gitconfig`, atau Anda dapat menggunakan perintah `git config` untuk menambahkan
+   alias. Informasi tentang alias git dapat ditemukan
+   [di sini](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
+1. Anda dapat mendefinisikan pola ignore global di `~/.gitignore_global` setelah menjalankan
+   `git config --global core.excludesfile ~/.gitignore_global`. Ini mengatur
+   lokasi file ignore global yang akan digunakan Git, tetapi Anda masih perlu
+   membuat file tersebut secara manual di path tersebut. Siapkan file gitignore global Anda untuk
+   mengabaikan file sementara yang spesifik untuk OS atau editor, seperti `.DS_Store`.
+1. Fork [repository untuk situs web
+   kelas](https://github.com/missing-semester/missing-semester), temukan typo
+   atau beberapa perbaikan lain yang dapat Anda buat, dan ajukan pull request di GitHub
+   (Anda mungkin ingin melihat [ini](https://github.com/firstcontributions/first-contributions)).
+   Harap hanya mengajukan PR yang berguna (tolong jangan spam kami!). Jika Anda
+   tidak dapat menemukan perbaikan yang dapat dibuat, Anda dapat melewati latihan ini.

--- a/_2020/version-control.md
+++ b/_2020/version-control.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Version Control (Git)"
 description: >
-  Learn Git's data model and how to use Git for version control and collaboration.
+  Pelajari model data Git dan cara menggunakan Git untuk version control dan kolaborasi.
 thumbnail: /static/assets/thumbnails/2020/lec6.png
 date: 2020-01-22
 ready: true

--- a/_2026/agentic-coding.md
+++ b/_2026/agentic-coding.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Agentic Coding"
 description: >
-  Learn how to use AI coding agents effectively for software development tasks.
+  Pelajari cara menggunakan AI coding agents secara efektif untuk tugas pengembangan perangkat lunak.
 thumbnail: /static/assets/thumbnails/2026/lec7.png
 date: 2026-01-21
 ready: true

--- a/_2026/agentic-coding.md
+++ b/_2026/agentic-coding.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Agentic Coding"
+title: "Coding dengan Agen AI"
 description: >
-  Learn how to use AI coding agents effectively for software development tasks.
+  Pelajari cara menggunakan agen coding AI secara efektif untuk tugas-tugas pengembangan perangkat lunak.
 thumbnail: /static/assets/thumbnails/2026/lec7.png
 date: 2026-01-21
 ready: true
@@ -11,9 +11,9 @@ video:
   id: sTdz6PZoAnw
 ---
 
-Coding agents are conversational AI models with access to tools such as reading/writing files, web search, and invoking shell commands. They live either in the IDE or in standalone command-line or GUI tools. Coding agents are highly autonomous and powerful tools, enabling a wide variety of use cases.
+Agen coding adalah model AI konversasional yang memiliki akses ke berbagai alat seperti membaca/menulis file, pencarian web, dan menjalankan perintah shell. Agen ini tersedia baik di dalam IDE maupun sebagai alat command-line atau GUI terpisah. Agen coding sangat otonom dan powerful, sehingga mendukung berbagai macam kasus penggunaan.
 
-This lecture builds on the AI-powered development material from the [Development Environment and Tools](/2026/development-environment/) lecture. As a quick demo, let's continue with the example from the [AI-powered development](/2026/development-environment/#ai-powered-development) section:
+Kuliah ini melanjutkan materi pengembangan berbasis AI dari kuliah [Development Environment and Tools](/2026/development-environment/). Sebagai demo singkat, mari kita lanjutkan contoh dari bagian [AI-powered development](/2026/development-environment/#ai-powered-development):
 
 ```python
 from urllib.request import urlopen
@@ -30,49 +30,49 @@ def extract(content: str) -> list[str]:
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
 ```
 
-We can try prompting a coding agent with the following task:
+Kita bisa mencoba memberikan tugas berikut kepada agen coding:
 
 ```
 Turn this into a proper command-line program, with argparse for argument parsing. Add type annotations, and make sure the program passes type checking.
 ```
 
-The agent will read the file to understand it, then make some edits, and finally invoke the type checker to make sure the type annotations are correct. If it makes a mistake such that it fails type checking, it will likely iterate, though this is a simple task so that is unlikely to happen. Because coding agents have access to tools that may be harmful, by default, agent harnesses prompt the user to confirm tool calls.
+Agen akan membaca file tersebut untuk memahaminya, kemudian melakukan beberapa perubahan, dan akhirnya menjalankan type checker untuk memastikan anotasi tipe sudah benar. Jika terjadi kesalahan sehingga gagal type checking, agen kemungkinan akan melakukan iterasi, meskipun ini adalah tugas sederhana sehingga kecil kemungkinannya terjadi kesalahan. Karena agen coding memiliki akses ke alat-alat yang berpotensi berbahaya, secara default, harness agen akan meminta pengguna untuk mengonfirmasi pemanggilan alat.
 
-> If the coding agent makes a mistake --- for example, if you have the `mypy` binary available directly on `$PATH` but the agent tries calling `python -m mypy` --- you can give it text feedback to help it course correct.
+> Jika agen coding membuat kesalahan --- misalnya, jika binary `mypy` tersedia langsung di `$PATH` tetapi agen mencoba memanggil `python -m mypy` --- Anda dapat memberikan umpan balik berupa teks untuk membantu agen mengoreksi arahnya.
 
-Coding agents support multi-turn interaction, so you can iterate on work over a back-and-forth conversation with the agent. You can even interrupt the agent if it's going down the wrong track. One helpful mental model might be that of a manager of an intern: the intern will do the nitty gritty work, but will require guidance, and will occasionally do the wrong thing and need to be corrected.
+Agen coding mendukung interaksi multi-turn, sehingga Anda dapat melakukan iterasi pekerjaan melalui percakapan bolak-balik dengan agen. Anda bahkan dapat menginterupsi agen jika arahnya salah. Satu model mental yang berguna adalah seperti seorang manajer yang mengelola seorang intern: intern akan mengerjakan detail-detail teknis, tetapi membutuhkan bimbingan, dan sesekali melakukan hal yang salah sehingga perlu dikoreksi.
 
-> For a more illustrative demo, try asking the agent as a follow-up to run the resulting script. Observe the outputs, and try asking it to make a change (e.g., ask it to include only absolute URLs).
+> Untuk demo yang lebih ilustratif, coba minta agen untuk menjalankan script hasilnya sebagai tindak lanjut. Amati outputnya, dan coba minta agen untuk melakukan perubahan (misalnya, minta agar hanya menyertakan URL absolut).
 
-# How AI models and agents work
+# Cara kerja model dan agen AI
 
-Fully explaining the inner workings of modern [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) and infrastructure such as agent harnesses is beyond the scope of this course. However, having a high-level understanding of some of the key ideas is helpful for effectively _using_ this bleeding edge technology and understanding its limitations.
+Menjelaskan secara lengkap cara kerja [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) modern dan infrastruktur seperti harness agen berada di luar cakupan kuliah ini. Namun, memahami beberapa ide kunci secara garis besar akan sangat membantu untuk _menggunakan_ teknologi mutakhir ini secara efektif dan memahami keterbatasannya.
 
-LLMs can be viewed as modeling the probability distribution of completion strings (outputs) given prompt strings (inputs). LLM inference (what happens when you, e.g., supply a query to a conversational chat app) _samples_ from this probability distribution. LLMs have a fixed _context window_, the maximum length of the input and output strings.
+LLM dapat dipandang sebagai pemodelan distribusi probabilitas dari string kompleksi (output) berdasarkan string prompt (input). Inferensi LLM (yang terjadi ketika Anda, misalnya, memberikan query ke aplikasi chat konversasional) _melakukan sampling_ dari distribusi probabilitas ini. LLM memiliki _context window_ yang tetap, yaitu panjang maksimum dari string input dan output.
 
 {% comment %}
 > In mathematical notation, the LLM models the probability distribution $\pi_\theta$ of completions $y$ conditioned on prompts $x$, and we sample from this distribution: $\hat{y} \sim \pi_\theta(\cdot \mid x)$.
 {% endcomment %}
 
-AI tools such as conversational chat and coding agents build on top of this primitive. For multi-turn interactions, chat apps and agents use turn markers and supply the entire conversation history as the prompt string every time there is a new user prompt, invoking LLM inference once per user prompt. For tool-calling agents, the harness interprets certain LLM outputs as requests to invoke a tool, and the harness supplies the results of the tool call back to the model as part of the prompt string (so LLM inference runs again every time there is a tool call/response). The core concepts in tool-calling agents can be [implemented in 200 lines of code](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/).
+Alat-alat AI seperti chat konversasional dan agen coding dibangun di atas primitif ini. Untuk interaksi multi-turn, aplikasi chat dan agen menggunakan penanda giliran dan menyediakan seluruh riwayat percakapan sebagai string prompt setiap kali ada prompt baru dari pengguna, sehingga menjalankan inferensi LLM sekali per prompt pengguna. Untuk agen yang mendukung pemanggilan alat, harness menginterpretasikan output LLM tertentu sebagai permintaan untuk memanggil sebuah alat, dan harness menyediakan hasil pemanggilan alat tersebut kembali ke model sebagai bagian dari string prompt (sehingga inferensi LLM dijalankan lagi setiap kali ada pemanggilan/respons alat). Konsep-konsep inti dalam agen pemanggilan alat dapat [diimplementasikan dalam 200 baris kode](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/).
 
-## Privacy
+## Privasi
 
-Most AI coding tools in their standard configurations send a lot of your data to the cloud. Sometimes the harness runs locally while LLM inference runs in the cloud, other times even more of the software is running in the cloud (and, e.g., the service provider might effectively get a copy of your entire repository as well as all interactions you have with the AI tool).
+Sebagian besar alat coding AI dalam konfigurasi standar mengirimkan banyak data Anda ke cloud. Terkadang harness berjalan secara lokal sementara inferensi LLM berjalan di cloud, dan terkadang lebih banyak lagi perangkat lunak yang berjalan di cloud (dan, misalnya, penyedia layanan mungkin secara efektif mendapatkan salinan seluruh repositori Anda serta semua interaksi Anda dengan alat AI).
 
-There are open-source AI coding tools and open-source LLMs that are pretty good (though not quite as good as the proprietary models), but at the present, for most users, running bleeding-edge open LLMs locally will be infeasible due to hardware limitations.
+Terdapat alat coding AI open-source dan LLM open-source yang cukup bagus (meskipun tidak sebaik model proprietary), namun saat ini, bagi sebagian besar pengguna, menjalankan LLM open mutakhir secara lokal tidak akan memungkinkan karena keterbatasan perangkat keras.
 
-# Use cases
+# Kasus penggunaan
 
-Coding agents can be helpful for a wide variety of tasks. Some examples:
+Agen coding dapat membantu untuk berbagai macam tugas. Beberapa contoh:
 
-- **Implementing new features.** As in the example above, you can ask a coding agent to implement a feature. Giving a good specification is more of an art than a science at this point; you want the input to the agent to be descriptive enough so that the agent does what you want it to do (at least heading in the right direction so you can iterate), but not overly descriptive to the point where you're doing too much work yourself. Test-driven development can be particularly effective: write tests (or use the coding agent to help you write tests), audit them to ensure they capture what you want, and then ask the coding agent to implement the feature. Models are continually improving, so you'll have to keep your intuition up-to-date on what the models are capable of.
-    > We used Claude Code to [implement](https://github.com/missing-semester/missing-semester/pull/345) these Tufte-style sidenotes.
+- **Mengimplementasikan fitur baru.** Seperti pada contoh di atas, Anda dapat meminta agen coding untuk mengimplementasikan sebuah fitur. Memberikan spesifikasi yang baik lebih merupakan seni daripada sains saat ini; Anda ingin input ke agen cukup deskriptif sehingga agen melakukan apa yang Anda inginkan (setidaknya mengarah ke arah yang benar sehingga Anda dapat melakukan iterasi), tetapi tidak terlalu deskriptif sampai-sampai Anda yang melakukan terlalu banyak pekerjaan. Test-driven development bisa sangat efektif: tulis test (atau gunakan agen coding untuk membantu Anda menulis test), audit test tersebut untuk memastikan mereka menangkap apa yang Anda inginkan, lalu minta agen coding untuk mengimplementasikan fiturnya. Model terus-menerus mengalami peningkatan, jadi Anda harus menjaga intuisi Anda tetap terkini tentang kemampuan model-model tersebut.
+    > Kami menggunakan Claude Code untuk [mengimplementasikan](https://github.com/missing-semester/missing-semester/pull/345) sidenotes bergaya Tufte ini.
 {%- comment %}
 No need to demo this, since the intro of a lecture was a small demo of adding a new feature.
 {% endcomment %}
-- **Fixing errors.** If you have errors from your compiler, linter, type checker, or tests, you can ask your agent to correct them, for example with a prompt like "fix the issues with mypy". Coding models are particularly effective when you can get them in a feedback loop, so try to set things up so that the model can run the failing check directly, which will let it iterate autonomously. If this is impractical, you can give the model feedback manually.
-    > On commit [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) of the missing-semester repo, we prompted Claude Code with "Review the agentic coding lecture for typos and grammatical issues" and subsequently asked it to fix the issues it found, which were committed in [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637).
+- **Memperbaiki error.** Jika Anda memiliki error dari compiler, linter, type checker, atau test, Anda dapat meminta agen untuk memperbaikinya, misalnya dengan prompt seperti "fix the issues with mypy". Model coding sangat efektif ketika Anda dapat memasukkannya ke dalam loop umpan balik, jadi cobalah mengatur agar model dapat menjalankan check yang gagal secara langsung, sehingga model dapat melakukan iterasi secara otonom. Jika hal ini tidak praktis, Anda dapat memberikan umpan balik ke model secara manual.
+    > Pada commit [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) di repositori missing-semester, kami memberikan prompt kepada Claude Code yaitu "Review the agentic coding lecture for typos and grammatical issues" dan kemudian memintanya untuk memperbaiki masalah yang ditemukannya, yang di-commit pada [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637).
 {%- comment %}
 Demo a coding agent fixing the bug in https://github.com/anishathalye/dotbot/commit/cef40c902ef0f52f484153413142b5154bbc5e99.
 
@@ -88,18 +88,18 @@ Can prompt coding agent with:
 
 Get it to commit the changes.
 {% endcomment %}
-- **Refactoring.** You can use coding agents to refactor code in various ways, from simple tasks like renaming a method (this kind of refactoring is also supported by [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers)) to more complex tasks like breaking out functionality into a separate module.
-    > We used Claude Code to [split](https://github.com/missing-semester/missing-semester/pull/344) agentic coding into its own lecture.
+- **Refactoring.** Anda dapat menggunakan agen coding untuk melakukan refactoring kode dalam berbagai cara, mulai dari tugas sederhana seperti mengubah nama method (refactoring semacam ini juga didukung oleh [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers)) hingga tugas yang lebih kompleks seperti memecah fungsionalitas ke dalam modul terpisah.
+    > Kami menggunakan Claude Code untuk [memisahkan](https://github.com/missing-semester/missing-semester/pull/344) coding dengan agen AI menjadi kuliah tersendiri.
 {%- comment %}
 Show usage in Missing Semester, point out that the agent did make some mistakes.
 {% endcomment %}
-- **Code review.** You can ask coding agents to review code. You can give them basic guidance, like "review my latest changes that are not yet committed". If you want to review a pull request and your coding agent supports web fetch, or you have command-line tools like the [GitHub CLI](https://cli.github.com/) installed, you might even be able to ask the coding agent "Review the pull request {link}" and it'll handle it from there.
+- **Code review.** Anda dapat meminta agen coding untuk melakukan review kode. Anda dapat memberikan panduan dasar, seperti "review my latest changes that are not yet committed". Jika Anda ingin me-review sebuah pull request dan agen coding Anda mendukung web fetch, atau Anda memiliki alat command-line seperti [GitHub CLI](https://cli.github.com/) yang terinstal, Anda bahkan mungkin bisa meminta agen coding "Review the pull request {link}" dan agen akan menanganinya dari sana.
 {%- comment %}
 In Porcupine repo, prompt agent with:
 
     Review this PR: https://github.com/anishathalye/porcupine/pull/39
 {% endcomment %}
-- **Code understanding.** You can ask a coding agent questions about a codebase, which can be particularly helpful for onboarding.
+- **Memahami kode.** Anda dapat mengajukan pertanyaan kepada agen coding tentang sebuah codebase, yang bisa sangat membantu untuk onboarding.
 {%- comment %}
 Some prompts to try in the missing-semester repo:
 
@@ -107,39 +107,39 @@ Some prompts to try in the missing-semester repo:
 
     How are the social preview cards implemented?
 {% endcomment %}
-- **As a shell.** You can ask the coding agent to use a particular tool to solve a task, so you can invoke a shell command using natural language, such as "use the find command to find all files older than 30 days" or "use mogrify to resize all the jpgs to 50% of their original size".
+- **Sebagai shell.** Anda dapat meminta agen coding untuk menggunakan alat tertentu guna menyelesaikan suatu tugas, sehingga Anda dapat menjalankan perintah shell menggunakan bahasa alami, seperti "use the find command to find all files older than 30 days" atau "use mogrify to resize all the jpgs to 50% of their original size".
 {%- comment %}
 In Dotbot repo, prompt agent with:
 
     Use the ag command to find all Python renaming imports
 {% endcomment %}
-- **Vibe coding.** Agents are powerful enough that you can implement some applications without writing a single line of code yourself.
-    > [Here is an example](https://github.com/cleanlab/office-presence-dashboard) of a real-world project that one of the instructors vibe-coded.
+- **Vibe coding.** Agen-agen cukup powerful sehingga Anda dapat mengimplementasikan beberapa aplikasi tanpa menulis satu baris kode pun.
+    > [Berikut adalah contoh](https://github.com/cleanlab/office-presence-dashboard) proyek dunia nyata yang di-vibe-code oleh salah satu instruktur.
 {%- comment %}
 In missing-semester repo, prompt agent with:
 
     Make this site look retro.
 {% endcomment %}
 
-# Advanced agents
+# Agen lanjutan
 
-Here, we give a brief overview of some more advanced usage patterns and capabilities of coding agents.
+Di sini, kami memberikan ringkasan singkat tentang beberapa pola penggunaan dan kemampuan agen coding yang lebih lanjutan.
 
-- **Reusable prompts.** Create reusable prompts or templates. For example, you can write a detailed prompt to do code review in a particular way, and save that as a reusable prompt.
-    > Agent tooling evolves quickly. In some tools, reusable prompts as a standalone feature are deprecated. For example, in Codex and Claude Code, they are [subsumed](https://developers.openai.com/codex/custom-prompts) by [skills](https://code.claude.com/docs/en/skills).
-- **Parallel agents.** Coding agents can be slow: you can prompt the agent, and it can work at a problem for tens of minutes. You can run multiple copies of agents at the same time, either working on the same task (LLMs are stochastic, so it can be helpful to run the same thing multiple times and take the best solution) or different tasks (e.g., implement two non-overlapping features at the same time). To keep the different agents' changes from interfering with each other, you can use [git worktrees](https://git-scm.com/docs/git-worktree), which we cover in the lecture on [version control](/2026/version-control/).
-- **MCPs.** MCP, which stands for _Model Context Protocol_, is an open protocol that you can use to connect your coding agents with tools. For example, this [Notion MCP server](https://github.com/makenotion/notion-mcp-server) can let your agent read/write Notion docs, enabling use cases like "read the spec linked in {Notion doc}, draft an implementation plan as a new page in Notion, and then implement a prototype". For discovering MCPs, you can use directories like [Pulse](https://www.pulsemcp.com/servers) and [Glama](https://glama.ai/mcp/servers).
-- **Context management.** As we noted [above](#how-ai-models-and-agents-work), the LLMs that underlie coding agents have a limited _context window_. Effective use of coding agents necessitates making good use of context. You want to make sure the agent has access to the information it needs, but avoid unnecessary context to avoid overflowing the context window or degrading the performance of the model (which tends to happen as context size grows, even if it doesn't overflow the context window). Agent harnesses automatically supply, and to some degree, manage context, but a lot of control is left to the user.
-    - **Clearing the context window.** The most basic control, coding agents support clearing the context window (starting a new conversation), which you should do for unrelated queries.
-    - **Rewinding the conversation.** Some coding agents support undoing steps in the conversation history. Rather than give a follow-up message steering the agent in a different direction, in situations where an "undo" makes more sense, this more effectively manages context.
+- **Prompt yang dapat digunakan kembali.** Buat prompt atau template yang dapat digunakan kembali. Misalnya, Anda dapat menulis prompt detail untuk melakukan code review dengan cara tertentu, dan menyimpannya sebagai prompt yang dapat digunakan kembali.
+    > Perkakas agen berkembang dengan cepat. Di beberapa alat, prompt yang dapat digunakan kembali sebagai fitur mandiri sudah di-deprecated. Misalnya, di Codex dan Claude Code, mereka [digantikan](https://developers.openai.com/codex/custom-prompts) oleh [skills](https://code.claude.com/docs/en/skills).
+- **Agen paralel.** Agen coding bisa lambat: Anda dapat memberikan prompt, dan agen bisa mengerjakan suatu masalah selama puluhan menit. Anda dapat menjalankan beberapa salinan agen secara bersamaan, baik mengerjakan tugas yang sama (LLM bersifat stokastik, jadi bisa membantu menjalankan hal yang sama beberapa kali dan mengambil solusi terbaik) maupun tugas yang berbeda (misalnya, mengimplementasikan dua fitur yang tidak tumpang tindih secara bersamaan). Untuk mencegah perubahan dari agen-agen yang berbeda saling mengganggu, Anda dapat menggunakan [git worktrees](https://git-scm.com/docs/git-worktree), yang kami bahas dalam kuliah tentang [version control](/2026/version-control/).
+- **MCP.** MCP, kepanjangan dari _Model Context Protocol_, adalah protokol terbuka yang dapat Anda gunakan untuk menghubungkan agen coding Anda dengan berbagai alat. Misalnya, [Notion MCP server](https://github.com/makenotion/notion-mcp-server) ini dapat membiarkan agen Anda membaca/menulis dokumen Notion, sehingga memungkinkan kasus penggunaan seperti "baca spesifikasi yang tertaut di {Notion doc}, buat rancangan implementasi sebagai halaman baru di Notion, lalu implementasikan prototipenya". Untuk menemukan MCP, Anda dapat menggunakan direktori seperti [Pulse](https://www.pulsemcp.com/servers) dan [Glama](https://glama.ai/mcp/servers).
+- **Manajemen konteks.** Seperti yang kami [sebutkan di atas](#cara-kerja-model-dan-agen-ai), LLM yang menjadi dasar agen coding memiliki _context window_ yang terbatas. Penggunaan agen coding secara efektif memerlukan pemanfaatan konteks yang baik. Anda ingin memastikan agen memiliki akses ke informasi yang dibutuhkan, tetapi menghindari konteks yang tidak perlu untuk mencegah overflow context window atau penurunan performa model (yang cenderung terjadi seiring bertambahnya ukuran konteks, meskipun tidak overflow context window). Harness agen secara otomatis menyediakan, dan sampai tingkat tertentu, mengelola konteks, tetapi banyak kontrol yang diserahkan kepada pengguna.
+    - **Mengosongkan context window.** Kontrol paling dasar, agen coding mendukung pengosongan context window (memulai percakapan baru), yang sebaiknya Anda lakukan untuk query yang tidak berkaitan.
+    - **Membatalkan langkah percakapan.** Beberapa agen coding mendukung pembatalan langkah-langkah dalam riwayat percakapan. Daripada memberikan pesan tindak lanjut yang mengarahkan agen ke arah yang berbeda, dalam situasi di mana "undo" lebih masuk akal, cara ini lebih efektif dalam mengelola konteks.
 {%- comment %}
 Make up a quick demo.
 {% endcomment %}
-    - **Compaction.** To enable conversations of unbounded length, coding agents support context _compaction_: if the conversation history grows too long, they will automatically call an LLM to summarize the prefix of the conversation, and replace the conversation history with the summary. Some agents give control to the user to invoke compaction when desired.
+    - **Kompaksi.** Untuk memungkinkan percakapan dengan panjang tak terbatas, agen coding mendukung _kompaksi_ konteks: jika riwayat percakapan menjadi terlalu panjang, mereka akan secara otomatis memanggil LLM untuk merangkum bagian awal percakapan, dan mengganti riwayat percakapan dengan rangkuman tersebut. Beberapa agen memberikan kontrol kepada pengguna untuk menjalankan kompaksi saat diinginkan.
 {%- comment %}
 Show `/compact` in Claude Code, show full summary.
 {% endcomment %}
-    - **llms.txt.** The `/llms.txt` file is a proposed [standard](https://llmstxt.org/) location for a document meant for LLMs to use at inference time. Products (e.g., [cursor.com/llms.txt](https://cursor.com/llms.txt)), software libraries (e.g., [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), and APIs (e.g., [apify.com/llms.txt](https://apify.com/llms.txt)) might have `llms.txt` files that are handy for development. Such documents are more information dense per token, and so they are more context-efficient than asking your coding agent to fetch and read an HTML page. External documentation is handy when a coding agent doesn't have built-in knowledge about a dependency you are trying to use (e.g., because it was published after the LLM's knowledge cutoff).
+    - **llms.txt.** File `/llms.txt` adalah lokasi [standar](https://llmstxt.org/) yang diusulkan untuk dokumen yang dimaksudkan untuk digunakan oleh LLM saat inferensi. Produk (misalnya, [cursor.com/llms.txt](https://cursor.com/llms.txt)), pustaka perangkat lunak (misalnya, [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), dan API (misalnya, [apify.com/llms.txt](https://apify.com/llms.txt)) mungkin memiliki file `llms.txt` yang berguna untuk pengembangan. Dokumen-dokumen ini lebih padat informasi per token, sehingga lebih efisien dalam penggunaan konteks dibandingkan meminta agen coding Anda untuk mengambil dan membaca halaman HTML. Dokumentasi eksternal sangat berguna ketika agen coding tidak memiliki pengetahuan bawaan tentang dependensi yang ingin Anda gunakan (misalnya, karena dependensi tersebut dipublikasikan setelah knowledge cutoff LLM).
 {%- comment %}
 Side-by-side comparison in an empty repo (on Desktop or some other self-contained place, with `git init` run in it):
 
@@ -149,7 +149,7 @@ Side-by-side comparison in an empty repo (on Desktop or some other self-containe
 
 Not sure why the agent doesn't do this by default. You'd probably put that last sentence in a CLAUDE.md file.
 {% endcomment %}
-    - **AGENTS.md.** Most coding agents support [AGENTS.md](https://agents.md/) or similar (e.g., Claude Code looks for `CLAUDE.md`) as a README for coding agents. When the agent starts, it pre-fills the context with the entire contents of `AGENTS.md`. You can use this to give the agent advice that is common across sessions (e.g., instruct it to always run the type-checker after making code changes, explain how to run unit tests, or provide links to third-party docs that the agent can browse). Some coding agents can auto-generate this file (e.g., the `/init` command in Claude Code). See [here](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) for a real-world example of an `AGENTS.md`.
+    - **AGENTS.md.** Sebagian besar agen coding mendukung [AGENTS.md](https://agents.md/) atau sejenisnya (misalnya, Claude Code mencari `CLAUDE.md`) sebagai README untuk agen coding. Ketika agen dimulai, ia mengisi konteks dengan seluruh isi `AGENTS.md`. Anda dapat menggunakan ini untuk memberikan saran kepada agen yang berlaku di semua sesi (misalnya, menginstruksikan agen untuk selalu menjalankan type-checker setelah melakukan perubahan kode, menjelaskan cara menjalankan unit test, atau memberikan tautan ke dokumentasi pihak ketiga yang dapat ditelusuri agen). Beberapa agen coding dapat menghasilkan file ini secara otomatis (misalnya, perintah `/init` di Claude Code). Lihat [di sini](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) untuk contoh `AGENTS.md` di dunia nyata.
 {%- comment %}
 Dotbot example, CLAUDE.md that includes @DEVELOPMENT.md and says to always run the type checker and code formatter after making any changes to Python code.
 
@@ -159,30 +159,30 @@ Example prompt, off of master:
 
 This is something that'll be fast, for demonstration purposes.
 {% endcomment %}
-    - **Skills.** Content in the `AGENTS.md` is always loaded, in its entirety, into the context window of an agent. _Skills_ add one level of indirection to avoid context bloat: you can provide the agent with a list of skills along with descriptions, and the agent can "open" the skill (load it into its context window) as desired.
-    - **Subagents.** Some coding agents let you define subagents, which are agents for task-specific workflows. The top-level coding agent can invoke a sub-agent to complete a particular task, which enables both the top-level agent and subagent to more effectively manage context. The top-level agent's context isn't bloated with everything the subagent sees, and the subagent can get just the context it needs for its task. As one example, some coding agents implement web research as a subagent: the top-level agent will pose a query to the subagent, which will run web search, retrieve individual web pages, analyze them, and provide an answer to the query to the top-level agent. This way, the top-level agent doesn't have its context bloated by the full content of all retrieved web pages, and the subagent doesn't have in its context the rest of the conversation history of the top-level agent.
+    - **Skills.** Konten dalam `AGENTS.md` selalu dimuat secara keseluruhan ke dalam context window agen. _Skills_ menambahkan satu tingkat indireksi untuk menghindari pembengkakan konteks: Anda dapat menyediakan agen dengan daftar skills beserta deskripsinya, dan agen dapat "membuka" skill tersebut (memuatnya ke dalam context window) sesuai kebutuhan.
+    - **Subagent.** Beberapa agen coding memungkinkan Anda mendefinisikan subagent, yaitu agen untuk alur kerja spesifik suatu tugas. Agen coding tingkat atas dapat memanggil sub-agent untuk menyelesaikan tugas tertentu, yang memungkinkan agen tingkat atas maupun subagent mengelola konteks secara lebih efektif. Konteks agen tingkat atas tidak membengkak dengan semua yang dilihat subagent, dan subagent hanya mendapatkan konteks yang dibutuhkan untuk tugasnya. Sebagai salah satu contoh, beberapa agen coding mengimplementasikan riset web sebagai subagent: agen tingkat atas akan mengajukan query ke subagent, yang akan menjalankan pencarian web, mengambil halaman-halaman web individual, menganalisisnya, dan memberikan jawaban atas query tersebut kepada agen tingkat atas. Dengan cara ini, konteks agen tingkat atas tidak membengkak oleh konten lengkap dari semua halaman web yang diambil, dan subagent tidak memiliki riwayat percakapan agen tingkat atas dalam konteksnya.
 
-For many of the advanced features that require writing prompts (e.g., skills or subagents), you can use LLMs to get you started. Some coding agents even have built-in support for doing this. For example, Claude Code can generate a subagent from a short prompt (invoke `/agents` and create a new agent). Try creating a subagent with this prompt:
+Untuk banyak fitur lanjutan yang memerlukan penulisan prompt (misalnya, skills atau subagent), Anda dapat menggunakan LLM untuk membantu Anda memulai. Beberapa agen coding bahkan memiliki dukungan bawaan untuk melakukan ini. Misalnya, Claude Code dapat menghasilkan subagent dari prompt singkat (panggil `/agents` dan buat agen baru). Cobalah membuat subagent dengan prompt berikut:
 
 ```
 A Python code checking agent that uses `mypy` and `ruff` to type-check, lint, and format *check* any files that have been modified from the last git commit.
 ```
 
-Then, you can use the top-level agent to explicitly invoke the subagent with a message like "use the code checker subagent". You might also be able to get the top-level agent to automatically invoke the subagent when appropriate, for example, after modifying any Python files.
+Kemudian, Anda dapat menggunakan agen tingkat atas untuk secara eksplisit memanggil subagent dengan pesan seperti "use the code checker subagent". Anda juga mungkin bisa membuat agen tingkat atas secara otomatis memanggil subagent ketika sesuai, misalnya setelah memodifikasi file Python manapun.
 
-# What to watch out for
+# Hal yang perlu diwaspadai
 
-AI tools can make mistakes. They are built on LLMs, which are just probabilistic next-token-prediction models. They are not "intelligent" in the same way as humans. Review AI output for correctness and security bugs. Sometimes verifying code can be harder than writing the code yourself; for critical code, consider writing it by hand. AI can go down rabbit holes and try to gaslight you; be aware of debugging spirals. Don't use AI as a crutch, and be wary of overreliance or having a shallow understanding. There's still a huge class of programming tasks that AI is still incapable of doing. Computational thinking is still valuable.
+Alat AI dapat membuat kesalahan. Mereka dibangun di atas LLM, yang pada dasarnya hanyalah model probabilistik untuk memprediksi token berikutnya. Mereka tidak "cerdas" dengan cara yang sama seperti manusia. Tinjau output AI untuk kebenaran dan bug keamanan. Terkadang memverifikasi kode bisa lebih sulit daripada menulis kode itu sendiri; untuk kode yang kritis, pertimbangkan untuk menulisnya secara manual. AI bisa terjebak dalam lubang kelinci dan mencoba membuat Anda bingung; waspadai spiral debugging yang berlarut-larut. Jangan menggunakan AI sebagai tumpuan, dan waspadai ketergantungan berlebihan atau pemahaman yang dangkal. Masih ada banyak sekali tugas pemrograman yang belum bisa diselesaikan oleh AI. Computational thinking tetap berharga.
 
-# Recommended software
+# Perangkat lunak yang direkomendasikan
 
-Many IDEs / AI coding extensions include coding agents (see recommendations from the [development environment lecture](/2026/development-environment/)). Other popular coding agents include Anthropic's [Claude Code](https://www.claude.com/product/claude-code), OpenAI's [Codex](https://openai.com/codex/), and open-source agents like [opencode](https://github.com/anomalyco/opencode).
+Banyak IDE / ekstensi coding AI menyertakan agen coding (lihat rekomendasi dari [kuliah development environment](/2026/development-environment/)). Agen coding populer lainnya termasuk [Claude Code](https://www.claude.com/product/claude-code) dari Anthropic, [Codex](https://openai.com/codex/) dari OpenAI, dan agen open-source seperti [opencode](https://github.com/anomalyco/opencode).
 
-# Exercises
+# Latihan
 
-1. Compare the experience of coding by hand, using AI autocomplete, inline chat, and agents by doing the same programming task four times. The best candidate is a small-sized feature from a project you're already working on. If you're looking for other ideas, you could consider completing "good first issue" style tasks in open-source projects on GitHub, or [Advent of Code](https://adventofcode.com/) or [LeetCode](https://leetcode.com/) problems.
-1. Use an AI coding agent to navigate an unfamiliar codebase. This is best done in the context of wanting to debug or add a new feature to a project you actually care about. If you don't have any that come to mind, try using an AI agent to understand how security-related features work in the [opencode](https://github.com/anomalyco/opencode) agent.
-1. Vibe code a small app from scratch. Do not write a single line of code by hand.
-1. For your coding agent of choice, create and test an `AGENTS.md` (or analogous for your agent of choice, such as `CLAUDE.md`), a skill (e.g., [skill in Claude Code](https://code.claude.com/docs/en/skills) or [skill in Codex](https://developers.openai.com/codex/skills/)), and a subagent (e.g., [subagent in Claude Code](https://code.claude.com/docs/en/sub-agents)). Think about when you'd want to use one of these versus another. Note that your coding agent of choice might not support some of these functionalities; you can either skip them, or try a different coding agent that has support.
-1. Use a coding agent to accomplish the same goal as in the Markdown bullet points regex exercise from the [Code Quality lecture](/2026/code-quality/). Does it complete the tasks via direct file edits? What are the downsides and limitations of an agent editing the file directly to complete such a task? Figure out how to prompt the agent such that it doesn't complete the task via direct file edits. Hint: ask the agent to use one of the command-line tools mentioned in the [first lecture](/2026/course-shell/).
-1. Most coding agents support a form of "yolo mode" (e.g., in Claude Code, `--dangerously-skip-permissions`). It is not secure to use this mode directly, but it may be acceptable to run a coding agent in an isolated environment like a virtual machine or container and then enable autonomous operation. Get this setup running on your machine. Documentation such as [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) or [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/agents/claude-code/) may come in handy. There is more than one way to set this up.
+1. Bandingkan pengalaman coding secara manual, menggunakan AI autocomplete, inline chat, dan agen dengan melakukan tugas pemrograman yang sama sebanyak empat kali. Kandidat terbaik adalah fitur berskala kecil dari proyek yang sedang Anda kerjakan. Jika Anda mencari ide lain, Anda bisa mempertimbangkan untuk menyelesaikan tugas bergaya "good first issue" di proyek-proyek open-source di GitHub, atau soal-soal [Advent of Code](https://adventofcode.com/) atau [LeetCode](https://leetcode.com/).
+1. Gunakan agen coding AI untuk menelusuri codebase yang tidak familiar. Hal ini paling baik dilakukan dalam konteks ketika Anda ingin men-debug atau menambahkan fitur baru ke proyek yang benar-benar Anda pedulikan. Jika tidak ada yang terlintas, cobalah menggunakan agen AI untuk memahami cara kerja fitur-fitur terkait keamanan di agen [opencode](https://github.com/anomalyco/opencode).
+1. Vibe-code sebuah aplikasi kecil dari nol. Jangan menulis satu baris kode pun secara manual.
+1. Untuk agen coding pilihan Anda, buat dan uji sebuah `AGENTS.md` (atau analognya untuk agen pilihan Anda, seperti `CLAUDE.md`), sebuah skill (misalnya, [skill di Claude Code](https://code.claude.com/docs/en/skills) atau [skill di Codex](https://developers.openai.com/codex/skills/)), dan sebuah subagent (misalnya, [subagent di Claude Code](https://code.claude.com/docs/en/sub-agents)). Pikirkan kapan Anda ingin menggunakan salah satu dari ini dibandingkan yang lain. Perhatikan bahwa agen coding pilihan Anda mungkin tidak mendukung beberapa fungsionalitas ini; Anda dapat melewatinya, atau mencoba agen coding lain yang memiliki dukungan tersebut.
+1. Gunakan agen coding untuk mencapai tujuan yang sama seperti pada latihan regex bullet points Markdown dari [Kuliah Code Quality](/2026/code-quality/). Apakah agen menyelesaikan tugas tersebut melalui pengeditan file secara langsung? Apa kekurangan dan keterbatasan dari agen yang mengedit file secara langsung untuk menyelesaikan tugas semacam ini? Cari cara untuk memberikan prompt kepada agen sehingga tidak menyelesaikan tugas melalui pengeditan file secara langsung. Petunjuk: minta agen untuk menggunakan salah satu alat command-line yang disebutkan dalam [kuliah pertama](/2026/course-shell/).
+1. Sebagian besar agen coding mendukung bentuk "yolo mode" (misalnya, di Claude Code, `--dangerously-skip-permissions`). Tidak aman menggunakan mode ini secara langsung, tetapi mungkin dapat diterima untuk menjalankan agen coding di lingkungan terisolasi seperti mesin virtual atau container dan kemudian mengaktifkan operasi otonom. Jalankan setup ini di mesin Anda. Dokumentasi seperti [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) atau [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/agents/claude-code/) mungkin berguna. Ada lebih dari satu cara untuk mengatur ini.

--- a/_2026/agentic-coding.md
+++ b/_2026/agentic-coding.md
@@ -11,9 +11,9 @@ video:
   id: sTdz6PZoAnw
 ---
 
-Coding agents are conversational AI models with access to tools such as reading/writing files, web search, and invoking shell commands. They live either in the IDE or in standalone command-line or GUI tools. Coding agents are highly autonomous and powerful tools, enabling a wide variety of use cases.
+Coding agents adalah model AI konversasional yang memiliki akses ke berbagai alat seperti membaca/menulis file, pencarian web, dan menjalankan perintah shell. Mereka berada di dalam IDE atau dalam alat command-line atau GUI mandiri. Coding agents adalah alat yang sangat otonom dan kuat, memungkinkan berbagai macam kasus penggunaan.
 
-This lecture builds on the AI-powered development material from the [Development Environment and Tools](/2026/development-environment/) lecture. As a quick demo, let's continue with the example from the [AI-powered development](/2026/development-environment/#ai-powered-development) section:
+Kuliah ini dibangun dari materi pengembangan berbasis AI dari kuliah [Development Environment and Tools](/2026/development-environment/). Sebagai demo singkat, mari kita lanjutkan dengan contoh dari bagian [AI-powered development](/2026/development-environment/#ai-powered-development):
 
 ```python
 from urllib.request import urlopen
@@ -30,49 +30,49 @@ def extract(content: str) -> list[str]:
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
 ```
 
-We can try prompting a coding agent with the following task:
+Kita bisa mencoba memberikan prompt kepada coding agent dengan tugas berikut:
 
 ```
 Turn this into a proper command-line program, with argparse for argument parsing. Add type annotations, and make sure the program passes type checking.
 ```
 
-The agent will read the file to understand it, then make some edits, and finally invoke the type checker to make sure the type annotations are correct. If it makes a mistake such that it fails type checking, it will likely iterate, though this is a simple task so that is unlikely to happen. Because coding agents have access to tools that may be harmful, by default, agent harnesses prompt the user to confirm tool calls.
+Agent akan membaca file untuk memahaminya, kemudian melakukan beberapa perubahan, dan akhirnya menjalankan type checker untuk memastikan anotasi tipe sudah benar. Jika terjadi kesalahan sehingga gagal dalam type checking, agent kemungkinan akan melakukan iterasi, meskipun ini adalah tugas sederhana sehingga kecil kemungkinannya terjadi. Karena coding agents memiliki akses ke alat yang mungkin berbahaya, secara default, agent harness meminta pengguna untuk mengonfirmasi pemanggilan alat.
 
-> If the coding agent makes a mistake --- for example, if you have the `mypy` binary available directly on `$PATH` but the agent tries calling `python -m mypy` --- you can give it text feedback to help it course correct.
+> Jika coding agent membuat kesalahan --- misalnya, jika Anda memiliki binary `mypy` yang tersedia langsung di `$PATH` tetapi agent mencoba memanggil `python -m mypy` --- Anda dapat memberikan umpan balik teks untuk membantunya memperbaiki arah.
 
-Coding agents support multi-turn interaction, so you can iterate on work over a back-and-forth conversation with the agent. You can even interrupt the agent if it's going down the wrong track. One helpful mental model might be that of a manager of an intern: the intern will do the nitty gritty work, but will require guidance, and will occasionally do the wrong thing and need to be corrected.
+Coding agents mendukung interaksi multi-turn, sehingga Anda dapat melakukan iterasi pekerjaan melalui percakapan bolak-balik dengan agent. Anda bahkan dapat menginterupsi agent jika ia mengambil arah yang salah. Satu model mental yang membantu mungkin adalah seperti seorang manajer dari seorang intern: intern akan melakukan pekerjaan detail, tetapi akan membutuhkan bimbingan, dan sesekali melakukan kesalahan dan perlu dikoreksi.
 
-> For a more illustrative demo, try asking the agent as a follow-up to run the resulting script. Observe the outputs, and try asking it to make a change (e.g., ask it to include only absolute URLs).
+> Untuk demo yang lebih ilustratif, coba minta agent sebagai tindak lanjut untuk menjalankan script yang dihasilkan. Amati outputnya, dan coba minta untuk melakukan perubahan (misalnya, minta untuk hanya menyertakan URL absolut).
 
-# How AI models and agents work
+# Cara kerja model dan agent AI
 
-Fully explaining the inner workings of modern [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) and infrastructure such as agent harnesses is beyond the scope of this course. However, having a high-level understanding of some of the key ideas is helpful for effectively _using_ this bleeding edge technology and understanding its limitations.
+Menjelaskan secara lengkap cara kerja [large language models (LLMs)](https://en.wikipedia.org/wiki/Large_language_model) modern dan infrastruktur seperti agent harness berada di luar cakupan kursus ini. Namun, memiliki pemahaman tingkat tinggi tentang beberapa ide kunci sangat membantu untuk _menggunakan_ teknologi mutakhir ini secara efektif dan memahami keterbatasannya.
 
-LLMs can be viewed as modeling the probability distribution of completion strings (outputs) given prompt strings (inputs). LLM inference (what happens when you, e.g., supply a query to a conversational chat app) _samples_ from this probability distribution. LLMs have a fixed _context window_, the maximum length of the input and output strings.
+LLM dapat dipandang sebagai pemodelan distribusi probabilitas dari string penyelesaian (output) berdasarkan string prompt (input). Inferensi LLM (apa yang terjadi ketika Anda, misalnya, memberikan query ke aplikasi chat konversasional) _mengambil sampel_ dari distribusi probabilitas ini. LLM memiliki _context window_ yang tetap, yaitu panjang maksimum dari string input dan output.
 
 {% comment %}
 > In mathematical notation, the LLM models the probability distribution $\pi_\theta$ of completions $y$ conditioned on prompts $x$, and we sample from this distribution: $\hat{y} \sim \pi_\theta(\cdot \mid x)$.
 {% endcomment %}
 
-AI tools such as conversational chat and coding agents build on top of this primitive. For multi-turn interactions, chat apps and agents use turn markers and supply the entire conversation history as the prompt string every time there is a new user prompt, invoking LLM inference once per user prompt. For tool-calling agents, the harness interprets certain LLM outputs as requests to invoke a tool, and the harness supplies the results of the tool call back to the model as part of the prompt string (so LLM inference runs again every time there is a tool call/response). The core concepts in tool-calling agents can be [implemented in 200 lines of code](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/).
+Alat AI seperti chat konversasional dan coding agent dibangun di atas primitif ini. Untuk interaksi multi-turn, aplikasi chat dan agent menggunakan penanda giliran dan menyediakan seluruh riwayat percakapan sebagai string prompt setiap kali ada prompt pengguna baru, menjalankan inferensi LLM sekali per prompt pengguna. Untuk agent pemanggil alat, harness menafsirkan output LLM tertentu sebagai permintaan untuk memanggil alat, dan harness menyediakan hasil pemanggilan alat kembali ke model sebagai bagian dari string prompt (sehingga inferensi LLM berjalan lagi setiap kali ada pemanggilan/respons alat). Konsep inti dalam agent pemanggil alat dapat [diimplementasikan dalam 200 baris kode](https://www.mihaileric.com/The-Emperor-Has-No-Clothes/).
 
-## Privacy
+## Privasi
 
-Most AI coding tools in their standard configurations send a lot of your data to the cloud. Sometimes the harness runs locally while LLM inference runs in the cloud, other times even more of the software is running in the cloud (and, e.g., the service provider might effectively get a copy of your entire repository as well as all interactions you have with the AI tool).
+Sebagian besar alat coding AI dalam konfigurasi standar mereka mengirim banyak data Anda ke cloud. Terkadang harness berjalan secara lokal sementara inferensi LLM berjalan di cloud, di lain waktu bahkan lebih banyak perangkat lunak yang berjalan di cloud (dan, misalnya, penyedia layanan mungkin secara efektif mendapatkan salinan seluruh repositori Anda serta semua interaksi yang Anda lakukan dengan alat AI).
 
-There are open-source AI coding tools and open-source LLMs that are pretty good (though not quite as good as the proprietary models), but at the present, for most users, running bleeding-edge open LLMs locally will be infeasible due to hardware limitations.
+Ada alat coding AI open-source dan LLM open-source yang cukup baik (meskipun tidak sebaik model proprietary), tetapi saat ini, bagi sebagian besar pengguna, menjalankan LLM open mutakhir secara lokal tidak akan memungkinkan karena keterbatasan perangkat keras.
 
-# Use cases
+# Kasus penggunaan
 
-Coding agents can be helpful for a wide variety of tasks. Some examples:
+Coding agent dapat membantu untuk berbagai macam tugas. Beberapa contoh:
 
-- **Implementing new features.** As in the example above, you can ask a coding agent to implement a feature. Giving a good specification is more of an art than a science at this point; you want the input to the agent to be descriptive enough so that the agent does what you want it to do (at least heading in the right direction so you can iterate), but not overly descriptive to the point where you're doing too much work yourself. Test-driven development can be particularly effective: write tests (or use the coding agent to help you write tests), audit them to ensure they capture what you want, and then ask the coding agent to implement the feature. Models are continually improving, so you'll have to keep your intuition up-to-date on what the models are capable of.
-    > We used Claude Code to [implement](https://github.com/missing-semester/missing-semester/pull/345) these Tufte-style sidenotes.
+- **Mengimplementasikan fitur baru.** Seperti pada contoh di atas, Anda dapat meminta coding agent untuk mengimplementasikan sebuah fitur. Memberikan spesifikasi yang baik lebih merupakan seni daripada ilmu pada titik ini; Anda ingin input ke agent cukup deskriptif sehingga agent melakukan apa yang Anda inginkan (setidaknya mengarah ke arah yang benar sehingga Anda dapat melakukan iterasi), tetapi tidak terlalu deskriptif sampai pada titik di mana Anda melakukan terlalu banyak pekerjaan sendiri. Test-driven development bisa sangat efektif: tulis tes (atau gunakan coding agent untuk membantu Anda menulis tes), audit untuk memastikan mereka menangkap apa yang Anda inginkan, dan kemudian minta coding agent untuk mengimplementasikan fitur tersebut. Model terus berkembang, jadi Anda harus menjaga intuisi Anda tetap terbaru tentang kemampuan model.
+    > Kami menggunakan Claude Code untuk [mengimplementasikan](https://github.com/missing-semester/missing-semester/pull/345) sidenotes gaya Tufte ini.
 {%- comment %}
 No need to demo this, since the intro of a lecture was a small demo of adding a new feature.
 {% endcomment %}
-- **Fixing errors.** If you have errors from your compiler, linter, type checker, or tests, you can ask your agent to correct them, for example with a prompt like "fix the issues with mypy". Coding models are particularly effective when you can get them in a feedback loop, so try to set things up so that the model can run the failing check directly, which will let it iterate autonomously. If this is impractical, you can give the model feedback manually.
-    > On commit [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) of the missing-semester repo, we prompted Claude Code with "Review the agentic coding lecture for typos and grammatical issues" and subsequently asked it to fix the issues it found, which were committed in [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637).
+- **Memperbaiki kesalahan.** Jika Anda memiliki kesalahan dari compiler, linter, type checker, atau tes, Anda dapat meminta agent Anda untuk memperbaikinya, misalnya dengan prompt seperti "fix the issues with mypy". Model coding sangat efektif ketika Anda dapat memasukkannya ke dalam loop umpan balik, jadi cobalah mengatur segala sesuatu sehingga model dapat menjalankan pemeriksaan yang gagal secara langsung, yang akan memungkinkannya melakukan iterasi secara otonom. Jika ini tidak praktis, Anda dapat memberikan umpan balik ke model secara manual.
+    > Pada commit [f552b55](https://github.com/missing-semester/missing-semester/commit/f552b5523462b22b8893a8404d2110c4e59613dd) dari repo missing-semester, kami memberikan prompt kepada Claude Code dengan "Review the agentic coding lecture for typos and grammatical issues" dan kemudian memintanya untuk memperbaiki masalah yang ditemukannya, yang di-commit dalam [f1e1c41](https://github.com/missing-semester/missing-semester/commit/f1e1c417adba6b4149f7eef91ff5624de40dc637).
 {%- comment %}
 Demo a coding agent fixing the bug in https://github.com/anishathalye/dotbot/commit/cef40c902ef0f52f484153413142b5154bbc5e99.
 
@@ -88,18 +88,18 @@ Can prompt coding agent with:
 
 Get it to commit the changes.
 {% endcomment %}
-- **Refactoring.** You can use coding agents to refactor code in various ways, from simple tasks like renaming a method (this kind of refactoring is also supported by [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers)) to more complex tasks like breaking out functionality into a separate module.
-    > We used Claude Code to [split](https://github.com/missing-semester/missing-semester/pull/344) agentic coding into its own lecture.
+- **Refactoring.** Anda dapat menggunakan coding agent untuk melakukan refactoring kode dalam berbagai cara, dari tugas sederhana seperti mengganti nama method (jenis refactoring ini juga didukung oleh [code intelligence](/2026/development-environment/#code-intelligence-and-language-servers)) hingga tugas yang lebih kompleks seperti memisahkan fungsionalitas ke dalam modul terpisah.
+    > Kami menggunakan Claude Code untuk [memisahkan](https://github.com/missing-semester/missing-semester/pull/344) agentic coding menjadi kuliah tersendiri.
 {%- comment %}
 Show usage in Missing Semester, point out that the agent did make some mistakes.
 {% endcomment %}
-- **Code review.** You can ask coding agents to review code. You can give them basic guidance, like "review my latest changes that are not yet committed". If you want to review a pull request and your coding agent supports web fetch, or you have command-line tools like the [GitHub CLI](https://cli.github.com/) installed, you might even be able to ask the coding agent "Review the pull request {link}" and it'll handle it from there.
+- **Code review.** Anda dapat meminta coding agent untuk me-review kode. Anda dapat memberikan mereka panduan dasar, seperti "review my latest changes that are not yet committed". Jika Anda ingin me-review pull request dan coding agent Anda mendukung web fetch, atau Anda memiliki alat command-line seperti [GitHub CLI](https://cli.github.com/) yang terinstal, Anda bahkan mungkin dapat meminta coding agent "Review the pull request {link}" dan ia akan menanganinya dari sana.
 {%- comment %}
 In Porcupine repo, prompt agent with:
 
     Review this PR: https://github.com/anishathalye/porcupine/pull/39
 {% endcomment %}
-- **Code understanding.** You can ask a coding agent questions about a codebase, which can be particularly helpful for onboarding.
+- **Pemahaman kode.** Anda dapat mengajukan pertanyaan kepada coding agent tentang codebase, yang bisa sangat membantu untuk onboarding.
 {%- comment %}
 Some prompts to try in the missing-semester repo:
 
@@ -107,39 +107,39 @@ Some prompts to try in the missing-semester repo:
 
     How are the social preview cards implemented?
 {% endcomment %}
-- **As a shell.** You can ask the coding agent to use a particular tool to solve a task, so you can invoke a shell command using natural language, such as "use the find command to find all files older than 30 days" or "use mogrify to resize all the jpgs to 50% of their original size".
+- **Sebagai shell.** Anda dapat meminta coding agent untuk menggunakan alat tertentu untuk menyelesaikan tugas, sehingga Anda dapat menjalankan perintah shell menggunakan bahasa alami, seperti "use the find command to find all files older than 30 days" atau "use mogrify to resize all the jpgs to 50% of their original size".
 {%- comment %}
 In Dotbot repo, prompt agent with:
 
     Use the ag command to find all Python renaming imports
 {% endcomment %}
-- **Vibe coding.** Agents are powerful enough that you can implement some applications without writing a single line of code yourself.
-    > [Here is an example](https://github.com/cleanlab/office-presence-dashboard) of a real-world project that one of the instructors vibe-coded.
+- **Vibe coding.** Agent cukup kuat sehingga Anda dapat mengimplementasikan beberapa aplikasi tanpa menulis satu baris kode pun sendiri.
+    > [Berikut adalah contoh](https://github.com/cleanlab/office-presence-dashboard) dari proyek dunia nyata yang di-vibe-code oleh salah satu instruktur.
 {%- comment %}
 In missing-semester repo, prompt agent with:
 
     Make this site look retro.
 {% endcomment %}
 
-# Advanced agents
+# Agent lanjutan
 
-Here, we give a brief overview of some more advanced usage patterns and capabilities of coding agents.
+Di sini, kami memberikan tinjauan singkat tentang beberapa pola penggunaan dan kemampuan coding agent yang lebih lanjut.
 
-- **Reusable prompts.** Create reusable prompts or templates. For example, you can write a detailed prompt to do code review in a particular way, and save that as a reusable prompt.
-    > Agent tooling evolves quickly. In some tools, reusable prompts as a standalone feature are deprecated. For example, in Codex and Claude Code, they are [subsumed](https://developers.openai.com/codex/custom-prompts) by [skills](https://code.claude.com/docs/en/skills).
-- **Parallel agents.** Coding agents can be slow: you can prompt the agent, and it can work at a problem for tens of minutes. You can run multiple copies of agents at the same time, either working on the same task (LLMs are stochastic, so it can be helpful to run the same thing multiple times and take the best solution) or different tasks (e.g., implement two non-overlapping features at the same time). To keep the different agents' changes from interfering with each other, you can use [git worktrees](https://git-scm.com/docs/git-worktree), which we cover in the lecture on [version control](/2026/version-control/).
-- **MCPs.** MCP, which stands for _Model Context Protocol_, is an open protocol that you can use to connect your coding agents with tools. For example, this [Notion MCP server](https://github.com/makenotion/notion-mcp-server) can let your agent read/write Notion docs, enabling use cases like "read the spec linked in {Notion doc}, draft an implementation plan as a new page in Notion, and then implement a prototype". For discovering MCPs, you can use directories like [Pulse](https://www.pulsemcp.com/servers) and [Glama](https://glama.ai/mcp/servers).
-- **Context management.** As we noted [above](#how-ai-models-and-agents-work), the LLMs that underlie coding agents have a limited _context window_. Effective use of coding agents necessitates making good use of context. You want to make sure the agent has access to the information it needs, but avoid unnecessary context to avoid overflowing the context window or degrading the performance of the model (which tends to happen as context size grows, even if it doesn't overflow the context window). Agent harnesses automatically supply, and to some degree, manage context, but a lot of control is left to the user.
-    - **Clearing the context window.** The most basic control, coding agents support clearing the context window (starting a new conversation), which you should do for unrelated queries.
-    - **Rewinding the conversation.** Some coding agents support undoing steps in the conversation history. Rather than give a follow-up message steering the agent in a different direction, in situations where an "undo" makes more sense, this more effectively manages context.
+- **Prompt yang dapat digunakan kembali.** Buat prompt atau template yang dapat digunakan kembali. Misalnya, Anda dapat menulis prompt terperinci untuk melakukan code review dengan cara tertentu, dan menyimpannya sebagai prompt yang dapat digunakan kembali.
+    > Tooling agent berkembang dengan cepat. Di beberapa alat, prompt yang dapat digunakan kembali sebagai fitur mandiri sudah didepresiasi. Misalnya, di Codex dan Claude Code, mereka [digantikan](https://developers.openai.com/codex/custom-prompts) oleh [skills](https://code.claude.com/docs/en/skills).
+- **Agent paralel.** Coding agent bisa lambat: Anda dapat memberikan prompt kepada agent, dan ia dapat mengerjakan suatu masalah selama puluhan menit. Anda dapat menjalankan beberapa salinan agent secara bersamaan, baik mengerjakan tugas yang sama (LLM bersifat stokastik, jadi bisa membantu untuk menjalankan hal yang sama beberapa kali dan mengambil solusi terbaik) atau tugas yang berbeda (misalnya, mengimplementasikan dua fitur yang tidak tumpang tindih secara bersamaan). Untuk mencegah perubahan dari agent yang berbeda saling mengganggu, Anda dapat menggunakan [git worktrees](https://git-scm.com/docs/git-worktree), yang kami bahas dalam kuliah tentang [version control](/2026/version-control/).
+- **MCP.** MCP, yang merupakan singkatan dari _Model Context Protocol_, adalah protokol terbuka yang dapat Anda gunakan untuk menghubungkan coding agent Anda dengan berbagai alat. Misalnya, [Notion MCP server](https://github.com/makenotion/notion-mcp-server) ini dapat membiarkan agent Anda membaca/menulis dokumen Notion, memungkinkan kasus penggunaan seperti "read the spec linked in {Notion doc}, draft an implementation plan as a new page in Notion, and then implement a prototype". Untuk menemukan MCP, Anda dapat menggunakan direktori seperti [Pulse](https://www.pulsemcp.com/servers) dan [Glama](https://glama.ai/mcp/servers).
+- **Manajemen konteks.** Seperti yang kami [sebutkan di atas](#how-ai-models-and-agents-work), LLM yang mendasari coding agent memiliki _context window_ yang terbatas. Penggunaan coding agent yang efektif mengharuskan pemanfaatan konteks yang baik. Anda ingin memastikan agent memiliki akses ke informasi yang dibutuhkan, tetapi menghindari konteks yang tidak perlu untuk mencegah overflow context window atau penurunan performa model (yang cenderung terjadi seiring bertambahnya ukuran konteks, bahkan jika tidak overflow context window). Agent harness secara otomatis menyediakan, dan sampai taraf tertentu, mengelola konteks, tetapi banyak kontrol yang diserahkan kepada pengguna.
+    - **Membersihkan context window.** Kontrol paling dasar, coding agent mendukung pembersihan context window (memulai percakapan baru), yang harus Anda lakukan untuk query yang tidak terkait.
+    - **Mundur percakapan.** Beberapa coding agent mendukung pembatalan langkah dalam riwayat percakapan. Daripada memberikan pesan tindak lanjut yang mengarahkan agent ke arah yang berbeda, dalam situasi di mana "undo" lebih masuk akal, ini mengelola konteks dengan lebih efektif.
 {%- comment %}
 Make up a quick demo.
 {% endcomment %}
-    - **Compaction.** To enable conversations of unbounded length, coding agents support context _compaction_: if the conversation history grows too long, they will automatically call an LLM to summarize the prefix of the conversation, and replace the conversation history with the summary. Some agents give control to the user to invoke compaction when desired.
+    - **Kompaksi.** Untuk memungkinkan percakapan dengan panjang yang tidak terbatas, coding agent mendukung _kompaksi_ konteks: jika riwayat percakapan menjadi terlalu panjang, mereka akan secara otomatis memanggil LLM untuk meringkas awalan percakapan, dan mengganti riwayat percakapan dengan ringkasan. Beberapa agent memberikan kontrol kepada pengguna untuk memanggil kompaksi saat diinginkan.
 {%- comment %}
 Show `/compact` in Claude Code, show full summary.
 {% endcomment %}
-    - **llms.txt.** The `/llms.txt` file is a proposed [standard](https://llmstxt.org/) location for a document meant for LLMs to use at inference time. Products (e.g., [cursor.com/llms.txt](https://cursor.com/llms.txt)), software libraries (e.g., [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), and APIs (e.g., [apify.com/llms.txt](https://apify.com/llms.txt)) might have `llms.txt` files that are handy for development. Such documents are more information dense per token, and so they are more context-efficient than asking your coding agent to fetch and read an HTML page. External documentation is handy when a coding agent doesn't have built-in knowledge about a dependency you are trying to use (e.g., because it was published after the LLM's knowledge cutoff).
+    - **llms.txt.** File `/llms.txt` adalah [standar](https://llmstxt.org/) yang diusulkan untuk lokasi dokumen yang dimaksudkan untuk digunakan oleh LLM pada waktu inferensi. Produk (misalnya, [cursor.com/llms.txt](https://cursor.com/llms.txt)), pustaka perangkat lunak (misalnya, [ai.pydantic.dev/llms.txt](https://ai.pydantic.dev/llms.txt)), dan API (misalnya, [apify.com/llms.txt](https://apify.com/llms.txt)) mungkin memiliki file `llms.txt` yang berguna untuk pengembangan. Dokumen seperti ini lebih padat informasi per token, sehingga lebih efisien konteks daripada meminta coding agent Anda untuk mengambil dan membaca halaman HTML. Dokumentasi eksternal berguna ketika coding agent tidak memiliki pengetahuan bawaan tentang dependensi yang coba Anda gunakan (misalnya, karena dipublikasikan setelah batas pengetahuan LLM).
 {%- comment %}
 Side-by-side comparison in an empty repo (on Desktop or some other self-contained place, with `git init` run in it):
 
@@ -149,7 +149,7 @@ Side-by-side comparison in an empty repo (on Desktop or some other self-containe
 
 Not sure why the agent doesn't do this by default. You'd probably put that last sentence in a CLAUDE.md file.
 {% endcomment %}
-    - **AGENTS.md.** Most coding agents support [AGENTS.md](https://agents.md/) or similar (e.g., Claude Code looks for `CLAUDE.md`) as a README for coding agents. When the agent starts, it pre-fills the context with the entire contents of `AGENTS.md`. You can use this to give the agent advice that is common across sessions (e.g., instruct it to always run the type-checker after making code changes, explain how to run unit tests, or provide links to third-party docs that the agent can browse). Some coding agents can auto-generate this file (e.g., the `/init` command in Claude Code). See [here](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) for a real-world example of an `AGENTS.md`.
+    - **AGENTS.md.** Sebagian besar coding agent mendukung [AGENTS.md](https://agents.md/) atau yang serupa (misalnya, Claude Code mencari `CLAUDE.md`) sebagai README untuk coding agent. Ketika agent dimulai, ia mengisi konteks dengan seluruh isi `AGENTS.md`. Anda dapat menggunakan ini untuk memberikan saran kepada agent yang umum di seluruh sesi (misalnya, instruksikan untuk selalu menjalankan type-checker setelah melakukan perubahan kode, jelaskan cara menjalankan unit test, atau berikan tautan ke dokumentasi pihak ketiga yang dapat ditelusuri agent). Beberapa coding agent dapat menghasilkan file ini secara otomatis (misalnya, perintah `/init` di Claude Code). Lihat [di sini](https://github.com/pydantic/pydantic-ai/blob/main/CLAUDE.md) untuk contoh dunia nyata dari `AGENTS.md`.
 {%- comment %}
 Dotbot example, CLAUDE.md that includes @DEVELOPMENT.md and says to always run the type checker and code formatter after making any changes to Python code.
 
@@ -159,30 +159,30 @@ Example prompt, off of master:
 
 This is something that'll be fast, for demonstration purposes.
 {% endcomment %}
-    - **Skills.** Content in the `AGENTS.md` is always loaded, in its entirety, into the context window of an agent. _Skills_ add one level of indirection to avoid context bloat: you can provide the agent with a list of skills along with descriptions, and the agent can "open" the skill (load it into its context window) as desired.
-    - **Subagents.** Some coding agents let you define subagents, which are agents for task-specific workflows. The top-level coding agent can invoke a sub-agent to complete a particular task, which enables both the top-level agent and subagent to more effectively manage context. The top-level agent's context isn't bloated with everything the subagent sees, and the subagent can get just the context it needs for its task. As one example, some coding agents implement web research as a subagent: the top-level agent will pose a query to the subagent, which will run web search, retrieve individual web pages, analyze them, and provide an answer to the query to the top-level agent. This way, the top-level agent doesn't have its context bloated by the full content of all retrieved web pages, and the subagent doesn't have in its context the rest of the conversation history of the top-level agent.
+    - **Skills.** Konten dalam `AGENTS.md` selalu dimuat, secara keseluruhan, ke dalam context window agent. _Skills_ menambahkan satu tingkat tidak langsung untuk menghindari context bloat: Anda dapat menyediakan agent dengan daftar skills beserta deskripsinya, dan agent dapat "membuka" skill tersebut (memuatnya ke dalam context window) sesuai keinginan.
+    - **Subagent.** Beberapa coding agent membiarkan Anda mendefinisikan subagent, yang merupakan agent untuk alur kerja spesifik tugas. Coding agent tingkat atas dapat memanggil sub-agent untuk menyelesaikan tugas tertentu, yang memungkinkan baik agent tingkat atas maupun subagent untuk mengelola konteks dengan lebih efektif. Konteks agent tingkat atas tidak membengkak dengan semua yang dilihat subagent, dan subagent dapat mendapatkan hanya konteks yang dibutuhkan untuk tugasnya. Sebagai satu contoh, beberapa coding agent mengimplementasikan penelitian web sebagai subagent: agent tingkat atas akan mengajukan query ke subagent, yang akan menjalankan pencarian web, mengambil halaman web individual, menganalisisnya, dan memberikan jawaban atas query ke agent tingkat atas. Dengan cara ini, konteks agent tingkat atas tidak membengkak oleh konten lengkap dari semua halaman web yang diambil, dan subagent tidak memiliki dalam konteksnya sisa riwayat percakapan agent tingkat atas.
 
-For many of the advanced features that require writing prompts (e.g., skills or subagents), you can use LLMs to get you started. Some coding agents even have built-in support for doing this. For example, Claude Code can generate a subagent from a short prompt (invoke `/agents` and create a new agent). Try creating a subagent with this prompt:
+Untuk banyak fitur lanjutan yang memerlukan penulisan prompt (misalnya, skills atau subagent), Anda dapat menggunakan LLM untuk membantu Anda memulai. Beberapa coding agent bahkan memiliki dukungan bawaan untuk melakukan ini. Misalnya, Claude Code dapat menghasilkan subagent dari prompt singkat (panggil `/agents` dan buat agent baru). Cobalah membuat subagent dengan prompt ini:
 
 ```
 A Python code checking agent that uses `mypy` and `ruff` to type-check, lint, and format *check* any files that have been modified from the last git commit.
 ```
 
-Then, you can use the top-level agent to explicitly invoke the subagent with a message like "use the code checker subagent". You might also be able to get the top-level agent to automatically invoke the subagent when appropriate, for example, after modifying any Python files.
+Kemudian, Anda dapat menggunakan agent tingkat atas untuk secara eksplisit memanggil subagent dengan pesan seperti "use the code checker subagent". Anda juga mungkin dapat membuat agent tingkat atas secara otomatis memanggil subagent ketika sesuai, misalnya, setelah memodifikasi file Python apa pun.
 
-# What to watch out for
+# Hal yang perlu diwaspadai
 
-AI tools can make mistakes. They are built on LLMs, which are just probabilistic next-token-prediction models. They are not "intelligent" in the same way as humans. Review AI output for correctness and security bugs. Sometimes verifying code can be harder than writing the code yourself; for critical code, consider writing it by hand. AI can go down rabbit holes and try to gaslight you; be aware of debugging spirals. Don't use AI as a crutch, and be wary of overreliance or having a shallow understanding. There's still a huge class of programming tasks that AI is still incapable of doing. Computational thinking is still valuable.
+Alat AI dapat membuat kesalahan. Mereka dibangun di atas LLM, yang hanyalah model prediksi token berikutnya yang probabilistik. Mereka tidak "cerdas" dengan cara yang sama seperti manusia. Tinjau output AI untuk kebenaran dan bug keamanan. Terkadang memverifikasi kode bisa lebih sulit daripada menulis kode sendiri; untuk kode yang kritis, pertimbangkan untuk menulisnya secara manual. AI dapat masuk ke lubang kelinci dan mencoba membuat Anda bingung; waspadai spiral debugging. Jangan gunakan AI sebagai alat bantu, dan waspadai ketergantungan berlebihan atau memiliki pemahaman yang dangkal. Masih ada kelas besar tugas pemrograman yang masih tidak dapat dilakukan AI. Pemikiran komputasional tetap berharga.
 
-# Recommended software
+# Perangkat lunak yang direkomendasikan
 
-Many IDEs / AI coding extensions include coding agents (see recommendations from the [development environment lecture](/2026/development-environment/)). Other popular coding agents include Anthropic's [Claude Code](https://www.claude.com/product/claude-code), OpenAI's [Codex](https://openai.com/codex/), and open-source agents like [opencode](https://github.com/anomalyco/opencode).
+Banyak IDE / ekstensi coding AI menyertakan coding agent (lihat rekomendasi dari [kuliah development environment](/2026/development-environment/)). Coding agent populer lainnya termasuk [Claude Code](https://www.claude.com/product/claude-code) dari Anthropic, [Codex](https://openai.com/codex/) dari OpenAI, dan agent open-source seperti [opencode](https://github.com/anomalyco/opencode).
 
-# Exercises
+# Latihan
 
-1. Compare the experience of coding by hand, using AI autocomplete, inline chat, and agents by doing the same programming task four times. The best candidate is a small-sized feature from a project you're already working on. If you're looking for other ideas, you could consider completing "good first issue" style tasks in open-source projects on GitHub, or [Advent of Code](https://adventofcode.com/) or [LeetCode](https://leetcode.com/) problems.
-1. Use an AI coding agent to navigate an unfamiliar codebase. This is best done in the context of wanting to debug or add a new feature to a project you actually care about. If you don't have any that come to mind, try using an AI agent to understand how security-related features work in the [opencode](https://github.com/anomalyco/opencode) agent.
-1. Vibe code a small app from scratch. Do not write a single line of code by hand.
-1. For your coding agent of choice, create and test an `AGENTS.md` (or analogous for your agent of choice, such as `CLAUDE.md`), a skill (e.g., [skill in Claude Code](https://code.claude.com/docs/en/skills) or [skill in Codex](https://developers.openai.com/codex/skills/)), and a subagent (e.g., [subagent in Claude Code](https://code.claude.com/docs/en/sub-agents)). Think about when you'd want to use one of these versus another. Note that your coding agent of choice might not support some of these functionalities; you can either skip them, or try a different coding agent that has support.
-1. Use a coding agent to accomplish the same goal as in the Markdown bullet points regex exercise from the [Code Quality lecture](/2026/code-quality/). Does it complete the tasks via direct file edits? What are the downsides and limitations of an agent editing the file directly to complete such a task? Figure out how to prompt the agent such that it doesn't complete the task via direct file edits. Hint: ask the agent to use one of the command-line tools mentioned in the [first lecture](/2026/course-shell/).
-1. Most coding agents support a form of "yolo mode" (e.g., in Claude Code, `--dangerously-skip-permissions`). It is not secure to use this mode directly, but it may be acceptable to run a coding agent in an isolated environment like a virtual machine or container and then enable autonomous operation. Get this setup running on your machine. Documentation such as [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) or [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/agents/claude-code/) may come in handy. There is more than one way to set this up.
+1. Bandingkan pengalaman coding secara manual, menggunakan AI autocomplete, inline chat, dan agent dengan melakukan tugas pemrograman yang sama empat kali. Kandidat terbaik adalah fitur berukuran kecil dari proyek yang sedang Anda kerjakan. Jika Anda mencari ide lain, Anda dapat mempertimbangkan untuk menyelesaikan tugas bergaya "good first issue" di proyek open-source di GitHub, atau masalah [Advent of Code](https://adventofcode.com/) atau [LeetCode](https://leetcode.com/).
+1. Gunakan coding agent AI untuk menavigasi codebase yang tidak dikenal. Ini paling baik dilakukan dalam konteks ingin melakukan debugging atau menambahkan fitur baru ke proyek yang benar-benar Anda pedulikan. Jika Anda tidak memiliki ide, cobalah menggunakan agent AI untuk memahami bagaimana fitur terkait keamanan bekerja di agent [opencode](https://github.com/anomalyco/opencode).
+1. Vibe-code aplikasi kecil dari awal. Jangan menulis satu baris kode pun secara manual.
+1. Untuk coding agent pilihan Anda, buat dan uji `AGENTS.md` (atau analog untuk agent pilihan Anda, seperti `CLAUDE.md`), sebuah skill (misalnya, [skill di Claude Code](https://code.claude.com/docs/en/skills) atau [skill di Codex](https://developers.openai.com/codex/skills/)), dan sebuah subagent (misalnya, [subagent di Claude Code](https://code.claude.com/docs/en/sub-agents)). Pikirkan kapan Anda ingin menggunakan salah satu dari ini versus yang lain. Perhatikan bahwa coding agent pilihan Anda mungkin tidak mendukung beberapa fungsionalitas ini; Anda dapat melewatinya, atau mencoba coding agent lain yang memiliki dukungan.
+1. Gunakan coding agent untuk mencapai tujuan yang sama seperti dalam latihan regex bullet point Markdown dari [kuliah Code Quality](/2026/code-quality/). Apakah ia menyelesaikan tugas melalui pengeditan file langsung? Apa kekurangan dan keterbatasan agent yang mengedit file secara langsung untuk menyelesaikan tugas seperti ini? Cari tahu cara memberikan prompt kepada agent sehingga tidak menyelesaikan tugas melalui pengeditan file langsung. Petunjuk: minta agent untuk menggunakan salah satu alat command-line yang disebutkan dalam [kuliah pertama](/2026/course-shell/).
+1. Sebagian besar coding agent mendukung bentuk "yolo mode" (misalnya, di Claude Code, `--dangerously-skip-permissions`). Tidak aman untuk menggunakan mode ini secara langsung, tetapi mungkin dapat diterima untuk menjalankan coding agent di lingkungan terisolasi seperti mesin virtual atau container dan kemudian mengaktifkan operasi otonom. Jalankan setup ini di mesin Anda. Dokumentasi seperti [Claude Code devcontainers](https://code.claude.com/docs/en/devcontainer) atau [Docker Sandboxes / Claude Code](https://docs.docker.com/ai/sandboxes/agents/claude-code/) mungkin berguna. Ada lebih dari satu cara untuk mengatur ini.

--- a/_2026/beyond-code.md
+++ b/_2026/beyond-code.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Beyond the Code"
+title: "Di Balik Kode"
 description: >
   Pelajari soft skills penting termasuk dokumentasi, norma komunitas open-source, dan etika AI.
 thumbnail: /static/assets/thumbnails/2026/lec8.png
@@ -11,408 +11,429 @@ video:
   id: 2DOEATfXT8k
 ---
 
-Being a good software engineer isn't just about writing code that
-works. It's about writing code that others (including future you) can
-understand, maintain, and build upon. It's about communicating
-clearly, contributing thoughtfully, and being a good citizen in the
-ecosystems you participate in—whether open source or proprietary.
+Menjadi software engineer yang baik bukan hanya tentang menulis kode yang
+berfungsi. Ini tentang menulis kode yang dapat dipahami, dipelihara, dan
+dikembangkan oleh orang lain (termasuk Anda di masa depan). Ini tentang
+berkomunikasi dengan jelas, berkontribusi dengan penuh pertimbangan, dan
+menjadi warga yang baik dalam ekosistem yang Anda ikuti—baik itu open source
+maupun proprietary.
 
-# One-way communication
+# Komunikasi satu arah
 
-Much of software engineering involves writing for people who lack your
-current context: teammates who join later, maintainers who inherit
-your code, or yourself in six months when you've forgotten why you
-made a particular choice. A key piece of advice for all this kind of
-writing is that your goal is to capture and convey the *why*, not just
-the *what*. The what tends to be self-explanatory, while the *why* is
-hard-earned knowledge that is easily lost to time.
+Sebagian besar pekerjaan software engineering melibatkan menulis untuk orang
+yang tidak memiliki konteks Anda saat ini: rekan tim yang bergabung nanti,
+maintainer yang mewarisi kode Anda, atau Anda sendiri enam bulan dari sekarang
+ketika Anda sudah lupa mengapa Anda membuat pilihan tertentu. Saran utama untuk
+semua jenis penulisan ini adalah tujuan Anda adalah menangkap dan menyampaikan
+*mengapa*, bukan hanya *apa*. Apa yang dilakukan cenderung dapat dijelaskan
+dengan sendirinya, sedangkan *mengapa* adalah pengetahuan yang diperoleh dengan
+sulit dan mudah hilang seiring waktu.
 
-Perhaps the most common form of engineer-to-engineer communication
-(apart from the code itself) is code comments. I've personally found
-that a lot of code comments are useless. But they don't have to be! Good
-comments explain things that the code itself cannot: *why* something is
-done a particular way, not *how* it works (which is what the code
-shows). They can save hours of confusion, while bad comments add noise
-or, worse, mislead.
+Mungkin bentuk komunikasi yang paling umum dari engineer ke engineer
+(terlepas dari kode itu sendiri) adalah komentar kode. Saya pribadi menemukan
+bahwa banyak komentar kode tidak berguna. Tapi tidak harus demikian! Komentar
+yang baik menjelaskan hal-hal yang tidak dapat dijelaskan oleh kode itu
+sendiri: *mengapa* sesuatu dilakukan dengan cara tertentu, bukan *bagaimana*
+cara kerjanya (yang sudah ditunjukkan oleh kode). Komentar yang baik dapat
+menghemat waktu berjam-jam dari kebingungan, sementara komentar yang buruk
+menambah kebisingan atau, lebih buruk lagi, menyesatkan.
 
-Types of comments that are nearly always worthwhile:
+Jenis komentar yang hampir selalu bermanfaat:
 
-- **TODOs**: Mark incomplete or unpolished code, but leave enough
-  context for someone else to understand what's outstanding and why it
-  was deferred. "TODO: optimize" is useless; "TODO: this O(n²) loop is
-  fine for `n<100`, but will need indexing if we scale" is actionable.
-- **References**: Link to external sources when code implements an
-  algorithm from a paper, adapts code from elsewhere, or encodes
-  behaviour specified in documentation. Use permalinks. Note any
-  divergences from the reference.
-- **Correctness arguments**: Explain *why* non-trivial code produces
-  correct results. The code shows the steps; a comment explains why
-  those steps work.
-- **Hard-learned lessons**: If you spent 30+ minutes debugging something
-  and the fix is a non-obvious incantation, document it. Your past self
-  didn't realize it was needed; future readers won't either.
-- **Rationale for constants**: Magic numbers deserve explanation. Why
-  1492? Why 16 bits? Was it chosen randomly, derived from testing, or
-  required for correctness? Even "chosen arbitrarily" is useful
-  information.
-- **Load-bearing choices**: If correctness depends on a
-  seemingly-innocent implementation detail (e.g., "must be a BTreeSet
-  because iteration order matters below"), call it out explicitly.
-- **"Why not"s**: When you deliberately avoid the obvious approach,
-  explain why. Otherwise someone will "fix" it later and break things.
+- **TODO**: Tandai kode yang belum selesai atau belum dipoles, tetapi berikan
+  konteks yang cukup agar orang lain dapat memahami apa yang masih tertunda dan
+  mengapa ditunda. "TODO: optimasi" tidak berguna; "TODO: loop O(n²) ini cukup
+  untuk `n<100`, tetapi akan memerlukan indexing jika kita scale" lebih dapat
+  ditindaklanjuti.
+- **Referensi**: Tautkan ke sumber eksternal ketika kode mengimplementasikan
+  algoritma dari sebuah paper, mengadaptasi kode dari tempat lain, atau
+  mengkodekan perilaku yang ditentukan dalam dokumentasi. Gunakan permalink.
+  Catat setiap penyimpangan dari referensi.
+- **Argumen kebenaran**: Jelaskan *mengapa* kode yang tidak trivial menghasilkan
+  hasil yang benar. Kode menunjukkan langkah-langkahnya; komentar menjelaskan
+  mengapa langkah-langkah tersebut bekerja.
+- **Pelajaran yang didapat dengan susah payah**: Jika Anda menghabiskan 30+
+  menit untuk men-debug sesuatu dan solusinya adalah sebuah incantation yang
+  tidak jelas, dokumentasikan. Diri Anda di masa lalu tidak menyadari itu
+  diperlukan; pembaca di masa depan juga tidak akan menyadarinya.
+- **Rasionalisasi konstanta**: Angka-angka ajaib layak diberi penjelasan. Mengapa
+  1492? Mengapa 16 bit? Apakah dipilih secara acak, diturunkan dari pengujian,
+  atau diperlukan untuk kebenaran? Bahkan "dipilih secara arbitrer" adalah
+  informasi yang berguna.
+- **Pilihan yang menopang kebenaran**: Jika kebenaran bergantung pada detail
+  implementasi yang tampaknya tidak berbahaya (misalnya, "harus berupa BTreeSet
+  karena urutan iterasi penting di bawah"), sebutkan secara eksplisit.
+- **"Mengapa tidak"**: Ketika Anda dengan sengaja menghindari pendekatan yang
+  jelas, jelaskan mengapa. Jika tidak, seseorang akan "memperbaikinya" nanti
+  dan merusak sesuatu.
 
-READMEs (you have one, right?) are also a common first touch-point with
-other developers. A good one answers four questions immediately: What
-does this do? Why should I care? How do I use it? How do I install it?
-In that order. Structure it like a funnel: a one-liner and maybe a
-visual demo at the top so someone can decide in seconds if this solves
-their problem, then progressively add depth. Show usage before
-installation — people want to see what they're getting before committing
-to setup steps.
+README (Anda punya satu, kan?) juga merupakan titik sentuhan pertama yang umum
+dengan developer lain. README yang baik menjawab empat pertanyaan segera: Apa
+yang dilakukan ini? Mengapa saya harus peduli? Bagaimana cara menggunakannya?
+Bagaimana cara menginstalnya? Dalam urutan tersebut. Struktur seperti corong:
+satu baris dan mungkin demo visual di atas agar seseorang dapat memutuskan dalam
+hitungan detik apakah ini memecahkan masalah mereka, kemudian tambahkan
+kedalaman secara bertahap. Tunjukkan penggunaan sebelum instalasi — orang ingin
+melihat apa yang mereka dapatkan sebelum berkomitmen pada langkah-langkah
+setup.
 
-Commit messages are another kind of "writing for others" that is often
-neglected. They are often written as "fixed blah" or "added foo", and
-while that may be sufficient in some cases, it's easy to forget that
-they form the historical record of *why* the codebase evolved the way it
-did. When someone (including you!) runs `git blame` trying to understand
-a confusing change, good commit messages should give them answers.
+Pesan commit adalah jenis lain dari "menulis untuk orang lain" yang sering
+diabaikan. Pesan commit sering ditulis sebagai "fixed blah" atau "added foo",
+dan meskipun itu mungkin cukup dalam beberapa kasus, mudah untuk lupa bahwa
+pesan commit membentuk catatan historis tentang *mengapa* codebase berkembang
+seperti itu. Ketika seseorang (termasuk Anda!) menjalankan `git blame` untuk
+mencoba memahami perubahan yang membingungkan, pesan commit yang baik harus
+memberi mereka jawaban.
 
-In general, the body should answer:
-- What problem forced this change?
-- What alternatives did you consider?
-- What are the trade-offs or implications?
-- What might be surprising about this approach?
+Secara umum, isi pesan commit harus menjawab:
+- Masalah apa yang memaksa perubahan ini?
+- Alternatif apa yang Anda pertimbangkan?
+- Apa trade-off atau implikasinya?
+- Apa yang mungkin mengejutkan tentang pendekatan ini?
 
-> Obviously you should scale detail with complexity. A one-line typo fix
-> needs only a subject. A subtle race condition fix that took hours to
-> debug deserves paragraphs explaining the problem and solution.
+> Jelas Anda harus menyesuaikan detail dengan kompleksitas. Perbaikan typo
+> satu baris hanya memerlukan subject. Perbaikan race condition yang halus
+> yang memakan waktu berjam-jam untuk di-debug layak mendapatkan paragraf yang
+> menjelaskan masalah dan solusinya.
 
-For complex changes, it can be useful to follow a Problem → Solution →
-Implications structure: Start with the forcing function or limitation,
-then explain what changed and the key design decisions, and then list
-noteworthy consequences (positive and negative). That last part is
-particularly important; real engineering involves balancing concerns,
-and documenting that a trade-off was intentional prevents future
-developers from thinking you missed the problem.
+Untuk perubahan yang kompleks, bisa berguna mengikuti struktur Masalah → Solusi
+→ Implikasi: Mulai dengan pemicu atau keterbatasan, kemudian jelaskan apa yang
+berubah dan keputusan desain utama, lalu daftar konsekuensi yang penting
+(positif dan negatif). Bagian terakhir sangat penting; rekayasa nyata melibatkan
+keseimbangan kepentingan, dan mendokumentasikan bahwa sebuah trade-off
+disengaja mencegah developer di masa depan berpikir Anda melewatkan masalah
+tersebut.
 
-LLMs _can_ be helpful in writing commit messages. However, if you simply
-point one at your change and ask it to write the commit message for the
-change, the LLM will only have access to the _what_, not the _why_. And
-the resulting commit message will thus be mostly descriptive (the
-opposite of what we want!). If you used an LLM to help you make the
-change in the first place, asking the LLM to write the commit in that
-same session can be a much better option since your conversation with
-the LLM is inherently a rich source of context about the change!
-Otherwise, or in addition, a useful trick is to specifically tell the
-LLM you'd like a commit message focused on the "why" (and other nuances
-from the notes above), and then _tell it to query you for missing
-context_. Essentially, you're acting like a MCP "tool" for the coding
-agent that it can use to "read" context.
+LLM _dapat_ membantu dalam menulis pesan commit. Namun, jika Anda hanya
+mengarahkannya ke perubahan Anda dan memintanya menulis pesan commit untuk
+perubahan tersebut, LLM hanya akan memiliki akses ke _apa_, bukan _mengapa_.
+Dan pesan commit yang dihasilkan akan sebagian besar bersifat deskriptif
+(kebalikan dari yang kita inginkan!). Jika Anda menggunakan LLM untuk membantu
+Anda membuat perubahan sejak awal, meminta LLM menulis commit dalam sesi yang
+sama bisa menjadi pilihan yang jauh lebih baik karena percakapan Anda dengan
+LLM secara inheren merupakan sumber konteks yang kaya tentang perubahan
+tersebut! Jika tidak, atau sebagai tambahan, trik yang berguna adalah secara
+khusus memberi tahu LLM bahwa Anda ingin pesan commit yang berfokus pada
+"mengapa" (dan nuansa lainnya dari catatan di atas), dan kemudian _suruh LLM
+untuk bertanya kepada Anda tentang konteks yang hilang_. Pada dasarnya, Anda
+bertindak seperti "tool" MCP yang dapat digunakan oleh coding agent untuk
+"membaca" konteks.
 
-As your changes get more complex, make sure to also break up commits
-logically (`git add -p` is your friend). Each commit should represent
-one coherent change that could be understood and reviewed independently.
-Don't mix refactoring with new features or combine unrelated bug fixes,
-as this muddies the story for which changes fixed what problem, and will
-almost certainly slow down the eventual review of your changes. It also
-gives you superpowers through `git bisect`, but that's a story for
-another time.
+Seiring perubahan Anda menjadi lebih kompleks, pastikan untuk juga memecah
+commit secara logis (`git add -p` adalah teman Anda). Setiap commit harus
+mewakili satu perubahan yang koheren yang dapat dipahami dan direview secara
+independen. Jangan mencampur refactoring dengan fitur baru atau menggabungkan
+perbaikan bug yang tidak terkait, karena ini mengaburkan cerita tentang
+perubahan mana yang memperbaiki masalah apa, dan hampir pasti akan memperlambat
+review perubahan Anda pada akhirnya. Ini juga memberi Anda kekuatan super
+melalui `git bisect`, tapi itu cerita untuk waktu lain.
 
-> One note as you start being more diligent about technical writing, and
-> using it more extensively, make sure you respect the reader. It's easy
-> to end up over-explaining once you start, but you have to resist that
-> urge lest the reader read _none_ of what you've written. Explain the
-> "why" and trust them to figure out the "how" for their situation.
+> Satu catatan saat Anda mulai lebih rajin dalam penulisan teknis, dan
+> menggunakannya secara lebih luas, pastikan Anda menghormati pembaca. Mudah
+> untuk berakhir dengan penjelasan berlebihan setelah Anda mulai, tetapi Anda
+> harus menahan dorongan itu agar pembaca tidak membaca _tidak satupun_ dari
+> apa yang telah Anda tulis. Jelaskan "mengapa" dan percayai mereka untuk
+> mencari tahu "bagaimana" untuk situasi mereka.
 
-# Collaboration
+# Kolaborasi
 
-As engineers, we may spend a large part of our job coding at our own
-keyboard, but a sizeable chunk of our time is also taken up by
-communicating with others. That time is usually split into collaboration
-and education, and the payoff from investing in getting better at both is
-significant.
+Sebagai engineer, kita mungkin menghabiskan sebagian besar pekerjaan kita
+dengan coding di keyboard sendiri, tetapi sebagian besar waktu kita juga
+dihabiskan untuk berkomunikasi dengan orang lain. Waktu tersebut biasanya
+terbagi antara kolaborasi dan edukasi, dan hasil dari berinvestasi untuk
+menjadi lebih baik di keduanya sangat signifikan.
 
-## Contributing
+## Berkontribusi
 
-Whether you are submitting a bug report, contributing a simple bug fix,
-or implementing a huge feature, it's worth keeping in mind that there
-are usually orders of magnitude more users than there are contributors,
-and an order of magnitude more contributors than there are maintainers.
-As a result, maintainer time is highly oversubscribed. If you want to
-increase the likelihood that your contribution goes somewhere
-productive, you have to ensure that your contributions carry a high
-signal-to-noise ratio and are worth the maintainers' time.
+Baik Anda mengirimkan laporan bug, berkontribusi perbaikan bug sederhana, atau
+mengimplementasikan fitur besar, perlu diingat bahwa biasanya ada urutan
+besaran lebih banyak pengguna daripada kontributor, dan satu urutan besaran
+lebih banyak kontributor daripada maintainer. Akibatnya, waktu maintainer
+sangat terbatas. Jika Anda ingin meningkatkan kemungkinan bahwa kontribusi
+Anda menghasilkan sesuatu yang produktif, Anda harus memastikan bahwa
+kontribusi Anda membawa rasio signal-to-noise yang tinggi dan layak mendapat
+waktu maintainer.
 
-For example, a good bug report respects the maintainer's time by
-providing everything needed to understand and reproduce the problem:
+Sebagai contoh, laporan bug yang baik menghormati waktu maintainer dengan
+menyediakan semua yang diperlukan untuk memahami dan mereproduksi masalah:
 
-- **Environment**: OS, version numbers, relevant configuration
-- **What you expected** vs **what actually happened**
-- **Steps to reproduce**: Be specific. "Click the button" is less useful
-  than "Click the Submit button on the /settings page while logged in as
-  an admin."
-- **What you've already tried**: This prevents duplicate suggestions and
-  shows you've done some investigation
+- **Environment**: OS, nomor versi, konfigurasi yang relevan
+- **Apa yang Anda harapkan** vs **apa yang sebenarnya terjadi**
+- **Langkah-langkah untuk mereproduksi**: Jadilah spesifik. "Klik tombolnya"
+  kurang berguna daripada "Klik tombol Submit di halaman /settings saat login
+  sebagai admin."
+- **Apa yang sudah Anda coba**: Ini mencegah saran duplikat dan menunjukkan
+  Anda telah melakukan penyelidikan
 
-> If you find a security vulnerability, don't post it publicly. Contact
-> the maintainers privately first and give them reasonable time to fix
-> it before disclosure. Many projects have a SECURITY.md file or
-> similar for this purpose.
+> Jika Anda menemukan kerentanan keamanan, jangan mempostingnya secara publik.
+> Hubungi maintainer secara pribadi terlebih dahulu dan beri mereka waktu yang
+> wajar untuk memperbaikinya sebelum disclosure. Banyak proyek memiliki file
+> SECURITY.md atau sejenisnya untuk tujuan ini.
 
-**Make sure you search for existing issues.** Your bug or feature
-request may already be reported, and it's far better to add information
-to existing discussions rather than creating duplicates. Not to mention,
-it reduces noise for the maintainers.
+**Pastikan Anda mencari issue yang sudah ada.** Bug atau permintaan fitur Anda
+mungkin sudah dilaporkan, dan jauh lebih baik menambahkan informasi ke
+diskusi yang sudah ada daripada membuat duplikat. Belum lagi, ini mengurangi
+kebisingan bagi maintainer.
 
-Minimal reproducible examples are gold, if you can come up with one.
-They save the maintainer a huge amount of time and effort, and
-reliably reproducing the bug is often the hardest part of fixing it. Not
-to mention, the effort you put into isolating the problem often helps
-you understand it better too, and sometimes leads you to find a fix
-yourself.
+Contoh reproduksi minimal adalah emas, jika Anda bisa membuatnya. Contoh ini
+menghemat banyak waktu dan usaha maintainer, dan mereproduksi bug secara
+andal sering kali merupakan bagian tersulit dari memperbaikinya. Belum lagi,
+usaha yang Anda lakukan untuk mengisolasi masalah sering kali membantu Anda
+memahaminya dengan lebih baik juga, dan terkadang menuntun Anda untuk
+menemukan solusi sendiri.
 
-If you don't hear back right away, keep in mind that maintainers are
-often volunteers with limited time. If you're waiting for a reply from
-them, a polite follow-up after a couple weeks is fine; daily pings are
-not. Similarly, "me too" comments, or bug reports that are just a
-copy-paste of some terminal output tend to be a net-negative in terms of
-getting traction for your issue.
+Jika Anda tidak segera mendapat tanggapan, ingatlah bahwa maintainer sering
+kali adalah relawan dengan waktu terbatas. Jika Anda menunggu balasan dari
+mereka, follow-up yang sopan setelah beberapa minggu tidak masalah; ping
+setiap hari tidak. Demikian pula, komentar "me too", atau laporan bug yang
+hanya berupa copy-paste output terminal cenderung menjadi beban netto dalam
+hal mendapatkan perhatian untuk issue Anda.
 
-If you're looking to make a code contribution, you'll also want to
-familiarize yourself with the contribution guidelines. Many projects
-have a `CONTRIBUTING.md` — follow it. You'll also usually want to start
-small; a typo fix or documentation improvement is a great first
-contribution as it helps you learn the project's processes without also
-having to go through lots of back and forth on the content.
+Jika Anda ingin membuat kontribusi kode, Anda juga perlu membiasakan diri
+dengan panduan kontribusi. Banyak proyek memiliki `CONTRIBUTING.md` — ikuti
+panduan tersebut. Anda juga biasanya ingin memulai dari yang kecil; perbaikan
+typo atau perbaikan dokumentasi adalah kontribusi pertama yang bagus karena
+membantu Anda mempelajari proses proyek tanpa harus melalui banyak bolak-balik
+tentang konten.
 
-> Check what license the project uses, as any code you contribute will
-> fall under the same license. In particular, look out for copyleft
-> licenses (like GPL), which requires derivatives to also be open source
-> and may have implications for your employer if you touch it!
-> [choosealicense.com](https://choosealicense.com/) has more useful
-> information.
+> Periksa lisensi apa yang digunakan proyek, karena setiap kode yang Anda
+> kontribusikan akan berada di bawah lisensi yang sama. Khususnya, perhatikan
+> lisensi copyleft (seperti GPL), yang mengharuskan karya turunan juga bersifat
+> open source dan mungkin memiliki implikasi bagi pemberi kerja Anda jika Anda
+> menyentuhnya! [choosealicense.com](https://choosealicense.com/) memiliki
+> informasi yang lebih berguna.
 
-When you've decided to open a pull request ("PR"), first make sure you
-isolate the change you actually want to be accepted. If your PR changes
-lots of other unrelated things at the same time, chances are the
-reviewer will send it back to you asking you to clean it up. This is
-similar to how you should break down your git commits into semantically
-related chunks.
+Ketika Anda memutuskan untuk membuka pull request ("PR"), pertama-tama pastikan
+Anda mengisolasi perubahan yang sebenarnya ingin Anda diterima. Jika PR Anda
+mengubah banyak hal lain yang tidak terkait pada saat yang sama, kemungkinan
+besar reviewer akan mengembalikannya kepada Anda dan meminta Anda untuk
+membersihkannya. Ini mirip dengan bagaimana Anda harus memecah commit git Anda
+menjadi bagian-bagian yang terkait secara semantis.
 
-In some cases, if you have many seemingly-disparate changes but
-they're all needed to enable one feature, it may be okay to open a
-larger PR that captures all the changes. However, in this case, commit
-hygiene is particularly important so that maintainers have the option
-to review the change "commit by commit".
+Dalam beberapa kasus, jika Anda memiliki banyak perubahan yang tampaknya
+berbeda-beda tetapi semuanya diperlukan untuk mengaktifkan satu fitur, mungkin
+tidak masalah membuka PR yang lebih besar yang mencakup semua perubahan.
+Namun, dalam kasus ini, kebersihan commit sangat penting agar maintainer
+memiliki opsi untuk mereview perubahan "commit demi commit".
 
-Next, make sure you explain the "why" behind the change well. Don't just
-describe _what_ changed — explain _why_ the change is needed and _why_
-this is a good way to address the problem. You should also proactively
-call out parts of the change that warrant special attention in the
-review, if any. Depending on `CONTRIBUTING.md` and the nature of your
-change, reviewers may also expect to see additional information like
-trade-offs you made or how to test the change.
+Selanjutnya, pastikan Anda menjelaskan "mengapa" di balik perubahan dengan
+baik. Jangan hanya mendeskripsikan _apa_ yang berubah — jelaskan _mengapa_
+perubahan diperlukan dan _mengapa_ ini adalah cara yang baik untuk mengatasi
+masalah. Anda juga harus secara proaktif menyebutkan bagian-bagian perubahan
+yang memerlukan perhatian khusus dalam review, jika ada. Tergantung pada
+`CONTRIBUTING.md` dan sifat perubahan Anda, reviewer mungkin juga mengharapkan
+informasi tambahan seperti trade-off yang Anda buat atau cara menguji
+perubahan.
 
-> We recommend contributing back to upstream projects rather than
-> "forking" the project, at least as a first approach. Forking (license
-> permitting) should be reserved for when the contributions you want to
-> make are out of scope for the original project. If you do fork, make
-> sure you acknowledge the original project!
+> Kami merekomendasikan untuk berkontribusi kembali ke proyek upstream daripada
+> "fork" proyek, setidaknya sebagai pendekatan pertama. Forking (dengan
+> memperhatikan lisensi) sebaiknya dicadangkan untuk ketika kontribusi yang
+> ingin Anda buat berada di luar ruang lingkup proyek asli. Jika Anda melakukan
+> fork, pastikan Anda mengakui proyek asli!
 
-AI makes it incredibly easy to generate plausible-looking code and PRs
-quickly, but this doesn't excuse you from understanding what you're
-contributing. Submitting AI-generated code you can't explain burdens
-maintainers with reviewing and potentially maintaining code that even
-its author doesn't understand. It's fine to use AI to help you
-identify issues and produce fixes/features, **so long as you still do
-the due diligence** to polish it into a worthwhile contribution, rather
-than passing that work on to the (already-overloaded) maintainers.
+AI membuat sangat mudah untuk menghasilkan kode dan PR yang terlihat masuk
+akal dengan cepat, tetapi ini tidak membebaskan Anda dari tanggung jawab untuk
+memahami apa yang Anda kontribusikan. Mengirimkan kode yang dihasilkan AI yang
+tidak dapat Anda jelaskan membebani maintainer dengan me-review dan mungkin
+memelihara kode yang bahkan pembuatnya tidak pahami. Tidak apa-apa menggunakan
+AI untuk membantu mengidentifikasi masalah dan menghasilkan perbaikan/fitur,
+**asalkan Anda tetap melakukan due diligence** untuk memolesnya menjadi
+kontribusi yang berharga, daripada menyerahkan pekerjaan itu kepada maintainer
+(yang sudah kelebihan beban).
 
-Remember that for maintainers, accepting a PR means accepting long-term
-responsibility. They will be maintaining this code long after the
-contributor has moved on, and so may decline changes that are
-well-intentioned but don't fit the project's direction, add complexity
-they don't want to maintain, or where the need simply isn't sufficiently
-well-documented. It's on _you_ as the contributor to make the case for
-why accepting the contribution is worth the maintenance burden.
+Ingat bahwa bagi maintainer, menerima PR berarti menerima tanggung jawab
+jangka panjang. Mereka akan memelihara kode ini jauh setelah kontributor
+beralih ke hal lain, dan mungkin menolak perubahan yang berniat baik tetapi
+tidak sesuai dengan arah proyek, menambah kompleksitas yang tidak ingin mereka
+pelihara, atau di mana kebutuhannya tidak terdokumentasi dengan cukup baik.
+Tugas _Anda_ sebagai kontributor untuk membuat argumen mengapa menerima
+kontribusi tersebut sepadan dengan beban pemeliharaan.
 
-> When receiving feedback on a PR, remember that your code is not you!
-> Reviewers are trying to make the code better, not criticizing you
-> personally. Ask clarifying questions if you disagree — you might learn
-> something, or maybe they will.
+> Saat menerima umpan balik pada PR, ingatlah bahwa kode Anda bukanlah Anda!
+> Reviewer berusaha membuat kode menjadi lebih baik, bukan mengkritik Anda
+> secara pribadi. Ajukan pertanyaan klarifikasi jika Anda tidak setuju — Anda
+> mungkin belajar sesuatu, atau mungkin mereka yang akan belajar.
 
-## Reviewing
+## Me-review
 
-You might think code review is something senior developers do, but
-you'll likely be asked to review code much earlier than you expect, and
-your perspective is valuable. Fresh eyes catch things that experienced
-developers overlook, and questions from someone less familiar with the
-code often reveal assumptions that should be documented or simplified.
+Anda mungkin berpikir code review adalah sesuatu yang dilakukan developer
+senior, tetapi Anda mungkin akan diminta untuk me-review kode lebih awal dari
+yang Anda kira, dan perspektif Anda berharga. Mata segar menangkap hal-hal
+yang diabaikan developer berpengalaman, dan pertanyaan dari seseorang yang
+kurang familiar dengan kode sering kali mengungkap asumsi yang seharusnya
+didokumentasikan atau disederhanakan.
 
-Review is also one of the fastest ways to learn. You'll see how others
-approach problems, pick up patterns and idioms, and develop intuition
-for what makes code readable. Beyond personal growth, reviews catch bugs
-before they reach production, spread knowledge across the team, and
-improve code quality through collaboration. They are not merely
-bureaucratic overhead.
+Review juga merupakan salah satu cara tercepat untuk belajar. Anda akan melihat
+bagaimana orang lain mendekati masalah, mengambil pola dan idiom, dan
+mengembangkan intuisi tentang apa yang membuat kode mudah dibaca. Di luar
+pertumbuhan pribadi, review menangkap bug sebelum mencapai produksi, menyebarkan
+pengetahuan ke seluruh tim, dan meningkatkan kualitas kode melalui kolaborasi.
+Review bukan sekadar overhead birokrasi.
 
-Good code review is a skill you need to hone over time, but there are
-some tips that can make them much better much faster:
+Code review yang baik adalah keterampilan yang perlu Anda asah seiring waktu,
+tetapi ada beberapa tips yang dapat membuatnya jauh lebih baik dengan lebih
+cepat:
 
-- **Review the code, not the person**:
-  "This function is confusing" vs "You wrote confusing code."
-- **Prefer actionable comments**:
-  "Can you replace these globals with a config dataclass" is an easier
-  comment to address than "Don't use globals here"
-- **Ask questions rather than making demands**:
-  "What happens if X is null here?" invites discussion better than
-  "Handle the null case."
-- **Explain the "why"**:
-  "Consider using a constant here" is less useful than "Consider using a
-  constant here so we can easily adjust the timeout based on
-  environment."
-- **Distinguish blocking issues from suggestions**:
-  Be clear about what must change versus what's a matter of preference.
-- **Acknowledge what's good**:
-  Pointing out clever solutions or clean implementations is encouraging
-  and helps the author know what to continue doing.
-- **Know when to stop**:
-  Contributors only have so much time and patience, and it's not always
-  best spent handling all the nits. Focus on the big things, and
-  consider tidying up nits yourself after the fact.
+- **Review kodenya, bukan orangnya**:
+  "Fungsi ini membingungkan" vs "Anda menulis kode yang membingungkan."
+- **Utamakan komentar yang dapat ditindaklanjuti**:
+  "Bisa ganti globals ini dengan config dataclass?" adalah komentar yang lebih
+  mudah ditangani daripada "Jangan gunakan globals di sini"
+- **Ajukan pertanyaan daripada membuat tuntutan**:
+  "Apa yang terjadi jika X null di sini?" mengundang diskusi lebih baik
+  daripada "Tangani kasus null."
+- **Jelaskan "mengapa"**:
+  "Pertimbangkan menggunakan konstanta di sini" kurang berguna daripada
+  "Pertimbangkan menggunakan konstanta di sini agar kita dapat dengan mudah
+  menyesuaikan timeout berdasarkan environment."
+- **Bedakan antara masalah yang memblokir dan saran**:
+  Jelaskan dengan jelas apa yang harus diubah versus apa yang merupakan masalah
+  preferensi.
+- **Akui apa yang baik**:
+  Menunjukkan solusi cerdas atau implementasi yang bersih sangat mendorong dan
+  membantu penulis mengetahui apa yang harus terus dilakukan.
+- **Tahu kapan harus berhenti**:
+  Kontributor hanya punya waktu dan kesabaran terbatas, dan tidak selalu
+  terbaik dihabiskan untuk menangani semua hal-hal kecil. Fokus pada hal-hal
+  besar, dan pertimbangkan untuk merapikan hal-hal kecil sendiri setelahnya.
 
-> AI tools can catch certain issues, but they're not a substitute for
-> human review. They miss context, don't understand product
-> requirements, and can confidently suggest wrong things. They're worth
-> using as a first pass, but not a replacement for thoughtful human
-> review.
+> Tool AI dapat menangkap masalah tertentu, tetapi bukan pengganti untuk review
+> manusia. Mereka melewatkan konteks, tidak memahami kebutuhan produk, dan
+> dapat dengan percaya diri menyarankan hal-hal yang salah. Mereka layak
+> digunakan sebagai pass pertama, tetapi bukan pengganti untuk review manusia
+> yang penuh pertimbangan.
 
-# Education
+# Edukasi
 
-A lot of our non-coding time as engineers is spent either asking or
-answering questions, possibly a mixture of both; during collaboration,
-in dialogue with peers, or while trying to learn. Asking good questions
-is a skill that makes you better at learning from anyone, not just
-perfect explainers. Julia Evans has some excellent blog posts on "[How
-to ask good questions](https://jvns.ca/blog/good-questions/)" and "[How
-to get useful answers to your
+Banyak waktu non-coding kita sebagai engineer dihabiskan untuk bertanya atau
+menjawab pertanyaan, mungkin campuran keduanya; selama kolaborasi, dalam
+dialog dengan rekan, atau saat mencoba belajar. Bertanya dengan baik adalah
+keterampilan yang membuat Anda lebih baik dalam belajar dari siapa pun, bukan
+hanya dari penjelas yang sempurna. Julia Evans memiliki beberapa posting blog
+yang sangat baik tentang "[How to ask good
+questions](https://jvns.ca/blog/good-questions/)" dan "[How to get useful
+answers to your
 questions](https://jvns.ca/blog/2021/10/21/how-to-get-useful-answers-to-your-questions/)"
-that are worth reading.
+yang layak dibaca.
 
-Some particularly valuable pieces of advice are:
+Beberapa saran yang sangat berharga adalah:
 
-- **State your understanding first**: Say what you think you know and
-  ask "is that right?" This helps the answerer identify your actual
-  knowledge gaps.
-- **Ask yes/no questions**: "Is X true?" prevents tangential
-  explanations and usually prompts useful elaboration anyway.
-- **Be specific**: "How do SQL joins work?" is too vague. "Does a LEFT
-  JOIN include rows where the right table has no match?" is answerable.
-- **Admit when you don't understand**: Interrupt to ask about unfamiliar
-  terms. This reflects confidence, not weakness. Similarly, if they ask
-  questions of you that you do not know the answer to, it's best to say
-  "I don't know", and possibly follow up with "but I think ..." or even
-  "but I can find out".
-- **Don't accept incomplete answers**: Keep asking follow-ups until you
-  actually understand.
-- **Do some research first**: Basic investigation helps you ask more
-  targeted questions (though casual questions among colleagues are
-  fine).
+- **Nyatakan pemahaman Anda terlebih dahulu**: Katakan apa yang Anda pikir Anda
+  ketahui dan tanyakan "apakah itu benar?" Ini membantu pemberi jawaban
+  mengidentifikasi celah pengetahuan Anda yang sebenarnya.
+- **Ajukan pertanyaan ya/tidak**: "Apakah X benar?" mencegah penjelasan yang
+  melebar dan biasanya tetap memicu elaborasi yang berguna.
+- **Jadilah spesifik**: "Bagaimana cara kerja SQL join?" terlalu kabur.
+  "Apakah LEFT JOIN menyertakan baris di mana tabel kanan tidak memiliki
+  kecocokan?" dapat dijawab.
+- **Akui ketika Anda tidak paham**: Sela untuk bertanya tentang istilah yang
+  tidak familiar. Ini mencerminkan kepercayaan diri, bukan kelemahan. Demikian
+  pula, jika mereka menanyakan sesuatu kepada Anda yang tidak Anda ketahui
+  jawabannya, yang terbaik adalah mengatakan "Saya tidak tahu", dan mungkin
+  melanjutkan dengan "tetapi saya pikir ..." atau bahkan "tetapi saya bisa
+  mencari tahu".
+- **Jangan terima jawaban yang tidak lengkap**: Terus ajukan pertanyaan lanjutan
+  sampai Anda benar-benar paham.
+- **Lakukan riset terlebih dahulu**: Investigasi dasar membantu Anda mengajukan
+  pertanyaan yang lebih tertarget (meskipun pertanyaan santai di antara rekan
+  kerja tidak masalah).
 
-Remember: well-crafted questions benefit entire communities. They
-surface hidden assumptions that others need to understand too.
+Ingat: pertanyaan yang dirancang dengan baik bermanfaat bagi seluruh komunitas.
+Pertanyaan tersebut mengungkap asumsi tersembunyi yang juga perlu dipahami
+orang lain.
 
-> Note that this advice applies just as much when communicating with
-> LLMs!
+> Perhatikan bahwa saran ini berlaku sama saat berkomunikasi dengan LLM!
 
-# AI etiquette
+# Etika AI
 
-With the growing use of LLMs and AI across software engineering, the
-social and professional norms around are still in flux. We already
-covered many of the tactical considerations in the [agentic coding
-lecture](/2026/agentic-coding/), but there are also "softer" parts of
-their use that are worth discussing.
+Dengan semakin meluasnya penggunaan LLM dan AI dalam software engineering,
+norma sosial dan profesional di sekitarnya masih dalam perubahan. Kami sudah
+membahas banyak pertimbangan taktis di [lecture agentic
+coding](/2026/agentic-coding/), tetapi ada juga bagian "lebih lunak" dari
+penggunaannya yang layak dibahas.
 
-The first of these is that when AI meaningfully contributed to your
-work, **disclose it**. This isn't about shame — it's about honesty,
-setting appropriate expectations, and ensuring the resulting work gets
-the appropriate level of review. It's also worthwhile to disclose which
-_parts_ you use AI for — there's a meaningful distinction between "this
-whole thing is vibecoded" and "I wrote this backup tool and used an LLM
-to style the web frontend". For example, we've used LLMs to help write
-some of these lecture notes, including proofreading, brainstorming, and
-generating first drafts of code snippets and exercises.
+Yang pertama adalah ketika AI berkontribusi secara signifikan terhadap pekerjaan
+Anda, **ungkapkan hal tersebut**. Ini bukan tentang rasa malu — ini tentang
+kejujuran, menetapkan ekspektasi yang tepat, dan memastikan pekerjaan yang
+dihasilkan mendapatkan tingkat review yang sesuai. Juga bermanfaat untuk
+mengungkapkan _bagian mana_ yang Anda gunakan AI — ada perbedaan yang bermakna
+antara "semua ini adalah vibecoded" dan "saya menulis tool backup ini dan
+menggunakan LLM untuk men-style frontend web". Sebagai contoh, kami telah
+menggunakan LLM untuk membantu menulis beberapa catatan lecture ini, termasuk
+proofreading, brainstorming, dan menghasilkan draft awal cuplikan kode dan
+latihan.
 
-You'll also want to follow the norms of the teams and projects you're
-contributing to here. Some teams have stricter policies around the use
-of AI than others (e.g., for compliance or data residency reasons), and
-you don't want to accidentally run afoul of that. Being open about your
-use helps prevent potentially costly mistakes.
+Anda juga perlu mengikuti norma-norma tim dan proyek yang Anda kontribusikan.
+Beberapa tim memiliki kebijakan yang lebih ketat tentang penggunaan AI
+dibandingkan yang lain (misalnya, untuk alasan kepatuhan atau residensi data),
+dan Anda tidak ingin secara tidak sengaja melanggarnya. Terbuka tentang
+penggunaan Anda membantu mencegah kesalahan yang berpotensi mahal.
 
-> If you're aiming to learn as part of the work you're doing, keep in
-> mind that if you have AI do all or most of the work for you can be
-> self-defeating; you're likely to learn more about prompting (and maybe
-> reviewing AI output) than the task itself. Especially when you're
-> learning, the point may be the journey, not the destination, so using
-> AI to "get the solution quickly" is an anti-goal.
+> Jika Anda bertujuan untuk belajar sebagai bagian dari pekerjaan yang Anda
+> lakukan, ingatlah bahwa jika Anda membiarkan AI melakukan semua atau sebagian
+> besar pekerjaan untuk Anda, itu bisa menjadi kontraproduktif; Anda mungkin
+> lebih banyak belajar tentang prompting (dan mungkin me-review output AI)
+> daripada tugas itu sendiri. Terutama ketika Anda sedang belajar, tujuannya
+> mungkin perjalanannya, bukan tujuannya, jadi menggunakan AI untuk
+> "mendapatkan solusi dengan cepat" adalah anti-tujuan.
 
-A related concern comes up in interviews and other assessment
-situations. These are often intended to specifically evaluate _your_
-skills and abilities, not those of an LLM. More companies now allow you
-to use LLMs and other AI-assisted tooling in interviews as long as you
-let them observe those interactions as part of the interview (i.e., they
-are evaluating your skill in making use of those tools too!), but those
-are still in the minority. If you are unsure about whether AI assistance
-is in scope for a particular task, ask!
+Keprihatinan terkait muncul dalam wawancara dan situasi penilaian lainnya.
+Situasi-situasi ini sering kali dimaksudkan secara khusus untuk mengevaluasi
+keterampilan dan kemampuan _Anda_, bukan LLM. Lebih banyak perusahaan sekarang
+mengizinkan Anda menggunakan LLM dan tool bantuan AI lainnya dalam wawancara
+selama Anda membiarkan mereka mengamati interaksi tersebut sebagai bagian dari
+wawancara (yaitu, mereka juga mengevaluasi keterampilan Anda dalam menggunakan
+tool-tool tersebut!), tetapi mereka masih merupakan minoritas. Jika Anda tidak
+yakin apakah bantuan AI diizinkan untuk tugas tertentu, tanyakan!
 
-> It should go without saying that if an assessment situation explicitly
-> calls for no external tools, no LLMs, etc., you should not use them.
-> Trying to do so discretely without getting caught **will** come back
-> to bite you.
+> Seharusnya tidak perlu dikatakan lagi bahwa jika situasi penilaian secara
+> eksplisit melarang tool eksternal, LLM, dll., Anda tidak boleh menggunakannya.
+> Mencoba melakukannya secara diam-diam tanpa ketahuan **akan** kembali
+> merugikan Anda.
 
-# Exercises
+# Latihan
 
-1. Browse the source code of a well-known project (e.g.,
-   [Redis](https://github.com/redis/redis) or
-   [curl](https://github.com/curl/curl)). Find examples of some of the
-   comment types mentioned in the lecture: a useful TODO, a reference to
-   external documentation, a "why not" comment explaining an avoided
-   approach, or a hard-learned lesson. What would be lost if that
-   comment was not there?
+1. Jelajahi source code dari proyek yang terkenal (misalnya,
+   [Redis](https://github.com/redis/redis) atau
+   [curl](https://github.com/curl/curl)). Temukan contoh beberapa jenis
+   komentar yang disebutkan dalam lecture: TODO yang berguna, referensi ke
+   dokumentasi eksternal, komentar "mengapa tidak" yang menjelaskan pendekatan
+   yang dihindari, atau pelajaran yang didapat dengan susah payah. Apa yang
+   akan hilang jika komentar tersebut tidak ada?
 
-1. Pick an open-source project you're interested in and look at its
-   recent commit history (`git log`). Find one commit with a good
-   message that explains *why* the change was made, and one with a weak
-   message that only describes *what* changed. For the weak one, look at
-   the diff (`git show <hash>`) and try to write a better commit message
-   following the Problem → Solution → Implications structure. Notice how
-   much work is required to reassemble the necessary context after the
-   fact!
+1. Pilih proyek open-source yang Anda minati dan lihat riwayat commit terbarunya
+   (`git log`). Temukan satu commit dengan pesan yang baik yang menjelaskan
+   *mengapa* perubahan dilakukan, dan satu dengan pesan yang lemah yang hanya
+   mendeskripsikan *apa* yang berubah. Untuk yang lemah, lihat diff (`git show
+   <hash>`) dan coba tulis pesan commit yang lebih baik mengikuti struktur
+   Masalah → Solusi → Implikasi. Perhatikan berapa banyak usaha yang diperlukan
+   untuk menyusun kembali konteks yang diperlukan setelah fakta!
 
-1. Compare the READMEs of three GitHub projects with 1000+ stars. Are
-   all of them equally useful? Look for things that come across mostly
-   as noise to you as a lesson for future READMEs you write yourself.
+1. Bandingkan README dari tiga proyek GitHub dengan 1000+ bintang. Apakah
+   semuanya sama-sama berguna? Carilah hal-hal yang menurut Anda sebagian besar
+   hanya kebisingan sebagai pelajaran untuk README yang Anda tulis sendiri di
+   masa depan.
 
-1. Find an open issue on a project you use (check the "good first issue"
-   or "help wanted" labels if they have it). Evaluate the issue against
-   the criteria from the lecture: does it seem like it values the
-   maintainer's time and contains all the information necessary to debug
-   it, or do you expect that the maintainer may need to go multiple
-   rounds of questions with the submitter to get to the root problem?
+1. Temukan issue terbuka pada proyek yang Anda gunakan (periksa label "good
+   first issue" atau "help wanted" jika ada). Evaluasi issue tersebut terhadap
+   kriteria dari lecture: apakah sepertinya menghargai waktu maintainer dan
+   berisi semua informasi yang diperlukan untuk men-debug-nya, atau Anda
+   memperkirakan maintainer mungkin perlu melalui beberapa putaran pertanyaan
+   dengan pengirim untuk sampai ke masalah inti?
 
-1. Think of a bug you've encountered in software you use (or find one in
-   an issue tracker). Practice creating a minimal reproducible example:
-   strip away everything unrelated to the bug until you have the
-   smallest case that still demonstrates the problem. Write up what you
-   removed and why.
+1. Pikirkan bug yang pernah Anda temui di software yang Anda gunakan (atau
+   temukan satu di issue tracker). Berlatihlah membuat contoh reproduksi
+   minimal: hilangkan semua yang tidak terkait dengan bug sampai Anda memiliki
+   kasus terkecil yang masih mendemonstrasikan masalah. Tuliskan apa yang Anda
+   hapus dan mengapa.
 
-1. Find a merged pull request on a project you're familiar with that has
-   substantive review comments (not just "LGTM"). Read through the
-   review. Were all the comments equally productive? If you were the PR
-   author, how would you find the experience of getting all those
-   comments?
+1. Temukan pull request yang sudah di-merge pada proyek yang Anda kenal yang
+   memiliki komentar review yang substantif (bukan hanya "LGTM"). Baca
+   review-nya. Apakah semua komentar sama-sama produktif? Jika Anda adalah
+   penulis PR, bagaimana pengalaman Anda menerima semua komentar tersebut?
 
-1. Go to Stack Overflow and find a question in a technology you know
-   that has a highly-voted answer. Then find one that was closed or
-   heavily downvoted. Compare them against the advice from the lecture;
-   was it predictable which question would get better answers?
+1. Pergi ke Stack Overflow dan temukan pertanyaan dalam teknologi yang Anda
+   ketahui yang memiliki jawaban dengan voting tinggi. Kemudian temukan satu
+   yang ditutup atau banyak downvote. Bandingkan mereka dengan saran dari
+   lecture; apakah dapat diprediksi pertanyaan mana yang akan mendapatkan
+   jawaban lebih baik?

--- a/_2026/beyond-code.md
+++ b/_2026/beyond-code.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Beyond the Code"
 description: >
-  Learn about essential soft skills including documentation, open-source community norms, and AI etiquette.
+  Pelajari soft skills penting termasuk dokumentasi, norma komunitas open-source, dan etika AI.
 thumbnail: /static/assets/thumbnails/2026/lec8.png
 date: 2026-01-22
 ready: true

--- a/_2026/beyond-code.md
+++ b/_2026/beyond-code.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Beyond the Code"
+title: "Lebih dari Sekadar Kode"
 description: >
-  Learn about essential soft skills including documentation, open-source community norms, and AI etiquette.
+  Pelajari keterampilan lunak penting termasuk dokumentasi, norma komunitas open-source, dan etika AI.
 thumbnail: /static/assets/thumbnails/2026/lec8.png
 date: 2026-01-22
 ready: true
@@ -11,408 +11,434 @@ video:
   id: 2DOEATfXT8k
 ---
 
-Being a good software engineer isn't just about writing code that
-works. It's about writing code that others (including future you) can
-understand, maintain, and build upon. It's about communicating
-clearly, contributing thoughtfully, and being a good citizen in the
-ecosystems you participate in—whether open source or proprietary.
+Menjadi software engineer yang baik bukan hanya tentang menulis kode yang
+berfungsi. Ini tentang menulis kode yang dapat dipahami, dipelihara, dan
+dikembangkan oleh orang lain (termasuk Anda di masa depan). Ini tentang
+berkomunikasi dengan jelas, berkontribusi dengan penuh pertimbangan, dan
+menjadi warga yang baik dalam ekosistem yang Anda ikuti—baik itu open source
+maupun proprietary.
 
-# One-way communication
+# Komunikasi satu arah
 
-Much of software engineering involves writing for people who lack your
-current context: teammates who join later, maintainers who inherit
-your code, or yourself in six months when you've forgotten why you
-made a particular choice. A key piece of advice for all this kind of
-writing is that your goal is to capture and convey the *why*, not just
-the *what*. The what tends to be self-explanatory, while the *why* is
-hard-earned knowledge that is easily lost to time.
+Sebagian besar pekerjaan software engineering melibatkan menulis untuk orang
+yang tidak memiliki konteks Anda saat ini: rekan tim yang bergabung nanti,
+maintainer yang mewarisi kode Anda, atau diri Anda sendiri enam bulan dari
+sekarang ketika Anda sudah lupa mengapa Anda membuat keputusan tertentu.
+Saran utama untuk semua jenis penulisan ini adalah tujuan Anda adalah
+menangkap dan menyampaikan *mengapa* (*why*), bukan hanya *apa* (*what*).
+Bagian *apa* cenderung dapat dijelaskan dengan sendirinya, sementara *mengapa*
+adalah pengetahuan yang diperoleh dengan susah payah dan mudah hilang
+tergerus waktu.
 
-Perhaps the most common form of engineer-to-engineer communication
-(apart from the code itself) is code comments. I've personally found
-that a lot of code comments are useless. But they don't have to be! Good
-comments explain things that the code itself cannot: *why* something is
-done a particular way, not *how* it works (which is what the code
-shows). They can save hours of confusion, while bad comments add noise
-or, worse, mislead.
+Mungkin bentuk komunikasi paling umum antar-engineer (selain kode itu
+sendiri) adalah komentar kode. Saya pribadi menemukan bahwa banyak komentar
+kode tidak berguna. Tapi tidak harus demikian! Komentar yang baik menjelaskan
+hal-hal yang tidak bisa dijelaskan oleh kode itu sendiri: *mengapa* sesuatu
+dilakukan dengan cara tertentu, bukan *bagaimana* cara kerjanya (yang
+ditunjukkan oleh kode). Komentar yang baik bisa menghemat waktu berjam-jam
+dari kebingungan, sementara komentar yang buruk menambah noise atau, lebih
+buruk lagi, menyesatkan.
 
-Types of comments that are nearly always worthwhile:
+Jenis komentar yang hampir selalu bermanfaat:
 
-- **TODOs**: Mark incomplete or unpolished code, but leave enough
-  context for someone else to understand what's outstanding and why it
-  was deferred. "TODO: optimize" is useless; "TODO: this O(n²) loop is
-  fine for `n<100`, but will need indexing if we scale" is actionable.
-- **References**: Link to external sources when code implements an
-  algorithm from a paper, adapts code from elsewhere, or encodes
-  behaviour specified in documentation. Use permalinks. Note any
-  divergences from the reference.
-- **Correctness arguments**: Explain *why* non-trivial code produces
-  correct results. The code shows the steps; a comment explains why
-  those steps work.
-- **Hard-learned lessons**: If you spent 30+ minutes debugging something
-  and the fix is a non-obvious incantation, document it. Your past self
-  didn't realize it was needed; future readers won't either.
-- **Rationale for constants**: Magic numbers deserve explanation. Why
-  1492? Why 16 bits? Was it chosen randomly, derived from testing, or
-  required for correctness? Even "chosen arbitrarily" is useful
-  information.
-- **Load-bearing choices**: If correctness depends on a
-  seemingly-innocent implementation detail (e.g., "must be a BTreeSet
-  because iteration order matters below"), call it out explicitly.
-- **"Why not"s**: When you deliberately avoid the obvious approach,
-  explain why. Otherwise someone will "fix" it later and break things.
+- **TODOs**: Tandai kode yang belum selesai atau belum dipoles, tetapi
+  berikan konteks yang cukup agar orang lain dapat memahami apa yang masih
+  harus diselesaikan dan mengapa ditunda. "TODO: optimize" tidak berguna;
+  "TODO: this O(n²) loop is fine for `n<100`, but will need indexing if we
+  scale" lebih dapat ditindaklanjuti.
+- **References**: Tautkan ke sumber eksternal ketika kode mengimplementasikan
+  algoritma dari sebuah paper, mengadaptasi kode dari tempat lain, atau
+  mengencode perilaku yang ditentukan dalam dokumentasi. Gunakan permalink.
+  Catat setiap penyimpangan dari referensi.
+- **Correctness arguments**: Jelaskan *mengapa* kode yang tidak trivial
+  menghasilkan hasil yang benar. Kode menunjukkan langkah-langkahnya;
+  komentar menjelaskan mengapa langkah-langkah tersebut berhasil.
+- **Hard-learned lessons**: Jika Anda menghabiskan 30+ menit untuk
+  men-debug sesuatu dan solusinya adalah sebuah incantation yang tidak
+  jelas, dokumentasikanlah. Diri Anda di masa lalu tidak menyadari bahwa
+  itu diperlukan; pembaca di masa depan juga tidak.
+- **Rationale for constants**: Angka-angka magic pantas dijelaskan. Mengapa
+  1492? Mengapa 16 bit? Apakah dipilih secara acak, diturunkan dari
+  pengujian, atau diperlukan untuk correctness? Bahkan "chosen arbitrarily"
+  adalah informasi yang berguna.
+- **Load-bearing choices**: Jika correctness bergantung pada detail
+  implementasi yang tampaknya tidak berbahaya (misalnya, "must be a BTreeSet
+  because iteration order matters below"), sebutkan secara eksplisit.
+- **"Why not"s**: Ketika Anda dengan sengaja menghindari pendekatan yang
+  jelas, jelaskan alasannya. Jika tidak, seseorang akan "memperbaikinya"
+  nanti dan merusak segalanya.
 
-READMEs (you have one, right?) are also a common first touch-point with
-other developers. A good one answers four questions immediately: What
-does this do? Why should I care? How do I use it? How do I install it?
-In that order. Structure it like a funnel: a one-liner and maybe a
-visual demo at the top so someone can decide in seconds if this solves
-their problem, then progressively add depth. Show usage before
-installation — people want to see what they're getting before committing
-to setup steps.
+README (Anda punya satu, kan?) juga merupakan titik sentuhan pertama yang
+umum dengan developer lain. README yang baik menjawab empat pertanyaan
+segera: Apa fungsi proyek ini? Mengapa saya harus peduli? Bagaimana cara
+menggunakannya? Bagaimana cara menginstalnya? Dalam urutan tersebut.
+Strukturkannya seperti corong: satu baris penjelasan dan mungkin demo
+visual di bagian atas agar seseorang dapat memutuskan dalam hitungan detik
+apakah ini menyelesaikan masalah mereka, kemudian tambahkan kedalaman secara
+bertahap. Tunjukkan penggunaan sebelum instalasi — orang ingin melihat apa
+yang mereka dapatkan sebelum melakukan langkah-langkah setup.
 
-Commit messages are another kind of "writing for others" that is often
-neglected. They are often written as "fixed blah" or "added foo", and
-while that may be sufficient in some cases, it's easy to forget that
-they form the historical record of *why* the codebase evolved the way it
-did. When someone (including you!) runs `git blame` trying to understand
-a confusing change, good commit messages should give them answers.
+Commit message adalah jenis lain dari "menulis untuk orang lain" yang sering
+diabaikan. Commit message sering ditulis sebagai "fixed blah" atau "added
+foo", dan meskipun itu mungkin cukup dalam beberapa kasus, mudah lupa bahwa
+mereka membentuk catatan historis tentang *mengapa* codebase berkembang
+seperti sekarang. Ketika seseorang (termasuk Anda!) menjalankan `git blame`
+untuk mencoba memahami perubahan yang membingungkan, commit message yang
+baik seharusnya memberikan jawaban.
 
-In general, the body should answer:
-- What problem forced this change?
-- What alternatives did you consider?
-- What are the trade-offs or implications?
-- What might be surprising about this approach?
+Secara umum, bagian body harus menjawab:
+- Masalah apa yang memaksa perubahan ini?
+- Alternatif apa saja yang Anda pertimbangkan?
+- Apa trade-off atau implikasinya?
+- Apa yang mungkin mengejutkan tentang pendekatan ini?
 
-> Obviously you should scale detail with complexity. A one-line typo fix
-> needs only a subject. A subtle race condition fix that took hours to
-> debug deserves paragraphs explaining the problem and solution.
+> Tentu saja Anda harus menyesuaikan tingkat detail dengan kompleksitas.
+> Perbaikan typo satu baris hanya membutuhkan subject. Perbaikan race
+> condition yang subtil yang memakan waktu berjam-jam untuk di-debug
+> pantas mendapatkan paragraf yang menjelaskan masalah dan solusinya.
 
-For complex changes, it can be useful to follow a Problem → Solution →
-Implications structure: Start with the forcing function or limitation,
-then explain what changed and the key design decisions, and then list
-noteworthy consequences (positive and negative). That last part is
-particularly important; real engineering involves balancing concerns,
-and documenting that a trade-off was intentional prevents future
-developers from thinking you missed the problem.
+Untuk perubahan yang kompleks, bisa berguna mengikuti struktur Problem →
+Solution → Implications: Mulai dengan pemicu atau limitasi, kemudian
+jelaskan apa yang berubah dan keputusan desain utama, lalu daftar
+konsekuensi yang patut diperhatikan (positif dan negatif). Bagian terakhir
+sangat penting; rekayasa nyata melibatkan menyeimbangkan berbagai
+pertimbangan, dan mendokumentasikan bahwa sebuah trade-off memang disengaja
+mencegah developer di masa depan mengira Anda melewatkan masalah tersebut.
 
-LLMs _can_ be helpful in writing commit messages. However, if you simply
-point one at your change and ask it to write the commit message for the
-change, the LLM will only have access to the _what_, not the _why_. And
-the resulting commit message will thus be mostly descriptive (the
-opposite of what we want!). If you used an LLM to help you make the
-change in the first place, asking the LLM to write the commit in that
-same session can be a much better option since your conversation with
-the LLM is inherently a rich source of context about the change!
-Otherwise, or in addition, a useful trick is to specifically tell the
-LLM you'd like a commit message focused on the "why" (and other nuances
-from the notes above), and then _tell it to query you for missing
-context_. Essentially, you're acting like a MCP "tool" for the coding
-agent that it can use to "read" context.
+LLM _bisa_ membantu dalam menulis commit message. Namun, jika Anda hanya
+menunjuk ke perubahan Anda dan memintanya menulis commit message untuk
+perubahan tersebut, LLM hanya akan memiliki akses ke _apa_, bukan _mengapa_.
+Dan commit message yang dihasilkan karenanya akan sebagian besar bersifat
+deskriptif (kebalikan dari yang kita inginkan!). Jika Anda menggunakan LLM
+untuk membantu Anda membuat perubahan sejak awal, meminta LLM menulis commit
+message di sesi yang sama bisa menjadi opsi yang jauh lebih baik karena
+percakapan Anda dengan LLM secara inheren merupakan sumber konteks yang kaya
+tentang perubahan tersebut! Jika tidak, atau sebagai tambahan, trik yang
+berguna adalah secara khusus memberi tahu LLM bahwa Anda ingin commit
+message yang berfokus pada "mengapa" (dan nuansa lainnya dari catatan di
+atas), kemudian _minta LLM untuk menanyakan konteks yang hilang kepada
+Anda_. Pada dasarnya, Anda bertindak seperti "tool" MCP yang bisa digunakan
+oleh coding agent untuk "membaca" konteks.
 
-As your changes get more complex, make sure to also break up commits
-logically (`git add -p` is your friend). Each commit should represent
-one coherent change that could be understood and reviewed independently.
-Don't mix refactoring with new features or combine unrelated bug fixes,
-as this muddies the story for which changes fixed what problem, and will
-almost certainly slow down the eventual review of your changes. It also
-gives you superpowers through `git bisect`, but that's a story for
-another time.
+Seiring perubahan Anda menjadi semakin kompleks, pastikan untuk juga
+memecah commit secara logis (`git add -p` adalah teman Anda). Setiap commit
+harus mewakili satu perubahan yang koheren yang dapat dipahami dan
+di-review secara independen. Jangan mencampur refactoring dengan fitur baru
+atau menggabungkan perbaikan bug yang tidak terkait, karena ini mengaburkan
+cerita tentang perubahan mana yang memperbaiki masalah apa, dan hampir
+pasti akan memperlambat review perubahan Anda pada akhirnya. Ini juga
+memberi Anda kekuatan super melalui `git bisect`, tapi itu cerita untuk
+waktu lain.
 
-> One note as you start being more diligent about technical writing, and
-> using it more extensively, make sure you respect the reader. It's easy
-> to end up over-explaining once you start, but you have to resist that
-> urge lest the reader read _none_ of what you've written. Explain the
-> "why" and trust them to figure out the "how" for their situation.
+> Satu catatan saat Anda mulai lebih rajin dalam menulis teknis, dan
+> menggunakannya secara lebih ekstensif, pastikan Anda menghormati pembaca.
+> Mudah terjebak dalam penjelasan berlebihan setelah Anda mulai, tetapi
+> Anda harus menahan dorongan itu agar pembaca tidak mengabaikan _semua_
+> yang telah Anda tulis. Jelaskan "mengapa" dan percayai mereka untuk
+> mencari tahu "bagaimana" untuk situasi mereka.
 
-# Collaboration
+# Kolaborasi
 
-As engineers, we may spend a large part of our job coding at our own
-keyboard, but a sizeable chunk of our time is also taken up by
-communicating with others. That time is usually split into collaboration
-and education, and the payoff from investing in getting better at both is
-significant.
+Sebagai engineer, kita mungkin menghabiskan sebagian besar pekerjaan kita
+untuk coding di depan keyboard, tetapi sebagian waktu kita juga dihabiskan
+untuk berkomunikasi dengan orang lain. Waktu tersebut biasanya terbagi
+menjadi kolaborasi dan edukasi, dan manfaat dari berinvestasi untuk menjadi
+lebih baik di keduanya sangat signifikan.
 
-## Contributing
+## Berkontribusi
 
-Whether you are submitting a bug report, contributing a simple bug fix,
-or implementing a huge feature, it's worth keeping in mind that there
-are usually orders of magnitude more users than there are contributors,
-and an order of magnitude more contributors than there are maintainers.
-As a result, maintainer time is highly oversubscribed. If you want to
-increase the likelihood that your contribution goes somewhere
-productive, you have to ensure that your contributions carry a high
-signal-to-noise ratio and are worth the maintainers' time.
+Baik Anda mengirimkan bug report, berkontribusi perbaikan bug sederhana,
+atau mengimplementasikan fitur besar, perlu diingat bahwa biasanya terdapat
+beberapa orde magnitudo lebih banyak pengguna daripada kontributor, dan
+satu orde magnitudo lebih banyak kontributor daripada maintainer. Akibatnya,
+waktu maintainer sangat terbatas. Jika Anda ingin meningkatkan kemungkinan
+kontribusi Anda membuahkan hasil yang produktif, Anda harus memastikan bahwa
+kontribusi Anda membawa rasio signal-to-noise yang tinggi dan sepadan dengan
+waktu para maintainer.
 
-For example, a good bug report respects the maintainer's time by
-providing everything needed to understand and reproduce the problem:
+Sebagai contoh, bug report yang baik menghormati waktu maintainer dengan
+menyediakan semua yang diperlukan untuk memahami dan mereproduksi masalah:
 
-- **Environment**: OS, version numbers, relevant configuration
-- **What you expected** vs **what actually happened**
-- **Steps to reproduce**: Be specific. "Click the button" is less useful
-  than "Click the Submit button on the /settings page while logged in as
-  an admin."
-- **What you've already tried**: This prevents duplicate suggestions and
-  shows you've done some investigation
+- **Environment**: OS, nomor versi, konfigurasi yang relevan
+- **Apa yang Anda harapkan** vs **apa yang sebenarnya terjadi**
+- **Langkah-langkah untuk mereproduksi**: Spesifik. "Click the button"
+  kurang berguna daripada "Click the Submit button on the /settings page
+  while logged in as an admin."
+- **Apa yang sudah Anda coba**: Ini mencegah saran yang duplikat dan
+  menunjukkan bahwa Anda sudah melakukan investigasi
 
-> If you find a security vulnerability, don't post it publicly. Contact
-> the maintainers privately first and give them reasonable time to fix
-> it before disclosure. Many projects have a SECURITY.md file or
-> similar for this purpose.
+> Jika Anda menemukan kerentanan keamanan, jangan mempublikasikannya secara
+> terbuka. Hubungi maintainer secara pribadi terlebih dahulu dan beri mereka
+> waktu yang memadai untuk memperbaikinya sebelum disclosure. Banyak proyek
+> memiliki file SECURITY.md atau sejenisnya untuk tujuan ini.
 
-**Make sure you search for existing issues.** Your bug or feature
-request may already be reported, and it's far better to add information
-to existing discussions rather than creating duplicates. Not to mention,
-it reduces noise for the maintainers.
+**Pastikan Anda mencari issue yang sudah ada.** Bug atau feature request
+Anda mungkin sudah dilaporkan, dan jauh lebih baik menambahkan informasi
+ke diskusi yang sudah ada daripada membuat duplikat. Belum lagi, ini
+mengurangi noise bagi para maintainer.
 
-Minimal reproducible examples are gold, if you can come up with one.
-They save the maintainer a huge amount of time and effort, and
-reliably reproducing the bug is often the hardest part of fixing it. Not
-to mention, the effort you put into isolating the problem often helps
-you understand it better too, and sometimes leads you to find a fix
-yourself.
+Minimal reproducible examples sangat berharga, jika Anda bisa
+menghasilkannya. Ini menghemat banyak waktu dan usaha maintainer, dan
+mereproduksi bug secara konsisten seringkali merupakan bagian tersulit
+dalam memperbaikinya. Belum lagi, usaha yang Anda lakukan untuk mengisolasi
+masalah seringkali membantu Anda memahaminya dengan lebih baik juga, dan
+kadang-kadang mengarahkan Anda untuk menemukan solusi sendiri.
 
-If you don't hear back right away, keep in mind that maintainers are
-often volunteers with limited time. If you're waiting for a reply from
-them, a polite follow-up after a couple weeks is fine; daily pings are
-not. Similarly, "me too" comments, or bug reports that are just a
-copy-paste of some terminal output tend to be a net-negative in terms of
-getting traction for your issue.
+Jika Anda tidak segera mendapat balasan, ingatlah bahwa maintainer seringkali
+adalah relawan dengan waktu terbatas. Jika Anda menunggu balasan dari mereka,
+follow-up yang sopan setelah beberapa minggu masih wajar; ping setiap hari
+tidak. Demikian pula, komentar "me too", atau bug report yang hanya berisi
+copy-paste output terminal cenderung bersifat net-negatif dalam hal
+mendapatkan perhatian untuk issue Anda.
 
-If you're looking to make a code contribution, you'll also want to
-familiarize yourself with the contribution guidelines. Many projects
-have a `CONTRIBUTING.md` — follow it. You'll also usually want to start
-small; a typo fix or documentation improvement is a great first
-contribution as it helps you learn the project's processes without also
-having to go through lots of back and forth on the content.
+Jika Anda ingin membuat kontribusi kode, Anda juga perlu membiasakan diri
+dengan panduan kontribusi. Banyak proyek memiliki `CONTRIBUTING.md` —
+ikutilah. Anda juga biasanya ingin mulai dari yang kecil; perbaikan typo
+atau perbaikan dokumentasi adalah kontribusi pertama yang bagus karena
+membantu Anda mempelajari proses proyek tanpa harus melalui banyak bolak-balik
+tentang kontennya.
 
-> Check what license the project uses, as any code you contribute will
-> fall under the same license. In particular, look out for copyleft
-> licenses (like GPL), which requires derivatives to also be open source
-> and may have implications for your employer if you touch it!
-> [choosealicense.com](https://choosealicense.com/) has more useful
-> information.
+> Periksa lisensi apa yang digunakan proyek, karena kode apa pun yang Anda
+> kontribusikan akan berada di bawah lisensi yang sama. Khususnya, perhatikan
+> lisensi copyleft (seperti GPL), yang mengharuskan karya turunan juga
+> bersifat open source dan mungkin memiliki implikasi bagi pemberi kerja
+> Anda jika Anda menyentuhnya! [choosealicense.com](https://choosealicense.com/)
+> memiliki informasi yang lebih berguna.
 
-When you've decided to open a pull request ("PR"), first make sure you
-isolate the change you actually want to be accepted. If your PR changes
-lots of other unrelated things at the same time, chances are the
-reviewer will send it back to you asking you to clean it up. This is
-similar to how you should break down your git commits into semantically
-related chunks.
+Ketika Anda memutuskan untuk membuka pull request ("PR"), pertama-tama
+pastikan Anda mengisolasi perubahan yang sebenarnya ingin Anda terima. Jika
+PR Anda mengubah banyak hal lain yang tidak terkait pada saat yang sama,
+kemungkinan reviewer akan mengembalikannya kepada Anda dan meminta Anda
+membersihkannya. Ini mirip dengan bagaimana Anda harus memecah git commit
+Anda menjadi bagian-bagian yang terkait secara semantis.
 
-In some cases, if you have many seemingly-disparate changes but
-they're all needed to enable one feature, it may be okay to open a
-larger PR that captures all the changes. However, in this case, commit
-hygiene is particularly important so that maintainers have the option
-to review the change "commit by commit".
+Dalam beberapa kasus, jika Anda memiliki banyak perubahan yang tampaknya
+berbeda-beda tetapi semuanya diperlukan untuk mengaktifkan satu fitur,
+mungkin boleh membuka PR yang lebih besar yang mencakup semua perubahan
+tersebut. Namun, dalam kasus ini, kebersihan commit sangat penting agar
+maintainer memiliki opsi untuk me-review perubahan tersebut "commit demi
+commit".
 
-Next, make sure you explain the "why" behind the change well. Don't just
-describe _what_ changed — explain _why_ the change is needed and _why_
-this is a good way to address the problem. You should also proactively
-call out parts of the change that warrant special attention in the
-review, if any. Depending on `CONTRIBUTING.md` and the nature of your
-change, reviewers may also expect to see additional information like
-trade-offs you made or how to test the change.
+Selanjutnya, pastikan Anda menjelaskan "mengapa" di balik perubahan dengan
+baik. Jangan hanya mendeskripsikan _apa_ yang berubah — jelaskan _mengapa_
+perubahan tersebut diperlukan dan _mengapa_ ini adalah cara yang baik untuk
+mengatasi masalah tersebut. Anda juga harus secara proaktif menyebut bagian-bagian
+perubahan yang memerlukan perhatian khusus dalam review, jika ada. Tergantung
+pada `CONTRIBUTING.md` dan sifat perubahan Anda, reviewer mungkin juga
+mengharapkan informasi tambahan seperti trade-off yang Anda buat atau cara
+menguji perubahan tersebut.
 
-> We recommend contributing back to upstream projects rather than
-> "forking" the project, at least as a first approach. Forking (license
-> permitting) should be reserved for when the contributions you want to
-> make are out of scope for the original project. If you do fork, make
-> sure you acknowledge the original project!
+> Kami merekomendasikan untuk berkontribusi kembali ke proyek upstream
+> daripada "mem-fork" proyek, setidaknya sebagai pendekatan pertama.
+> Forking (jika lisensi mengizinkan) sebaiknya dicadangkan untuk ketika
+> kontribusi yang ingin Anda buat berada di luar lingkup proyek asli.
+> Jika Anda melakukan fork, pastikan Anda mengakui proyek aslinya!
 
-AI makes it incredibly easy to generate plausible-looking code and PRs
-quickly, but this doesn't excuse you from understanding what you're
-contributing. Submitting AI-generated code you can't explain burdens
-maintainers with reviewing and potentially maintaining code that even
-its author doesn't understand. It's fine to use AI to help you
-identify issues and produce fixes/features, **so long as you still do
-the due diligence** to polish it into a worthwhile contribution, rather
-than passing that work on to the (already-overloaded) maintainers.
+AI membuat sangat mudah untuk menghasilkan kode dan PR yang terlihat
+masuk akal dengan cepat, tetapi ini tidak membebaskan Anda dari kewajiban
+untuk memahami apa yang Anda kontribusikan. Mengirimkan kode hasil
+generate AI yang tidak dapat Anda jelaskan membebani maintainer dengan
+review dan potensi pemeliharaan kode yang bahkan pembuatnya sendiri tidak
+paham. Tidak masalah menggunakan AI untuk membantu mengidentifikasi masalah
+dan menghasilkan perbaikan/fitur, **selama Anda tetap melakukan due
+diligence** untuk memolesnya menjadi kontribusi yang berharga, daripada
+meneruskan pekerjaan tersebut kepada maintainer (yang sudah kelebihan beban).
 
-Remember that for maintainers, accepting a PR means accepting long-term
-responsibility. They will be maintaining this code long after the
-contributor has moved on, and so may decline changes that are
-well-intentioned but don't fit the project's direction, add complexity
-they don't want to maintain, or where the need simply isn't sufficiently
-well-documented. It's on _you_ as the contributor to make the case for
-why accepting the contribution is worth the maintenance burden.
+Ingat bahwa bagi maintainer, menerima PR berarti menerima tanggung jawab
+jangka panjang. Mereka akan memelihara kode ini jauh setelah kontributor
+beralih ke hal lain, dan mungkin menolak perubahan yang bermaksud baik
+tetapi tidak sesuai dengan arah proyek, menambah kompleksitas yang tidak
+ingin mereka pelihara, atau di mana kebutuhannya simplemente tidak
+terdokumentasi dengan cukup baik. Ini menjadi tanggung jawab _Anda_ sebagai
+kontributor untuk memberikan argumen mengapa menerima kontribusi tersebut
+sepadan dengan beban pemeliharaannya.
 
-> When receiving feedback on a PR, remember that your code is not you!
-> Reviewers are trying to make the code better, not criticizing you
-> personally. Ask clarifying questions if you disagree — you might learn
-> something, or maybe they will.
+> Saat menerima umpan balik pada PR, ingatlah bahwa kode Anda bukanlah
+> diri Anda! Reviewer berusaha membuat kode menjadi lebih baik, bukan
+> mengkritik Anda secara pribadi. Ajukan pertanyaan klarifikasi jika Anda
+> tidak setuju — Anda mungkin belajar sesuatu, atau mungkin mereka yang
+> akan belajar.
 
-## Reviewing
+## Me-review
 
-You might think code review is something senior developers do, but
-you'll likely be asked to review code much earlier than you expect, and
-your perspective is valuable. Fresh eyes catch things that experienced
-developers overlook, and questions from someone less familiar with the
-code often reveal assumptions that should be documented or simplified.
+Anda mungkin berpikir code review adalah sesuatu yang dilakukan developer
+senior, tetapi Anda mungkin akan diminta untuk me-review kode jauh lebih
+awal dari yang Anda duga, dan perspektif Anda berharga. Mata yang segar
+dapat menangkap hal-hal yang dilewatkan oleh developer berpengalaman, dan
+pertanyaan dari seseorang yang kurang familiar dengan kode seringkali
+mengungkap asumsi yang seharusnya didokumentasikan atau disederhanakan.
 
-Review is also one of the fastest ways to learn. You'll see how others
-approach problems, pick up patterns and idioms, and develop intuition
-for what makes code readable. Beyond personal growth, reviews catch bugs
-before they reach production, spread knowledge across the team, and
-improve code quality through collaboration. They are not merely
-bureaucratic overhead.
+Review juga merupakan salah satu cara tercepat untuk belajar. Anda akan
+melihat bagaimana orang lain mendekati masalah, mempelajari pola dan idiom,
+dan mengembangkan intuisi tentang apa yang membuat kode mudah dibaca. Di
+luar pertumbuhan pribadi, review menangkap bug sebelum mencapai production,
+menyebarkan pengetahuan di seluruh tim, dan meningkatkan kualitas kode
+melalui kolaborasi. Review bukan sekadar overhead birokrasi.
 
-Good code review is a skill you need to hone over time, but there are
-some tips that can make them much better much faster:
+Code review yang baik adalah keterampilan yang perlu Anda asah seiring
+waktu, tetapi ada beberapa tips yang bisa membuatnya jauh lebih baik
+dengan lebih cepat:
 
-- **Review the code, not the person**:
+- **Review kodenya, bukan orangnya**:
   "This function is confusing" vs "You wrote confusing code."
-- **Prefer actionable comments**:
-  "Can you replace these globals with a config dataclass" is an easier
-  comment to address than "Don't use globals here"
-- **Ask questions rather than making demands**:
-  "What happens if X is null here?" invites discussion better than
+- **Utamakan komentar yang dapat ditindaklanjuti**:
+  "Can you replace these globals with a config dataclass" adalah komentar
+  yang lebih mudah ditangani daripada "Don't use globals here"
+- **Ajukan pertanyaan daripada membuat tuntutan**:
+  "What happens if X is null here?" lebih mengundang diskusi daripada
   "Handle the null case."
-- **Explain the "why"**:
-  "Consider using a constant here" is less useful than "Consider using a
-  constant here so we can easily adjust the timeout based on
-  environment."
-- **Distinguish blocking issues from suggestions**:
-  Be clear about what must change versus what's a matter of preference.
-- **Acknowledge what's good**:
-  Pointing out clever solutions or clean implementations is encouraging
-  and helps the author know what to continue doing.
-- **Know when to stop**:
-  Contributors only have so much time and patience, and it's not always
-  best spent handling all the nits. Focus on the big things, and
-  consider tidying up nits yourself after the fact.
+- **Jelaskan "mengapa"**:
+  "Consider using a constant here" kurang berguna daripada "Consider using
+  a constant here so we can easily adjust the timeout based on environment."
+- **Bedakan antara masalah blocking dan saran**:
+  Jelaskan dengan jelas apa yang harus diubah versus apa yang hanya masalah
+  preferensi.
+- **Akui apa yang baik**:
+  Menunjukkan solusi yang cerdas atau implementasi yang bersih sangat
+  mendorong dan membantu penulis mengetahui apa yang harus dilanjutkan.
+- **Tahu kapan harus berhenti**:
+  Kontributor hanya punya waktu dan kesabaran terbatas, dan tidak selalu
+  terbaik dihabiskan untuk menangani semua hal-hal kecil. Fokus pada hal-hal
+  besar, dan pertimbangkan untuk merapikan hal-hal kecil sendiri setelahnya.
 
-> AI tools can catch certain issues, but they're not a substitute for
-> human review. They miss context, don't understand product
-> requirements, and can confidently suggest wrong things. They're worth
-> using as a first pass, but not a replacement for thoughtful human
-> review.
+> Tool AI dapat menangkap masalah tertentu, tetapi bukan pengganti untuk
+> review manusia. Mereka melewatkan konteks, tidak memahami persyaratan
+> produk, dan dapat dengan percaya diri menyarankan hal-hal yang salah.
+> Mereka layak digunakan sebagai first pass, tetapi bukan pengganti untuk
+> review manusia yang penuh pertimbangan.
 
-# Education
+# Edukasi
 
-A lot of our non-coding time as engineers is spent either asking or
-answering questions, possibly a mixture of both; during collaboration,
-in dialogue with peers, or while trying to learn. Asking good questions
-is a skill that makes you better at learning from anyone, not just
-perfect explainers. Julia Evans has some excellent blog posts on "[How
-to ask good questions](https://jvns.ca/blog/good-questions/)" and "[How
-to get useful answers to your
+Banyak waktu non-coding kita sebagai engineer dihabiskan untuk mengajukan
+atau menjawab pertanyaan, mungkin campuran keduanya; selama kolaborasi,
+dalam dialog dengan rekan, atau saat mencoba belajar. Mengajukan pertanyaan
+yang baik adalah keterampilan yang membuat Anda lebih baik dalam belajar
+dari siapa pun, bukan hanya dari penjelas yang sempurna. Julia Evans
+memiliki beberapa posting blog yang sangat bagus tentang "[How to ask good
+questions](https://jvns.ca/blog/good-questions/)" dan "[How to get useful
+answers to your
 questions](https://jvns.ca/blog/2021/10/21/how-to-get-useful-answers-to-your-questions/)"
-that are worth reading.
+yang layak dibaca.
 
-Some particularly valuable pieces of advice are:
+Beberapa saran yang sangat berharga adalah:
 
-- **State your understanding first**: Say what you think you know and
-  ask "is that right?" This helps the answerer identify your actual
-  knowledge gaps.
-- **Ask yes/no questions**: "Is X true?" prevents tangential
-  explanations and usually prompts useful elaboration anyway.
-- **Be specific**: "How do SQL joins work?" is too vague. "Does a LEFT
-  JOIN include rows where the right table has no match?" is answerable.
-- **Admit when you don't understand**: Interrupt to ask about unfamiliar
-  terms. This reflects confidence, not weakness. Similarly, if they ask
-  questions of you that you do not know the answer to, it's best to say
-  "I don't know", and possibly follow up with "but I think ..." or even
-  "but I can find out".
-- **Don't accept incomplete answers**: Keep asking follow-ups until you
-  actually understand.
-- **Do some research first**: Basic investigation helps you ask more
-  targeted questions (though casual questions among colleagues are
-  fine).
+- **Nyatakan pemahaman Anda terlebih dahulu**: Katakan apa yang Anda pikir
+  Anda ketahui dan tanyakan "is that right?" Ini membantu pemberi jawaban
+  mengidentifikasi celah pengetahuan Anda yang sebenarnya.
+- **Ajukan pertanyaan ya/tidak**: "Is X true?" mencegah penjelasan yang
+  melebar dan biasanya tetap mendorong elaborasi yang berguna.
+- **Spesifik**: "How do SQL joins work?" terlalu umum. "Does a LEFT JOIN
+  include rows where the right table has no match?" dapat dijawab.
+- **Akui ketika Anda tidak paham**: Potong pembicaraan untuk bertanya
+  tentang istilah yang tidak familiar. Ini mencerminkan kepercayaan diri,
+  bukan kelemahan. Demikian pula, jika mereka mengajukan pertanyaan kepada
+  Anda yang tidak Anda ketahui jawabannya, yang terbaik adalah mengatakan
+  "I don't know", dan mungkin melanjutkan dengan "but I think ..." atau
+  bahkan "but I can find out".
+- **Jangan menerima jawaban yang tidak lengkap**: Terus ajukan pertanyaan
+  lanjutan sampai Anda benar-benar paham.
+- **Lakukan riset terlebih dahulu**: Investigasi dasar membantu Anda
+  mengajukan pertanyaan yang lebih tertarget (meskipun pertanyaan kasual
+  antar rekan kerja tidak masalah).
 
-Remember: well-crafted questions benefit entire communities. They
-surface hidden assumptions that others need to understand too.
+Ingat: pertanyaan yang dirancang dengan baik bermanfaat bagi seluruh
+komunitas. Mereka mengungkap asumsi tersembunyi yang juga perlu dipahami
+oleh orang lain.
 
-> Note that this advice applies just as much when communicating with
-> LLMs!
+> Perhatikan bahwa saran ini juga berlaku saat berkomunikasi dengan LLM!
 
-# AI etiquette
+# Etika AI
 
-With the growing use of LLMs and AI across software engineering, the
-social and professional norms around are still in flux. We already
-covered many of the tactical considerations in the [agentic coding
-lecture](/2026/agentic-coding/), but there are also "softer" parts of
-their use that are worth discussing.
+Dengan meningkatnya penggunaan LLM dan AI dalam software engineering,
+norma sosial dan profesional di sekitarnya masih dalam perubahan. Kami
+sudah membahas banyak pertimbangan taktis di [agentic coding
+lecture](/2026/agentic-coding/), tetapi ada juga bagian "lebih lunak" dari
+penggunaannya yang patut dibahas.
 
-The first of these is that when AI meaningfully contributed to your
-work, **disclose it**. This isn't about shame — it's about honesty,
-setting appropriate expectations, and ensuring the resulting work gets
-the appropriate level of review. It's also worthwhile to disclose which
-_parts_ you use AI for — there's a meaningful distinction between "this
-whole thing is vibecoded" and "I wrote this backup tool and used an LLM
-to style the web frontend". For example, we've used LLMs to help write
-some of these lecture notes, including proofreading, brainstorming, and
-generating first drafts of code snippets and exercises.
+Yang pertama adalah ketika AI berkontribusi secara signifikan terhadap
+pekerjaan Anda, **ungkapkan hal tersebut**. Ini bukan tentang rasa malu —
+ini tentang kejujuran, menetapkan ekspektasi yang sesuai, dan memastikan
+karya yang dihasilkan mendapatkan tingkat review yang tepat. Juga berguna
+untuk mengungkapkan _bagian mana_ yang Anda gunakan AI — ada perbedaan
+yang bermakna antara "this whole thing is vibecoded" dan "I wrote this
+backup tool and used an LLM to style the web frontend". Sebagai contoh,
+kami telah menggunakan LLM untuk membantu menulis beberapa catatan kuliah
+ini, termasuk proofreading, brainstorming, dan menghasilkan draf pertama
+dari cuplikan kode dan latihan.
 
-You'll also want to follow the norms of the teams and projects you're
-contributing to here. Some teams have stricter policies around the use
-of AI than others (e.g., for compliance or data residency reasons), and
-you don't want to accidentally run afoul of that. Being open about your
-use helps prevent potentially costly mistakes.
+Anda juga perlu mengikuti norma-norma tim dan proyek yang Anda kontribusikan.
+Beberapa tim memiliki kebijakan yang lebih ketat tentang penggunaan AI
+daripada yang lain (misalnya, karena alasan kepatuhan atau residensi data),
+dan Anda tidak ingin secara tidak sengaja melanggarnya. Terbuka tentang
+penggunaan Anda membantu mencegah kesalahan yang berpotensi mahal.
 
-> If you're aiming to learn as part of the work you're doing, keep in
-> mind that if you have AI do all or most of the work for you can be
-> self-defeating; you're likely to learn more about prompting (and maybe
-> reviewing AI output) than the task itself. Especially when you're
-> learning, the point may be the journey, not the destination, so using
-> AI to "get the solution quickly" is an anti-goal.
+> Jika Anda bertujuan untuk belajar sebagai bagian dari pekerjaan yang Anda
+> lakukan, ingatlah bahwa jika Anda membiarkan AI melakukan semua atau
+> sebagian besar pekerjaan untuk Anda bisa menjadi bumerang; Anda mungkin
+> lebih banyak belajar tentang prompting (dan mungkin me-review output AI)
+> daripada tugas itu sendiri. Terutama ketika Anda sedang belajar, tujuannya
+> mungkin perjalanannya, bukan destinasinya, jadi menggunakan AI untuk
+> "mendapatkan solusi dengan cepat" adalah anti-goal.
 
-A related concern comes up in interviews and other assessment
-situations. These are often intended to specifically evaluate _your_
-skills and abilities, not those of an LLM. More companies now allow you
-to use LLMs and other AI-assisted tooling in interviews as long as you
-let them observe those interactions as part of the interview (i.e., they
-are evaluating your skill in making use of those tools too!), but those
-are still in the minority. If you are unsure about whether AI assistance
-is in scope for a particular task, ask!
+Keprihatinan yang terkait muncul dalam wawancara dan situasi penilaian
+lainnya. Ini seringkali dimaksudkan untuk secara khusus mengevaluasi
+keterampilan dan kemampuan _Anda_, bukan kemampuan LLM. Semakin banyak
+perusahaan yang kini mengizinkan Anda menggunakan LLM dan tool bantuan AI
+lainnya dalam wawancara selama Anda membiarkan mereka mengamati interaksi
+tersebut sebagai bagian dari wawancara (yaitu, mereka juga mengevaluasi
+keterampilan Anda dalam menggunakan tool-tool tersebut!), tetapi mereka
+masih dalam minoritas. Jika Anda tidak yakin apakah bantuan AI diizinkan
+untuk tugas tertentu, tanyakanlah!
 
-> It should go without saying that if an assessment situation explicitly
-> calls for no external tools, no LLMs, etc., you should not use them.
-> Trying to do so discretely without getting caught **will** come back
-> to bite you.
+> Sudah seharusnya jika situasi penilaian secara eksplisit melarang tool
+> eksternal, LLM, dll., Anda tidak boleh menggunakannya. Mencoba melakukannya
+> secara diam-diam tanpa ketahuan **pasti** akan berbalik merugikan Anda.
 
-# Exercises
+# Latihan
 
-1. Browse the source code of a well-known project (e.g.,
-   [Redis](https://github.com/redis/redis) or
-   [curl](https://github.com/curl/curl)). Find examples of some of the
-   comment types mentioned in the lecture: a useful TODO, a reference to
-   external documentation, a "why not" comment explaining an avoided
-   approach, or a hard-learned lesson. What would be lost if that
-   comment was not there?
+1. Telusuri source code dari proyek yang terkenal (misalnya,
+   [Redis](https://github.com/redis/redis) atau
+   [curl](https://github.com/curl/curl)). Temukan contoh beberapa jenis
+   komentar yang disebutkan dalam kuliah: TODO yang berguna, referensi ke
+   dokumentasi eksternal, komentar "why not" yang menjelaskan pendekatan
+   yang dihindari, atau hard-learned lesson. Apa yang akan hilang jika
+   komentar tersebut tidak ada?
 
-1. Pick an open-source project you're interested in and look at its
-   recent commit history (`git log`). Find one commit with a good
-   message that explains *why* the change was made, and one with a weak
-   message that only describes *what* changed. For the weak one, look at
-   the diff (`git show <hash>`) and try to write a better commit message
-   following the Problem → Solution → Implications structure. Notice how
-   much work is required to reassemble the necessary context after the
-   fact!
+1. Pilih proyek open-source yang Anda minati dan lihat riwayat commit
+   terbarunya (`git log`). Temukan satu commit dengan pesan yang baik yang
+   menjelaskan *mengapa* perubahan tersebut dibuat, dan satu dengan pesan
+   yang lemah yang hanya mendeskripsikan *apa* yang berubah. Untuk yang
+   lemah, lihat diff-nya (`git show <hash>`) dan coba tulis commit message
+   yang lebih baik mengikuti struktur Problem → Solution → Implications.
+   Perhatikan betapa banyak usaha yang diperlukan untuk menyusun kembali
+   konteks yang diperlukan setelah fakta!
 
-1. Compare the READMEs of three GitHub projects with 1000+ stars. Are
-   all of them equally useful? Look for things that come across mostly
-   as noise to you as a lesson for future READMEs you write yourself.
+1. Bandingkan README dari tiga proyek GitHub dengan 1000+ bintang. Apakah
+   semuanya sama-sama berguna? Carilah hal-hal yang menurut Anda lebih
+   merupakan noise sebagai pelajaran untuk README yang Anda tulis sendiri
+   di masa depan.
 
-1. Find an open issue on a project you use (check the "good first issue"
-   or "help wanted" labels if they have it). Evaluate the issue against
-   the criteria from the lecture: does it seem like it values the
-   maintainer's time and contains all the information necessary to debug
-   it, or do you expect that the maintainer may need to go multiple
-   rounds of questions with the submitter to get to the root problem?
+1. Temukan issue terbuka pada proyek yang Anda gunakan (periksa label "good
+   first issue" atau "help wanted" jika ada). Evaluasi issue tersebut
+   berdasarkan kriteria dari kuliah: apakah sepertinya menghargai waktu
+   maintainer dan berisi semua informasi yang diperlukan untuk men-debug,
+   atau Anda berharap maintainer mungkin perlu melalui beberapa putaran
+   pertanyaan dengan pengirim untuk sampai ke masalah inti?
 
-1. Think of a bug you've encountered in software you use (or find one in
-   an issue tracker). Practice creating a minimal reproducible example:
-   strip away everything unrelated to the bug until you have the
-   smallest case that still demonstrates the problem. Write up what you
-   removed and why.
+1. Pikirkan bug yang pernah Anda temui di perangkat lunak yang Anda gunakan
+   (atau temukan satu di issue tracker). Berlatihlah membuat minimal
+   reproducible example: hapus semua yang tidak terkait dengan bug sampai
+   Anda memiliki kasus terkecil yang masih mendemonstrasikan masalah
+   tersebut. Tuliskan apa yang Anda hapus dan alasannya.
 
-1. Find a merged pull request on a project you're familiar with that has
-   substantive review comments (not just "LGTM"). Read through the
-   review. Were all the comments equally productive? If you were the PR
-   author, how would you find the experience of getting all those
-   comments?
+1. Temukan pull request yang sudah di-merge pada proyek yang Anda kenal
+   yang memiliki komentar review yang substantif (bukan hanya "LGTM").
+   Baca review-nya. Apakah semua komentar sama-sama produktif? Jika Anda
+   adalah penulis PR, bagaimana pengalaman Anda menerima semua komentar
+   tersebut?
 
-1. Go to Stack Overflow and find a question in a technology you know
-   that has a highly-voted answer. Then find one that was closed or
-   heavily downvoted. Compare them against the advice from the lecture;
-   was it predictable which question would get better answers?
+1. Buka Stack Overflow dan temukan pertanyaan dalam teknologi yang Anda
+   ketahui yang memiliki jawaban dengan vote tinggi. Kemudian temukan satu
+   yang ditutup atau banyak downvote. Bandingkan dengan saran dari kuliah;
+   apakah bisa diprediksi pertanyaan mana yang akan mendapatkan jawaban
+   lebih baik?

--- a/_2026/code-quality.md
+++ b/_2026/code-quality.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Code Quality"
 description: >
-  Learn about formatting, linting, testing, continuous integration, and more.
+  Pelajari tentang formatting, linting, pengujian, continuous integration, dan lainnya.
 thumbnail: /static/assets/thumbnails/2026/lec9.png
 date: 2026-01-23
 ready: true

--- a/_2026/code-quality.md
+++ b/_2026/code-quality.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Code Quality"
+title: "Kualitas Kode"
 description: >
   Pelajari tentang formatting, linting, pengujian, continuous integration, dan lainnya.
 thumbnail: /static/assets/thumbnails/2026/lec9.png
@@ -11,7 +11,7 @@ video:
   id: XBiLUNx84CQ
 ---
 
-There are a variety of tools and techniques that support developers in writing high-quality code. In this lecture, we'll cover:
+Terdapat berbagai alat dan teknik yang mendukung developer dalam menulis kode berkualitas tinggi. Dalam kuliah ini, kita akan membahas:
 
 - [Formatting](#formatting)
 - [Linting](#linting)
@@ -20,115 +20,115 @@ There are a variety of tools and techniques that support developers in writing h
 - [Continuous integration](#continuous-integration)
 - [Command runners](#command-runners)
 
-As a bonus topic, we'll also cover [regular expressions](#regular-expressions), a cross-cutting topic that has applications in code quality (e.g., for running a subset of tests that match a pattern) as well as other domains like IDEs (e.g., for search and replace).
+Sebagai topik bonus, kita juga akan membahas [regular expressions](#regular-expressions), topik lintas bidang yang memiliki aplikasi dalam kualitas kode (misalnya, untuk menjalankan subset tes yang cocok dengan pola) maupun domain lain seperti IDE (misalnya, untuk search and replace).
 
-Many of these tools will be language-specific (e.g., the [Ruff](https://docs.astral.sh/ruff/) linter/formatter for Python). In some cases, tools will support multiple languages (e.g., the [Prettier](https://prettier.io/) code formatter). The concepts, however, are near universal --- you can find code formatters, linters, testing libraries, and so on for any programming language.
+Banyak dari alat-alat ini bersifat spesifik untuk bahasa pemrograman tertentu (misalnya, [Ruff](https://docs.astral.sh/ruff/) linter/formatter untuk Python). Dalam beberapa kasus, alat akan mendukung beberapa bahasa (misalnya, [Prettier](https://prettier.io/) code formatter). Namun, konsep-konsepnya hampir universal --- Anda dapat menemukan code formatter, linter, testing library, dan sebagainya untuk bahasa pemrograman apa pun.
 
-# Formatting
+# Pemformatan
 
-Code auto-formatters automatically prettify surface syntax. This way, you can focus on the more deep and challenging problems, while the auto-formatting tool handles mundane details such as consistency of `'` versus `"` syntax for strings, having spaces surrounding binary operators (`x + y` instead of `x+y`), having `import` statements in sorted order, and avoiding over-length lines. One major benefit of code formatters is that they standardize code style across all developers working on a codebase.
+Code auto-formatter secara otomatis mempercantik sintaks permukaan. Dengan cara ini, Anda dapat fokus pada masalah yang lebih dalam dan menantang, sementara alat auto-formatting menangani detail-detail sepele seperti konsistensi sintaks `'` versus `"` untuk string, memiliki spasi di sekitar operator biner (`x + y` alih-alih `x+y`), memiliki pernyataan `import` dalam urutan terurut, dan menghindari baris yang melebihi panjang tertentu. Salah satu manfaat utama code formatter adalah mereka menstandarisasi gaya kode di semua developer yang bekerja pada sebuah codebase.
 
-Some tools such as Prettier are [highly configurable](https://prettier.io/docs/configuration); you should check in the configuration file into [version control](/2026/version-control/) for your project. Other tools, such as [Black](https://github.com/psf/black) and [gofmt](https://pkg.go.dev/cmd/gofmt) have limited or no configurability, to reduce [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
+Beberapa alat seperti Prettier [sangat dapat dikonfigurasi](https://prettier.io/docs/configuration); Anda harus menyimpan file konfigurasi dalam [version control](/2026/version-control/) untuk proyek Anda. Alat lain, seperti [Black](https://github.com/psf/black) dan [gofmt](https://pkg.go.dev/cmd/gofmt) memiliki konfigurasi yang terbatas atau tidak ada, untuk mengurangi [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
 
-You can set up [IDE integration](/2026/development-environment/#code-intelligence-and-language-servers) with your code formatter, so that your code will be auto-formatted as you type or when you save a file. You can also add an [EditorConfig](https://editorconfig.org/) file to your project, which communicates to your IDE certain project-level settings like indent size for each file type.
+Anda dapat mengatur [integrasi IDE](/2026/development-environment/#code-intelligence-and-language-servers) dengan code formatter Anda, sehingga kode Anda akan secara otomatis di-format saat Anda mengetik atau ketika Anda menyimpan file. Anda juga dapat menambahkan file [EditorConfig](https://editorconfig.org/) ke proyek Anda, yang mengkomunikasikan pengaturan tingkat proyek tertentu ke IDE Anda seperti ukuran indentasi untuk setiap jenis file.
 
 # Linting
 
-Linters run static analysis (analyze your code without running it) to find antipatterns and potential issues in your code. These tools go deeper than autoformatters, looking beyond surface syntax. The depth of analysis varies by tool.
+Linter menjalankan analisis statis (menganalisis kode Anda tanpa menjalankannya) untuk menemukan antipola dan masalah potensial dalam kode Anda. Alat-alat ini lebih mendalam daripada autoformatter, melihat melampaui sintaks permukaan. Kedalaman analisis bervariasi tergantung alat.
 
-Linters come equipped with lists of _rules_, with presets that can be configured on a project-level basis. Some linter rules produce false positives, so you can disable them on a per-file or per-line basis.
+Linter dilengkapi dengan daftar _aturan_, dengan preset yang dapat dikonfigurasi pada tingkat proyek. Beberapa aturan linter menghasilkan positif palsu, sehingga Anda dapat menonaktifkannya per file atau per baris.
 
-Good linters will have built-in help or documentation that explains each linter rule --- what the rule is looking for, why it's bad, and what's a better alternative for the code pattern. For example, see the documentation for the [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) rule in [Ruff](https://docs.astral.sh/ruff/) which catches unnecessarily nested `if` statements in Python code.
+Linter yang baik akan memiliki bantuan bawaan atau dokumentasi yang menjelaskan setiap aturan linter --- apa yang dicari oleh aturan tersebut, mengapa itu buruk, dan apa alternatif yang lebih baik untuk pola kode tersebut. Misalnya, lihat dokumentasi untuk aturan [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) di [Ruff](https://docs.astral.sh/ruff/) yang menangkap pernyataan `if` bersarang yang tidak perlu dalam kode Python.
 
-Some linters can not only flag issues but also automatically fix certain issues for you.
+Beberapa linter tidak hanya menandai masalah tetapi juga secara otomatis memperbaiki masalah tertentu untuk Anda.
 
-Aside from language-specific linters, another tool that might come in handy is [semgrep](https://github.com/semgrep/semgrep), a "semantic grep" tool that works at the AST level (rather than character level, like grep) and supports many languages. You can use semgrep to easily write custom linter rules for your projects. For example, if you wanted to prevent the dangerous `subprocess.Popen(..., shell=True)` in Python, you could find that code pattern with:
+Selain linter spesifik bahasa, alat lain yang mungkin berguna adalah [semgrep](https://github.com/semgrep/semgrep), alat "semantic grep" yang bekerja pada tingkat AST (bukan tingkat karakter, seperti grep) dan mendukung banyak bahasa. Anda dapat menggunakan semgrep untuk menulis aturan linter kustom dengan mudah untuk proyek Anda. Misalnya, jika Anda ingin mencegah `subprocess.Popen(..., shell=True)` yang berbahaya dalam Python, Anda dapat menemukan pola kode tersebut dengan:
 
 ```bash
 semgrep -l python -e "subprocess.Popen(..., shell=True, ...)"
 ```
 
-# Testing
+# Pengujian
 
-Software testing is a standard technique to increase your confidence in the correctness of your code. You write code, and then you write code that exercises the code you wrote and raises an error if the code doesn't work as expected.
+Pengujian perangkat lunak adalah teknik standar untuk meningkatkan kepercayaan Anda pada kebenaran kode Anda. Anda menulis kode, dan kemudian Anda menulis kode yang menjalankan kode yang Anda tulis dan memunculkan error jika kode tidak bekerja sesuai yang diharapkan.
 
-You can write tests for chunks of code at different levels of granularity: _unit tests_ for individual functions, _integration tests_ for interaction between modules or services, and _functional tests_ for end-to-end scenarios. You can do _test-driven development_, where you write tests before you write any implementation code. When you find bugs in your code, you can write _regression tests_, so you'll catch if the functionality ever breaks in the future. You can write _property-based tests_, pioneered in [QuickCheck](https://hackage.haskell.org/package/QuickCheck) in Haskell, and implemented in many libraries, like [Hypothesis](https://hypothesis.readthedocs.io/) for Python. Which approach to testing is right depends on your project; likely, you will adopt some combination.
+Anda dapat menulis tes untuk bagian-bagian kode pada berbagai tingkat granularitas: _unit test_ untuk fungsi individual, _integration test_ untuk interaksi antar modul atau layanan, dan _functional test_ untuk skenario end-to-end. Anda dapat melakukan _test-driven development_, di mana Anda menulis tes sebelum menulis kode implementasi. Ketika Anda menemukan bug dalam kode Anda, Anda dapat menulis _regression test_, sehingga Anda akan menangkap jika fungsionalitas tersebut rusak di masa depan. Anda dapat menulis _property-based test_, yang dipelopori oleh [QuickCheck](https://hackage.haskell.org/package/QuickCheck) di Haskell, dan diimplementasikan dalam banyak library, seperti [Hypothesis](https://hypothesis.readthedocs.io/) untuk Python. Pendekatan pengujian mana yang tepat tergantung pada proyek Anda; kemungkinan, Anda akan mengadopsi beberapa kombinasi.
 
-If your program has external dependencies like a database or web API, it may be helpful to _mock_ those dependencies in your tests, rather than have your code interact with third-party dependencies at test time.
+Jika program Anda memiliki dependensi eksternal seperti database atau web API, mungkin berguna untuk melakukan _mock_ terhadap dependensi tersebut dalam tes Anda, daripada membiarkan kode Anda berinteraksi dengan dependensi pihak ketiga pada saat pengujian.
 
 ## Code coverage
 
-Code coverage is a metric by which you can measure how good your tests are. Code coverage looks at which lines of your code are executed when your tests are run, so you can ensure you are covering all code paths. Code coverage tools can show you line-by-line coverage to guide you in writing tests. Services such as [Codecov](https://app.codecov.io) provide web interfaces for tracking and viewing code coverage over the history of a project.
+Code coverage adalah metrik yang dapat Anda gunakan untuk mengukur seberapa baik tes Anda. Code coverage melihat baris kode mana yang dijalankan ketika tes Anda dijalankan, sehingga Anda dapat memastikan Anda mencakup semua jalur kode. Alat code coverage dapat menampilkan coverage baris per baris untuk memandu Anda dalam menulis tes. Layanan seperti [Codecov](https://app.codecov.io) menyediakan antarmuka web untuk melacak dan melihat code coverage sepanjang riwayat proyek.
 
-Like any metric, code coverage is not perfect; don't over-index on coverage, focus on writing high-quality tests.
+Seperti metrik lainnya, code coverage tidak sempurna; jangan terlalu berfokus pada coverage, fokuslah pada menulis tes berkualitas tinggi.
 
-# Pre-commit hooks
+# Hook pre-commit
 
-Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), made easier by the [pre-commit](https://pre-commit.com/) framework, automatically run user-specified code prior to every Git commit. Projects commonly use pre-commit hooks to run formatters and linters, and sometimes tests, automatically before every commit, to ensure that committed code matches the project code style and is free of certain issues.
+Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), yang dipermudah oleh framework [pre-commit](https://pre-commit.com/), secara otomatis menjalankan kode yang ditentukan pengguna sebelum setiap Git commit. Proyek-proyek umumnya menggunakan pre-commit hooks untuk menjalankan formatter dan linter, dan terkadang tes, secara otomatis sebelum setiap commit, untuk memastikan bahwa kode yang di-commit sesuai dengan gaya kode proyek dan bebas dari masalah tertentu.
 
-# Continuous integration
+# Integrasi berkelanjutan
 
-Continuous integration (CI) services like [GitHub Actions](https://github.com/features/actions) can run scripts for you every time you push code (or on every pull request, or on a schedule). Developers commonly use CI services to run code quality tools including formatters, linters, and tests. For compiled languages, you can ensure code compiles; for statically typed languages, you can make sure it type checks. Running CI every push of new commits can catch errors introduced into the main version of the code; running on pull requests can catch issues with contributor submissions; running on a schedule can catch issues with external dependencies (e.g., a developer accidentally releases a breaking change as [semver-compatible](/2026/shipping-code/#releases--versioning)).
+Layanan continuous integration (CI) seperti [GitHub Actions](https://github.com/features/actions) dapat menjalankan skrip untuk Anda setiap kali Anda mendorong kode (atau pada setiap pull request, atau sesuai jadwal). Developer umumnya menggunakan layanan CI untuk menjalankan alat kualitas kode termasuk formatter, linter, dan tes. Untuk bahasa yang dikompilasi, Anda dapat memastikan kode dapat dikompilasi; untuk bahasa yang secara statis di-type, Anda dapat memastikan type checking berhasil. Menjalankan CI pada setiap push commit baru dapat menangkap error yang dimasukkan ke dalam versi utama kode; menjalankan pada pull request dapat menangkap masalah pada kontribusi dari kontributor; menjalankan sesuai jadwal dapat menangkap masalah dengan dependensi eksternal (misalnya, seorang developer secara tidak sengaja merilis breaking change sebagai [semver-compatible](/2026/shipping-code/#releases--versioning)).
 
-Because CI scripts run separately from developer machines, you can easily run long-running jobs there. This can be leveraged, for example, to run a _matrix_ of tests across different operating systems and programming language versions to ensure that the software works properly across all of them.
+Karena skrip CI berjalan secara terpisah dari mesin developer, Anda dapat dengan mudah menjalankan pekerjaan yang memakan waktu lama di sana. Ini dapat dimanfaatkan, misalnya, untuk menjalankan _matrix_ tes di berbagai sistem operasi dan versi bahasa pemrograman untuk memastikan bahwa perangkat lunak bekerja dengan baik di semua lingkungan tersebut.
 
-Generally, the script running in CI will not directly make changes to your code: it will run tools in "check-only" mode rather than "fix" mode, so for example, the auto-formatter will raise an error when the code is not compliant with the format.
+Secara umum, skrip yang berjalan di CI tidak akan langsung membuat perubahan pada kode Anda: ia akan menjalankan alat dalam mode "check-only" alih-alih mode "fix", sehingga misalnya, auto-formatter akan memunculkan error ketika kode tidak sesuai dengan format.
 
-Repositories often include [status badges](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) in their README, showing CI status and other information such as code coverage. For example, below is Missing Semester's current build status.
+Repositori sering menyertakan [status badge](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) di README mereka, menampilkan status CI dan informasi lainnya seperti code coverage. Sebagai contoh, di bawah ini adalah status build Missing Semester saat ini.
 
 [![Build Status](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml) [![Links Status](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml)
 
-> Our [links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml), which uses the [proof-html](https://github.com/anishathalye/proof-html) GitHub Action is often failing, usually due to issues with third-party websites. Still, it has helped us catch and fix many broken links (sometimes due to typos, most of the time due to websites moving around content without adding redirects or websites disappearing).
+> [Links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml) kami, yang menggunakan GitHub Action [proof-html](https://github.com/anishathalye/proof-html) sering gagal, biasanya karena masalah dengan situs web pihak ketiga. Namun, ini telah membantu kami menangkap dan memperbaiki banyak tautan yang rusak (terkadang karena kesalahan ketik, sebagian besar karena situs web memindahkan konten tanpa menambahkan redirect atau situs web yang menghilang).
 
-A good way to learn the particulars of CI services, formatters, linters, and testing libraries is by example. Find high-quality open-source projects on GitHub---the more similar to your project in programming language, domain, size and scope, and so on, the better---and study their `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md`, and other relevant files.
+Cara yang baik untuk mempelajari detail layanan CI, formatter, linter, dan testing library adalah melalui contoh. Temukan proyek open-source berkualitas tinggi di GitHub --- semakin mirip dengan proyek Anda dalam bahasa pemrograman, domain, ukuran dan cakupan, dan sebagainya, semakin baik --- dan pelajari file `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md`, dan file relevan lainnya.
 
-## Continuous deployment
+## Deployment berkelanjutan
 
-Continuous deployment makes use of CI infrastructure to actually _deploy_ changes. For example, the Missing Semester repository uses continuous deployment to GitHub pages so that whenever we `git push` updated lecture notes, the site is automatically built and deployed. You can build other types of [artifacts](/2026/shipping-code/) in CI, such as binaries for applications or Docker images for services.
+Continuous deployment memanfaatkan infrastruktur CI untuk benar-benar melakukan _deploy_ perubahan. Misalnya, repositori Missing Semester menggunakan continuous deployment ke GitHub pages sehingga setiap kali kita melakukan `git push` catatan kuliah yang diperbarui, situs secara otomatis di-build dan di-deploy. Anda dapat membangun [artifacts](/2026/shipping-code/) lain di CI, seperti biner untuk aplikasi atau Docker image untuk layanan.
 
-# Command runners
+# Command runner
 
-Command runners like [just](https://github.com/casey/just) simplify the task of running commands in the context of a project. As you build up code quality infrastructure for your project, you don't want to make your developers memorize commands like `uv run ruff check --fix`. With a command runner, this can turn into `just lint`, and you can have analogous invocations like `just format`, `just typecheck`, etc., for all the different tools a developer might want to run for your project.
+Command runner seperti [just](https://github.com/casey/just) menyederhanakan tugas menjalankan perintah dalam konteks proyek. Saat Anda membangun infrastruktur kualitas kode untuk proyek Anda, Anda tidak ingin membuat developer Anda menghafal perintah seperti `uv run ruff check --fix`. Dengan command runner, ini bisa berubah menjadi `just lint`, dan Anda dapat memiliki pemanggilan analog seperti `just format`, `just typecheck`, dll., untuk semua alat berbeda yang mungkin ingin dijalankan oleh developer untuk proyek Anda.
 
-Some language-specific project or package managers have built-in support for such functionality, which means you don't need to use a language-agnostic tool like `just`. For example, the `scripts` section of a `package.json` for [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) and the `tool.hatch.envs.*.scripts` sections of a `pyproject.toml` for [Hatch](https://hatch.pypa.io/) (Python) support this functionality.
+Beberapa manajer proyek atau paket spesifik bahasa memiliki dukungan bawaan untuk fungsionalitas semacam ini, yang berarti Anda tidak perlu menggunakan alat yang tidak spesifik bahasa seperti `just`. Misalnya, bagian `scripts` dari `package.json` untuk [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) dan bagian `tool.hatch.envs.*.scripts` dari `pyproject.toml` untuk [Hatch](https://hatch.pypa.io/) (Python) mendukung fungsionalitas ini.
 
-# Regular expressions
+# Ekspresi reguler
 
-_Regular expressions_, commonly abbreviated as "regex", is a language used to represent sets of strings. Regex patterns are commonly used for pattern matching in various contexts such as command-line tools and IDEs. For example, [ag](https://github.com/ggreer/the_silver_searcher) supports regex patterns for codebase-wide search (e.g., `ag "import .* as .*"` will find all renamed imports in Python), and [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) supports a `-run [regexp]` option for selecting a subset of tests. Furthermore, programming languages have built-in support or third-party libraries for regular expression matching, so you can use regexes for functionality such as pattern matching, validation, and parsing.
+_Regular expressions_, yang umum disingkat sebagai "regex", adalah bahasa yang digunakan untuk merepresentasikan kumpulan string. Pola regex umumnya digunakan untuk pencocokan pola dalam berbagai konteks seperti alat command-line dan IDE. Misalnya, [ag](https://github.com/ggreer/the_silver_searcher) mendukung pola regex untuk pencarian di seluruh codebase (misalnya, `ag "import .* as .*"` akan menemukan semua import yang di-rename dalam Python), dan [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) mendukung opsi `-run [regexp]` untuk memilih subset tes. Lebih lanjut, bahasa pemrograman memiliki dukungan bawaan atau library pihak ketiga untuk pencocokan regular expression, sehingga Anda dapat menggunakan regex untuk fungsionalitas seperti pencocokan pola, validasi, dan parsing.
 
-To help build intuition, below are some examples of regex patterns. In this lecture, we use [Python regex syntax](https://docs.python.org/3/library/re.html). There are many flavors of regex, with slight variation between them, especially in the more sophisticated functionality. You can use an online regex tester like [regex101](https://regex101.com/) to develop and debug regular expressions.
+Untuk membantu membangun intuisi, berikut adalah beberapa contoh pola regex. Dalam kuliah ini, kita menggunakan [sintaks regex Python](https://docs.python.org/3/library/re.html). Terdapat banyak varian regex, dengan sedikit perbedaan di antaranya, terutama dalam fungsionalitas yang lebih canggih. Anda dapat menggunakan penguji regex online seperti [regex101](https://regex101.com/) untuk mengembangkan dan men-debug regular expression.
 
-- `abc` --- matches the literal "abc".
-- `missing|semester` --- matches the string "missing" or the string "semester".
-- `\d{4}-\d{2}-\d{2}` --- matches dates in YYYY-MM-DD format, such as "2026-01-14". Beyond ensuring that the string consists of four digits, a dash, two digits, a dash, and two digits, this does not validate the date, so "2026-01-99" matches this regex pattern too.
-- `.+@.+` --- matches email addresses, strings that contain some text, then an "@", and then some more text. This does only the most basic validation and matches strings like "nonsense@@@email". A regex that matches email addresses with no false positives or negatives [exists](https://pdw.ex-parrot.com/Mail-RFC822-Address.html) but is impractical.
+- `abc` --- mencocokkan string literal "abc".
+- `missing|semester` --- mencocokkan string "missing" atau string "semester".
+- `\d{4}-\d{2}-\d{2}` --- mencocokkan tanggal dalam format YYYY-MM-DD, seperti "2026-01-14". Selain memastikan string terdiri dari empat digit, tanda hubung, dua digit, tanda hubung, dan dua digit, ini tidak memvalidasi tanggal, sehingga "2026-01-99" juga cocok dengan pola regex ini.
+- `.+@.+` --- mencocokkan alamat email, string yang berisi beberapa teks, kemudian "@", dan kemudian beberapa teks lagi. Ini hanya melakukan validasi paling dasar dan mencocokkan string seperti "nonsense@@@email". Regex yang mencocokkan alamat email tanpa positif atau negatif palsu [ada](https://pdw.ex-parrot.com/Mail-RFC822-Address.html) tetapi tidak praktis.
 
-## Regex syntax
+## Sintaks Regex
 
-You can find a comprehensive guide to regex syntax in [this documentation](https://docs.python.org/3/library/re.html#regular-expression-syntax) (or one of many other resources available online). Here are some of the basic building blocks:
+Anda dapat menemukan panduan lengkap sintaks regex di [dokumentasi ini](https://docs.python.org/3/library/re.html#regular-expression-syntax) (atau salah satu dari banyak sumber lain yang tersedia online). Berikut adalah beberapa blok bangunan dasar:
 
-- `abc` matches the literal string, when the characters have no special meaning (in this example, "abc")
-- `.` matches any single character
-- `[abc]` matches a single character contained in the brackets (in this example, "a", "b", or "c")
-- `[^abc]` matches a single character except those contained in the brackets (e.g., "d")
-- `[a-f]` matches a single character contained in the range indicated in the brackets (e.g., "c", but not "q")
-- `a|b` matches either pattern (e.g., "a" or "b")
-- `\d` matches any digit character (e.g., "3")
-- `\w` matches any word character (e.g., "x")
-- `\b` matches any word _boundary_ (e.g., in the string "missing semester", matches just before the "m", just after the "g", just before the "s", and just after the "r")
-- `(...)` matches the group of a pattern
-- `...?` matches zero or one of a pattern, such as `words?` to match "word" or "words"
-- `...*` matches any number of a pattern, such as `.*` to match any number of any character
-- `...+` matches one or more of a pattern, such as `\d+` to match any non-zero number of digits
-- `...{N}` matches exactly N of a pattern, such as `\d{4}` for 4 digits
-- `\.` matches a literal "."
-- `\\` matches a literal "\\"
-- `^` matches the start of the line
-- `$` matches the end of the line
+- `abc` mencocokkan string literal, ketika karakter tidak memiliki makna khusus (dalam contoh ini, "abc")
+- `.` mencocokkan karakter apa pun
+- `[abc]` mencocokkan satu karakter yang ada dalam kurung (dalam contoh ini, "a", "b", atau "c")
+- `[^abc]` mencocokkan satu karakter kecuali yang ada dalam kurung (misalnya, "d")
+- `[a-f]` mencocokkan satu karakter yang ada dalam rentang yang ditunjukkan dalam kurung (misalnya, "c", tetapi bukan "q")
+- `a|b` mencocokkan salah satu pola (misalnya, "a" atau "b")
+- `\d` mencocokkan karakter digit apa pun (misalnya, "3")
+- `\w` mencocokkan karakter kata apa pun (misalnya, "x")
+- `\b` mencocokkan _batas_ kata apa pun (misalnya, dalam string "missing semester", mencocokkan tepat sebelum "m", tepat setelah "g", tepat sebelum "s", dan tepat setelah "r")
+- `(...)` mencocokkan grup dari sebuah pola
+- `...?` mencocokkan nol atau satu dari sebuah pola, seperti `words?` untuk mencocokkan "word" atau "words"
+- `...*` mencocokkan berapa pun dari sebuah pola, seperti `.*` untuk mencocokkan berapa pun dari karakter apa pun
+- `...+` mencocokkan satu atau lebih dari sebuah pola, seperti `\d+` untuk mencocokkan digit dalam jumlah tidak nol
+- `...{N}` mencocokkan tepat N dari sebuah pola, seperti `\d{4}` untuk 4 digit
+- `\.` mencocokkan "." literal
+- `\\` mencocokkan "\\" literal
+- `^` mencocokkan awal baris
+- `$` mencocokkan akhir baris
 
-## Capture groups and references
+## Capture group dan referensi
 
-If you use regex groups `(...)`, you can refer to sub-parts of the match for extraction or search-and-replace purposes. For example, to extract just the month from a YYYY-MM-DD style date, you can use the following Python code:
+Jika Anda menggunakan grup regex `(...)`, Anda dapat merujuk ke bagian-bagian dari pencocokan untuk tujuan ekstraksi atau search-and-replace. Misalnya, untuk mengekstrak hanya bulan dari tanggal gaya YYYY-MM-DD, Anda dapat menggunakan kode Python berikut:
 
 ```python
 >>> import re
@@ -136,17 +136,17 @@ If you use regex groups `(...)`, you can refer to sub-parts of the match for ext
 '01'
 ```
 
-In your text editor, you can use reference capture groups in replace patterns. The syntax might vary between IDEs. For example, in VS Code, you can use variables like `$1`, `$2`, etc., and in Vim, you can use `\1`, `\2`, etc., to reference groups.
+Di editor teks Anda, Anda dapat menggunakan referensi capture group dalam pola replace. Sintaksnya mungkin berbeda antar IDE. Misalnya, di VS Code, Anda dapat menggunakan variabel seperti `$1`, `$2`, dll., dan di Vim, Anda dapat menggunakan `\1`, `\2`, dll., untuk mereferensikan grup.
 
-## Limitations
+## Keterbatasan
 
-[Regular languages](https://en.wikipedia.org/wiki/Regular_language) are powerful but limited; there are classes of strings that cannot be expressed as a standard regex (e.g., it is [not possible](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) to write a regular expression that matches the set of strings {a^n b^n \| n &ge; 0}, the set of strings of a number of "a"s followed by the same number of "b"s; more practically, languages like HTML are not regular languages). In practice, modern regex engines support features like lookahead and backreferences that extend support beyond regular languages, and they are practically extremely useful, but it is important to know that they are still limited in their expressive power. For more sophisticated languages, you might need to reach for a more capable type of parser (for one example, see [pyparsing](https://github.com/pyparsing/pyparsing), a [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) parser).
+[Bahasa reguler](https://en.wikipedia.org/wiki/Regular_language) sangat kuat tetapi terbatas; ada kelas string yang tidak dapat diekspresikan sebagai regex standar (misalnya, [tidak mungkin](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) untuk menulis regular expression yang mencocokkan kumpulan string {a^n b^n \| n &ge; 0}, kumpulan string sejumlah "a" diikuti oleh jumlah "b" yang sama; lebih praktis, bahasa seperti HTML bukan bahasa reguler). Dalam praktiknya, mesin regex modern mendukung fitur seperti lookahead dan backreference yang memperluas dukungan di luar bahasa reguler, dan mereka sangat berguna secara praktis, tetapi penting untuk mengetahui bahwa mereka masih terbatas dalam kekuatan ekspresifnya. Untuk bahasa yang lebih canggih, Anda mungkin perlu menggunakan jenis parser yang lebih mampu (salah satu contohnya, lihat [pyparsing](https://github.com/pyparsing/pyparsing), parser [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar)).
 
-## Learning regex
+## Belajar regex
 
-We recommend learning the fundamentals (what we have covered in this lecture), and then looking at regex references as you need them, rather than memorizing the entirety of the language.
+Kami merekomendasikan untuk mempelajari dasar-dasarnya (apa yang telah kita bahas dalam kuliah ini), dan kemudian melihat referensi regex saat Anda membutuhkannya, daripada menghafal keseluruhan bahasa.
 
-Conversational AI tools can be effective at helping you generating regex patterns. For example, try prompting your favorite LLM with the following query:
+Alat AI percakapan dapat efektif dalam membantu Anda menghasilkan pola regex. Misalnya, coba berikan prompt ke LLM favorit Anda dengan query berikut:
 
 ```
 Write a Python-style regex pattern that matches the requested path from log lines from Nginx. Here is an example log line:
@@ -154,13 +154,13 @@ Write a Python-style regex pattern that matches the requested path from log line
 169.254.1.1 - - [09/Jan/2026:21:28:51 +0000] "GET /feed.xml HTTP/2.0" 200 2995 "-" "python-requests/2.32.3"
 ```
 
-# Exercises
+# Latihan
 
-1. Configure a formatter, linter, and pre-commit hooks for a project you're working on. If you have lots of errors: autoformatting should take care of the format errors. For the linter errors, try using an [AI agent](/2026/agentic-coding/) to fix all the linter errors. Make sure the AI agent can run the linter and observe the results, so that it can run in an iterative loop to fix all the issues. Check the results carefully to ensure the AI doesn't break your code!
-1. Learn a testing library for a language you know and write a unit test for a project you're working on. Run a code coverage tool, generate an HTML-formatted coverage report, and observe the results. Can you find the lines that are covered? Your code coverage will likely be very low. Try manually writing some tests to improve it. Try using an [AI agent](/2026/agentic-coding/) to improve coverage; make sure the coding agent can run tests with coverage and produce a line-by-line coverage report, so it knows where to focus. Are the AI-generated tests actually good?
-1. Set up continuous integration to run on every push for a project you're working on. Have CI run formatting, linting, and tests. Break your code on purpose (e.g., introduce a linter violation), and ensure that CI catches it.
-1. Try writing a [regex pattern](#regular-expressions) and use the `grep` [command-line tool](/2026/course-shell/) to find occurrences of `subprocess.Popen(..., shell=True)` in your code. Now, try to "break" the regex pattern. Does [semgrep](#linting) still successfully match the dangerous code that trips up your grep invocation?
-1. Practice regex search-and-replace in your IDE or text editor by replacing the `-` [Markdown bullet markers](https://spec.commonmark.org/0.31.2/#bullet-list-marker) with `*` bullet markers in [these lecture notes](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md). Note that just replacing all the "-" characters in the file would be incorrect, as there are many uses of that character that are not bullet markers.
-1. Write a regex to capture from JSON structures of the form `{"name": "Alyssa P. Hacker", "college": "MIT"}` the name (e.g., `Alyssa P. Hacker`, in this example). Hint: in your first attempt, you might end up writing a regex that extracts `Alyssa P. Hacker", "college": "MIT`; read about greedy quantifiers in the [Python regex docs](https://docs.python.org/3/library/re.html) to figure out how to fix it.
-    1. Make the regex pattern work even in situations where the name has a `"` character in it (double quotes can be escaped in JSON with `\"`).
-    1. We do **not** recommend using regular expressions for sophisticated parsing problems in practice. Figure out how to use your programming language's JSON parser for this task. Write a command-line program that takes as input, on stdin, a JSON structure of the form described above, and output, on stdout, the name. You should only need a couple lines of code to do this. In Python, you can do it easily in one line of code beyond `import json`.
+1. Konfigurasikan formatter, linter, dan pre-commit hooks untuk proyek yang sedang Anda kerjakan. Jika Anda memiliki banyak error: autoformatting akan menangani error format. Untuk error linter, coba gunakan [AI agent](/2026/agentic-coding/) untuk memperbaiki semua error linter. Pastikan AI agent dapat menjalankan linter dan mengamati hasilnya, sehingga dapat berjalan dalam loop iteratif untuk memperbaiki semua masalah. Periksa hasilnya dengan hati-hati untuk memastikan AI tidak merusak kode Anda!
+1. Pelajari testing library untuk bahasa yang Anda kuasai dan tulis unit test untuk proyek yang sedang Anda kerjakan. Jalankan alat code coverage, buat laporan coverage dalam format HTML, dan amati hasilnya. Dapatkah Anda menemukan baris-baris yang ter-cover? Code coverage Anda kemungkinan akan sangat rendah. Coba tulis beberapa tes secara manual untuk meningkatkannya. Coba gunakan [AI agent](/2026/agentic-coding/) untuk meningkatkan coverage; pastikan coding agent dapat menjalankan tes dengan coverage dan menghasilkan laporan coverage baris per baris, sehingga ia tahu di mana harus fokus. Apakah tes yang dihasilkan AI benar-benar bagus?
+1. Atur continuous integration untuk berjalan pada setiap push untuk proyek yang sedang Anda kerjakan. Buat CI menjalankan formatting, linting, dan tes. Rusak kode Anda dengan sengaja (misalnya, perkenalkan pelanggaran linter), dan pastikan CI menangkapnya.
+1. Coba tulis [pola regex](#regular-expressions) dan gunakan [alat command-line](/2026/course-shell/) `grep` untuk menemukan kemunculan `subprocess.Popen(..., shell=True)` dalam kode Anda. Sekarang, coba "rusak" pola regex tersebut. Apakah [semgrep](#linting) masih berhasil mencocokkan kode berbahaya yang membingungkan pemanggilan grep Anda?
+1. Latih search-and-replace regex di IDE atau editor teks Anda dengan mengganti [penanda bullet Markdown](https://spec.commonmark.org/0.31.2/#bullet-list-marker) `-` dengan penanda bullet `*` di [catatan kuliah ini](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md). Perhatikan bahwa mengganti semua karakter "-" dalam file akan salah, karena ada banyak penggunaan karakter tersebut yang bukan penanda bullet.
+1. Tulis regex untuk menangkap dari struktur JSON berbentuk `{"name": "Alyssa P. Hacker", "college": "MIT"}` nama tersebut (misalnya, `Alyssa P. Hacker`, dalam contoh ini). Petunjuk: dalam percobaan pertama Anda, Anda mungkin berakhir menulis regex yang mengekstrak `Alyssa P. Hacker", "college": "MIT`; baca tentang greedy quantifier di [dokumentasi regex Python](https://docs.python.org/3/library/re.html) untuk mengetahui cara memperbaikinya.
+    1. Buat pola regex bekerja bahkan dalam situasi di mana nama memiliki karakter `"` di dalamnya (tanda kutip ganda dapat di-escape dalam JSON dengan `\"`).
+    1. Kami **tidak** merekomendasikan menggunakan regular expression untuk masalah parsing yang canggih dalam praktiknya. Cari tahu cara menggunakan JSON parser bahasa pemrograman Anda untuk tugas ini. Tulis program command-line yang menerima sebagai input, pada stdin, struktur JSON berbentuk seperti yang dijelaskan di atas, dan mengeluarkan, pada stdout, nama tersebut. Anda hanya perlu beberapa baris kode untuk melakukan ini. Dalam Python, Anda dapat melakukannya dengan mudah dalam satu baris kode di luar `import json`.

--- a/_2026/code-quality.md
+++ b/_2026/code-quality.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Code Quality"
+title: "Kualitas Kode"
 description: >
-  Learn about formatting, linting, testing, continuous integration, and more.
+  Pelajari tentang formatting, linting, testing, continuous integration, dan lainnya.
 thumbnail: /static/assets/thumbnails/2026/lec9.png
 date: 2026-01-23
 ready: true
@@ -11,7 +11,7 @@ video:
   id: XBiLUNx84CQ
 ---
 
-There are a variety of tools and techniques that support developers in writing high-quality code. In this lecture, we'll cover:
+Terdapat berbagai alat dan teknik yang membantu developer dalam menulis kode berkualitas tinggi. Dalam kuliah ini, kita akan membahas:
 
 - [Formatting](#formatting)
 - [Linting](#linting)
@@ -20,29 +20,29 @@ There are a variety of tools and techniques that support developers in writing h
 - [Continuous integration](#continuous-integration)
 - [Command runners](#command-runners)
 
-As a bonus topic, we'll also cover [regular expressions](#regular-expressions), a cross-cutting topic that has applications in code quality (e.g., for running a subset of tests that match a pattern) as well as other domains like IDEs (e.g., for search and replace).
+Sebagai topik bonus, kita juga akan membahas [regular expressions](#regular-expressions), topik yang berkaitan dengan kualitas kode (misalnya, untuk menjalankan subset tes yang cocok dengan pola tertentu) serta domain lain seperti IDE (misalnya, untuk search and replace).
 
-Many of these tools will be language-specific (e.g., the [Ruff](https://docs.astral.sh/ruff/) linter/formatter for Python). In some cases, tools will support multiple languages (e.g., the [Prettier](https://prettier.io/) code formatter). The concepts, however, are near universal --- you can find code formatters, linters, testing libraries, and so on for any programming language.
+Banyak dari alat-alat ini bersifat spesifik terhadap bahasa pemrograman tertentu (misalnya, [Ruff](https://docs.astral.sh/ruff/) linter/formatter untuk Python). Dalam beberapa kasus, alat akan mendukung beberapa bahasa (misalnya, [Prettier](https://prettier.io/) code formatter). Namun, konsep-konsepnya hampir universal --- Anda dapat menemukan code formatter, linter, testing library, dan sebagainya untuk bahasa pemrograman apa pun.
 
 # Formatting
 
-Code auto-formatters automatically prettify surface syntax. This way, you can focus on the more deep and challenging problems, while the auto-formatting tool handles mundane details such as consistency of `'` versus `"` syntax for strings, having spaces surrounding binary operators (`x + y` instead of `x+y`), having `import` statements in sorted order, and avoiding over-length lines. One major benefit of code formatters is that they standardize code style across all developers working on a codebase.
+Code auto-formatter secara otomatis mempercantik sintaks permukaan. Dengan cara ini, Anda dapat fokus pada masalah yang lebih dalam dan menantang, sementara alat auto-formatting menangani detail-detail rutin seperti konsistensi sintaks `'` versus `"` untuk string, penggunaan spasi di sekitar operator biner (`x + y` bukan `x+y`), pengurutan statement `import`, dan menghindari baris yang terlalu panjang. Salah satu manfaat utama code formatter adalah mereka menstandarisasi gaya kode di antara semua developer yang bekerja pada suatu codebase.
 
-Some tools such as Prettier are [highly configurable](https://prettier.io/docs/configuration); you should check in the configuration file into [version control](/2026/version-control/) for your project. Other tools, such as [Black](https://github.com/psf/black) and [gofmt](https://pkg.go.dev/cmd/gofmt) have limited or no configurability, to reduce [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
+Beberapa alat seperti Prettier [sangat dapat dikonfigurasi](https://prettier.io/docs/configuration); Anda harus menyimpan file konfigurasi di [version control](/2026/version-control/) untuk project Anda. Alat lain, seperti [Black](https://github.com/psf/black) dan [gofmt](https://pkg.go.dev/cmd/gofmt) memiliki konfigurasi yang terbatas atau tidak ada sama sekali, untuk mengurangi [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality).
 
-You can set up [IDE integration](/2026/development-environment/#code-intelligence-and-language-servers) with your code formatter, so that your code will be auto-formatted as you type or when you save a file. You can also add an [EditorConfig](https://editorconfig.org/) file to your project, which communicates to your IDE certain project-level settings like indent size for each file type.
+Anda dapat mengatur [integrasi IDE](/2026/development-environment/#code-intelligence-and-language-servers) dengan code formatter Anda, sehingga kode Anda akan secara otomatis di-format saat Anda mengetik atau ketika Anda menyimpan file. Anda juga dapat menambahkan file [EditorConfig](https://editorconfig.org/) ke project Anda, yang mengkomunikasikan pengaturan tingkat project tertentu ke IDE Anda seperti ukuran indentasi untuk setiap tipe file.
 
 # Linting
 
-Linters run static analysis (analyze your code without running it) to find antipatterns and potential issues in your code. These tools go deeper than autoformatters, looking beyond surface syntax. The depth of analysis varies by tool.
+Linter menjalankan analisis statis (menganalisis kode Anda tanpa menjalankannya) untuk menemukan antipola dan potensi masalah dalam kode Anda. Alat-alat ini lebih mendalam daripada autoformatter, melihat melampaui sintaks permukaan. Kedalaman analisis bervariasi tergantung alatnya.
 
-Linters come equipped with lists of _rules_, with presets that can be configured on a project-level basis. Some linter rules produce false positives, so you can disable them on a per-file or per-line basis.
+Linter dilengkapi dengan daftar _rules_, dengan preset yang dapat dikonfigurasi pada tingkat project. Beberapa aturan linter menghasilkan false positive, sehingga Anda dapat menonaktifkannya per file atau per baris.
 
-Good linters will have built-in help or documentation that explains each linter rule --- what the rule is looking for, why it's bad, and what's a better alternative for the code pattern. For example, see the documentation for the [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) rule in [Ruff](https://docs.astral.sh/ruff/) which catches unnecessarily nested `if` statements in Python code.
+Linter yang baik akan memiliki bantuan bawaan atau dokumentasi yang menjelaskan setiap aturan linter --- apa yang dicari oleh aturan tersebut, mengapa itu buruk, dan apa alternatif yang lebih baik untuk pola kode tersebut. Misalnya, lihat dokumentasi untuk aturan [SIM102](https://docs.astral.sh/ruff/rules/collapsible-if/) di [Ruff](https://docs.astral.sh/ruff/) yang menangkap statement `if` yang bersarang secara tidak perlu dalam kode Python.
 
-Some linters can not only flag issues but also automatically fix certain issues for you.
+Beberapa linter tidak hanya menandai masalah tetapi juga dapat secara otomatis memperbaiki masalah tertentu untuk Anda.
 
-Aside from language-specific linters, another tool that might come in handy is [semgrep](https://github.com/semgrep/semgrep), a "semantic grep" tool that works at the AST level (rather than character level, like grep) and supports many languages. You can use semgrep to easily write custom linter rules for your projects. For example, if you wanted to prevent the dangerous `subprocess.Popen(..., shell=True)` in Python, you could find that code pattern with:
+Selain linter spesifik bahasa, alat lain yang mungkin berguna adalah [semgrep](https://github.com/semgrep/semgrep), alat "semantic grep" yang bekerja pada tingkat AST (bukan tingkat karakter, seperti grep) dan mendukung banyak bahasa. Anda dapat menggunakan semgrep untuk menulis aturan linter kustom dengan mudah untuk project Anda. Misalnya, jika Anda ingin mencegah `subprocess.Popen(..., shell=True)` yang berbahaya di Python, Anda dapat menemukan pola kode tersebut dengan:
 
 ```bash
 semgrep -l python -e "subprocess.Popen(..., shell=True, ...)"
@@ -50,85 +50,85 @@ semgrep -l python -e "subprocess.Popen(..., shell=True, ...)"
 
 # Testing
 
-Software testing is a standard technique to increase your confidence in the correctness of your code. You write code, and then you write code that exercises the code you wrote and raises an error if the code doesn't work as expected.
+Software testing adalah teknik standar untuk meningkatkan kepercayaan Anda terhadap kebenaran kode Anda. Anda menulis kode, dan kemudian Anda menulis kode yang menguji kode yang Anda tulis dan menghasilkan error jika kode tidak bekerja sesuai harapan.
 
-You can write tests for chunks of code at different levels of granularity: _unit tests_ for individual functions, _integration tests_ for interaction between modules or services, and _functional tests_ for end-to-end scenarios. You can do _test-driven development_, where you write tests before you write any implementation code. When you find bugs in your code, you can write _regression tests_, so you'll catch if the functionality ever breaks in the future. You can write _property-based tests_, pioneered in [QuickCheck](https://hackage.haskell.org/package/QuickCheck) in Haskell, and implemented in many libraries, like [Hypothesis](https://hypothesis.readthedocs.io/) for Python. Which approach to testing is right depends on your project; likely, you will adopt some combination.
+Anda dapat menulis tes untuk bagian-bagian kode pada berbagai tingkat granularitas: _unit tests_ untuk fungsi individual, _integration tests_ untuk interaksi antar modul atau layanan, dan _functional tests_ untuk skenario end-to-end. Anda dapat melakukan _test-driven development_, di mana Anda menulis tes sebelum menulis kode implementasi. Ketika Anda menemukan bug dalam kode Anda, Anda dapat menulis _regression tests_, sehingga Anda akan menangkap jika fungsionalitas tersebut rusak di masa depan. Anda dapat menulis _property-based tests_, yang dipelopori oleh [QuickCheck](https://hackage.haskell.org/package/QuickCheck) di Haskell, dan diimplementasikan dalam banyak library, seperti [Hypothesis](https://hypothesis.readthedocs.io/) untuk Python. Pendekatan testing mana yang tepat tergantung pada project Anda; kemungkinan, Anda akan mengadopsi beberapa kombinasi.
 
-If your program has external dependencies like a database or web API, it may be helpful to _mock_ those dependencies in your tests, rather than have your code interact with third-party dependencies at test time.
+Jika program Anda memiliki dependensi eksternal seperti database atau web API, mungkin berguna untuk melakukan _mock_ terhadap dependensi tersebut dalam tes Anda, daripada membiarkan kode Anda berinteraksi dengan dependensi pihak ketiga saat testing.
 
 ## Code coverage
 
-Code coverage is a metric by which you can measure how good your tests are. Code coverage looks at which lines of your code are executed when your tests are run, so you can ensure you are covering all code paths. Code coverage tools can show you line-by-line coverage to guide you in writing tests. Services such as [Codecov](https://app.codecov.io) provide web interfaces for tracking and viewing code coverage over the history of a project.
+Code coverage adalah metrik yang dapat Anda gunakan untuk mengukur seberapa baik tes Anda. Code coverage melihat baris kode mana yang dijalankan ketika tes Anda dijalankan, sehingga Anda dapat memastikan Anda mencakup semua jalur kode. Alat code coverage dapat menampilkan coverage baris per baris untuk memandu Anda dalam menulis tes. Layanan seperti [Codecov](https://app.codecov.io) menyediakan antarmuka web untuk melacak dan melihat code coverage sepanjang riwayat project.
 
-Like any metric, code coverage is not perfect; don't over-index on coverage, focus on writing high-quality tests.
+Seperti metrik lainnya, code coverage tidak sempurna; jangan terlalu terpaku pada coverage, fokuslah pada menulis tes berkualitas tinggi.
 
 # Pre-commit hooks
 
-Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), made easier by the [pre-commit](https://pre-commit.com/) framework, automatically run user-specified code prior to every Git commit. Projects commonly use pre-commit hooks to run formatters and linters, and sometimes tests, automatically before every commit, to ensure that committed code matches the project code style and is free of certain issues.
+Git pre-commit [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), yang dipermudah oleh framework [pre-commit](https://pre-commit.com/), secara otomatis menjalankan kode yang ditentukan pengguna sebelum setiap Git commit. Project umumnya menggunakan pre-commit hooks untuk menjalankan formatter dan linter, dan terkadang tes, secara otomatis sebelum setiap commit, untuk memastikan bahwa kode yang di-commit sesuai dengan gaya kode project dan bebas dari masalah tertentu.
 
 # Continuous integration
 
-Continuous integration (CI) services like [GitHub Actions](https://github.com/features/actions) can run scripts for you every time you push code (or on every pull request, or on a schedule). Developers commonly use CI services to run code quality tools including formatters, linters, and tests. For compiled languages, you can ensure code compiles; for statically typed languages, you can make sure it type checks. Running CI every push of new commits can catch errors introduced into the main version of the code; running on pull requests can catch issues with contributor submissions; running on a schedule can catch issues with external dependencies (e.g., a developer accidentally releases a breaking change as [semver-compatible](/2026/shipping-code/#releases--versioning)).
+Layanan continuous integration (CI) seperti [GitHub Actions](https://github.com/features/actions) dapat menjalankan skrip untuk Anda setiap kali Anda melakukan push kode (atau pada setiap pull request, atau sesuai jadwal). Developer umumnya menggunakan layanan CI untuk menjalankan alat kualitas kode termasuk formatter, linter, dan tes. Untuk bahasa yang dikompilasi, Anda dapat memastikan kode dapat dikompilasi; untuk bahasa yang di-type secara statis, Anda dapat memastikan kode lolos type check. Menjalankan CI setiap push commit baru dapat menangkap error yang dimasukkan ke versi utama kode; menjalankan pada pull request dapat menangkap masalah dengan kontribusi dari kontributor; menjalankan sesuai jadwal dapat menangkap masalah dengan dependensi eksternal (misalnya, seorang developer secara tidak sengaja merilis breaking change sebagai [semver-compatible](/2026/shipping-code/#releases--versioning)).
 
-Because CI scripts run separately from developer machines, you can easily run long-running jobs there. This can be leveraged, for example, to run a _matrix_ of tests across different operating systems and programming language versions to ensure that the software works properly across all of them.
+Karena skrip CI dijalankan secara terpisah dari mesin developer, Anda dapat dengan mudah menjalankan pekerjaan yang memakan waktu lama di sana. Ini dapat dimanfaatkan, misalnya, untuk menjalankan _matrix_ tes di berbagai sistem operasi dan versi bahasa pemrograman untuk memastikan bahwa perangkat lunak bekerja dengan baik di semua lingkungan tersebut.
 
-Generally, the script running in CI will not directly make changes to your code: it will run tools in "check-only" mode rather than "fix" mode, so for example, the auto-formatter will raise an error when the code is not compliant with the format.
+Secara umum, skrip yang berjalan di CI tidak akan langsung membuat perubahan pada kode Anda: skrip akan menjalankan alat dalam mode "check-only" daripada mode "fix", sehingga misalnya, auto-formatter akan menghasilkan error ketika kode tidak sesuai dengan format.
 
-Repositories often include [status badges](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) in their README, showing CI status and other information such as code coverage. For example, below is Missing Semester's current build status.
+Repository sering menyertakan [status badges](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge) di README mereka, yang menampilkan status CI dan informasi lain seperti code coverage. Misalnya, di bawah ini adalah status build Missing Semester saat ini.
 
 [![Build Status](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/build.yml) [![Links Status](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml/badge.svg)](https://github.com/missing-semester/missing-semester/actions/workflows/links.yml)
 
-> Our [links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml), which uses the [proof-html](https://github.com/anishathalye/proof-html) GitHub Action is often failing, usually due to issues with third-party websites. Still, it has helped us catch and fix many broken links (sometimes due to typos, most of the time due to websites moving around content without adding redirects or websites disappearing).
+> [Links checker](https://github.com/missing-semester/missing-semester/blob/master/.github/workflows/links.yml) kami, yang menggunakan GitHub Action [proof-html](https://github.com/anishathalye/proof-html) sering kali gagal, biasanya karena masalah dengan situs web pihak ketiga. Namun, alat ini telah membantu kami menangkap dan memperbaiki banyak tautan yang rusak (terkadang karena kesalahan ketik, sebagian besar karena situs web memindahkan konten tanpa menambahkan redirect atau situs web yang menghilang).
 
-A good way to learn the particulars of CI services, formatters, linters, and testing libraries is by example. Find high-quality open-source projects on GitHub---the more similar to your project in programming language, domain, size and scope, and so on, the better---and study their `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md`, and other relevant files.
+Cara yang baik untuk mempelajari detail layanan CI, formatter, linter, dan testing library adalah melalui contoh. Temukan project open-source berkualitas tinggi di GitHub --- semakin mirip dengan project Anda dalam bahasa pemrograman, domain, ukuran dan cakupan, dan sebagainya, semakin baik --- dan pelajari file `pyproject.toml`, `.github/workflows/`, `DEVELOPMENT.md`, dan file relevan lainnya.
 
 ## Continuous deployment
 
-Continuous deployment makes use of CI infrastructure to actually _deploy_ changes. For example, the Missing Semester repository uses continuous deployment to GitHub pages so that whenever we `git push` updated lecture notes, the site is automatically built and deployed. You can build other types of [artifacts](/2026/shipping-code/) in CI, such as binaries for applications or Docker images for services.
+Continuous deployment memanfaatkan infrastruktur CI untuk benar-benar mendeploy perubahan. Misalnya, repository Missing Semester menggunakan continuous deployment ke GitHub pages sehingga setiap kali kami melakukan `git push` catatan kuliah yang diperbarui, situs secara otomatis di-build dan di-deploy. Anda dapat membangun [artifacts](/2026/shipping-code/) lain di CI, seperti biner untuk aplikasi atau Docker image untuk layanan.
 
 # Command runners
 
-Command runners like [just](https://github.com/casey/just) simplify the task of running commands in the context of a project. As you build up code quality infrastructure for your project, you don't want to make your developers memorize commands like `uv run ruff check --fix`. With a command runner, this can turn into `just lint`, and you can have analogous invocations like `just format`, `just typecheck`, etc., for all the different tools a developer might want to run for your project.
+Command runner seperti [just](https://github.com/casey/just) menyederhanakan tugas menjalankan perintah dalam konteks suatu project. Saat Anda membangun infrastruktur kualitas kode untuk project Anda, Anda tidak ingin membuat developer Anda menghafal perintah seperti `uv run ruff check --fix`. Dengan command runner, ini dapat berubah menjadi `just lint`, dan Anda dapat memiliki pemanggilan yang serupa seperti `just format`, `just typecheck`, dll., untuk semua alat berbeda yang mungkin ingin dijalankan oleh developer untuk project Anda.
 
-Some language-specific project or package managers have built-in support for such functionality, which means you don't need to use a language-agnostic tool like `just`. For example, the `scripts` section of a `package.json` for [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) and the `tool.hatch.envs.*.scripts` sections of a `pyproject.toml` for [Hatch](https://hatch.pypa.io/) (Python) support this functionality.
+Beberapa manajer project atau package spesifik bahasa memiliki dukungan bawaan untuk fungsionalitas semacam ini, yang berarti Anda tidak perlu menggunakan alat yang tidak spesifik bahasa seperti `just`. Misalnya, bagian `scripts` dari `package.json` untuk [npm](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) (Node.js) dan bagian `tool.hatch.envs.*.scripts` dari `pyproject.toml` untuk [Hatch](https://hatch.pypa.io/) (Python) mendukung fungsionalitas ini.
 
 # Regular expressions
 
-_Regular expressions_, commonly abbreviated as "regex", is a language used to represent sets of strings. Regex patterns are commonly used for pattern matching in various contexts such as command-line tools and IDEs. For example, [ag](https://github.com/ggreer/the_silver_searcher) supports regex patterns for codebase-wide search (e.g., `ag "import .* as .*"` will find all renamed imports in Python), and [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) supports a `-run [regexp]` option for selecting a subset of tests. Furthermore, programming languages have built-in support or third-party libraries for regular expression matching, so you can use regexes for functionality such as pattern matching, validation, and parsing.
+_Regular expressions_, yang sering disingkat sebagai "regex", adalah bahasa yang digunakan untuk merepresentasikan kumpulan string. Pola regex umumnya digunakan untuk pencocokan pola dalam berbagai konteks seperti alat command-line dan IDE. Misalnya, [ag](https://github.com/ggreer/the_silver_searcher) mendukung pola regex untuk pencarian di seluruh codebase (misalnya, `ag "import .* as .*"` akan menemukan semua import yang diganti namanya di Python), dan [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) mendukung opsi `-run [regexp]` untuk memilih subset tes. Selain itu, bahasa pemrograman memiliki dukungan bawaan atau library pihak ketiga untuk pencocokan regular expression, sehingga Anda dapat menggunakan regex untuk fungsionalitas seperti pencocokan pola, validasi, dan parsing.
 
-To help build intuition, below are some examples of regex patterns. In this lecture, we use [Python regex syntax](https://docs.python.org/3/library/re.html). There are many flavors of regex, with slight variation between them, especially in the more sophisticated functionality. You can use an online regex tester like [regex101](https://regex101.com/) to develop and debug regular expressions.
+Untuk membantu membangun intuisi, berikut adalah beberapa contoh pola regex. Dalam kuliah ini, kita menggunakan [sintaks regex Python](https://docs.python.org/3/library/re.html). Terdapat banyak varian regex, dengan sedikit perbedaan di antaranya, terutama dalam fungsionalitas yang lebih canggih. Anda dapat menggunakan penguji regex online seperti [regex101](https://regex101.com/) untuk mengembangkan dan men-debug regular expression.
 
-- `abc` --- matches the literal "abc".
-- `missing|semester` --- matches the string "missing" or the string "semester".
-- `\d{4}-\d{2}-\d{2}` --- matches dates in YYYY-MM-DD format, such as "2026-01-14". Beyond ensuring that the string consists of four digits, a dash, two digits, a dash, and two digits, this does not validate the date, so "2026-01-99" matches this regex pattern too.
-- `.+@.+` --- matches email addresses, strings that contain some text, then an "@", and then some more text. This does only the most basic validation and matches strings like "nonsense@@@email". A regex that matches email addresses with no false positives or negatives [exists](https://pdw.ex-parrot.com/Mail-RFC822-Address.html) but is impractical.
+- `abc` --- mencocokkan string literal "abc".
+- `missing|semester` --- mencocokkan string "missing" atau string "semester".
+- `\d{4}-\d{2}-\d{2}` --- mencocokkan tanggal dalam format YYYY-MM-DD, seperti "2026-01-14". Selain memastikan bahwa string terdiri dari empat digit, tanda hubung, dua digit, tanda hubung, dan dua digit, ini tidak memvalidasi tanggal, sehingga "2026-01-99" juga cocok dengan pola regex ini.
+- `.+@.+` --- mencocokkan alamat email, string yang berisi beberapa teks, kemudian "@", dan kemudian beberapa teks lagi. Ini hanya melakukan validasi paling dasar dan mencocokkan string seperti "nonsense@@@email". Regex yang mencocokkan alamat email tanpa false positive atau negatif [ada](https://pdw.ex-parrot.com/Mail-RFC822-Address.html) tetapi tidak praktis.
 
 ## Regex syntax
 
-You can find a comprehensive guide to regex syntax in [this documentation](https://docs.python.org/3/library/re.html#regular-expression-syntax) (or one of many other resources available online). Here are some of the basic building blocks:
+Anda dapat menemukan panduan lengkap sintaks regex di [dokumentasi ini](https://docs.python.org/3/library/re.html#regular-expression-syntax) (atau salah satu dari banyak sumber lain yang tersedia online). Berikut adalah beberapa blok bangunan dasar:
 
-- `abc` matches the literal string, when the characters have no special meaning (in this example, "abc")
-- `.` matches any single character
-- `[abc]` matches a single character contained in the brackets (in this example, "a", "b", or "c")
-- `[^abc]` matches a single character except those contained in the brackets (e.g., "d")
-- `[a-f]` matches a single character contained in the range indicated in the brackets (e.g., "c", but not "q")
-- `a|b` matches either pattern (e.g., "a" or "b")
-- `\d` matches any digit character (e.g., "3")
-- `\w` matches any word character (e.g., "x")
-- `\b` matches any word _boundary_ (e.g., in the string "missing semester", matches just before the "m", just after the "g", just before the "s", and just after the "r")
-- `(...)` matches the group of a pattern
-- `...?` matches zero or one of a pattern, such as `words?` to match "word" or "words"
-- `...*` matches any number of a pattern, such as `.*` to match any number of any character
-- `...+` matches one or more of a pattern, such as `\d+` to match any non-zero number of digits
-- `...{N}` matches exactly N of a pattern, such as `\d{4}` for 4 digits
-- `\.` matches a literal "."
-- `\\` matches a literal "\\"
-- `^` matches the start of the line
-- `$` matches the end of the line
+- `abc` mencocokkan string literal, ketika karakter tidak memiliki makna khusus (dalam contoh ini, "abc")
+- `.` mencocokkan karakter apa pun
+- `[abc]` mencocokkan satu karakter yang ada dalam kurung (dalam contoh ini, "a", "b", atau "c")
+- `[^abc]` mencocokkan satu karakter kecuali yang ada dalam kurung (misalnya, "d")
+- `[a-f]` mencocokkan satu karakter yang ada dalam rentang yang ditunjukkan dalam kurung (misalnya, "c", tetapi bukan "q")
+- `a|b` mencocokkan salah satu pola (misalnya, "a" atau "b")
+- `\d` mencocokkan karakter digit apa pun (misalnya, "3")
+- `\w` mencocokkan karakter kata apa pun (misalnya, "x")
+- `\b` mencocokkan _boundary_ kata apa pun (misalnya, dalam string "missing semester", mencocokkan tepat sebelum "m", tepat setelah "g", tepat sebelum "s", dan tepat setelah "r")
+- `(...)` mencocokkan grup dari suatu pola
+- `...?` mencocokkan nol atau satu dari suatu pola, seperti `words?` untuk mencocokkan "word" atau "words"
+- `...*` mencocokkan berapa pun jumlah dari suatu pola, seperti `.*` untuk mencocokkan berapa pun jumlah dari karakter apa pun
+- `...+` mencocokkan satu atau lebih dari suatu pola, seperti `\d+` untuk mencocokkan jumlah digit yang tidak nol
+- `...{N}` mencocokkan tepat N dari suatu pola, seperti `\d{4}` untuk 4 digit
+- `\.` mencocokkan "." literal
+- `\\` mencocokkan "\\" literal
+- `^` mencocokkan awal baris
+- `$` mencocokkan akhir baris
 
-## Capture groups and references
+## Capture groups dan references
 
-If you use regex groups `(...)`, you can refer to sub-parts of the match for extraction or search-and-replace purposes. For example, to extract just the month from a YYYY-MM-DD style date, you can use the following Python code:
+Jika Anda menggunakan grup regex `(...)`, Anda dapat merujuk ke bagian-bagian dari hasil pencocokan untuk tujuan ekstraksi atau search-and-replace. Misalnya, untuk mengekstrak hanya bulan dari tanggal bergaya YYYY-MM-DD, Anda dapat menggunakan kode Python berikut:
 
 ```python
 >>> import re
@@ -136,17 +136,17 @@ If you use regex groups `(...)`, you can refer to sub-parts of the match for ext
 '01'
 ```
 
-In your text editor, you can use reference capture groups in replace patterns. The syntax might vary between IDEs. For example, in VS Code, you can use variables like `$1`, `$2`, etc., and in Vim, you can use `\1`, `\2`, etc., to reference groups.
+Di text editor Anda, Anda dapat menggunakan reference capture groups dalam pola replace. Sintaksnya mungkin berbeda antar IDE. Misalnya, di VS Code, Anda dapat menggunakan variabel seperti `$1`, `$2`, dll., dan di Vim, Anda dapat menggunakan `\1`, `\2`, dll., untuk mereferensikan grup.
 
 ## Limitations
 
-[Regular languages](https://en.wikipedia.org/wiki/Regular_language) are powerful but limited; there are classes of strings that cannot be expressed as a standard regex (e.g., it is [not possible](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) to write a regular expression that matches the set of strings {a^n b^n \| n &ge; 0}, the set of strings of a number of "a"s followed by the same number of "b"s; more practically, languages like HTML are not regular languages). In practice, modern regex engines support features like lookahead and backreferences that extend support beyond regular languages, and they are practically extremely useful, but it is important to know that they are still limited in their expressive power. For more sophisticated languages, you might need to reach for a more capable type of parser (for one example, see [pyparsing](https://github.com/pyparsing/pyparsing), a [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) parser).
+[Regular languages](https://en.wikipedia.org/wiki/Regular_language) sangat kuat tetapi terbatas; ada kelas string yang tidak dapat diekspresikan sebagai regex standar (misalnya, [tidak mungkin](https://en.wikipedia.org/wiki/Pumping_lemma_for_regular_languages) untuk menulis regular expression yang mencocokkan himpunan string {a^n b^n \| n &ge; 0}, himpunan string sejumlah "a" diikuti oleh jumlah "b" yang sama; lebih praktis, bahasa seperti HTML bukan regular language). Dalam praktiknya, mesin regex modern mendukung fitur seperti lookahead dan backreference yang memperluas dukungan di luar regular language, dan mereka sangat berguna secara praktis, tetapi penting untuk mengetahui bahwa mereka masih terbatas dalam kekuatan ekspresifnya. Untuk bahasa yang lebih canggih, Anda mungkin perlu menggunakan parser yang lebih mampu (salah satu contohnya, lihat [pyparsing](https://github.com/pyparsing/pyparsing), parser [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar)).
 
 ## Learning regex
 
-We recommend learning the fundamentals (what we have covered in this lecture), and then looking at regex references as you need them, rather than memorizing the entirety of the language.
+Kami merekomendasikan untuk mempelajari dasar-dasarnya (apa yang telah kita bahas dalam kuliah ini), dan kemudian melihat referensi regex saat Anda membutuhkannya, daripada menghafal keseluruhan bahasa.
 
-Conversational AI tools can be effective at helping you generating regex patterns. For example, try prompting your favorite LLM with the following query:
+Alat AI percakapan dapat efektif dalam membantu Anda menghasilkan pola regex. Misalnya, coba berikan prompt berikut ke LLM favorit Anda:
 
 ```
 Write a Python-style regex pattern that matches the requested path from log lines from Nginx. Here is an example log line:
@@ -156,11 +156,11 @@ Write a Python-style regex pattern that matches the requested path from log line
 
 # Exercises
 
-1. Configure a formatter, linter, and pre-commit hooks for a project you're working on. If you have lots of errors: autoformatting should take care of the format errors. For the linter errors, try using an [AI agent](/2026/agentic-coding/) to fix all the linter errors. Make sure the AI agent can run the linter and observe the results, so that it can run in an iterative loop to fix all the issues. Check the results carefully to ensure the AI doesn't break your code!
-1. Learn a testing library for a language you know and write a unit test for a project you're working on. Run a code coverage tool, generate an HTML-formatted coverage report, and observe the results. Can you find the lines that are covered? Your code coverage will likely be very low. Try manually writing some tests to improve it. Try using an [AI agent](/2026/agentic-coding/) to improve coverage; make sure the coding agent can run tests with coverage and produce a line-by-line coverage report, so it knows where to focus. Are the AI-generated tests actually good?
-1. Set up continuous integration to run on every push for a project you're working on. Have CI run formatting, linting, and tests. Break your code on purpose (e.g., introduce a linter violation), and ensure that CI catches it.
-1. Try writing a [regex pattern](#regular-expressions) and use the `grep` [command-line tool](/2026/course-shell/) to find occurrences of `subprocess.Popen(..., shell=True)` in your code. Now, try to "break" the regex pattern. Does [semgrep](#linting) still successfully match the dangerous code that trips up your grep invocation?
-1. Practice regex search-and-replace in your IDE or text editor by replacing the `-` [Markdown bullet markers](https://spec.commonmark.org/0.31.2/#bullet-list-marker) with `*` bullet markers in [these lecture notes](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md). Note that just replacing all the "-" characters in the file would be incorrect, as there are many uses of that character that are not bullet markers.
-1. Write a regex to capture from JSON structures of the form `{"name": "Alyssa P. Hacker", "college": "MIT"}` the name (e.g., `Alyssa P. Hacker`, in this example). Hint: in your first attempt, you might end up writing a regex that extracts `Alyssa P. Hacker", "college": "MIT`; read about greedy quantifiers in the [Python regex docs](https://docs.python.org/3/library/re.html) to figure out how to fix it.
-    1. Make the regex pattern work even in situations where the name has a `"` character in it (double quotes can be escaped in JSON with `\"`).
-    1. We do **not** recommend using regular expressions for sophisticated parsing problems in practice. Figure out how to use your programming language's JSON parser for this task. Write a command-line program that takes as input, on stdin, a JSON structure of the form described above, and output, on stdout, the name. You should only need a couple lines of code to do this. In Python, you can do it easily in one line of code beyond `import json`.
+1. Konfigurasikan formatter, linter, dan pre-commit hooks untuk project yang sedang Anda kerjakan. Jika Anda memiliki banyak error: autoformatting akan menangani error format. Untuk error linter, coba gunakan [AI agent](/2026/agentic-coding/) untuk memperbaiki semua error linter. Pastikan AI agent dapat menjalankan linter dan mengamati hasilnya, sehingga dapat berjalan dalam loop iteratif untuk memperbaiki semua masalah. Periksa hasilnya dengan hati-hati untuk memastikan AI tidak merusak kode Anda!
+1. Pelajari testing library untuk bahasa yang Anda kuasai dan tulis unit test untuk project yang sedang Anda kerjakan. Jalankan alat code coverage, buat laporan coverage dalam format HTML, dan amati hasilnya. Dapatkah Anda menemukan baris-baris yang ter-cover? Code coverage Anda kemungkinan akan sangat rendah. Coba tulis beberapa tes secara manual untuk meningkatkannya. Coba gunakan [AI agent](/2026/agentic-coding/) untuk meningkatkan coverage; pastikan coding agent dapat menjalankan tes dengan coverage dan menghasilkan laporan coverage baris per baris, sehingga ia tahu di mana harus fokus. Apakah tes yang dihasilkan AI benar-benar bagus?
+1. Atur continuous integration agar berjalan pada setiap push untuk project yang sedang Anda kerjakan. Biarkan CI menjalankan formatting, linting, dan tes. Rusak kode Anda secara sengaja (misalnya, buat pelanggaran linter), dan pastikan CI menangkapnya.
+1. Coba tulis [pola regex](#regular-expressions) dan gunakan [alat command-line](/2026/course-shell/) `grep` untuk menemukan kemunculan `subprocess.Popen(..., shell=True)` dalam kode Anda. Sekarang, coba "rusak" pola regex tersebut. Apakah [semgrep](#linting) masih berhasil mencocokkan kode berbahaya yang mengecoh pemanggilan grep Anda?
+1. Latih search-and-replace regex di IDE atau text editor Anda dengan mengganti [penanda bullet](https://spec.commonmark.org/0.31.2/#bullet-list-marker) Markdown `-` dengan penanda bullet `*` di [catatan kuliah ini](https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/code-quality.md). Perhatikan bahwa mengganti semua karakter "-" dalam file akan salah, karena ada banyak penggunaan karakter tersebut yang bukan penanda bullet.
+1. Tulis regex untuk menangkap dari struktur JSON berbentuk `{"name": "Alyssa P. Hacker", "college": "MIT"}` nama tersebut (misalnya, `Alyssa P. Hacker`, dalam contoh ini). Petunjuk: dalam percobaan pertama Anda, Anda mungkin berakhir menulis regex yang mengekstrak `Alyssa P. Hacker", "college": "MIT`; baca tentang greedy quantifier di [dokumentasi regex Python](https://docs.python.org/3/library/re.html) untuk mengetahui cara memperbaikinya.
+    1. Buat pola regex tersebut tetap berfungsi bahkan dalam situasi di mana nama memiliki karakter `"` (tanda kutip ganda dapat di-escape di JSON dengan `\"`).
+    1. Kami **tidak** merekomendasikan menggunakan regular expression untuk masalah parsing yang canggih dalam praktiknya. Cari tahu cara menggunakan JSON parser bahasa pemrograman Anda untuk tugas ini. Tulis program command-line yang menerima sebagai input, pada stdin, struktur JSON berbentuk seperti yang dijelaskan di atas, dan mengeluarkan, pada stdout, nama tersebut. Anda hanya perlu beberapa baris kode untuk melakukan ini. Di Python, Anda dapat melakukannya dengan mudah dalam satu baris kode selain `import json`.

--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Command-line Environment"
+title: "Lingkungan Command-line"
 description: >
   Pelajari cara kerja program command-line, termasuk input/output streams, environment variables, dan mesin remote dengan SSH.
 thumbnail: /static/assets/thumbnails/2026/lec2.png
@@ -11,24 +11,24 @@ video:
   id: ccBGsPedE9Q
 ---
 
-As we covered in the previous lecture, most shells are not a mere launcher to start up other programs,
-but in practice they provide an entire programming language full of common patterns and abstractions.
-However, unlike the majority of programming languages, in shell scripting everything is designed around running programs and getting them to communicate with each other simply and efficiently.
+Seperti yang telah kita bahas di kuliah sebelumnya, sebagian besar shell bukan sekadar launcher untuk menjalankan program lain,
+melainkan dalam praktiknya mereka menyediakan seluruh bahasa pemrograman yang penuh dengan pola-pola umum dan abstraksi.
+Namun, berbeda dengan mayoritas bahasa pemrograman, dalam shell scripting semuanya dirancang untuk menjalankan program dan membuat mereka berkomunikasi satu sama lain secara sederhana dan efisien.
 
-In particular, shell scripting is tightly bound by _conventions_. For a command line interface (CLI) program to play nicely within the broader shell environment there are some common patterns that it needs to follow.
-We will now cover many of the concepts required to understand how command line programs work as well as ubiquitous conventions on how to use and configure them.
+Secara khusus, shell scripting sangat terikat oleh _konvensi_. Agar sebuah program command-line interface (CLI) dapat bekerja dengan baik dalam lingkungan shell yang lebih luas, ada beberapa pola umum yang perlu diikuti.
+Sekarang kita akan membahas banyak konsep yang diperlukan untuk memahami cara kerja program command-line serta konvensi yang ada di mana-mana tentang cara menggunakan dan mengonfigurasinya.
 
-# The Command Line Interface
+# Command-line Interface
 
-Writing a function in most programming languages looks something like:
+Menulis sebuah fungsi dalam sebagian besar bahasa pemrograman terlihat seperti:
 
 ```
 def add(x: int, y: int) -> int:
     return x + y
 ```
 
-Here we can explicitly see the inputs and the outputs of the program.
-In contrast, shell scripts can look quite different at first glance.
+Di sini kita dapat melihat secara eksplisit input dan output dari program.
+Sebaliknya, shell script bisa terlihat sangat berbeda pada pandangan pertama.
 
 ```shell
 #!/usr/bin/env bash
@@ -46,7 +46,7 @@ else
 fi
 ```
 
-To properly understand what is going in scripts like this one we first need to introduce a few concepts that appear often when shell programs communicate with each other or with the shell environment:
+Untuk memahami secara benar apa yang terjadi dalam script seperti ini, pertama-tama kita perlu memperkenalkan beberapa konsep yang sering muncul ketika program shell berkomunikasi satu sama lain atau dengan lingkungan shell:
 
 - Arguments
 - Streams
@@ -56,29 +56,29 @@ To properly understand what is going in scripts like this one we first need to i
 
 ## Arguments
 
-Shell programs receive a list of arguments when they are executed.
-Arguments are plain strings in shell, and it is up to the program how to interpret them.
-For instance when we do `ls -l folder/`, we are executing the program `/bin/ls` with arguments `['-l', 'folder/']`.
+Program shell menerima daftar arguments ketika dijalankan.
+Arguments adalah string biasa dalam shell, dan terserah program bagaimana menafsirkannya.
+Misalnya ketika kita melakukan `ls -l folder/`, kita menjalankan program `/bin/ls` dengan arguments `['-l', 'folder/']`.
 
-From within a shell script we access these via special shell syntax.
-To access the first argument we access the variable `$1`, second argument `$2` and so on and so forth until `$9`. To access all arguments as a list we use `$@` and to retrieve the number of arguments `$#`. Additionally we can also access the name of the program with `$0`.
+Dari dalam shell script, kita mengaksesnya melalui sintaks shell khusus.
+Untuk mengakses argument pertama kita mengakses variabel `$1`, argument kedua `$2` dan seterusnya hingga `$9`. Untuk mengakses semua arguments sebagai daftar kita gunakan `$@` dan untuk mendapatkan jumlah arguments kita gunakan `$#`. Selain itu, kita juga dapat mengakses nama program dengan `$0`.
 
-For most programs the arguments will consist of a mixture of _flags_ and regular strings.
-Flags can be identified because they are preceded by a dash (`-`) or double-dash (`--`).
-Flags are usually optional and their role is to modify the behavior of the program.
-For example `ls -l` changes how `ls` formats its output.
+Untuk sebagian besar program, arguments akan terdiri dari campuran _flags_ dan string biasa.
+Flags dapat diidentifikasi karena didahului oleh dash (`-`) atau double-dash (`--`).
+Flags biasanya bersifat opsional dan perannya adalah untuk memodifikasi perilaku program.
+Sebagai contoh, `ls -l` mengubah cara `ls` memformat outputnya.
 
-You will see double dash flags with long names like `--all`, and single dash flags like `-a`, which are most often followed by a single letter.
-The same option might be specified in both formats, `ls -a` and `ls --all` are equivalent.
-Single dash flags are often grouped, so `ls -l -a` and `ls -la` are also equivalent.
-The order of flags usually doesn't matter either, `ls -la` and `ls -al` produce the same result.
-Some flags are quite prevalent and as you get more familiar with the shell environment you'll intuitively reach for them, for example (`--help`, `--verbose`, `--version`).
+Anda akan melihat flags double-dash dengan nama panjang seperti `--all`, dan flags single-dash seperti `-a`, yang paling sering diikuti oleh satu huruf.
+Opsi yang sama dapat ditentukan dalam kedua format, `ls -a` dan `ls --all` adalah setara.
+Flags single-dash sering digabungkan, sehingga `ls -l -a` dan `ls -la` juga setara.
+Urutan flags biasanya juga tidak masalah, `ls -la` dan `ls -al` menghasilkan output yang sama.
+Beberapa flags cukup umum digunakan dan seiring Anda semakin familiar dengan lingkungan shell, Anda akan secara intuitif menggunakannya, misalnya (`--help`, `--verbose`, `--version`).
 
-> Flags are a first good example of shell conventions. The shell language does not require that our program uses `-` or `--` in this particular way.
-Nothing prevents us from writing a program with syntax `myprogram +myoption myfile`, but it would lead to confusion since the expectation is that we use dashes.
-> In practice, most programming languages provide CLI flag parsing libraries (e.g. `argparse` in python to parse arguments with the dash syntax).
+> Flags adalah contoh pertama yang baik dari konvensi shell. Bahasa shell tidak mengharuskan program Anda menggunakan `-` atau `--` dengan cara tertentu ini.
+Tidak ada yang mencegah kita menulis program dengan sintaks `myprogram +myoption myfile`, tetapi hal itu akan menyebabkan kebingungan karena ekspektasinya adalah kita menggunakan dashes.
+> Dalam praktiknya, sebagian besar bahasa pemrograman menyediakan library parsing flag CLI (misalnya `argparse` di python untuk mengurai arguments dengan sintaks dash).
 
-Another common convention in CLI programs is for programs to accept a variable number of arguments of the same type. When given arguments in this way the command performs the same operation on each one of them.
+Konvensi umum lainnya dalam program CLI adalah program menerima sejumlah arguments variabel dengan tipe yang sama. Ketika diberikan arguments dengan cara ini, perintah melakukan operasi yang sama pada masing-masing argument.
 
 ```shell
 mkdir src
@@ -87,10 +87,10 @@ mkdir docs
 mkdir src docs
 ```
 
-This syntax sugar might seem unnecessary at first, but it becomes really powerful when combined with _globbing_.
-Globbing or globs are special patterns that the shell will expand before calling the program.
+Syntax sugar ini mungkin tampak tidak perlu pada awalnya, tetapi menjadi sangat kuat ketika dikombinasikan dengan _globbing_.
+Globbing atau globs adalah pola-pola khusus yang akan diekspansi oleh shell sebelum memanggil program.
 
-Say we wanted to delete all .py files in the current folder nonrecursively. From what we learned in the previous lecture we could achieve this by running
+Misalnya kita ingin menghapus semua file .py di folder saat ini secara non-rekursif. Dari apa yang kita pelajari di kuliah sebelumnya, kita dapat mencapainya dengan menjalankan
 
 ```shell
 for file in $(ls | grep -P '\.py$'); do
@@ -98,16 +98,16 @@ for file in $(ls | grep -P '\.py$'); do
 done
 ```
 
-But we can replace that with just `rm *.py`!
+Tapi kita bisa menggantinya dengan hanya `rm *.py`!
 
-When we type `rm *.py` into the terminal, the shell will not call the `/bin/rm` program with arguments `['*.py']`.
-Instead, the shell will search for files in the current folder matching the pattern `*.py` where `*` can match any string of zero or more characters of any type.
-So if our folder has `main.py` and `utils.py` then the `rm` program will receive arguments `['main.py', 'utils.py']`.
+Ketika kita mengetik `rm *.py` ke terminal, shell tidak akan memanggil program `/bin/rm` dengan arguments `['*.py']`.
+Sebaliknya, shell akan mencari file di folder saat ini yang cocok dengan pola `*.py` di mana `*` dapat mencocokkan string apa pun dengan nol atau lebih karakter tipe apa pun.
+Jadi jika folder kita memiliki `main.py` dan `utils.py` maka program `rm` akan menerima arguments `['main.py', 'utils.py']`.
 
-The most common globs you will find are wildcards `*` (zero or more of anything), `?` (exactly one of anything) and curly braces.
-Curly braces `{}` expand a comma-separated list of patterns into multiple arguments.
+Globs yang paling umum Anda temukan adalah wildcard `*` (nol atau lebih dari apa pun), `?` (tepat satu dari apa pun) dan curly braces.
+Curly braces `{}` mengekspansi daftar pola yang dipisahkan koma menjadi beberapa arguments.
 
-In practice, globs are best understood with motivating examples.
+Dalam praktiknya, globs paling baik dipahami dengan contoh-contoh yang motivatif.
 
 ```shell
 touch folder/{a,b,c}.py
@@ -127,25 +127,25 @@ mv *{.py,.sh} folder
 # Will move all *.py and *.sh files
 ```
 
-> Some shells (e.g. zsh) support even more advanced forms of globbing such as `**` that will expand to include recursive paths. So `rm **/*.py` will delete all .py files recursively.
+> Beberapa shell (misalnya zsh) mendukung bentuk globbing yang bahkan lebih canggih seperti `**` yang akan diekspansi untuk menyertakan path rekursif. Jadi `rm **/*.py` akan menghapus semua file .py secara rekursif.
 
 
 ## Streams
 
-Whenever we execute a program pipeline like
+Setiap kali kita menjalankan pipeline program seperti
 
 ```shell
 cat myfile | grep -P '\d+' | uniq -c
 ```
 
-we see that the `grep` program is communicating with both the `cat` and `uniq` programs.
+kita melihat bahwa program `grep` berkomunikasi dengan kedua program `cat` dan `uniq`.
 
-An important observation here is that all three programs are executing at once.
-Namely, the shell is not first calling cat, then grep, and then uniq.
-Instead, all three programs are being spawned and the shell is connecting the output of cat to the input of grep and the output of grep to the input of uniq.
-When using the pipe operator `|`, the shell operates on streams of data that flow from one program to the next in the chain.
+Pengamatan penting di sini adalah bahwa ketiga program tersebut dijalankan secara bersamaan.
+Artinya, shell tidak pertama-tama memanggil cat, lalu grep, lalu uniq.
+Sebaliknya, ketiga program dijalankan dan shell menghubungkan output cat ke input grep dan output grep ke input uniq.
+Ketika menggunakan operator pipe `|`, shell beroperasi pada stream data yang mengalir dari satu program ke program berikutnya dalam rantai.
 
-We can demonstrate this concurrency, all commands in a pipeline start immediately:
+Kita dapat mendemonstrasikan konkurensi ini, semua perintah dalam pipeline dimulai secara langsung:
 
 ```console
 $ (sleep 15 && cat numbers.txt) | grep -P '^\d$' | sort | uniq  &
@@ -158,9 +158,9 @@ $ ps | grep -P '(sleep|cat|grep|sort|uniq)'
   32948 pts/1    00:00:00 grep
 ```
 
-We can see that all processes but `cat` are running right away. The shell spawns all processes and connects their streams before any of them finish. `cat` will only get started once sleep finishes, and the output of `cat` will be sent to grep and so on and so forth.
+Kita dapat melihat bahwa semua proses kecuali `cat` berjalan langsung. Shell menjalankan semua proses dan menghubungkan stream mereka sebelum ada yang selesai. `cat` baru akan dimulai setelah sleep selesai, dan output dari `cat` akan dikirim ke grep dan seterusnya.
 
-Every program has an input stream, labeled stdin (for standard input). When piping, stdin is connected automatically. Within a script, many programs accept `-` as a filename to mean "read from stdin":
+Setiap program memiliki input stream, yang diberi label stdin (untuk standard input). Ketika melakukan piping, stdin terhubung secara otomatis. Dalam script, banyak program menerima `-` sebagai nama file yang berarti "baca dari stdin":
 
 ```shell
 # These are equivalent when data comes from a pipe
@@ -168,9 +168,9 @@ echo "hello" | grep "hello"
 echo "hello" | grep "hello" -
 ```
 
-Similarly, every program has two output streams: stdout and stderr.
-The standard output is the one most commonly encountered and it is the one that is used for piping the output of the program to the next command in the pipeline.
-The standard error is an alternative stream that is intended for programs to report warnings and other types of issues, without that output getting parsed by the next command in the chain.
+Demikian pula, setiap program memiliki dua output stream: stdout dan stderr.
+Standard output adalah yang paling umum ditemui dan merupakan yang digunakan untuk piping output program ke perintah berikutnya dalam pipeline.
+Standard error adalah stream alternatif yang ditujukan bagi program untuk melaporkan peringatan dan jenis masalah lainnya, tanpa output tersebut diurai oleh perintah berikutnya dalam rantai.
 
 ```console
 $ ls /nonexistent
@@ -182,7 +182,7 @@ $ ls /nonexistent 2>/dev/null
 # No output - stderr was redirected to /dev/null
 ```
 
-The shell provides syntax for redirecting these streams. Here are some illustrative examples.
+Shell menyediakan sintaks untuk me-redirect stream ini. Berikut beberapa contoh ilustratif.
 
 ```shell
 # Redirect stdout to a file (overwrite)
@@ -204,26 +204,26 @@ grep "pattern" < input.txt
 cmd > /dev/null 2>&1
 ```
 
-Another powerful tool that exemplifies the Unix philosophy is [`fzf`](https://github.com/junegunn/fzf), a fuzzy finder. It reads lines from stdin and provides an interactive interface to filter and select:
+Alat lain yang kuat yang mencerminkan filosofi Unix adalah [`fzf`](https://github.com/junegunn/fzf), sebuah fuzzy finder. Alat ini membaca baris dari stdin dan menyediakan antarmuka interaktif untuk memfilter dan memilih:
 
 ```console
 $ ls | fzf
 $ cat ~/.bash_history | fzf
 ```
 
-`fzf` can be integrated with many shell operations. We'll see more uses of it when we discuss shell customization.
+`fzf` dapat diintegrasikan dengan banyak operasi shell. Kita akan melihat lebih banyak penggunaannya ketika kita membahas kustomisasi shell.
 
 
 ## Environment variables
 
-To assign variables in bash we use the syntax `foo=bar`, and then access the value of the variable with the `$foo` syntax.
-Note that `foo = bar` is invalid syntax as the shell will parse it as calling the program `foo` with arguments `['=', 'bar']`.
-In shell scripting the role of the space character is to perform argument splitting.
-This behavior can be confusing and tricky to get used to, so keep it in mind.
+Untuk menetapkan variabel dalam bash kita menggunakan sintaks `foo=bar`, dan kemudian mengakses nilai variabel tersebut dengan sintaks `$foo`.
+Perhatikan bahwa `foo = bar` adalah sintaks yang tidak valid karena shell akan mengurainya sebagai memanggil program `foo` dengan arguments `['=', 'bar']`.
+Dalam shell scripting, peran karakter spasi adalah untuk melakukan pemisahan arguments.
+Perilaku ini bisa membingungkan dan butuh waktu untuk membiasakan diri, jadi ingatlah hal ini.
 
-Shell variables do not have types, they are all strings.
-Note that when writing string expressions in the shell single and double quotes are not interchangeable.
-Strings delimited with `'` are literal strings and will not expand variables, perform command substitution, or process escape sequences, whereas `"` delimited strings will.
+Variabel shell tidak memiliki tipe, semuanya adalah string.
+Perhatikan bahwa ketika menulis ekspresi string dalam shell, tanda kutip tunggal dan tanda kutip ganda tidak dapat dipertukarkan.
+String yang dibatasi dengan `'` adalah string literal dan tidak akan mengekspansi variabel, melakukan substitusi perintah, atau memproses escape sequence, sedangkan string yang dibatasi dengan `"` akan melakukannya.
 
 ```shell
 foo=bar
@@ -233,32 +233,32 @@ echo '$foo'
 # prints $foo
 ```
 
-To capture the output of a command into a variable we use _command substitution_.
-When we execute
+Untuk menangkap output dari sebuah perintah ke dalam variabel kita menggunakan _command substitution_.
+Ketika kita menjalankan
 ```shell
 files=$(ls)
 echo "$files" | grep README
 echo "$files" | grep ".py"
 ```
-the output (concretely the stdout) of ls is placed into the variable `$files` which we can access later.
-The content of the `$files` variable does include the newlines from the ls output, which is how programs like `grep` know to operate on each item independently.
+output (secara konkret stdout) dari ls ditempatkan ke dalam variabel `$files` yang dapat kita akses nanti.
+Isi dari variabel `$files` memang menyertakan newline dari output ls, yang merupakan cara program seperti `grep` mengetahui untuk beroperasi pada setiap item secara independen.
 
-A lesser known similar feature is _process substitution_, `<( CMD )` will execute `CMD` and place the output in a temporary file and substitute the `<()` with that file's name.
-This is useful when commands expect values to be passed by file instead of by STDIN.
-For example, `diff <(ls src) <(ls docs)` will show differences between files in dirs `src` and `docs`.
+Fitur serupa yang kurang dikenal adalah _process substitution_, `<( CMD )` akan menjalankan `CMD` dan menempatkan output dalam file sementara dan mensubstitusi `<()` dengan nama file tersebut.
+Ini berguna ketika perintah mengharapkan nilai diberikan melalui file bukan melalui STDIN.
+Sebagai contoh, `diff <(ls src) <(ls docs)` akan menunjukkan perbedaan antara file-file di direktori `src` dan `docs`.
 
-Whenever a shell program calls another program it passes along a set of variables that are often referred to as _environment variables_.
-From within a shell we can find the current environment variables by running `printenv`.
-To pass an environment variable explicitly we can prepend a command with a variable assignment
+Setiap kali program shell memanggil program lain, ia mengirimkan seperangkat variabel yang sering disebut sebagai _environment variables_.
+Dari dalam shell kita dapat menemukan environment variables saat ini dengan menjalankan `printenv`.
+Untuk memberikan environment variable secara eksplisit kita dapat mendahului perintah dengan penetapan variabel
 
-> Environment variables are conventionally written in ALL_CAPS (e.g., `HOME`, `PATH`, `DEBUG`). This is a convention, not a technical requirement, but following it helps distinguish environment variables from local shell variables which are typically lowercase.
+> Environment variables secara konvensi ditulis dalam ALL_CAPS (misalnya, `HOME`, `PATH`, `DEBUG`). Ini adalah konvensi, bukan persyaratan teknis, tetapi mengikutinya membantu membedakan environment variables dari variabel shell lokal yang biasanya menggunakan huruf kecil.
 
 ```shell
 TZ=Asia/Tokyo date  # prints the current time in Tokyo
 echo $TZ  # this will be empty, since TZ was only set for the child command
 ```
 
-Alternatively, we can use the `export` built-in function that will modify our current environment and thus all child processes will inherit the variable:
+Sebagai alternatif, kita dapat menggunakan fungsi built-in `export` yang akan memodifikasi environment saat ini sehingga semua child process akan mewarisi variabel tersebut:
 
 ```shell
 export DEBUG=1
@@ -267,23 +267,23 @@ bash -c 'echo $DEBUG'
 # prints 1
 ```
 
-To delete a variable use the `unset` built-in command, e.g. `unset DEBUG`.
+Untuk menghapus variabel gunakan perintah built-in `unset`, misalnya `unset DEBUG`.
 
-> Environment variables are another shell convention. They can be used to modify the behavior of many programs implicitly rather than explicitly. For example, the shell sets the `$HOME` environment variable with the path of the home folder of the current user. Then programs can access this variable to get this information instead of requiring an explicit `--home /home/alice`. Another common example is `$TZ`, which many programs use to format dates and times according to the specified timezone.
+> Environment variables adalah konvensi shell lainnya. Mereka dapat digunakan untuk memodifikasi perilaku banyak program secara implisit daripada eksplisit. Sebagai contoh, shell menetapkan environment variable `$HOME` dengan path folder home pengguna saat ini. Kemudian program dapat mengakses variabel ini untuk mendapatkan informasi tersebut daripada memerlukan `--home /home/alice` secara eksplisit. Contoh umum lainnya adalah `$TZ`, yang digunakan banyak program untuk memformat tanggal dan waktu sesuai zona waktu yang ditentukan.
 
 ## Return codes
 
-As we saw earlier, the main output of a shell program is conveyed through the stdout/stderr streams and filesystem side effects.
+Seperti yang kita lihat sebelumnya, output utama dari program shell disampaikan melalui stream stdout/stderr dan efek samping filesystem.
 
-By default a shell script will return exit code zero.
-The convention is that zero means everything went well whereas nonzero means some issues were encountered.
-To return a nonzero exit code we have to use the `exit NUM` shell built-in.
-We can access the return code of the last command that was run by accessing the special variable `$?`.
+Secara default, shell script akan mengembalikan exit code nol.
+Konvensinya adalah nol berarti semuanya berjalan dengan baik sedangkan bukan-nol berarti ada beberapa masalah yang ditemui.
+Untuk mengembalikan exit code bukan-nol kita harus menggunakan built-in shell `exit NUM`.
+Kita dapat mengakses return code dari perintah terakhir yang dijalankan dengan mengakses variabel khusus `$?`.
 
-The shell has boolean operators `&&` and `||` for performing AND and OR operations respectively.
-Unlike those encountered in regular programming languages, the ones in the shell operate on the return code of programs.
-Both of these are [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators.
-This means that they can be used to conditionally run commands based on the success or failure of previous commands, where success is determined based on whether the return code is zero or not. Some examples:
+Shell memiliki operator boolean `&&` dan `||` untuk melakukan operasi AND dan OR masing-masing.
+Berbeda dengan yang ditemui dalam bahasa pemrograman biasa, yang di shell beroperasi pada return code program.
+Keduanya adalah operator [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation).
+Ini berarti keduanya dapat digunakan untuk menjalankan perintah secara kondisional berdasarkan keberhasilan atau kegagalan perintah sebelumnya, di mana keberhasilan ditentukan berdasarkan apakah return code-nya nol atau bukan. Beberapa contoh:
 
 ```shell
 # echo will only run if grep succeeds (finds a match)
@@ -299,7 +299,7 @@ true && echo "This will always print"
 false || echo "This will always print"
 ```
 
-The same principle applies to `if` and `while` statements, they both use return codes to make decisions:
+Prinsip yang sama berlaku untuk pernyataan `if` dan `while`, keduanya menggunakan return code untuk membuat keputusan:
 
 ```shell
 # if uses the return code of the condition command (0 = true, nonzero = false)
@@ -315,9 +315,9 @@ done < file.txt
 
 ## Signals
 
-In some cases you will need to interrupt a program while it is executing, for instance if a command is taking too long to complete.
-The simplest way to interrupt a program is to press `Ctrl-C` and the command will probably stop.
-But how does this actually work and why does it sometimes fail to stop the process?
+Dalam beberapa kasus Anda perlu menginterupsi program saat sedang berjalan, misalnya jika sebuah perintah memakan waktu terlalu lama untuk selesai.
+Cara termudah untuk menginterupsi program adalah dengan menekan `Ctrl-C` dan perintah tersebut mungkin akan berhenti.
+Tetapi bagaimana cara kerja sebenarnya dan mengapa terkadang gagal menghentikan proses?
 
 ```console
 $ sleep 100
@@ -325,21 +325,21 @@ $ sleep 100
 $
 ```
 
-> Note, here `^C` is how `Ctrl-C` is displayed when typed in the terminal.
+> Perhatikan, di sini `^C` adalah cara `Ctrl-C` ditampilkan ketika diketik di terminal.
 
-Under the hood, what happened here is the following:
+Di balik layar, yang terjadi adalah sebagai berikut:
 
-1. We pressed `Ctrl-C`
-2. The shell identified the special combination of characters
-3. The shell process sent a SIGINT signal to the `sleep` process
-4. The signal interrupted the execution of the `sleep` process
+1. Kita menekan `Ctrl-C`
+2. Shell mengidentifikasi kombinasi karakter khusus
+3. Proses shell mengirimkan sinyal SIGINT ke proses `sleep`
+4. Sinyal tersebut menginterupsi eksekusi proses `sleep`
 
-Signals are a special communication mechanism.
-When a process receives a signal it stops its execution, deals with the signal and potentially changes the flow of execution based on the information that the signal delivered. For this reason, signals are _software interrupts_.
+Signals adalah mekanisme komunikasi khusus.
+Ketika sebuah proses menerima sinyal, ia menghentikan eksekusinya, menangani sinyal tersebut dan mungkin mengubah alur eksekusi berdasarkan informasi yang disampaikan oleh sinyal tersebut. Karena alasan ini, signals adalah _software interrupts_.
 
 
-In our case, when typing `Ctrl-C` this prompts the shell to deliver a `SIGINT` signal to the process.
-Here's a minimal example of a Python program that captures `SIGINT` and ignores it, no longer stopping. To kill this program we can now use the `SIGQUIT` signal instead, by typing `Ctrl-\`.
+Dalam kasus kita, ketika mengetik `Ctrl-C` ini memicu shell untuk mengirimkan sinyal `SIGINT` ke proses.
+Berikut adalah contoh minimal program Python yang menangkap `SIGINT` dan mengabaikannya, sehingga tidak lagi berhenti. Untuk menghentikan program ini sekarang kita dapat menggunakan sinyal `SIGQUIT` sebagai gantinya, dengan mengetik `Ctrl-\`.
 
 ```python
 #!/usr/bin/env python
@@ -356,7 +356,7 @@ while True:
     i += 1
 ```
 
-Here's what happens if we send `SIGINT` twice to this program, followed by `SIGQUIT`. Note that `^` is how `Ctrl` is displayed when typed in the terminal.
+Berikut yang terjadi jika kita mengirimkan `SIGINT` dua kali ke program ini, diikuti oleh `SIGQUIT`. Perhatikan bahwa `^` adalah cara `Ctrl` ditampilkan ketika diketik di terminal.
 
 ```console
 $ python sigint.py
@@ -367,25 +367,25 @@ I got a SIGINT, but I am not stopping
 30^\[1]    39913 quit       python sigint.py
 ```
 
-While `SIGINT` and `SIGQUIT` are both usually associated with terminal related requests, a more generic signal for asking a process to exit gracefully is the `SIGTERM` signal.
-To send this signal we can use the [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html) command, with the syntax `kill -TERM <PID>`.
+Meskipun `SIGINT` dan `SIGQUIT` keduanya biasanya terkait dengan permintaan terminal, sinyal yang lebih umum untuk meminta proses keluar dengan baik adalah sinyal `SIGTERM`.
+Untuk mengirimkan sinyal ini kita dapat menggunakan perintah [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html), dengan sintaks `kill -TERM <PID>`.
 
-Signals can do other things beyond killing a process. For instance, `SIGSTOP` pauses a process. In the terminal, typing `Ctrl-Z` will prompt the shell to send a `SIGTSTP` signal, short for Terminal Stop (i.e. the terminal's version of `SIGSTOP`).
+Signals dapat melakukan hal lain selain menghentikan proses. Misalnya, `SIGSTOP` menjeda proses. Di terminal, mengetik `Ctrl-Z` akan memicu shell untuk mengirimkan sinyal `SIGTSTP`, singkatan dari Terminal Stop (yaitu versi `SIGSTOP` dari terminal).
 
-We can then continue the paused job in the foreground or in the background using [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) or [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), respectively.
+Kita kemudian dapat melanjutkan pekerjaan yang dijeda di foreground atau di background menggunakan [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) atau [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), masing-masing.
 
-The [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) command lists the unfinished jobs associated with the current terminal session.
-You can refer to those jobs using their pid (you can use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find that out).
-More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` special parameter.
+Perintah [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) mencantumkan pekerjaan yang belum selesai yang terkait dengan sesi terminal saat ini.
+Anda dapat merujuk ke pekerjaan tersebut menggunakan pid mereka (Anda dapat menggunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk mengetahuinya).
+Secara lebih intuitif, Anda juga dapat merujuk ke proses menggunakan simbol persen diikuti dengan nomor pekerjaan mereka (ditampilkan oleh `jobs`). Untuk merujuk ke pekerjaan terakhir yang di-background Anda dapat menggunakan parameter khusus `$!`.
 
-One more thing to know is that the `&` suffix in a command will run the command in the background, giving you the prompt back, although it will still use the shell's STDOUT which can be annoying (use shell redirections in that case). Equivalently, to background an already running program you can do `Ctrl-Z` followed by `bg`.
+Satu hal lagi yang perlu diketahui adalah bahwa suffix `&` dalam perintah akan menjalankan perintah di background, memberikan Anda prompt kembali, meskipun tetap menggunakan STDOUT shell yang bisa mengganggu (gunakan shell redirections dalam kasus tersebut). Setara dengan itu, untuk mem-background program yang sedang berjalan Anda dapat melakukan `Ctrl-Z` diikuti dengan `bg`.
 
 
-Note that backgrounded processes are still children processes of your terminal and will die if you close the terminal (this will send yet another signal, `SIGHUP`).
-To prevent that from happening you can run the program with [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (a wrapper to ignore `SIGHUP`), or use `disown` if the process has already been started.
-Alternatively, you can use a terminal multiplexer as we will see in the next section.
+Perhatikan bahwa proses yang di-background masih merupakan child process dari terminal Anda dan akan mati jika Anda menutup terminal (ini akan mengirimkan sinyal lain, `SIGHUP`).
+Untuk mencegah hal itu terjadi Anda dapat menjalankan program dengan [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (wrapper untuk mengabaikan `SIGHUP`), atau gunakan `disown` jika proses sudah dimulai.
+Sebagai alternatif, Anda dapat menggunakan terminal multiplexer seperti yang akan kita lihat di bagian berikutnya.
 
-Below is a sample session to showcase some of these concepts.
+Berikut adalah contoh sesi untuk memperlihatkan beberapa konsep ini.
 
 ```
 $ sleep 1000
@@ -412,11 +412,11 @@ $ kill %2
 [2]  + 18745 terminated  nohup sleep 2000
 ```
 
-A special signal is `SIGKILL` since it cannot be captured by the process and it will always terminate it immediately. However, it can have bad side effects such as leaving orphaned children processes.
+Sinyal khusus adalah `SIGKILL` karena tidak dapat ditangkap oleh proses dan akan selalu menghentikannya secara langsung. Namun, ini bisa memiliki efek samping yang buruk seperti meninggalkan child process yatim piatu.
 
-You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -l`.
+Anda dapat mempelajari lebih lanjut tentang sinyal-sinyal ini dan sinyal lainnya [di sini](https://en.wikipedia.org/wiki/Signal_(IPC)) atau dengan mengetik [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) atau `kill -l`.
 
-Within shell scripts, you can use the `trap` built-in to execute commands when signals are received. This is useful for cleanup operations:
+Dalam shell script, Anda dapat menggunakan built-in `trap` untuk menjalankan perintah ketika sinyal diterima. Ini berguna untuk operasi pembersihan:
 
 ```shell
 #!/usr/bin/env bash
@@ -490,17 +490,17 @@ So far we've focused on your local machine, but many of these skills become even
 
 {% endcomment %}
 
-# Remote Machines
+# Mesin Remote
 
-It has become more and more common for programmers to work with remote servers in their everyday work. The most common tool for the job here is SSH (Secure Shell) which will help us connect to a remote server and provide the now familiar shell interface. We connect to a server with a command like:
+Semakin umum bagi programmer untuk bekerja dengan server remote dalam pekerjaan sehari-hari mereka. Alat yang paling umum untuk tugas ini adalah SSH (Secure Shell) yang akan membantu kita terhubung ke server remote dan menyediakan antarmuka shell yang sekarang sudah familiar. Kita terhubung ke server dengan perintah seperti:
 
 ```bash
 ssh alice@server.mit.edu
 ```
 
-Here we are trying to ssh as user `alice` in server `server.mit.edu`.
+Di sini kita mencoba ssh sebagai user `alice` di server `server.mit.edu`.
 
-An often overlooked feature of `ssh` is the ability to run commands non-interactively. `ssh` correctly handles sending the stdin and receiving the stdout of the command, so we can combine it with other commands
+Fitur `ssh` yang sering terlewatkan adalah kemampuan untuk menjalankan perintah secara non-interaktif. `ssh` menangani pengiriman stdin dan penerimaan stdout dari perintah dengan benar, sehingga kita dapat menggabungkannya dengan perintah lain
 
 ```shell
 # here ls runs in the remote, and wc runs locally
@@ -511,22 +511,22 @@ ssh alice@server 'ls | wc -l'
 
 ```
 
-> Try installing [Mosh](https://mosh.org/) as a SSH replacement that can handle disconnections, entering/exiting sleep, changing networks and dealing with high latency links.
+> Cobalah menginstal [Mosh](https://mosh.org/) sebagai pengganti SSH yang dapat menangani diskoneksi, masuk/keluar sleep, berpindah jaringan dan menangani link dengan latensi tinggi.
 
-For `ssh` to let us run commands in the remote server we need to prove that we are authorized to do so.
-We can do this via passwords or ssh keys.
-Key-based authentication utilizes public-key cryptography to prove to the server that the client owns the secret private key without revealing the key.
-Key based authentication is both more convenient and more secure, so you should prefer it.
-Note that the private key (often `~/.ssh/id_rsa` and more recently `~/.ssh/id_ed25519`) is effectively your password, so treat it like so and never share its contents.
+Agar `ssh` mengizinkan kita menjalankan perintah di server remote, kita perlu membuktikan bahwa kita berwenang untuk melakukannya.
+Kita dapat melakukannya melalui password atau ssh key.
+Autentikasi berbasis key menggunakan public-key cryptography untuk membuktikan kepada server bahwa klien memiliki secret private key tanpa mengungkapkan key tersebut.
+Autentikasi berbasis key lebih nyaman dan lebih aman, jadi Anda sebaiknya lebih memilihnya.
+Perhatikan bahwa private key (sering `~/.ssh/id_rsa` dan yang lebih baru `~/.ssh/id_ed25519`) secara efektif adalah password Anda, jadi perlakukan seperti itu dan jangan pernah membagikan isinya.
 
-To generate a pair you can run [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
+Untuk menghasilkan pair Anda dapat menjalankan [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
 ```bash
 ssh-keygen -a 100 -t ed25519 -f ~/.ssh/id_ed25519
 ```
 
-If you have ever configured pushing to GitHub using SSH keys, then you have probably done the steps outlined [here](https://help.github.com/articles/connecting-to-github-with-ssh/) and have a valid key pair already. To check if you have a passphrase and validate it you can run `ssh-keygen -y -f /path/to/key`.
+Jika Anda pernah mengonfigurasi push ke GitHub menggunakan SSH key, maka Anda mungkin sudah melakukan langkah-langkah yang diuraikan [di sini](https://help.github.com/articles/connecting-to-github-with-ssh/) dan sudah memiliki pasangan key yang valid. Untuk memeriksa apakah Anda memiliki passphrase dan memvalidasinya Anda dapat menjalankan `ssh-keygen -y -f /path/to/key`.
 
-At the server side `ssh` will look into `.ssh/authorized_keys` to determine which clients it should let in. To copy a public key over you can use:
+Di sisi server `ssh` akan melihat `.ssh/authorized_keys` untuk menentukan klien mana yang seharusnya diizinkan masuk. Untuk menyalin public key Anda dapat menggunakan:
 
 ```bash
 cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
@@ -536,9 +536,9 @@ cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
 ssh-copy-id -i .ssh/id_ed25519 alice@remote
 ```
 
-Beyond running commands, the connection that ssh establishes can be used to transfer files from and to the server securely. [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) is the most traditional tool and the syntax is `scp path/to/local_file remote_host:path/to/remote_file`. [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) improves upon `scp` by detecting identical files in local and remote, and preventing copying them again. It also provides more fine grained control over symlinks, permissions and has extra features like the `--partial` flag that can resume from a previously interrupted copy. `rsync` has a similar syntax to `scp`.
+Selain menjalankan perintah, koneksi yang dibentuk ssh dapat digunakan untuk mentransfer file dari dan ke server secara aman. [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) adalah alat yang paling tradisional dan sintaksnya adalah `scp path/to/local_file remote_host:path/to/remote_file`. [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) meningkatkan `scp` dengan mendeteksi file yang identik di lokal dan remote, dan mencegah penyalinan ulang. Ini juga menyediakan kontrol yang lebih terperinci atas symlink, permission, dan memiliki fitur tambahan seperti flag `--partial` yang dapat melanjutkan salinan yang sebelumnya terinterupsi. `rsync` memiliki sintaks yang mirip dengan `scp`.
 
-SSH client configuration is located at `~/.ssh/config` and it lets us declare hosts and set default settings for them. This configuration file is not just read by `ssh` but also other programs like `scp`, `rsync`, `mosh`, &c.
+Konfigurasi klien SSH terletak di `~/.ssh/config` dan memungkinkan kita mendeklarasikan host dan menetapkan pengaturan default untuk mereka. File konfigurasi ini tidak hanya dibaca oleh `ssh` tetapi juga program lain seperti `scp`, `rsync`, `mosh`, &c.
 
 ```bash
 Host vm
@@ -555,80 +555,80 @@ Host *.mit.edu
 
 
 
-# Terminal Multiplexers
+# Terminal Multiplexer
 
-When using the command line interface you will often want to run more than one thing at once.
-For instance, you might want to run your editor and your program side by side.
-Although this can be achieved by opening new terminal windows, using a terminal multiplexer is a more versatile solution.
+Ketika menggunakan command-line interface Anda sering ingin menjalankan lebih dari satu hal sekaligus.
+Misalnya, Anda mungkin ingin menjalankan editor dan program Anda secara berdampingan.
+Meskipun ini dapat dicapai dengan membuka jendela terminal baru, menggunakan terminal multiplexer adalah solusi yang lebih fleksibel.
 
-Terminal multiplexers like [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) allow you to multiplex terminal windows using panes and tabs so you can interact with multiple shell sessions in an efficient manner.
-Moreover, terminal multiplexers let you detach a current terminal session and reattach at some point later in time.
-Because of this, terminal multiplexers are really convenient when working with remote machines, as it avoids the need to use `nohup` and similar tricks.
+Terminal multiplexer seperti [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) memungkinkan Anda melakukan multiplex jendela terminal menggunakan pane dan tab sehingga Anda dapat berinteraksi dengan beberapa sesi shell secara efisien.
+Selain itu, terminal multiplexer memungkinkan Anda melepas sesi terminal saat ini dan menghubungkannya kembali di kemudian waktu.
+Karena ini, terminal multiplexer sangat nyaman ketika bekerja dengan mesin remote, karena menghindari kebutuhan untuk menggunakan `nohup` dan trik-trik serupa.
 
-The most popular terminal multiplexer these days is [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` is highly configurable and by using the associated keybindings you can create multiple tabs and panes and quickly navigate through them.
+Terminal multiplexer yang paling populer saat ini adalah [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` sangat dapat dikonfigurasi dan dengan menggunakan keybinding yang terkait Anda dapat membuat beberapa tab dan pane serta menavigasi dengan cepat.
 
-`tmux` expects you to know its keybindings, and they all have the form `<C-b> x` where that means (1) press `Ctrl+b`, (2) release `Ctrl+b`, and then (3) press `x`. `tmux` has the following hierarchy of objects:
-- **Sessions** - a session is an independent workspace with one or more windows
-    + `tmux` starts a new session.
-    + `tmux new -s NAME` starts it with that name.
-    + `tmux ls` lists the current sessions
-    + Within `tmux` typing `<C-b> d`  detaches the current session
-    + `tmux a` attaches the last session. You can use `-t` flag to specify which
+`tmux` mengharapkan Anda mengetahui keybinding-nya, dan semuanya memiliki bentuk `<C-b> x` yang berarti (1) tekan `Ctrl+b`, (2) lepaskan `Ctrl+b`, lalu (3) tekan `x`. `tmux` memiliki hierarki objek berikut:
+- **Sessions** - sebuah session adalah workspace independen dengan satu atau lebih window
+    + `tmux` memulai session baru.
+    + `tmux new -s NAME` memulainya dengan nama tersebut.
+    + `tmux ls` mencantumkan session saat ini
+    + Dalam `tmux` mengetik `<C-b> d`  melepas session saat ini
+    + `tmux a` menghubungkan session terakhir. Anda dapat menggunakan flag `-t` untuk menentukan yang mana
 
-- **Windows** - Equivalent to tabs in editors or browsers, they are visually separate parts of the same session
-    + `<C-b> c` Creates a new window. To close it you can just terminate the shells doing `<C-d>`
-    + `<C-b> N` Go to the _N_ th window. Note they are numbered
-    + `<C-b> p` Goes to the previous window
-    + `<C-b> n` Goes to the next window
-    + `<C-b> ,` Rename the current window
-    + `<C-b> w` List current windows
+- **Windows** - Setara dengan tab di editor atau browser, mereka adalah bagian visual yang terpisah dari session yang sama
+    + `<C-b> c` Membuat window baru. Untuk menutupnya Anda cukup menghentikan shell dengan `<C-d>`
+    + `<C-b> N` Pergi ke window ke-_N_. Perhatikan mereka diberi nomor
+    + `<C-b> p` Pergi ke window sebelumnya
+    + `<C-b> n` Pergi ke window berikutnya
+    + `<C-b> ,` Mengubah nama window saat ini
+    + `<C-b> w` Mencantumkan window saat ini
 
-- **Panes** - Like vim splits, panes let you have multiple shells in the same visual display.
-    + `<C-b> "` Split the current pane horizontally
-    + `<C-b> %` Split the current pane vertically
-    + `<C-b> <direction>` Move to the pane in the specified _direction_. Direction here means arrow keys.
-    + `<C-b> z` Toggle zoom for the current pane
-    + `<C-b> [` Start scrollback. You can then press `<space>` to start a selection and `<enter>` to copy that selection.
-    + `<C-b> <space>` Cycle through pane arrangements.
+- **Panes** - Seperti vim splits, pane memungkinkan Anda memiliki beberapa shell dalam tampilan visual yang sama.
+    + `<C-b> "` Membelah pane saat ini secara horizontal
+    + `<C-b> %` Membelah pane saat ini secara vertikal
+    + `<C-b> <direction>` Pindah ke pane di _arah_ yang ditentukan. Direction di sini berarti tombol panah.
+    + `<C-b> z` Toggle zoom untuk pane saat ini
+    + `<C-b> [` Memulai scrollback. Anda kemudian dapat menekan `<space>` untuk memulai seleksi dan `<enter>` untuk menyalin seleksi tersebut.
+    + `<C-b> <space>` Berpindah melalui susunan pane.
 
-> To learn more about tmux, consider reading [this](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) quick tutorial and [this](https://linuxcommand.org/lc3_adv_termmux.php) more detailed explanation.
+> Untuk mempelajari lebih lanjut tentang tmux, pertimbangkan untuk membaca tutorial singkat [ini](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) dan penjelasan yang lebih detail [ini](https://linuxcommand.org/lc3_adv_termmux.php).
 
-With tmux and SSH in your toolkit, you'll want to make your environment feel like home on any machine. That's where shell customization comes in.
+Dengan tmux dan SSH dalam toolkit Anda, Anda ingin membuat lingkungan Anda terasa seperti di rumah di mesin mana pun. Di situlah kustomisasi shell berperan.
 
-# Customizing the Shell
+# Kustomisasi Shell
 
-A wide array of command line programs are configured using plain-text files known as _dotfiles_
-(because the file names begin with a `.`, e.g. `~/.vimrc`, so that they are
-hidden in the directory listing `ls` by default).
+Berbagai macam program command-line dikonfigurasi menggunakan file teks biasa yang dikenal sebagai _dotfiles_
+(karena nama file dimulai dengan `.`, misalnya `~/.vimrc`, sehingga mereka
+tersembunyi dalam daftar direktori `ls` secara default).
 
-> Dotfiles are yet another shell convention. The dot in the front is to "hide" them when listing (yes, another convention).
+> Dotfiles adalah konvensi shell lainnya. Titik di depan adalah untuk "menyembunyikan" mereka saat melakukan daftar (ya, konvensi lainnya).
 
-Shells are one example of programs configured with such files. On startup, your shell will read many files to load its configuration.
-Depending on the shell and whether you are starting a login and/or interactive session, the entire process can be quite complex.
-[Here](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) is an excellent resource on the topic.
+Shell adalah salah satu contoh program yang dikonfigurasi dengan file seperti ini. Saat startup, shell Anda akan membaca banyak file untuk memuat konfigurasinya.
+Tergantung pada shell dan apakah Anda memulai sesi login dan/atau interaktif, keseluruhan proses bisa cukup kompleks.
+[Di sini](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) adalah sumber daya yang sangat baik tentang topik ini.
 
-For `bash`, editing your `.bashrc` or `.bash_profile` will work in most systems.
-Some other examples of tools that can be configured through dotfiles are:
+Untuk `bash`, mengedit `.bashrc` atau `.bash_profile` Anda akan berfungsi di sebagian besar sistem.
+Beberapa contoh lain alat yang dapat dikonfigurasi melalui dotfiles adalah:
 
 - `bash` - `~/.bashrc`, `~/.bash_profile`
 - `git` - `~/.gitconfig`
-- `vim` - `~/.vimrc` and the `~/.vim` folder
+- `vim` - `~/.vimrc` dan folder `~/.vim`
 - `ssh` - `~/.ssh/config`
 - `tmux` - `~/.tmux.conf`
 
-A common configuration change is adding new locations for the shell to find programs. You will encounter this pattern when installing software:
+Perubahan konfigurasi yang umum adalah menambahkan lokasi baru untuk shell menemukan program. Anda akan menemui pola ini saat menginstal perangkat lunak:
 
 ```shell
 export PATH="$PATH:path/to/append"
 ```
 
-Here, we are telling the shell to set the value of the $PATH variable to its current value plus a new path, and have all children processes inherit this new value for PATH.
-This will allow children processes to find programs located under `path/to/append`.
+Di sini, kita memberitahu shell untuk menetapkan nilai variabel $PATH ke nilai saat ini ditambah path baru, dan membuat semua child process mewarisi nilai baru untuk PATH ini.
+Ini akan memungkinkan child process untuk menemukan program yang terletak di bawah `path/to/append`.
 
 
-Customizing your shell often means installing new command-line tools. Package managers make this easy. They handle downloading, installing, and updating software. Different operating systems have different package managers: macOS uses [Homebrew](https://brew.sh/), Ubuntu/Debian use `apt`, Fedora uses `dnf`, and Arch uses `pacman`. We'll cover package managers in more depth in the shipping code lecture.
+Kustomisasi shell sering berarti menginstal alat command-line baru. Package manager memudahkan hal ini. Mereka menangani pengunduhan, pemasangan, dan pembaruan perangkat lunak. Sistem operasi yang berbeda memiliki package manager yang berbeda: macOS menggunakan [Homebrew](https://brew.sh/), Ubuntu/Debian menggunakan `apt`, Fedora menggunakan `dnf`, dan Arch menggunakan `pacman`. Kita akan membahas package manager lebih mendalam di kuliah shipping code.
 
-Here's how to install two useful tools using Homebrew on macOS:
+Berikut cara menginstal dua alat yang berguna menggunakan Homebrew di macOS:
 
 ```shell
 # ripgrep: a faster grep with better defaults
@@ -638,19 +638,19 @@ brew install ripgrep
 brew install fd
 ```
 
-With these installed, you can use `rg` instead of `grep` and `fd` instead of `find`.
+Dengan ini terinstal, Anda dapat menggunakan `rg` sebagai pengganti `grep` dan `fd` sebagai pengganti `find`.
 
-> **Warning about `curl | bash`**: You'll often see installation instructions like `curl -fsSL https://example.com/install.sh | bash`. This pattern downloads a script and immediately executes it, which is convenient but risky; you're running code you haven't inspected. A safer approach is to download first, review, then execute:
+> **Peringatan tentang `curl | bash`**: Anda sering akan melihat instruksi instalasi seperti `curl -fsSL https://example.com/install.sh | bash`. Pola ini mengunduh script dan segera mengeksekusinya, yang nyaman tetapi berisiko; Anda menjalankan kode yang belum Anda periksa. Pendekatan yang lebih aman adalah mengunduh terlebih dahulu, meninjau, lalu mengeksekusi:
 > ```shell
 > curl -fsSL https://example.com/install.sh -o install.sh
 > less install.sh  # review the script
 > bash install.sh
 > ```
-> Some installers use a slightly safer variant: `/bin/bash -c "$(curl -fsSL https://url)"` which at least ensures bash interprets the script rather than your current shell.
+> Beberapa installer menggunakan varian yang sedikit lebih aman: `/bin/bash -c "$(curl -fsSL https://url)"` yang setidaknya memastikan bash menafsirkan script tersebut daripada shell Anda saat ini.
 
-When you try to run a command that isn't installed, your shell will show `command not found`. The website [command-not-found.com](https://command-not-found.com) is a helpful resource you can use to search for any command to find out how to install it across different package managers and distributions.
+Ketika Anda mencoba menjalankan perintah yang belum terinstal, shell Anda akan menampilkan `command not found`. Situs web [command-not-found.com](https://command-not-found.com) adalah sumber daya bermanfaat yang dapat Anda gunakan untuk mencari perintah apa pun dan mengetahui cara menginstalnya di berbagai package manager dan distribusi.
 
-Another useful tool is [`tldr`](https://tldr.sh/), which provides simplified, example-focused man pages. Instead of reading through lengthy documentation, you can quickly see common usage patterns:
+Alat lain yang berguna adalah [`tldr`](https://tldr.sh/), yang menyediakan halaman man yang disederhanakan dan berfokus pada contoh. Alih-alih membaca dokumentasi yang panjang, Anda dapat dengan cepat melihat pola penggunaan umum:
 
 ```console
 $ tldr fd
@@ -667,19 +667,19 @@ $ tldr fd
       fd --extension txt
 ```
 
-Sometimes you don't need a whole new program, but rather just a shortcut for an existing command with specific flags. That's where aliases come in.
+Terkadang Anda tidak membutuhkan program baru sepenuhnya, melainkan hanya pintasan untuk perintah yang sudah ada dengan flag tertentu. Di situlah alias berperan.
 
-We can also create our own command aliases using the `alias` shell built-in.
-A shell alias is a short form for another command that your shell will replace automatically before evaluating the expression.
-For instance, an alias in bash has the following structure:
+Kita juga dapat membuat alias perintah kita sendiri menggunakan built-in shell `alias`.
+Alias shell adalah bentuk pendek untuk perintah lain yang akan diganti oleh shell secara otomatis sebelum mengevaluasi ekspresi.
+Misalnya, alias dalam bash memiliki struktur berikut:
 
 ```bash
 alias alias_name="command_to_alias arg1 arg2"
 ```
 
-> Note that there is no space around the equal sign `=`, because [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) is a shell command that takes a single argument.
+> Perhatikan bahwa tidak ada spasi di sekitar tanda sama dengan `=`, karena [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) adalah perintah shell yang menerima satu argument.
 
-Aliases have many convenient features:
+Alias memiliki banyak fitur yang nyaman:
 
 ```bash
 # Make shorthands for common flags
@@ -711,65 +711,65 @@ alias ll
 # Will print ll='ls -lh'
 ```
 
-Aliases have limitations: they cannot take arguments in the middle of a command. For more complex behavior, you should use shell functions instead.
+Alias memiliki keterbatasan: mereka tidak dapat mengambil arguments di tengah perintah. Untuk perilaku yang lebih kompleks, Anda sebaiknya menggunakan fungsi shell.
 
-Most shells support `Ctrl-R` for reverse history search. Type `Ctrl-R` and start typing to search through previous commands. Earlier we introduced `fzf` as a fuzzy finder; with fzf's shell integration configured, `Ctrl-R` becomes an interactive fuzzy search through your entire history, far more powerful than the default.
+Sebagian besar shell mendukung `Ctrl-R` untuk pencarian history terbalik. Ketik `Ctrl-R` dan mulai mengetik untuk mencari melalui perintah sebelumnya. Sebelumnya kita memperkenalkan `fzf` sebagai fuzzy finder; dengan integrasi shell fzf yang dikonfigurasi, `Ctrl-R` menjadi pencarian fuzzy interaktif melalui seluruh history Anda, jauh lebih kuat dari default.
 
-How should you organize your dotfiles? They should be in their own folder,
-under version control, and **symlinked** into place using a script. This has
-the benefits of:
+Bagaimana sebaiknya Anda mengatur dotfiles Anda? Mereka harus berada di folder mereka sendiri,
+di bawah version control, dan **di-symlink** ke tempatnya menggunakan script. Ini memiliki
+keuntungan:
 
-- **Easy installation**: if you log in to a new machine, applying your
-customizations will only take a minute.
-- **Portability**: your tools will work the same way everywhere.
-- **Synchronization**: you can update your dotfiles anywhere and keep them all
-in sync.
-- **Change tracking**: you're probably going to be maintaining your dotfiles
-for your entire programming career, and version history is nice to have for
-long-lived projects.
+- **Instalasi mudah**: jika Anda login ke mesin baru, menerapkan
+kustomisasi Anda hanya akan memakan waktu satu menit.
+- **Portabilitas**: alat Anda akan bekerja dengan cara yang sama di mana saja.
+- **Sinkronisasi**: Anda dapat memperbarui dotfiles Anda di mana saja dan menjaga semuanya
+tetap sinkron.
+- **Pelacakan perubahan**: Anda mungkin akan memelihara dotfiles Anda
+selama seluruh karir pemrograman Anda, dan riwayat versi berguna untuk
+proyek jangka panjang.
 
-What should you put in your dotfiles?
-You can learn about your tool's settings by reading online documentation or
-[man pages](https://en.wikipedia.org/wiki/Man_page). Another great way is to
-search the internet for blog posts about specific programs, where authors will
-tell you about their preferred customizations. Yet another way to learn about
-customizations is to look through other people's dotfiles: you can find tons of
-[dotfiles
-repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on GitHub --- see the most popular one
-[here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
-copy configurations though).
-[Here](https://dotfiles.github.io/) is another good resource on the topic.
+Apa yang harus Anda masukkan ke dotfiles Anda?
+Anda dapat mempelajari tentang pengaturan alat Anda dengan membaca dokumentasi online atau
+[man pages](https://en.wikipedia.org/wiki/Man_page). Cara hebat lainnya adalah
+mencari di internet untuk posting blog tentang program tertentu, di mana penulis akan
+memberitahu Anda tentang kustomisasi pilihan mereka. Cara lain untuk mempelajari
+kustomisasi adalah dengan melihat dotfiles orang lain: Anda dapat menemukan banyak
+[repository
+dotfiles](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
+di GitHub --- lihat yang paling populer
+[di sini](https://github.com/mathiasbynens/dotfiles) (kami menyarankan Anda untuk tidak
+menyalin konfigurasi secara membabi buta).
+[Di sini](https://dotfiles.github.io/) adalah sumber daya bagus lainnya tentang topik ini.
 
-All of the class instructors have their dotfiles publicly accessible on GitHub: [Anish](https://github.com/anishathalye/dotfiles),
+Semua instruktur kelas memiliki dotfiles mereka yang dapat diakses secara publik di GitHub: [Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
 [Jose](https://github.com/jjgo/dotfiles).
 
-**Frameworks and plugins** can improve your shell as well. Some popular general frameworks are [prezto](https://github.com/sorin-ionescu/prezto) or [oh-my-zsh](https://ohmyz.sh/), and smaller plugins that focus on specific features:
+**Framework dan plugin** juga dapat meningkatkan shell Anda. Beberapa framework umum yang populer adalah [prezto](https://github.com/sorin-ionescu/prezto) atau [oh-my-zsh](https://ohmyz.sh/), dan plugin yang lebih kecil yang berfokus pada fitur tertentu:
 
-- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - colors valid/invalid commands as you type
-- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - suggests commands from history as you type
-- [zsh-completions](https://github.com/zsh-users/zsh-completions) - additional completion definitions
-- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - fish-like history search
-- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - fast, customizable prompt theme
+- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - mewarnai perintah valid/invalid saat Anda mengetik
+- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - menyarankan perintah dari history saat Anda mengetik
+- [zsh-completions](https://github.com/zsh-users/zsh-completions) - definisi completion tambahan
+- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - pencarian history seperti fish
+- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - tema prompt yang cepat dan dapat dikustomisasi
 
-Shells like [fish](https://fishshell.com/) include many of these features by default.
+Shell seperti [fish](https://fishshell.com/) menyertakan banyak fitur ini secara default.
 
-> You don't need a massive framework like oh-my-zsh to get these features. Installing individual plugins is often faster and gives you more control. Large frameworks can significantly slow down shell startup time, so consider installing only what you actually use.
+> Anda tidak memerlukan framework besar seperti oh-my-zsh untuk mendapatkan fitur-fitur ini. Menginstal plugin individual sering kali lebih cepat dan memberi Anda lebih banyak kontrol. Framework besar dapat secara signifikan memperlambat waktu startup shell, jadi pertimbangkan untuk menginstal hanya yang benar-benar Anda gunakan.
 
 
-# AI in the Shell
+# AI di Shell
 
-There are many ways to incorporate AI tooling in the shell. Here are a few examples at different levels of integration:
+Ada banyak cara untuk mengintegrasikan alat AI di shell. Berikut beberapa contoh pada tingkat integrasi yang berbeda:
 
-**Command generation**: Tools like [`simonw/llm`](https://github.com/simonw/llm) can help generate shell commands from natural language descriptions:
+**Pembuatan perintah**: Alat seperti [`simonw/llm`](https://github.com/simonw/llm) dapat membantu menghasilkan perintah shell dari deskripsi bahasa alami:
 
 ```console
 $ llm cmd "find all python files modified in the last week"
 find . -name "*.py" -mtime -7
 ```
 
-**Pipeline integration**: LLMs can be integrated into shell pipelines to process and transform data. They're particularly useful when you need to extract information from inconsistent formats where regex would be painful:
+**Integrasi pipeline**: LLM dapat diintegrasikan ke dalam pipeline shell untuk memproses dan mengubah data. Mereka sangat berguna ketika Anda perlu mengekstrak informasi dari format yang tidak konsisten di mana regex akan menyakitkan:
 
 ```console
 $ cat users.txt
@@ -789,40 +789,40 @@ mike_wilson
 sarah.connor
 ```
 
-Note how we use `"$INSTRUCTIONS"` (quoted) because the variable contains spaces, and `< users.txt` to redirect the file's content to stdin.
+Perhatikan bagaimana kita menggunakan `"$INSTRUCTIONS"` (dengan tanda kutip) karena variabel berisi spasi, dan `< users.txt` untuk me-redirect konten file ke stdin.
 
-**AI shells**: Tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) act as a meta-shell that accepts English commands and translates them into shell operations, file edits, and more complex multi-step tasks.
+**Shell AI**: Alat seperti [Claude Code](https://docs.anthropic.com/en/docs/claude-code) bertindak sebagai meta-shell yang menerima perintah bahasa Inggris dan menerjemahkannya menjadi operasi shell, edit file, dan tugas multi-langkah yang lebih kompleks.
 
-# Terminal Emulators
+# Terminal Emulator
 
-Along with customizing your shell, it is worth spending some time figuring out your choice of **terminal emulator** and its settings.
-A terminal emulator is a GUI program that provides the text-based interface where your shell runs.
-There are many terminal emulators out there.
+Bersamaan dengan mengkustomisasi shell Anda, ada baiknya meluangkan waktu untuk memilih **terminal emulator** dan pengaturannya.
+Terminal emulator adalah program GUI yang menyediakan antarmuka berbasis teks tempat shell Anda berjalan.
+Ada banyak terminal emulator di luar sana.
 
-Since you might be spending hundreds to thousands of hours in your terminal it pays off to look into its settings. Some of the aspects that you may want to modify in your terminal include:
+Karena Anda mungkin menghabiskan ratusan hingga ribuan jam di terminal Anda, ada baiknya untuk menyelidiki pengaturannya. Beberapa aspek yang mungkin ingin Anda modifikasi di terminal Anda meliputi:
 
-- Font choice
-- Color Scheme
-- Keyboard shortcuts
-- Tab/Pane support
-- Scrollback configuration
-- Performance (some newer terminals like [Alacritty](https://github.com/alacritty/alacritty) or [Ghostty](https://ghostty.org/) offer GPU acceleration).
+- Pilihan font
+- Skema warna
+- Pintasan keyboard
+- Dukungan tab/pane
+- Konfigurasi scrollback
+- Performa (beberapa terminal yang lebih baru seperti [Alacritty](https://github.com/alacritty/alacritty) atau [Ghostty](https://ghostty.org/) menawarkan akselerasi GPU).
 
 
 
-# Exercises
+# Latihan
 
-## Arguments and Globs
+## Arguments dan Globs
 
-1. You might see commands like `cmd --flag -- --notaflag`. The `--` is a special argument that tells the program to stop parsing flags. Everything after `--` is treated as a positional argument. Why might this be useful? Try running `touch -- -myfile` and then removing it without `--`.
+1. Anda mungkin melihat perintah seperti `cmd --flag -- --notaflag`. `--` adalah argument khusus yang memberitahu program untuk berhenti mem-parsing flag. Semua yang setelah `--` diperlakukan sebagai argument posisional. Mengapa ini berguna? Cobalah menjalankan `touch -- -myfile` dan kemudian menghapusnya tanpa `--`.
 
-1. Read [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) and write an `ls` command that lists files in the following manner:
-    - Includes all files, including hidden files
-    - Sizes are listed in human readable format (e.g. 454M instead of 454279954)
-    - Files are ordered by recency
-    - Output is colorized
+1. Baca [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) dan tulis perintah `ls` yang mencantumkan file dengan cara berikut:
+    - Menyertakan semua file, termasuk file tersembunyi
+    - Ukuran ditampilkan dalam format yang mudah dibaca (misalnya 454M bukan 454279954)
+    - File diurutkan berdasarkan yang paling baru
+    - Output diberi warna
 
-    A sample output would look like this:
+    Contoh output akan terlihat seperti ini:
 
     ```
     -rw-r--r--   1 user group 1.1M Jan 14 09:53 baz
@@ -836,11 +836,11 @@ Since you might be spending hundreds to thousands of hours in your terminal it p
 ls -lath --color=auto
 {% endcomment %}
 
-1. Process substitution `<(command)` lets you use a command's output as if it were a file. Use `diff` with process substitution to compare the output of `printenv` and `export`. Why are they different? (Hint: try `diff <(printenv | sort) <(export | sort)`).
+1. Process substitution `<(command)` memungkinkan Anda menggunakan output perintah seolah-olah itu adalah file. Gunakan `diff` dengan process substitution untuk membandingkan output `printenv` dan `export`. Mengapa mereka berbeda? (Petunjuk: coba `diff <(printenv | sort) <(export | sort)`).
 
-## Environment Variables
+## Variabel Lingkungan
 
-1. Write bash functions `marco` and `polo` that do the following: whenever you execute `marco` the current working directory should be saved in some manner, then when you execute `polo`, no matter what directory you are in, `polo` should `cd` you back to the directory where you executed `marco`. For ease of debugging you can write the code in a file `marco.sh` and (re)load the definitions to your shell by executing `source marco.sh`.
+1. Tulis fungsi bash `marco` dan `polo` yang melakukan hal berikut: setiap kali Anda menjalankan `marco` direktori kerja saat ini harus disimpan dengan cara tertentu, kemudian ketika Anda menjalankan `polo`, tidak peduli di direktori mana Anda berada, `polo` harus melakukan `cd` mengembalikan Anda ke direktori tempat Anda menjalankan `marco`. Untuk memudahkan debugging Anda dapat menulis kode dalam file `marco.sh` dan (re)load definisi ke shell Anda dengan menjalankan `source marco.sh`.
 
 {% comment %}
 marco() {
@@ -854,7 +854,7 @@ polo() {
 
 ## Return Codes
 
-1. Say you have a command that fails rarely. In order to debug it you need to capture its output but it can be time consuming to get a failure run. Write a bash script that runs the following script until it fails and captures its standard output and error streams to files and prints everything at the end. Bonus points if you can also report how many runs it took for the script to fail.
+1. Katakan Anda memiliki perintah yang jarang gagal. Untuk men-debug-nya Anda perlu menangkap outputnya tetapi bisa memakan waktu lama untuk mendapatkan hasil yang gagal. Tulis script bash yang menjalankan script berikut sampai gagal dan menangkap standard output dan error stream ke file dan mencetak semuanya di akhir. Nilai tambah jika Anda juga dapat melaporkan berapa kali percobaan yang diperlukan sampai script gagal.
 
     ```bash
     #!/usr/bin/env bash
@@ -884,47 +884,47 @@ echo "found error after $count runs"
 cat out.txt
 {% endcomment %}
 
-## Signals and Job Control
+## Signals dan Job Control
 
-1. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-lf` flags).
+1. Jalankan pekerjaan `sleep 10000` di terminal, background-kan dengan `Ctrl-Z` dan lanjutkan eksekusinya dengan `bg`. Sekarang gunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk menemukan pid-nya dan [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) untuk menghentikannya tanpa pernah mengetik pid itu sendiri. (Petunjuk: gunakan flag `-lf`).
 
-1. Say you don't want to start a process until another completes. How would you go about it? In this exercise, our limiting process will always be `sleep 60 &`. One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command. Try launching the sleep command and having an `ls` wait until the background process finishes.
+1. Katakan Anda tidak ingin memulai sebuah proses sampai proses lain selesai. Bagaimana cara Anda melakukannya? Dalam latihan ini, proses pembatas kita akan selalu menjadi `sleep 60 &`. Salah satu cara untuk mencapainya adalah dengan menggunakan perintah [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html). Cobalah meluncurkan perintah sleep dan membuat `ls` menunggu sampai proses background selesai.
 
-    However, this strategy will fail if we start in a different bash session, since `wait` only works for child processes. One feature we did not discuss in the notes is that the `kill` command's exit status will be zero on success and nonzero otherwise. `kill -0` does not send a signal but will give a nonzero exit status if the process does not exist. Write a bash function called `pidwait` that takes a pid and waits until the given process completes. You should use `sleep` to avoid wasting CPU unnecessarily.
+    Namun, strategi ini akan gagal jika kita memulai di sesi bash yang berbeda, karena `wait` hanya berfungsi untuk child process. Satu fitur yang tidak kita bahas dalam catatan adalah bahwa exit status perintah `kill` akan nol jika berhasil dan bukan-nol jika gagal. `kill -0` tidak mengirimkan sinyal tetapi akan memberikan exit status bukan-nol jika proses tidak ada. Tulis fungsi bash yang disebut `pidwait` yang menerima pid dan menunggu sampai proses yang diberikan selesai. Anda sebaiknya menggunakan `sleep` untuk menghindari pemborosan CPU secara tidak perlu.
 
-## Files and Permissions
+## File dan Permissions
 
-1. (Advanced) Write a command or script to recursively find the most recently modified file in a directory. More generally, can you list all files by recency?
+1. (Lanjutan) Tulis perintah atau script untuk menemukan file yang paling baru dimodifikasi secara rekursif di dalam direktori. Lebih umumnya, dapatkah Anda mencantumkan semua file berdasarkan kebaruannya?
 
-## Terminal Multiplexers
+## Terminal Multiplexer
 
-1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
+1. Ikuti [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) `tmux` ini dan kemudian pelajari cara melakukan beberapa kustomisasi dasar dengan mengikuti [langkah-langkah ini](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
 
-## Aliases and Dotfiles
+## Alias dan Dotfiles
 
-1. Create an alias `dc` that resolves to `cd` for when you type it wrong.
+1. Buat alias `dc` yang mengarah ke `cd` untuk ketika Anda salah mengetiknya.
 
-1. Run `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` to get your top 10 most used commands and consider writing shorter aliases for them. Note: this works for Bash; if you're using ZSH, use `history 1` instead of just `history`.
+1. Jalankan `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` untuk mendapatkan 10 perintah yang paling sering Anda gunakan dan pertimbangkan untuk menulis alias yang lebih pendek untuk mereka. Catatan: ini berfungsi untuk Bash; jika Anda menggunakan ZSH, gunakan `history 1` bukan hanya `history`.
 
-1. Create a folder for your dotfiles and set up version control.
+1. Buat folder untuk dotfiles Anda dan atur version control.
 
-1. Add a configuration for at least one program, e.g. your shell, with some customization (to start off, it can be something as simple as customizing your shell prompt by setting `$PS1`).
+1. Tambahkan konfigurasi untuk setidaknya satu program, misalnya shell Anda, dengan beberapa kustomisasi (untuk memulai, bisa sesederhana mengkustomisasi prompt shell Anda dengan menetapkan `$PS1`).
 
-1. Set up a method to install your dotfiles quickly (and without manual effort) on a new machine. This can be as simple as a shell script that calls `ln -s` for each file, or you could use a [specialized utility](https://dotfiles.github.io/utilities/).
+1. Siapkan metode untuk menginstal dotfiles Anda dengan cepat (dan tanpa usaha manual) di mesin baru. Ini bisa sesederhana script shell yang memanggil `ln -s` untuk setiap file, atau Anda bisa menggunakan [utilitas khusus](https://dotfiles.github.io/utilities/).
 
-1. Test your installation script on a fresh virtual machine.
+1. Uji script instalasi Anda di virtual machine yang masih segar.
 
-1. Migrate all of your current tool configurations to your dotfiles repository.
+1. Migrasikan semua konfigurasi alat Anda saat ini ke repository dotfiles Anda.
 
-1. Publish your dotfiles on GitHub.
+1. Publikasikan dotfiles Anda di GitHub.
 
-## Remote Machines (SSH)
+## Mesin Remote (SSH)
 
-Install a Linux virtual machine (or use an already existing one) for these exercises. If you are not familiar with virtual machines check out [this](https://hibbard.eu/install-ubuntu-virtual-box/) tutorial for installing one.
+Instal virtual machine Linux (atau gunakan yang sudah ada) untuk latihan ini. Jika Anda tidak familiar dengan virtual machine, lihat [tutorial](https://hibbard.eu/install-ubuntu-virtual-box/) ini untuk menginstal satu.
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent`, more info [here](https://www.ssh.com/ssh/agent).
+1. Pergi ke `~/.ssh/` dan periksa apakah Anda memiliki pasangan SSH key di sana. Jika tidak, buat dengan `ssh-keygen -a 100 -t ed25519`. Disarankan bahwa Anda menggunakan password dan menggunakan `ssh-agent`, info lebih lanjut [di sini](https://www.ssh.com/ssh/agent).
 
-1. Edit `.ssh/config` to have an entry as follows:
+1. Edit `.ssh/config` untuk memiliki entri seperti berikut:
 
     ```bash
     Host vm
@@ -934,12 +934,12 @@ Install a Linux virtual machine (or use an already existing one) for these exerc
         LocalForward 9999 localhost:8888
     ```
 
-1. Use `ssh-copy-id vm` to copy your ssh key to the server.
+1. Gunakan `ssh-copy-id vm` untuk menyalin SSH key Anda ke server.
 
-1. Start a webserver in your VM by executing `python -m http.server 8888`. Access the VM webserver by navigating to `http://localhost:9999` in your machine.
+1. Jalankan webserver di VM Anda dengan menjalankan `python -m http.server 8888`. Akses webserver VM dengan menavigasi ke `http://localhost:9999` di mesin Anda.
 
-1. Edit your SSH server config by doing `sudo vim /etc/ssh/sshd_config` and disable password authentication by editing the value of `PasswordAuthentication`. Disable root login by editing the value of `PermitRootLogin`. Restart the `ssh` service with `sudo service sshd restart`. Try sshing in again.
+1. Edit konfigurasi server SSH Anda dengan melakukan `sudo vim /etc/ssh/sshd_config` dan nonaktifkan autentikasi password dengan mengedit nilai `PasswordAuthentication`. Nonaktifkan login root dengan mengedit nilai `PermitRootLogin`. Restart layanan `ssh` dengan `sudo service sshd restart`. Cobalah ssh lagi.
 
-1. (Challenge) Install [`mosh`](https://mosh.org/) in the VM and establish a connection. Then disconnect the network adapter of the server/VM. Can mosh properly recover from it?
+1. (Tantangan) Instal [`mosh`](https://mosh.org/) di VM dan buat koneksi. Kemudian putuskan adapter jaringan server/VM. Dapatkah mosh pulih dengan baik dari hal tersebut?
 
-1. (Challenge) Look into what the `-N` and `-f` flags do in `ssh` and figure out a command to achieve background port forwarding.
+1. (Tantangan) Cari tahu apa yang dilakukan flag `-N` dan `-f` di `ssh` dan temukan perintah untuk melakukan background port forwarding.

--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Command-line Environment"
 description: >
-  Learn how command-line programs work, including input/output streams, environment variables, and remote machines with SSH.
+  Pelajari cara kerja program command-line, termasuk input/output streams, environment variables, dan mesin remote dengan SSH.
 thumbnail: /static/assets/thumbnails/2026/lec2.png
 date: 2026-01-13
 ready: true

--- a/_2026/command-line-environment.md
+++ b/_2026/command-line-environment.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Command-line Environment"
+title: "Lingkungan Command-line"
 description: >
-  Learn how command-line programs work, including input/output streams, environment variables, and remote machines with SSH.
+  Pelajari cara kerja program command-line, termasuk stream input/output, variabel environment, dan mesin remote dengan SSH.
 thumbnail: /static/assets/thumbnails/2026/lec2.png
 date: 2026-01-13
 ready: true
@@ -11,24 +11,24 @@ video:
   id: ccBGsPedE9Q
 ---
 
-As we covered in the previous lecture, most shells are not a mere launcher to start up other programs,
-but in practice they provide an entire programming language full of common patterns and abstractions.
-However, unlike the majority of programming languages, in shell scripting everything is designed around running programs and getting them to communicate with each other simply and efficiently.
+Seperti yang telah kita bahas di kuliah sebelumnya, sebagian besar shell bukan sekadar launcher untuk menjalankan program lain,
+melainkan dalam praktiknya mereka menyediakan seluruh bahasa pemrograman yang penuh dengan pola-pola umum dan abstraksi.
+Namun, berbeda dengan mayoritas bahasa pemrograman, dalam shell scripting semuanya dirancang untuk menjalankan program dan membuat mereka berkomunikasi satu sama lain secara sederhana dan efisien.
 
-In particular, shell scripting is tightly bound by _conventions_. For a command line interface (CLI) program to play nicely within the broader shell environment there are some common patterns that it needs to follow.
-We will now cover many of the concepts required to understand how command line programs work as well as ubiquitous conventions on how to use and configure them.
+Secara khusus, shell scripting sangat terikat oleh _konvensi_. Agar sebuah program command-line interface (CLI) dapat bekerja dengan baik dalam lingkungan shell yang lebih luas, ada beberapa pola umum yang perlu diikuti.
+Sekarang kita akan membahas banyak konsep yang diperlukan untuk memahami cara kerja program command-line serta konvensi yang sangat umum tentang cara menggunakan dan mengonfigurasinya.
 
-# The Command Line Interface
+# Command Line Interface
 
-Writing a function in most programming languages looks something like:
+Menulis fungsi di sebagian besar bahasa pemrograman kurang lebih seperti ini:
 
 ```
 def add(x: int, y: int) -> int:
     return x + y
 ```
 
-Here we can explicitly see the inputs and the outputs of the program.
-In contrast, shell scripts can look quite different at first glance.
+Di sini kita dapat melihat secara eksplisit input dan output dari program.
+Sebaliknya, shell script bisa terlihat cukup berbeda pada pandangan pertama.
 
 ```shell
 #!/usr/bin/env bash
@@ -46,7 +46,7 @@ else
 fi
 ```
 
-To properly understand what is going in scripts like this one we first need to introduce a few concepts that appear often when shell programs communicate with each other or with the shell environment:
+Untuk memahami dengan benar apa yang terjadi dalam script seperti ini, pertama-tama kita perlu memperkenalkan beberapa konsep yang sering muncul ketika program shell berkomunikasi satu sama lain atau dengan lingkungan shell:
 
 - Arguments
 - Streams
@@ -56,29 +56,29 @@ To properly understand what is going in scripts like this one we first need to i
 
 ## Arguments
 
-Shell programs receive a list of arguments when they are executed.
-Arguments are plain strings in shell, and it is up to the program how to interpret them.
-For instance when we do `ls -l folder/`, we are executing the program `/bin/ls` with arguments `['-l', 'folder/']`.
+Program shell menerima daftar arguments saat dijalankan.
+Arguments adalah string biasa di shell, dan terserah program bagaimana cara menginterpretasikannya.
+Misalnya ketika kita melakukan `ls -l folder/`, kita menjalankan program `/bin/ls` dengan arguments `['-l', 'folder/']`.
 
-From within a shell script we access these via special shell syntax.
-To access the first argument we access the variable `$1`, second argument `$2` and so on and so forth until `$9`. To access all arguments as a list we use `$@` and to retrieve the number of arguments `$#`. Additionally we can also access the name of the program with `$0`.
+Dari dalam shell script kita mengaksesnya melalui sintaks shell khusus.
+Untuk mengakses argument pertama kita mengakses variabel `$1`, argument kedua `$2` dan seterusnya hingga `$9`. Untuk mengakses semua arguments sebagai daftar kita gunakan `$@` dan untuk mendapatkan jumlah arguments `$#`. Selain itu kita juga bisa mengakses nama program dengan `$0`.
 
-For most programs the arguments will consist of a mixture of _flags_ and regular strings.
-Flags can be identified because they are preceded by a dash (`-`) or double-dash (`--`).
-Flags are usually optional and their role is to modify the behavior of the program.
-For example `ls -l` changes how `ls` formats its output.
+Untuk sebagian besar program, arguments akan terdiri dari campuran _flags_ dan string biasa.
+Flags dapat diidentifikasi karena didahului oleh tanda dash (`-`) atau double-dash (`--`).
+Flags biasanya bersifat opsional dan fungsinya untuk memodifikasi perilaku program.
+Sebagai contoh `ls -l` mengubah cara `ls` memformat outputnya.
 
-You will see double dash flags with long names like `--all`, and single dash flags like `-a`, which are most often followed by a single letter.
-The same option might be specified in both formats, `ls -a` and `ls --all` are equivalent.
-Single dash flags are often grouped, so `ls -l -a` and `ls -la` are also equivalent.
-The order of flags usually doesn't matter either, `ls -la` and `ls -al` produce the same result.
-Some flags are quite prevalent and as you get more familiar with the shell environment you'll intuitively reach for them, for example (`--help`, `--verbose`, `--version`).
+Anda akan melihat flags double dash dengan nama panjang seperti `--all`, dan flags single dash seperti `-a`, yang paling sering diikuti oleh satu huruf.
+Opsi yang sama bisa ditentukan dalam kedua format, `ls -a` dan `ls --all` adalah setara.
+Flags single dash sering digabungkan, jadi `ls -l -a` dan `ls -la` juga setara.
+Urutan flags biasanya juga tidak masalah, `ls -la` dan `ls -al` menghasilkan output yang sama.
+Beberapa flags cukup umum digunakan dan seiring Anda semakin familiar dengan lingkungan shell, Anda akan secara intuitif menggunakannya, misalnya (`--help`, `--verbose`, `--version`).
 
-> Flags are a first good example of shell conventions. The shell language does not require that our program uses `-` or `--` in this particular way.
-Nothing prevents us from writing a program with syntax `myprogram +myoption myfile`, but it would lead to confusion since the expectation is that we use dashes.
-> In practice, most programming languages provide CLI flag parsing libraries (e.g. `argparse` in python to parse arguments with the dash syntax).
+> Flags adalah contoh pertama yang bagus dari konvensi shell. Bahasa shell tidak mengharuskan program kita menggunakan `-` atau `--` dengan cara tertentu ini.
+Tidak ada yang mencegah kita menulis program dengan sintaks `myprogram +myoption myfile`, tetapi hal itu akan menyebabkan kebingungan karena ekspektasinya adalah kita menggunakan dash.
+> Dalam praktiknya, sebagian besar bahasa pemrograman menyediakan library parsing flag CLI (misalnya `argparse` di python untuk mengurai arguments dengan sintaks dash).
 
-Another common convention in CLI programs is for programs to accept a variable number of arguments of the same type. When given arguments in this way the command performs the same operation on each one of them.
+Konvensi umum lainnya dalam program CLI adalah program menerima sejumlah variabel arguments dengan tipe yang sama. Ketika diberikan arguments dengan cara ini, perintah melakukan operasi yang sama pada masing-masing arguments tersebut.
 
 ```shell
 mkdir src
@@ -87,10 +87,10 @@ mkdir docs
 mkdir src docs
 ```
 
-This syntax sugar might seem unnecessary at first, but it becomes really powerful when combined with _globbing_.
-Globbing or globs are special patterns that the shell will expand before calling the program.
+Sugar sintaks ini mungkin terlihat tidak perlu pada awalnya, tetapi menjadi sangat berguna ketika dikombinasikan dengan _globbing_.
+Globbing atau globs adalah pola khusus yang akan di-expand oleh shell sebelum memanggil program.
 
-Say we wanted to delete all .py files in the current folder nonrecursively. From what we learned in the previous lecture we could achieve this by running
+Misalkan kita ingin menghapus semua file .py di folder saat ini secara non-rekursif. Dari apa yang kita pelajari di kuliah sebelumnya, kita bisa mencapainya dengan menjalankan
 
 ```shell
 for file in $(ls | grep -P '\.py$'); do
@@ -98,16 +98,16 @@ for file in $(ls | grep -P '\.py$'); do
 done
 ```
 
-But we can replace that with just `rm *.py`!
+Tetapi kita bisa menggantinya dengan cukup `rm *.py`!
 
-When we type `rm *.py` into the terminal, the shell will not call the `/bin/rm` program with arguments `['*.py']`.
-Instead, the shell will search for files in the current folder matching the pattern `*.py` where `*` can match any string of zero or more characters of any type.
-So if our folder has `main.py` and `utils.py` then the `rm` program will receive arguments `['main.py', 'utils.py']`.
+Ketika kita mengetik `rm *.py` ke terminal, shell tidak akan memanggil program `/bin/rm` dengan arguments `['*.py']`.
+Sebaliknya, shell akan mencari file di folder saat ini yang cocok dengan pola `*.py` di mana `*` dapat mencocokkan string dengan nol atau lebih karakter dari tipe apa pun.
+Jadi jika folder kita memiliki `main.py` dan `utils.py` maka program `rm` akan menerima arguments `['main.py', 'utils.py']`.
 
-The most common globs you will find are wildcards `*` (zero or more of anything), `?` (exactly one of anything) and curly braces.
-Curly braces `{}` expand a comma-separated list of patterns into multiple arguments.
+Globs yang paling sering Anda temui adalah wildcard `*` (nol atau lebih dari apa saja), `?` (tepat satu dari apa saja) dan curly braces.
+Curly braces `{}` meng-expand daftar pola yang dipisahkan koma menjadi beberapa arguments.
 
-In practice, globs are best understood with motivating examples.
+Dalam praktiknya, globs paling baik dipahami dengan contoh-contoh yang memotivasi.
 
 ```shell
 touch folder/{a,b,c}.py
@@ -127,25 +127,25 @@ mv *{.py,.sh} folder
 # Will move all *.py and *.sh files
 ```
 
-> Some shells (e.g. zsh) support even more advanced forms of globbing such as `**` that will expand to include recursive paths. So `rm **/*.py` will delete all .py files recursively.
+> Beberapa shell (misalnya zsh) mendukung bentuk globbing yang lebih canggih seperti `**` yang akan meng-expand untuk menyertakan path rekursif. Jadi `rm **/*.py` akan menghapus semua file .py secara rekursif.
 
 
 ## Streams
 
-Whenever we execute a program pipeline like
+Setiap kali kita menjalankan pipeline program seperti
 
 ```shell
 cat myfile | grep -P '\d+' | uniq -c
 ```
 
-we see that the `grep` program is communicating with both the `cat` and `uniq` programs.
+kita melihat bahwa program `grep` berkomunikasi dengan program `cat` maupun `uniq`.
 
-An important observation here is that all three programs are executing at once.
-Namely, the shell is not first calling cat, then grep, and then uniq.
-Instead, all three programs are being spawned and the shell is connecting the output of cat to the input of grep and the output of grep to the input of uniq.
-When using the pipe operator `|`, the shell operates on streams of data that flow from one program to the next in the chain.
+Pengamatan penting di sini adalah ketiga program berjalan secara bersamaan.
+Artinya, shell tidak pertama-tama memanggil cat, lalu grep, kemudian uniq.
+Sebaliknya, ketiga program dijalankan dan shell menghubungkan output cat ke input grep dan output grep ke input uniq.
+Ketika menggunakan operator pipe `|`, shell beroperasi pada stream data yang mengalir dari satu program ke program berikutnya dalam rantai.
 
-We can demonstrate this concurrency, all commands in a pipeline start immediately:
+Kita dapat mendemonstrasikan konkurensi ini, semua perintah dalam pipeline dimulai secara bersamaan:
 
 ```console
 $ (sleep 15 && cat numbers.txt) | grep -P '^\d$' | sort | uniq  &
@@ -158,9 +158,9 @@ $ ps | grep -P '(sleep|cat|grep|sort|uniq)'
   32948 pts/1    00:00:00 grep
 ```
 
-We can see that all processes but `cat` are running right away. The shell spawns all processes and connects their streams before any of them finish. `cat` will only get started once sleep finishes, and the output of `cat` will be sent to grep and so on and so forth.
+Kita dapat melihat bahwa semua proses kecuali `cat` langsung berjalan. Shell menjalankan semua proses dan menghubungkan stream mereka sebelum ada yang selesai. `cat` baru akan dimulai setelah sleep selesai, dan output `cat` akan dikirim ke grep dan seterusnya.
 
-Every program has an input stream, labeled stdin (for standard input). When piping, stdin is connected automatically. Within a script, many programs accept `-` as a filename to mean "read from stdin":
+Setiap program memiliki input stream, yang diberi label stdin (untuk standard input). Ketika melakukan piping, stdin terhubung secara otomatis. Di dalam script, banyak program menerima `-` sebagai nama file yang berarti "baca dari stdin":
 
 ```shell
 # These are equivalent when data comes from a pipe
@@ -168,9 +168,9 @@ echo "hello" | grep "hello"
 echo "hello" | grep "hello" -
 ```
 
-Similarly, every program has two output streams: stdout and stderr.
-The standard output is the one most commonly encountered and it is the one that is used for piping the output of the program to the next command in the pipeline.
-The standard error is an alternative stream that is intended for programs to report warnings and other types of issues, without that output getting parsed by the next command in the chain.
+Demikian pula, setiap program memiliki dua output stream: stdout dan stderr.
+Standard output adalah yang paling sering ditemui dan digunakan untuk men-piping output program ke perintah berikutnya dalam pipeline.
+Standard error adalah stream alternatif yang ditujukan bagi program untuk melaporkan peringatan dan jenis masalah lainnya, tanpa output tersebut diurai oleh perintah berikutnya dalam rantai.
 
 ```console
 $ ls /nonexistent
@@ -182,7 +182,7 @@ $ ls /nonexistent 2>/dev/null
 # No output - stderr was redirected to /dev/null
 ```
 
-The shell provides syntax for redirecting these streams. Here are some illustrative examples.
+Shell menyediakan sintaks untuk me-redirect stream ini. Berikut beberapa contoh ilustratif.
 
 ```shell
 # Redirect stdout to a file (overwrite)
@@ -204,26 +204,26 @@ grep "pattern" < input.txt
 cmd > /dev/null 2>&1
 ```
 
-Another powerful tool that exemplifies the Unix philosophy is [`fzf`](https://github.com/junegunn/fzf), a fuzzy finder. It reads lines from stdin and provides an interactive interface to filter and select:
+Alat canggih lainnya yang mencerminkan filosofi Unix adalah [`fzf`](https://github.com/junegunn/fzf), sebuah fuzzy finder. Program ini membaca baris dari stdin dan menyediakan antarmuka interaktif untuk memfilter dan memilih:
 
 ```console
 $ ls | fzf
 $ cat ~/.bash_history | fzf
 ```
 
-`fzf` can be integrated with many shell operations. We'll see more uses of it when we discuss shell customization.
+`fzf` dapat diintegrasikan dengan banyak operasi shell. Kita akan melihat lebih banyak penggunaannya ketika membahas kustomisasi shell.
 
 
 ## Environment variables
 
-To assign variables in bash we use the syntax `foo=bar`, and then access the value of the variable with the `$foo` syntax.
-Note that `foo = bar` is invalid syntax as the shell will parse it as calling the program `foo` with arguments `['=', 'bar']`.
-In shell scripting the role of the space character is to perform argument splitting.
-This behavior can be confusing and tricky to get used to, so keep it in mind.
+Untuk menetapkan variabel di bash kita menggunakan sintaks `foo=bar`, dan kemudian mengakses nilai variabel tersebut dengan sintaks `$foo`.
+Perhatikan bahwa `foo = bar` adalah sintaks yang tidak valid karena shell akan mengurainya sebagai memanggil program `foo` dengan arguments `['=', 'bar']`.
+Dalam shell scripting, peran karakter spasi adalah untuk melakukan pemisahan arguments.
+Perilaku ini bisa membingungkan dan butuh waktu untuk membiasakan diri, jadi ingatlah hal ini.
 
-Shell variables do not have types, they are all strings.
-Note that when writing string expressions in the shell single and double quotes are not interchangeable.
-Strings delimited with `'` are literal strings and will not expand variables, perform command substitution, or process escape sequences, whereas `"` delimited strings will.
+Variabel shell tidak memiliki tipe, semuanya adalah string.
+Perhatikan bahwa ketika menulis ekspresi string di shell, tanda kutip tunggal dan ganda tidak dapat dipertukarkan.
+String yang dibatasi dengan `'` adalah string literal dan tidak akan meng-expand variabel, melakukan substitusi perintah, atau memproses escape sequence, sedangkan string yang dibatasi dengan `"` akan melakukannya.
 
 ```shell
 foo=bar
@@ -233,32 +233,32 @@ echo '$foo'
 # prints $foo
 ```
 
-To capture the output of a command into a variable we use _command substitution_.
-When we execute
+Untuk menangkap output perintah ke dalam variabel kita menggunakan _command substitution_.
+Ketika kita menjalankan
 ```shell
 files=$(ls)
 echo "$files" | grep README
 echo "$files" | grep ".py"
 ```
-the output (concretely the stdout) of ls is placed into the variable `$files` which we can access later.
-The content of the `$files` variable does include the newlines from the ls output, which is how programs like `grep` know to operate on each item independently.
+output (secara konkret stdout) dari ls ditempatkan ke dalam variabel `$files` yang bisa kita akses nanti.
+Isi variabel `$files` memang menyertakan newline dari output ls, yang menjadi cara program seperti `grep` tahu untuk mengoperasikan setiap item secara independen.
 
-A lesser known similar feature is _process substitution_, `<( CMD )` will execute `CMD` and place the output in a temporary file and substitute the `<()` with that file's name.
-This is useful when commands expect values to be passed by file instead of by STDIN.
-For example, `diff <(ls src) <(ls docs)` will show differences between files in dirs `src` and `docs`.
+Fitur serupa yang kurang dikenal adalah _process substitution_, `<( CMD )` akan menjalankan `CMD` dan menempatkan outputnya di file sementara serta mengganti `<()` dengan nama file tersebut.
+Ini berguna ketika perintah mengharapkan nilai diberikan melalui file bukan melalui STDIN.
+Sebagai contoh, `diff <(ls src) <(ls docs)` akan menunjukkan perbedaan antara file di direktori `src` dan `docs`.
 
-Whenever a shell program calls another program it passes along a set of variables that are often referred to as _environment variables_.
-From within a shell we can find the current environment variables by running `printenv`.
-To pass an environment variable explicitly we can prepend a command with a variable assignment
+Setiap kali program shell memanggil program lain, ia meneruskan sekumpulan variabel yang sering disebut sebagai _environment variables_.
+Dari dalam shell kita bisa mengetahui variabel environment saat ini dengan menjalankan `printenv`.
+Untuk meneruskan environment variable secara eksplisit kita bisa menambahkan assignment variabel sebelum perintah
 
-> Environment variables are conventionally written in ALL_CAPS (e.g., `HOME`, `PATH`, `DEBUG`). This is a convention, not a technical requirement, but following it helps distinguish environment variables from local shell variables which are typically lowercase.
+> Environment variables secara konvensi ditulis dalam ALL_CAPS (misalnya, `HOME`, `PATH`, `DEBUG`). Ini adalah konvensi, bukan persyaratan teknis, tetapi mengikutinya membantu membedakan environment variables dari variabel shell lokal yang biasanya menggunakan huruf kecil.
 
 ```shell
 TZ=Asia/Tokyo date  # prints the current time in Tokyo
 echo $TZ  # this will be empty, since TZ was only set for the child command
 ```
 
-Alternatively, we can use the `export` built-in function that will modify our current environment and thus all child processes will inherit the variable:
+Sebagai alternatif, kita bisa menggunakan fungsi built-in `export` yang akan memodifikasi environment saat ini sehingga semua child process akan mewarisi variabel tersebut:
 
 ```shell
 export DEBUG=1
@@ -267,23 +267,23 @@ bash -c 'echo $DEBUG'
 # prints 1
 ```
 
-To delete a variable use the `unset` built-in command, e.g. `unset DEBUG`.
+Untuk menghapus variabel gunakan perintah built-in `unset`, misalnya `unset DEBUG`.
 
-> Environment variables are another shell convention. They can be used to modify the behavior of many programs implicitly rather than explicitly. For example, the shell sets the `$HOME` environment variable with the path of the home folder of the current user. Then programs can access this variable to get this information instead of requiring an explicit `--home /home/alice`. Another common example is `$TZ`, which many programs use to format dates and times according to the specified timezone.
+> Environment variables adalah konvensi shell lainnya. Mereka dapat digunakan untuk memodifikasi perilaku banyak program secara implisit daripada eksplisit. Misalnya, shell menetapkan variabel environment `$HOME` dengan path folder home pengguna saat ini. Kemudian program dapat mengakses variabel ini untuk mendapatkan informasi tersebut alih-alih memerlukan `--home /home/alice` secara eksplisit. Contoh umum lainnya adalah `$TZ`, yang digunakan banyak program untuk memformat tanggal dan waktu sesuai zona waktu yang ditentukan.
 
 ## Return codes
 
-As we saw earlier, the main output of a shell program is conveyed through the stdout/stderr streams and filesystem side effects.
+Seperti yang kita lihat sebelumnya, output utama dari program shell disampaikan melalui stream stdout/stderr dan efek samping filesystem.
 
-By default a shell script will return exit code zero.
-The convention is that zero means everything went well whereas nonzero means some issues were encountered.
-To return a nonzero exit code we have to use the `exit NUM` shell built-in.
-We can access the return code of the last command that was run by accessing the special variable `$?`.
+Secara default script shell akan mengembalikan exit code nol.
+Konvensinya adalah nol berarti semuanya berjalan baik sedangkan bukan-nol berarti ada masalah yang ditemui.
+Untuk mengembalikan exit code bukan-nol kita harus menggunakan built-in shell `exit NUM`.
+Kita dapat mengakses return code dari perintah terakhir yang dijalankan dengan mengakses variabel khusus `$?`.
 
-The shell has boolean operators `&&` and `||` for performing AND and OR operations respectively.
-Unlike those encountered in regular programming languages, the ones in the shell operate on the return code of programs.
-Both of these are [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation) operators.
-This means that they can be used to conditionally run commands based on the success or failure of previous commands, where success is determined based on whether the return code is zero or not. Some examples:
+Shell memiliki operator boolean `&&` dan `||` untuk melakukan operasi AND dan OR.
+Berbeda dengan yang ditemui di bahasa pemrograman biasa, yang di shell beroperasi pada return code program.
+Keduanya adalah operator [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation).
+Ini berarti keduanya dapat digunakan untuk menjalankan perintah secara kondisional berdasarkan keberhasilan atau kegagalan perintah sebelumnya, di mana keberhasilan ditentukan berdasarkan apakah return code-nya nol atau bukan. Beberapa contoh:
 
 ```shell
 # echo will only run if grep succeeds (finds a match)
@@ -299,7 +299,7 @@ true && echo "This will always print"
 false || echo "This will always print"
 ```
 
-The same principle applies to `if` and `while` statements, they both use return codes to make decisions:
+Prinsip yang sama berlaku untuk pernyataan `if` dan `while`, keduanya menggunakan return code untuk membuat keputusan:
 
 ```shell
 # if uses the return code of the condition command (0 = true, nonzero = false)
@@ -315,9 +315,9 @@ done < file.txt
 
 ## Signals
 
-In some cases you will need to interrupt a program while it is executing, for instance if a command is taking too long to complete.
-The simplest way to interrupt a program is to press `Ctrl-C` and the command will probably stop.
-But how does this actually work and why does it sometimes fail to stop the process?
+Dalam beberapa kasus Anda perlu menginterupsi program saat sedang berjalan, misalnya jika sebuah perintah membutuhkan waktu terlalu lama untuk selesai.
+Cara paling sederhana untuk menginterupsi program adalah dengan menekan `Ctrl-C` dan perintah tersebut kemungkinan akan berhenti.
+Tetapi bagaimana sebenarnya cara kerjanya dan mengapa terkadang gagal menghentikan proses?
 
 ```console
 $ sleep 100
@@ -325,21 +325,21 @@ $ sleep 100
 $
 ```
 
-> Note, here `^C` is how `Ctrl-C` is displayed when typed in the terminal.
+> Perhatikan, di sini `^C` adalah cara `Ctrl-C` ditampilkan saat diketik di terminal.
 
-Under the hood, what happened here is the following:
+Di balik layar, yang terjadi adalah sebagai berikut:
 
-1. We pressed `Ctrl-C`
-2. The shell identified the special combination of characters
-3. The shell process sent a SIGINT signal to the `sleep` process
-4. The signal interrupted the execution of the `sleep` process
+1. Kita menekan `Ctrl-C`
+2. Shell mengidentifikasi kombinasi karakter khusus
+3. Proses shell mengirimkan sinyal SIGINT ke proses `sleep`
+4. Sinyal tersebut menginterupsi eksekusi proses `sleep`
 
-Signals are a special communication mechanism.
-When a process receives a signal it stops its execution, deals with the signal and potentially changes the flow of execution based on the information that the signal delivered. For this reason, signals are _software interrupts_.
+Signals adalah mekanisme komunikasi khusus.
+Ketika sebuah proses menerima sinyal, ia menghentikan eksekusinya, menangani sinyal tersebut dan mungkin mengubah alur eksekusi berdasarkan informasi yang disampaikan sinyal. Karena alasan ini, signals disebut _software interrupts_.
 
 
-In our case, when typing `Ctrl-C` this prompts the shell to deliver a `SIGINT` signal to the process.
-Here's a minimal example of a Python program that captures `SIGINT` and ignores it, no longer stopping. To kill this program we can now use the `SIGQUIT` signal instead, by typing `Ctrl-\`.
+Dalam kasus kita, ketika mengetik `Ctrl-C` ini memicu shell untuk mengirimkan sinyal `SIGINT` ke proses.
+Berikut contoh minimal program Python yang menangkap `SIGINT` dan mengabaikannya, sehingga tidak lagi berhenti. Untuk mematikan program ini kita bisa menggunakan sinyal `SIGQUIT` sebagai gantinya, dengan mengetik `Ctrl-\`.
 
 ```python
 #!/usr/bin/env python
@@ -356,7 +356,7 @@ while True:
     i += 1
 ```
 
-Here's what happens if we send `SIGINT` twice to this program, followed by `SIGQUIT`. Note that `^` is how `Ctrl` is displayed when typed in the terminal.
+Berikut yang terjadi jika kita mengirimkan `SIGINT` dua kali ke program ini, diikuti oleh `SIGQUIT`. Perhatikan bahwa `^` adalah cara `Ctrl` ditampilkan saat diketik di terminal.
 
 ```console
 $ python sigint.py
@@ -367,25 +367,25 @@ I got a SIGINT, but I am not stopping
 30^\[1]    39913 quit       python sigint.py
 ```
 
-While `SIGINT` and `SIGQUIT` are both usually associated with terminal related requests, a more generic signal for asking a process to exit gracefully is the `SIGTERM` signal.
-To send this signal we can use the [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html) command, with the syntax `kill -TERM <PID>`.
+Sementara `SIGINT` dan `SIGQUIT` keduanya biasanya terkait dengan permintaan terminal, sinyal yang lebih umum untuk meminta proses keluar secara graceful adalah sinyal `SIGTERM`.
+Untuk mengirimkan sinyal ini kita bisa menggunakan perintah [`kill`](https://www.man7.org/linux/man-pages/man1/kill.1.html), dengan sintaks `kill -TERM <PID>`.
 
-Signals can do other things beyond killing a process. For instance, `SIGSTOP` pauses a process. In the terminal, typing `Ctrl-Z` will prompt the shell to send a `SIGTSTP` signal, short for Terminal Stop (i.e. the terminal's version of `SIGSTOP`).
+Signals dapat melakukan hal lain selain menghentikan proses. Misalnya, `SIGSTOP` menjeda proses. Di terminal, mengetik `Ctrl-Z` akan memicu shell mengirimkan sinyal `SIGTSTP`, singkatan dari Terminal Stop (yaitu versi `SIGSTOP` milik terminal).
 
-We can then continue the paused job in the foreground or in the background using [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) or [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), respectively.
+Kita kemudian bisa melanjutkan job yang dijeda di foreground atau background menggunakan [`fg`](https://www.man7.org/linux/man-pages/man1/fg.1p.html) atau [`bg`](https://man7.org/linux/man-pages/man1/bg.1p.html), masing-masing.
 
-The [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) command lists the unfinished jobs associated with the current terminal session.
-You can refer to those jobs using their pid (you can use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find that out).
-More intuitively, you can also refer to a process using the percent symbol followed by its job number (displayed by `jobs`). To refer to the last backgrounded job you can use the `$!` special parameter.
+Perintah [`jobs`](https://www.man7.org/linux/man-pages/man1/jobs.1p.html) menampilkan daftar job yang belum selesai yang terkait dengan sesi terminal saat ini.
+Anda dapat merujuk ke job tersebut menggunakan pid mereka (Anda bisa menggunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk mengetahuinya).
+Secara lebih intuitif, Anda juga bisa merujuk ke proses menggunakan simbol persen diikuti nomor job-nya (ditampilkan oleh `jobs`). Untuk merujuk ke job background terakhir Anda bisa menggunakan parameter khusus `$!`.
 
-One more thing to know is that the `&` suffix in a command will run the command in the background, giving you the prompt back, although it will still use the shell's STDOUT which can be annoying (use shell redirections in that case). Equivalently, to background an already running program you can do `Ctrl-Z` followed by `bg`.
+Satu hal lagi yang perlu diketahui adalah bahwa sufiks `&` dalam perintah akan menjalankan perintah di background, memberikan Anda prompt kembali, meskipun tetap menggunakan STDOUT shell yang bisa mengganggu (gunakan shell redirections dalam kasus tersebut). Demikian pula, untuk memindahkan program yang sedang berjalan ke background Anda bisa melakukan `Ctrl-Z` diikuti `bg`.
 
 
-Note that backgrounded processes are still children processes of your terminal and will die if you close the terminal (this will send yet another signal, `SIGHUP`).
-To prevent that from happening you can run the program with [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (a wrapper to ignore `SIGHUP`), or use `disown` if the process has already been started.
-Alternatively, you can use a terminal multiplexer as we will see in the next section.
+Perhatikan bahwa proses background tetap merupakan child process dari terminal Anda dan akan mati jika Anda menutup terminal (ini akan mengirimkan sinyal lainnya, yaitu `SIGHUP`).
+Untuk mencegah hal itu terjadi Anda bisa menjalankan program dengan [`nohup`](https://www.man7.org/linux/man-pages/man1/nohup.1.html) (wrapper untuk mengabaikan `SIGHUP`), atau gunakan `disown` jika proses sudah dijalankan.
+Sebagai alternatif, Anda bisa menggunakan terminal multiplexer seperti yang akan kita lihat di bagian berikutnya.
 
-Below is a sample session to showcase some of these concepts.
+Berikut adalah contoh sesi untuk mendemonstrasikan beberapa konsep ini.
 
 ```
 $ sleep 1000
@@ -412,11 +412,11 @@ $ kill %2
 [2]  + 18745 terminated  nohup sleep 2000
 ```
 
-A special signal is `SIGKILL` since it cannot be captured by the process and it will always terminate it immediately. However, it can have bad side effects such as leaving orphaned children processes.
+Sinyal khusus adalah `SIGKILL` karena tidak bisa ditangkap oleh proses dan akan selalu menghentikannya secara langsung. Namun, bisa memiliki efek samping yang buruk seperti meninggalkan child process yang yatim.
 
-You can learn more about these and other signals [here](https://en.wikipedia.org/wiki/Signal_(IPC)) or typing [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) or `kill -l`.
+Anda dapat mempelajari lebih lanjut tentang sinyal-sinyal ini dan lainnya [di sini](https://en.wikipedia.org/wiki/Signal_(IPC)) atau dengan mengetik [`man signal`](https://www.man7.org/linux/man-pages/man7/signal.7.html) atau `kill -l`.
 
-Within shell scripts, you can use the `trap` built-in to execute commands when signals are received. This is useful for cleanup operations:
+Di dalam shell script, Anda bisa menggunakan built-in `trap` untuk menjalankan perintah ketika sinyal diterima. Ini berguna untuk operasi pembersihan:
 
 ```shell
 #!/usr/bin/env bash
@@ -492,15 +492,15 @@ So far we've focused on your local machine, but many of these skills become even
 
 # Remote Machines
 
-It has become more and more common for programmers to work with remote servers in their everyday work. The most common tool for the job here is SSH (Secure Shell) which will help us connect to a remote server and provide the now familiar shell interface. We connect to a server with a command like:
+Semakin umum bagi programmer untuk bekerja dengan server remote dalam pekerjaan sehari-hari. Alat yang paling umum untuk tugas ini adalah SSH (Secure Shell) yang akan membantu kita terhubung ke server remote dan menyediakan antarmuka shell yang sudah familiar. Kita terhubung ke server dengan perintah seperti:
 
 ```bash
 ssh alice@server.mit.edu
 ```
 
-Here we are trying to ssh as user `alice` in server `server.mit.edu`.
+Di sini kita mencoba ssh sebagai user `alice` di server `server.mit.edu`.
 
-An often overlooked feature of `ssh` is the ability to run commands non-interactively. `ssh` correctly handles sending the stdin and receiving the stdout of the command, so we can combine it with other commands
+Fitur `ssh` yang sering diabaikan adalah kemampuan untuk menjalankan perintah secara non-interaktif. `ssh` menangani pengiriman stdin dan penerimaan stdout dari perintah dengan benar, sehingga kita bisa menggabungkannya dengan perintah lain
 
 ```shell
 # here ls runs in the remote, and wc runs locally
@@ -511,22 +511,22 @@ ssh alice@server 'ls | wc -l'
 
 ```
 
-> Try installing [Mosh](https://mosh.org/) as a SSH replacement that can handle disconnections, entering/exiting sleep, changing networks and dealing with high latency links.
+> Cobalah menginstal [Mosh](https://mosh.org/) sebagai pengganti SSH yang dapat menangani diskoneksi, masuk/keluar sleep, berpindah jaringan dan menangani link dengan latensi tinggi.
 
-For `ssh` to let us run commands in the remote server we need to prove that we are authorized to do so.
-We can do this via passwords or ssh keys.
-Key-based authentication utilizes public-key cryptography to prove to the server that the client owns the secret private key without revealing the key.
-Key based authentication is both more convenient and more secure, so you should prefer it.
-Note that the private key (often `~/.ssh/id_rsa` and more recently `~/.ssh/id_ed25519`) is effectively your password, so treat it like so and never share its contents.
+Agar `ssh` mengizinkan kita menjalankan perintah di server remote, kita perlu membuktikan bahwa kita berwenang melakukannya.
+Kita bisa melakukannya melalui password atau ssh key.
+Autentikasi berbasis key menggunakan kriptografi public-key untuk membuktikan kepada server bahwa klien memiliki private key rahasia tanpa mengungkap key tersebut.
+Autentikasi berbasis key lebih nyaman dan lebih aman, jadi Anda sebaiknya menggunakannya.
+Perhatikan bahwa private key (biasanya `~/.ssh/id_rsa` dan yang lebih baru `~/.ssh/id_ed25519`) secara efektif adalah password Anda, jadi perlakukan seperti itu dan jangan pernah membagikan isinya.
 
-To generate a pair you can run [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
+Untuk menghasilkan pasangan key Anda bisa menjalankan [`ssh-keygen`](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html).
 ```bash
 ssh-keygen -a 100 -t ed25519 -f ~/.ssh/id_ed25519
 ```
 
-If you have ever configured pushing to GitHub using SSH keys, then you have probably done the steps outlined [here](https://help.github.com/articles/connecting-to-github-with-ssh/) and have a valid key pair already. To check if you have a passphrase and validate it you can run `ssh-keygen -y -f /path/to/key`.
+Jika Anda pernah mengonfigurasi push ke GitHub menggunakan SSH key, maka Anda mungkin sudah melakukan langkah-langkah yang diuraikan [di sini](https://help.github.com/articles/connecting-to-github-with-ssh/) dan sudah memiliki pasangan key yang valid. Untuk memeriksa apakah Anda memiliki passphrase dan memvalidasinya Anda bisa menjalankan `ssh-keygen -y -f /path/to/key`.
 
-At the server side `ssh` will look into `.ssh/authorized_keys` to determine which clients it should let in. To copy a public key over you can use:
+Di sisi server `ssh` akan melihat `.ssh/authorized_keys` untuk menentukan klien mana yang seharusnya diizinkan masuk. Untuk menyalin public key Anda bisa menggunakan:
 
 ```bash
 cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
@@ -536,9 +536,9 @@ cat .ssh/id_ed25519.pub | ssh alice@remote 'cat >> ~/.ssh/authorized_keys'
 ssh-copy-id -i .ssh/id_ed25519 alice@remote
 ```
 
-Beyond running commands, the connection that ssh establishes can be used to transfer files from and to the server securely. [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) is the most traditional tool and the syntax is `scp path/to/local_file remote_host:path/to/remote_file`. [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) improves upon `scp` by detecting identical files in local and remote, and preventing copying them again. It also provides more fine grained control over symlinks, permissions and has extra features like the `--partial` flag that can resume from a previously interrupted copy. `rsync` has a similar syntax to `scp`.
+Selain menjalankan perintah, koneksi yang dibangun ssh dapat digunakan untuk mentransfer file dari dan ke server secara aman. [`scp`](https://www.man7.org/linux/man-pages/man1/scp.1.html) adalah alat yang paling tradisional dan sintaksnya adalah `scp path/to/local_file remote_host:path/to/remote_file`. [`rsync`](https://www.man7.org/linux/man-pages/man1/rsync.1.html) meningkatkan `scp` dengan mendeteksi file yang identik di lokal dan remote, serta mencegah penyalinan ulang. Ini juga memberikan kontrol yang lebih detail atas symlink, permission, dan memiliki fitur tambahan seperti flag `--partial` yang dapat melanjutkan salinan yang sebelumnya terinterupsi. `rsync` memiliki sintaks yang mirip dengan `scp`.
 
-SSH client configuration is located at `~/.ssh/config` and it lets us declare hosts and set default settings for them. This configuration file is not just read by `ssh` but also other programs like `scp`, `rsync`, `mosh`, &c.
+Konfigurasi klien SSH terletak di `~/.ssh/config` dan memungkinkan kita mendeklarasikan host serta menetapkan pengaturan default untuk mereka. File konfigurasi ini tidak hanya dibaca oleh `ssh` tetapi juga program lain seperti `scp`, `rsync`, `mosh`, &c.
 
 ```bash
 Host vm
@@ -557,78 +557,77 @@ Host *.mit.edu
 
 # Terminal Multiplexers
 
-When using the command line interface you will often want to run more than one thing at once.
-For instance, you might want to run your editor and your program side by side.
-Although this can be achieved by opening new terminal windows, using a terminal multiplexer is a more versatile solution.
+Ketika menggunakan command-line interface Anda sering kali ingin menjalankan lebih dari satu hal secara bersamaan.
+Misalnya, Anda mungkin ingin menjalankan editor dan program Anda secara berdampingan.
+Meskipun ini bisa dicapai dengan membuka jendela terminal baru, menggunakan terminal multiplexer adalah solusi yang lebih fleksibel.
 
-Terminal multiplexers like [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) allow you to multiplex terminal windows using panes and tabs so you can interact with multiple shell sessions in an efficient manner.
-Moreover, terminal multiplexers let you detach a current terminal session and reattach at some point later in time.
-Because of this, terminal multiplexers are really convenient when working with remote machines, as it avoids the need to use `nohup` and similar tricks.
+Terminal multiplexer seperti [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html) memungkinkan Anda melakukan multiplex jendela terminal menggunakan pane dan tab sehingga Anda bisa berinteraksi dengan beberapa sesi shell secara efisien.
+Selain itu, terminal multiplexer memungkinkan Anda melepas sesi terminal saat ini dan menghubungkannya kembali di kemudian waktu.
+Karena alasan ini, terminal multiplexer sangat nyaman ketika bekerja dengan mesin remote, karena menghindari kebutuhan menggunakan `nohup` dan trik serupa.
 
-The most popular terminal multiplexer these days is [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` is highly configurable and by using the associated keybindings you can create multiple tabs and panes and quickly navigate through them.
+Terminal multiplexer yang paling populer saat ini adalah [`tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html). `tmux` sangat dapat dikonfigurasi dan dengan menggunakan keybinding yang terkait Anda bisa membuat beberapa tab dan pane serta menavigasi dengan cepat di antaranya.
 
-`tmux` expects you to know its keybindings, and they all have the form `<C-b> x` where that means (1) press `Ctrl+b`, (2) release `Ctrl+b`, and then (3) press `x`. `tmux` has the following hierarchy of objects:
-- **Sessions** - a session is an independent workspace with one or more windows
-    + `tmux` starts a new session.
-    + `tmux new -s NAME` starts it with that name.
-    + `tmux ls` lists the current sessions
-    + Within `tmux` typing `<C-b> d`  detaches the current session
-    + `tmux a` attaches the last session. You can use `-t` flag to specify which
+`tmux` mengharapkan Anda mengetahui keybinding-nya, dan semuanya memiliki bentuk `<C-b> x` yang berarti (1) tekan `Ctrl+b`, (2) lepaskan `Ctrl+b`, lalu (3) tekan `x`. `tmux` memiliki hierarki objek berikut:
+- **Sessions** - session adalah workspace independen dengan satu atau lebih window
+    + `tmux` memulai session baru.
+    + `tmux new -s NAME` memulainya dengan nama tersebut.
+    + `tmux ls` menampilkan daftar session saat ini
+    + Di dalam `tmux` mengetik `<C-b> d`  melepaskan session saat ini
+    + `tmux a` menghubungkan session terakhir. Anda bisa menggunakan flag `-t` untuk menentukan yang mana
 
-- **Windows** - Equivalent to tabs in editors or browsers, they are visually separate parts of the same session
-    + `<C-b> c` Creates a new window. To close it you can just terminate the shells doing `<C-d>`
-    + `<C-b> N` Go to the _N_ th window. Note they are numbered
-    + `<C-b> p` Goes to the previous window
-    + `<C-b> n` Goes to the next window
-    + `<C-b> ,` Rename the current window
-    + `<C-b> w` List current windows
+- **Windows** - Setara dengan tab di editor atau browser, mereka adalah bagian yang terpisah secara visual dalam session yang sama
+    + `<C-b> c` Membuat window baru. Untuk menutupnya Anda cukup menghentikan shell dengan `<C-d>`
+    + `<C-b> N` Pergi ke window ke-_N_. Perhatikan mereka diberi nomor
+    + `<C-b> p` Pergi ke window sebelumnya
+    + `<C-b> n` Pergi ke window berikutnya
+    + `<C-b> ,` Mengubah nama window saat ini
+    + `<C-b> w` Menampilkan daftar window saat ini
 
-- **Panes** - Like vim splits, panes let you have multiple shells in the same visual display.
-    + `<C-b> "` Split the current pane horizontally
-    + `<C-b> %` Split the current pane vertically
-    + `<C-b> <direction>` Move to the pane in the specified _direction_. Direction here means arrow keys.
-    + `<C-b> z` Toggle zoom for the current pane
-    + `<C-b> [` Start scrollback. You can then press `<space>` to start a selection and `<enter>` to copy that selection.
-    + `<C-b> <space>` Cycle through pane arrangements.
+- **Panes** - Seperti split di vim, pane memungkinkan Anda memiliki beberapa shell dalam tampilan visual yang sama.
+    + `<C-b> "` Membelah pane saat ini secara horizontal
+    + `<C-b> %` Membelah pane saat ini secara vertikal
+    + `<C-b> <direction>` Pindah ke pane di _direction_ yang ditentukan. Direction di sini berarti tombol panah.
+    + `<C-b> z` Toggle zoom untuk pane saat ini
+    + `<C-b> [` Memulai scrollback. Anda kemudian bisa menekan `<space>` untuk memulai seleksi dan `<enter>` untuk menyalin seleksi tersebut.
+    + `<C-b> <space>` Berpindah melalui susunan pane.
 
-> To learn more about tmux, consider reading [this](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) quick tutorial and [this](https://linuxcommand.org/lc3_adv_termmux.php) more detailed explanation.
+> Untuk mempelajari lebih lanjut tentang tmux, pertimbangkan untuk membaca tutorial singkat [ini](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) dan penjelasan lebih detail [ini](https://linuxcommand.org/lc3_adv_termmux.php).
 
-With tmux and SSH in your toolkit, you'll want to make your environment feel like home on any machine. That's where shell customization comes in.
+Dengan tmux dan SSH dalam toolkit Anda, Anda ingin membuat lingkungan Anda terasa seperti di rumah di mesin mana pun. Di situlah kustomisasi shell berperan.
 
 # Customizing the Shell
 
-A wide array of command line programs are configured using plain-text files known as _dotfiles_
-(because the file names begin with a `.`, e.g. `~/.vimrc`, so that they are
-hidden in the directory listing `ls` by default).
+Sejumlah besar program command-line dikonfigurasi menggunakan file teks biasa yang dikenal sebagai _dotfiles_
+(karena nama file dimulai dengan `.`, misalnya `~/.vimrc`, sehingga mereka tersembunyi dalam daftar direktori `ls` secara default).
 
-> Dotfiles are yet another shell convention. The dot in the front is to "hide" them when listing (yes, another convention).
+> Dotfiles adalah konvensi shell lainnya. Titik di depan adalah untuk "menyembunyikan" mereka saat melakukan listing (ya, konvensi lainnya).
 
-Shells are one example of programs configured with such files. On startup, your shell will read many files to load its configuration.
-Depending on the shell and whether you are starting a login and/or interactive session, the entire process can be quite complex.
-[Here](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) is an excellent resource on the topic.
+Shell adalah salah satu contoh program yang dikonfigurasi dengan file tersebut. Saat startup, shell Anda akan membaca banyak file untuk memuat konfigurasinya.
+Tergantung pada shell dan apakah Anda memulai sesi login dan/atau interaktif, seluruh prosesnya bisa cukup kompleks.
+[Di sini](https://web.archive.org/web/20260329133158/https://blog.flowblok.id.au/2013-02/shell-startup-scripts.html) adalah sumber daya yang sangat bagus tentang topik ini.
 
-For `bash`, editing your `.bashrc` or `.bash_profile` will work in most systems.
-Some other examples of tools that can be configured through dotfiles are:
+Untuk `bash`, mengedit `.bashrc` atau `.bash_profile` Anda akan berfungsi di sebagian besar sistem.
+Beberapa contoh lain alat yang dapat dikonfigurasi melalui dotfiles adalah:
 
 - `bash` - `~/.bashrc`, `~/.bash_profile`
 - `git` - `~/.gitconfig`
-- `vim` - `~/.vimrc` and the `~/.vim` folder
+- `vim` - `~/.vimrc` dan folder `~/.vim`
 - `ssh` - `~/.ssh/config`
 - `tmux` - `~/.tmux.conf`
 
-A common configuration change is adding new locations for the shell to find programs. You will encounter this pattern when installing software:
+Perubahan konfigurasi yang umum adalah menambahkan lokasi baru bagi shell untuk menemukan program. Anda akan menemui pola ini saat menginstal perangkat lunak:
 
 ```shell
 export PATH="$PATH:path/to/append"
 ```
 
-Here, we are telling the shell to set the value of the $PATH variable to its current value plus a new path, and have all children processes inherit this new value for PATH.
-This will allow children processes to find programs located under `path/to/append`.
+Di sini, kita memberitahu shell untuk menetapkan nilai variabel $PATH ke nilai saat ini ditambah path baru, dan membuat semua child process mewarisi nilai PATH yang baru ini.
+Ini akan memungkinkan child process menemukan program yang terletak di `path/to/append`.
 
 
-Customizing your shell often means installing new command-line tools. Package managers make this easy. They handle downloading, installing, and updating software. Different operating systems have different package managers: macOS uses [Homebrew](https://brew.sh/), Ubuntu/Debian use `apt`, Fedora uses `dnf`, and Arch uses `pacman`. We'll cover package managers in more depth in the shipping code lecture.
+Mengkustomisasi shell sering berarti menginstal alat command-line baru. Package manager memudahkan hal ini. Mereka menangani pengunduhan, penginstalan, dan pembaruan perangkat lunak. Sistem operasi yang berbeda memiliki package manager yang berbeda: macOS menggunakan [Homebrew](https://brew.sh/), Ubuntu/Debian menggunakan `apt`, Fedora menggunakan `dnf`, dan Arch menggunakan `pacman`. Kita akan membahas package manager lebih mendalam di kuliah shipping code.
 
-Here's how to install two useful tools using Homebrew on macOS:
+Berikut cara menginstal dua alat berguna menggunakan Homebrew di macOS:
 
 ```shell
 # ripgrep: a faster grep with better defaults
@@ -638,19 +637,19 @@ brew install ripgrep
 brew install fd
 ```
 
-With these installed, you can use `rg` instead of `grep` and `fd` instead of `find`.
+Dengan ini terinstal, Anda bisa menggunakan `rg` sebagai pengganti `grep` dan `fd` sebagai pengganti `find`.
 
-> **Warning about `curl | bash`**: You'll often see installation instructions like `curl -fsSL https://example.com/install.sh | bash`. This pattern downloads a script and immediately executes it, which is convenient but risky; you're running code you haven't inspected. A safer approach is to download first, review, then execute:
+> **Peringatan tentang `curl | bash`**: Anda sering akan melihat instruksi instalasi seperti `curl -fsSL https://example.com/install.sh | bash`. Pola ini mengunduh script dan langsung menjalankannya, yang nyaman tetapi berisiko; Anda menjalankan kode yang belum Anda periksa. Pendekatan yang lebih aman adalah mengunduh terlebih dahulu, meninjau, lalu menjalankan:
 > ```shell
 > curl -fsSL https://example.com/install.sh -o install.sh
 > less install.sh  # review the script
 > bash install.sh
 > ```
-> Some installers use a slightly safer variant: `/bin/bash -c "$(curl -fsSL https://url)"` which at least ensures bash interprets the script rather than your current shell.
+> Beberapa installer menggunakan varian yang sedikit lebih aman: `/bin/bash -c "$(curl -fsSL https://url)"` yang setidaknya memastikan bash menginterpretasikan script tersebut alih-alih shell Anda saat ini.
 
-When you try to run a command that isn't installed, your shell will show `command not found`. The website [command-not-found.com](https://command-not-found.com) is a helpful resource you can use to search for any command to find out how to install it across different package managers and distributions.
+Ketika Anda mencoba menjalankan perintah yang belum terinstal, shell Anda akan menampilkan `command not found`. Situs web [command-not-found.com](https://command-not-found.com) adalah sumber daya berguna yang bisa Anda gunakan untuk mencari perintah apa pun dan menemukan cara menginstalnya di berbagai package manager dan distribusi.
 
-Another useful tool is [`tldr`](https://tldr.sh/), which provides simplified, example-focused man pages. Instead of reading through lengthy documentation, you can quickly see common usage patterns:
+Alat berguna lainnya adalah [`tldr`](https://tldr.sh/), yang menyediakan man page yang disederhanakan dan berfokus pada contoh. Alih-alih membaca dokumentasi yang panjang, Anda bisa dengan cepat melihat pola penggunaan umum:
 
 ```console
 $ tldr fd
@@ -667,19 +666,19 @@ $ tldr fd
       fd --extension txt
 ```
 
-Sometimes you don't need a whole new program, but rather just a shortcut for an existing command with specific flags. That's where aliases come in.
+Terkadang Anda tidak memerlukan program baru sepenuhnya, melainkan hanya shortcut untuk perintah yang sudah ada dengan flags tertentu. Di situlah alias berperan.
 
-We can also create our own command aliases using the `alias` shell built-in.
-A shell alias is a short form for another command that your shell will replace automatically before evaluating the expression.
-For instance, an alias in bash has the following structure:
+Kita juga bisa membuat alias perintah sendiri menggunakan built-in shell `alias`.
+Alias shell adalah bentuk pendek dari perintah lain yang akan diganti secara otomatis oleh shell sebelum mengevaluasi ekspresi.
+Misalnya, alias di bash memiliki struktur berikut:
 
 ```bash
 alias alias_name="command_to_alias arg1 arg2"
 ```
 
-> Note that there is no space around the equal sign `=`, because [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) is a shell command that takes a single argument.
+> Perhatikan bahwa tidak ada spasi di sekitar tanda sama dengan `=`, karena [`alias`](https://www.man7.org/linux/man-pages/man1/alias.1p.html) adalah perintah shell yang menerima satu arguments.
 
-Aliases have many convenient features:
+Alias memiliki banyak fitur yang berguna:
 
 ```bash
 # Make shorthands for common flags
@@ -711,65 +710,65 @@ alias ll
 # Will print ll='ls -lh'
 ```
 
-Aliases have limitations: they cannot take arguments in the middle of a command. For more complex behavior, you should use shell functions instead.
+Alias memiliki keterbatasan: mereka tidak bisa menerima arguments di tengah perintah. Untuk perilaku yang lebih kompleks, Anda sebaiknya menggunakan fungsi shell.
 
-Most shells support `Ctrl-R` for reverse history search. Type `Ctrl-R` and start typing to search through previous commands. Earlier we introduced `fzf` as a fuzzy finder; with fzf's shell integration configured, `Ctrl-R` becomes an interactive fuzzy search through your entire history, far more powerful than the default.
+Sebagian besar shell mendukung `Ctrl-R` untuk pencarian history terbalik. Ketik `Ctrl-R` dan mulai mengetik untuk mencari melalui perintah sebelumnya. Sebelumnya kita memperkenalkan `fzf` sebagai fuzzy finder; dengan integrasi shell fzf yang dikonfigurasi, `Ctrl-R` menjadi pencarian fuzzy interaktif melalui seluruh history Anda, jauh lebih kuat dari default.
 
-How should you organize your dotfiles? They should be in their own folder,
-under version control, and **symlinked** into place using a script. This has
-the benefits of:
+Bagaimana cara mengatur dotfiles Anda? Mereka seharusnya berada di folder tersendiri,
+dalam version control, dan **di-symlink** ke tempatnya menggunakan script. Ini memiliki
+manfaat:
 
-- **Easy installation**: if you log in to a new machine, applying your
-customizations will only take a minute.
-- **Portability**: your tools will work the same way everywhere.
-- **Synchronization**: you can update your dotfiles anywhere and keep them all
-in sync.
-- **Change tracking**: you're probably going to be maintaining your dotfiles
-for your entire programming career, and version history is nice to have for
-long-lived projects.
+- **Instalasi mudah**: jika Anda login ke mesin baru, menerapkan kustomisasi Anda
+hanya membutuhkan satu menit.
+- **Portabilitas**: alat Anda akan bekerja dengan cara yang sama di mana saja.
+- **Sinkronisasi**: Anda bisa memperbarui dotfiles Anda di mana saja dan menjaga semuanya
+tetap sinkron.
+- **Pelacakan perubahan**: Anda mungkin akan memelihara dotfiles Anda
+sepanjang karir pemrograman Anda, dan history versi berguna untuk
+proyek jangka panjang.
 
-What should you put in your dotfiles?
-You can learn about your tool's settings by reading online documentation or
-[man pages](https://en.wikipedia.org/wiki/Man_page). Another great way is to
-search the internet for blog posts about specific programs, where authors will
-tell you about their preferred customizations. Yet another way to learn about
-customizations is to look through other people's dotfiles: you can find tons of
-[dotfiles
-repositories](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
-on GitHub --- see the most popular one
-[here](https://github.com/mathiasbynens/dotfiles) (we advise you not to blindly
-copy configurations though).
-[Here](https://dotfiles.github.io/) is another good resource on the topic.
+Apa yang seharusnya Anda masukkan ke dotfiles Anda?
+Anda bisa mempelajari pengaturan alat Anda dengan membaca dokumentasi online atau
+[man page](https://en.wikipedia.org/wiki/Man_page). Cara hebat lainnya adalah
+mencari di internet postingan blog tentang program tertentu, di mana penulis akan
+memberitahu Anda tentang kustomisasi preferensi mereka. Cara lain untuk mempelajari
+kustomisasi adalah dengan melihat dotfiles orang lain: Anda bisa menemukan banyak
+[repository
+dotfiles](https://github.com/search?o=desc&q=dotfiles&s=stars&type=Repositories)
+di GitHub --- lihat yang paling populer
+[di sini](https://github.com/mathiasbynens/dotfiles) (kami menyarankan Anda untuk tidak
+menyalin konfigurasi secara membabi buta).
+[Di sini](https://dotfiles.github.io/) adalah sumber daya bagus lainnya tentang topik ini.
 
-All of the class instructors have their dotfiles publicly accessible on GitHub: [Anish](https://github.com/anishathalye/dotfiles),
+Semua instruktur kelas memiliki dotfiles mereka yang dapat diakses secara publik di GitHub: [Anish](https://github.com/anishathalye/dotfiles),
 [Jon](https://github.com/jonhoo/configs),
 [Jose](https://github.com/jjgo/dotfiles).
 
-**Frameworks and plugins** can improve your shell as well. Some popular general frameworks are [prezto](https://github.com/sorin-ionescu/prezto) or [oh-my-zsh](https://ohmyz.sh/), and smaller plugins that focus on specific features:
+**Framework dan plugin** dapat meningkatkan shell Anda juga. Beberapa framework umum yang populer adalah [prezto](https://github.com/sorin-ionescu/prezto) atau [oh-my-zsh](https://ohmyz.sh/), dan plugin yang lebih kecil yang berfokus pada fitur tertentu:
 
-- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - colors valid/invalid commands as you type
-- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - suggests commands from history as you type
-- [zsh-completions](https://github.com/zsh-users/zsh-completions) - additional completion definitions
-- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - fish-like history search
-- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - fast, customizable prompt theme
+- [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - mewarnai perintah valid/invalid saat Anda mengetik
+- [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - menyarankan perintah dari history saat Anda mengetik
+- [zsh-completions](https://github.com/zsh-users/zsh-completions) - definisi completion tambahan
+- [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - pencarian history seperti fish
+- [powerlevel10k](https://github.com/romkatv/powerlevel10k) - tema prompt yang cepat dan dapat dikustomisasi
 
-Shells like [fish](https://fishshell.com/) include many of these features by default.
+Shell seperti [fish](https://fishshell.com/) menyertakan banyak fitur ini secara default.
 
-> You don't need a massive framework like oh-my-zsh to get these features. Installing individual plugins is often faster and gives you more control. Large frameworks can significantly slow down shell startup time, so consider installing only what you actually use.
+> Anda tidak memerlukan framework besar seperti oh-my-zsh untuk mendapatkan fitur-fitur ini. Menginstal plugin individual sering kali lebih cepat dan memberi Anda lebih banyak kontrol. Framework besar dapat memperlambat waktu startup shell secara signifikan, jadi pertimbangkan untuk menginstal hanya yang benar-benar Anda gunakan.
 
 
 # AI in the Shell
 
-There are many ways to incorporate AI tooling in the shell. Here are a few examples at different levels of integration:
+Ada banyak cara untuk mengintegrasikan alat AI di shell. Berikut beberapa contoh pada tingkat integrasi yang berbeda:
 
-**Command generation**: Tools like [`simonw/llm`](https://github.com/simonw/llm) can help generate shell commands from natural language descriptions:
+**Command generation**: Alat seperti [`simonw/llm`](https://github.com/simonw/llm) dapat membantu menghasilkan perintah shell dari deskripsi bahasa alami:
 
 ```console
 $ llm cmd "find all python files modified in the last week"
 find . -name "*.py" -mtime -7
 ```
 
-**Pipeline integration**: LLMs can be integrated into shell pipelines to process and transform data. They're particularly useful when you need to extract information from inconsistent formats where regex would be painful:
+**Pipeline integration**: LLM dapat diintegrasikan ke dalam pipeline shell untuk memproses dan mentransformasi data. Mereka sangat berguna ketika Anda perlu mengekstrak informasi dari format yang tidak konsisten di mana regex akan menyakitkan:
 
 ```console
 $ cat users.txt
@@ -789,24 +788,24 @@ mike_wilson
 sarah.connor
 ```
 
-Note how we use `"$INSTRUCTIONS"` (quoted) because the variable contains spaces, and `< users.txt` to redirect the file's content to stdin.
+Perhatikan bagaimana kita menggunakan `"$INSTRUCTIONS"` (dengan tanda kutip) karena variabel mengandung spasi, dan `< users.txt` untuk me-redirect konten file ke stdin.
 
-**AI shells**: Tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) act as a meta-shell that accepts English commands and translates them into shell operations, file edits, and more complex multi-step tasks.
+**AI shells**: Alat seperti [Claude Code](https://docs.anthropic.com/en/docs/claude-code) bertindak sebagai meta-shell yang menerima perintah dalam bahasa Inggris dan menerjemahkannya menjadi operasi shell, edit file, dan tugas multi-langkah yang lebih kompleks.
 
 # Terminal Emulators
 
-Along with customizing your shell, it is worth spending some time figuring out your choice of **terminal emulator** and its settings.
-A terminal emulator is a GUI program that provides the text-based interface where your shell runs.
-There are many terminal emulators out there.
+Selain mengkustomisasi shell Anda, ada baiknya meluangkan waktu untuk memilih **terminal emulator** dan pengaturannya.
+Terminal emulator adalah program GUI yang menyediakan antarmuka berbasis teks tempat shell Anda berjalan.
+Ada banyak terminal emulator di luar sana.
 
-Since you might be spending hundreds to thousands of hours in your terminal it pays off to look into its settings. Some of the aspects that you may want to modify in your terminal include:
+Karena Anda mungkin menghabiskan ratusan hingga ribuan jam di terminal Anda, ada baiknya memperhatikan pengaturannya. Beberapa aspek yang mungkin ingin Anda modifikasi di terminal Anda meliputi:
 
-- Font choice
-- Color Scheme
-- Keyboard shortcuts
-- Tab/Pane support
-- Scrollback configuration
-- Performance (some newer terminals like [Alacritty](https://github.com/alacritty/alacritty) or [Ghostty](https://ghostty.org/) offer GPU acceleration).
+- Pilihan font
+- Skema warna
+- Shortcut keyboard
+- Dukungan Tab/Pane
+- Konfigurasi scrollback
+- Performa (beberapa terminal baru seperti [Alacritty](https://github.com/alacritty/alacritty) atau [Ghostty](https://ghostty.org/) menawarkan akselerasi GPU).
 
 
 
@@ -814,15 +813,15 @@ Since you might be spending hundreds to thousands of hours in your terminal it p
 
 ## Arguments and Globs
 
-1. You might see commands like `cmd --flag -- --notaflag`. The `--` is a special argument that tells the program to stop parsing flags. Everything after `--` is treated as a positional argument. Why might this be useful? Try running `touch -- -myfile` and then removing it without `--`.
+1. Anda mungkin melihat perintah seperti `cmd --flag -- --notaflag`. `--` adalah arguments khusus yang memberitahu program untuk berhenti mengurai flags. Semua yang setelah `--` diperlakukan sebagai positional argument. Mengapa ini berguna? Cobalah menjalankan `touch -- -myfile` dan kemudian menghapusnya tanpa `--`.
 
-1. Read [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) and write an `ls` command that lists files in the following manner:
-    - Includes all files, including hidden files
-    - Sizes are listed in human readable format (e.g. 454M instead of 454279954)
-    - Files are ordered by recency
-    - Output is colorized
+1. Baca [`man ls`](https://www.man7.org/linux/man-pages/man1/ls.1.html) dan tulis perintah `ls` yang menampilkan file dengan cara berikut:
+    - Menyertakan semua file, termasuk file tersembunyi
+    - Ukuran ditampilkan dalam format yang mudah dibaca manusia (misalnya 454M alih-alih 454279954)
+    - File diurutkan berdasarkan terbaru
+    - Output diberi warna
 
-    A sample output would look like this:
+    Contoh output akan terlihat seperti ini:
 
     ```
     -rw-r--r--   1 user group 1.1M Jan 14 09:53 baz
@@ -836,11 +835,11 @@ Since you might be spending hundreds to thousands of hours in your terminal it p
 ls -lath --color=auto
 {% endcomment %}
 
-1. Process substitution `<(command)` lets you use a command's output as if it were a file. Use `diff` with process substitution to compare the output of `printenv` and `export`. Why are they different? (Hint: try `diff <(printenv | sort) <(export | sort)`).
+1. Process substitution `<(command)` memungkinkan Anda menggunakan output perintah seolah-olah itu adalah file. Gunakan `diff` dengan process substitution untuk membandingkan output `printenv` dan `export`. Mengapa mereka berbeda? (Petunjuk: cobalah `diff <(printenv | sort) <(export | sort)`).
 
 ## Environment Variables
 
-1. Write bash functions `marco` and `polo` that do the following: whenever you execute `marco` the current working directory should be saved in some manner, then when you execute `polo`, no matter what directory you are in, `polo` should `cd` you back to the directory where you executed `marco`. For ease of debugging you can write the code in a file `marco.sh` and (re)load the definitions to your shell by executing `source marco.sh`.
+1. Tulis fungsi bash `marco` dan `polo` yang melakukan hal berikut: setiap kali Anda menjalankan `marco` direktori kerja saat ini harus disimpan, kemudian ketika Anda menjalankan `polo`, tidak peduli di direktori mana Anda berada, `polo` harus melakukan `cd` mengembalikan Anda ke direktori tempat Anda menjalankan `marco`. Untuk kemudahan debugging Anda bisa menulis kode di file `marco.sh` dan (memuat ulang) definisi ke shell Anda dengan menjalankan `source marco.sh`.
 
 {% comment %}
 marco() {
@@ -854,7 +853,7 @@ polo() {
 
 ## Return Codes
 
-1. Say you have a command that fails rarely. In order to debug it you need to capture its output but it can be time consuming to get a failure run. Write a bash script that runs the following script until it fails and captures its standard output and error streams to files and prints everything at the end. Bonus points if you can also report how many runs it took for the script to fail.
+1. Misalkan Anda memiliki perintah yang jarang gagal. Untuk men-debug-nya Anda perlu menangkap outputnya tetapi bisa memakan waktu untuk mendapatkan run yang gagal. Tulis script bash yang menjalankan script berikut sampai gagal dan menangkap standard output dan error stream ke file serta mencetak semuanya di akhir. Poin bonus jika Anda juga bisa melaporkan berapa kali run yang diperlukan sampai script gagal.
 
     ```bash
     #!/usr/bin/env bash
@@ -886,45 +885,45 @@ cat out.txt
 
 ## Signals and Job Control
 
-1. Start a `sleep 10000` job in a terminal, background it with `Ctrl-Z` and continue its execution with `bg`. Now use [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) to find its pid and [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) to kill it without ever typing the pid itself. (Hint: use the `-lf` flags).
+1. Jalankan job `sleep 10000` di terminal, pindahkan ke background dengan `Ctrl-Z` dan lanjutkan eksekusinya dengan `bg`. Sekarang gunakan [`pgrep`](https://www.man7.org/linux/man-pages/man1/pgrep.1.html) untuk menemukan pid-nya dan [`pkill`](https://man7.org/linux/man-pages/man1/pgrep.1.html) untuk menghentikannya tanpa pernah mengetik pid itu sendiri. (Petunjuk: gunakan flags `-lf`).
 
-1. Say you don't want to start a process until another completes. How would you go about it? In this exercise, our limiting process will always be `sleep 60 &`. One way to achieve this is to use the [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html) command. Try launching the sleep command and having an `ls` wait until the background process finishes.
+1. Misalkan Anda tidak ingin memulai sebuah proses sampai proses lain selesai. Bagaimana cara melakukannya? Dalam latihan ini, proses pembatas kita akan selalu menjadi `sleep 60 &`. Salah satu cara untuk mencapainya adalah menggunakan perintah [`wait`](https://www.man7.org/linux/man-pages/man1/wait.1p.html). Cobalah meluncurkan perintah sleep dan membuat `ls` menunggu sampai proses background selesai.
 
-    However, this strategy will fail if we start in a different bash session, since `wait` only works for child processes. One feature we did not discuss in the notes is that the `kill` command's exit status will be zero on success and nonzero otherwise. `kill -0` does not send a signal but will give a nonzero exit status if the process does not exist. Write a bash function called `pidwait` that takes a pid and waits until the given process completes. You should use `sleep` to avoid wasting CPU unnecessarily.
+    Namun, strategi ini akan gagal jika kita memulai di sesi bash yang berbeda, karena `wait` hanya bekerja untuk child process. Satu fitur yang tidak kita bahas di catatan adalah bahwa exit status perintah `kill` akan nol jika berhasil dan bukan-nol jika gagal. `kill -0` tidak mengirimkan sinyal tetapi akan memberikan exit status bukan-nol jika proses tidak ada. Tulis fungsi bash yang disebut `pidwait` yang menerima pid dan menunggu sampai proses yang diberikan selesai. Anda sebaiknya menggunakan `sleep` untuk menghindari pemborosan CPU secara tidak perlu.
 
 ## Files and Permissions
 
-1. (Advanced) Write a command or script to recursively find the most recently modified file in a directory. More generally, can you list all files by recency?
+1. (Lanjutan) Tulis perintah atau script untuk secara rekursif menemukan file yang paling baru diubah di sebuah direktori. Lebih umumnya, bisakah Anda menampilkan semua file berdasarkan terbaru?
 
 ## Terminal Multiplexers
 
-1. Follow this `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) and then learn how to do some basic customizations following [these steps](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
+1. Ikuti `tmux` [tutorial](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) ini dan kemudian pelajari cara melakukan beberapa kustomisasi dasar mengikuti [langkah-langkah ini](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/).
 
 ## Aliases and Dotfiles
 
-1. Create an alias `dc` that resolves to `cd` for when you type it wrong.
+1. Buat alias `dc` yang mengarah ke `cd` untuk saat Anda salah mengetiknya.
 
-1. Run `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` to get your top 10 most used commands and consider writing shorter aliases for them. Note: this works for Bash; if you're using ZSH, use `history 1` instead of just `history`.
+1. Jalankan `history | awk '{$1="";print substr($0,2)}' | sort | uniq -c | sort -n | tail -n 10` untuk mendapatkan 10 perintah yang paling sering Anda gunakan dan pertimbangkan untuk menulis alias yang lebih pendek untuk mereka. Catatan: ini berfungsi untuk Bash; jika Anda menggunakan ZSH, gunakan `history 1` alih-alih `history`.
 
-1. Create a folder for your dotfiles and set up version control.
+1. Buat folder untuk dotfiles Anda dan atur version control.
 
-1. Add a configuration for at least one program, e.g. your shell, with some customization (to start off, it can be something as simple as customizing your shell prompt by setting `$PS1`).
+1. Tambahkan konfigurasi untuk setidaknya satu program, misalnya shell Anda, dengan beberapa kustomisasi (untuk memulai, bisa sesederhana mengkustomisasi prompt shell Anda dengan menetapkan `$PS1`).
 
-1. Set up a method to install your dotfiles quickly (and without manual effort) on a new machine. This can be as simple as a shell script that calls `ln -s` for each file, or you could use a [specialized utility](https://dotfiles.github.io/utilities/).
+1. Siapkan metode untuk menginstal dotfiles Anda dengan cepat (dan tanpa usaha manual) di mesin baru. Ini bisa sesederhana script shell yang memanggil `ln -s` untuk setiap file, atau Anda bisa menggunakan [utilitas khusus](https://dotfiles.github.io/utilities/).
 
-1. Test your installation script on a fresh virtual machine.
+1. Uji script instalasi Anda di virtual machine yang masih baru.
 
-1. Migrate all of your current tool configurations to your dotfiles repository.
+1. Migrasikan semua konfigurasi alat Anda saat ini ke repository dotfiles.
 
-1. Publish your dotfiles on GitHub.
+1. Publikasikan dotfiles Anda di GitHub.
 
 ## Remote Machines (SSH)
 
-Install a Linux virtual machine (or use an already existing one) for these exercises. If you are not familiar with virtual machines check out [this](https://hibbard.eu/install-ubuntu-virtual-box/) tutorial for installing one.
+Instal virtual machine Linux (atau gunakan yang sudah ada) untuk latihan ini. Jika Anda tidak familiar dengan virtual machine, lihat [tutorial ini](https://hibbard.eu/install-ubuntu-virtual-box/) untuk menginstal satu.
 
-1. Go to `~/.ssh/` and check if you have a pair of SSH keys there. If not, generate them with `ssh-keygen -a 100 -t ed25519`. It is recommended that you use a password and use `ssh-agent`, more info [here](https://www.ssh.com/ssh/agent).
+1. Pergi ke `~/.ssh/` dan periksa apakah Anda memiliki pasangan SSH key di sana. Jika tidak, buatlah dengan `ssh-keygen -a 100 -t ed25519`. Disarankan bahwa Anda menggunakan password dan menggunakan `ssh-agent`, informasi lebih lanjut [di sini](https://www.ssh.com/ssh/agent).
 
-1. Edit `.ssh/config` to have an entry as follows:
+1. Edit `.ssh/config` untuk memiliki entri seperti berikut:
 
     ```bash
     Host vm
@@ -934,12 +933,12 @@ Install a Linux virtual machine (or use an already existing one) for these exerc
         LocalForward 9999 localhost:8888
     ```
 
-1. Use `ssh-copy-id vm` to copy your ssh key to the server.
+1. Gunakan `ssh-copy-id vm` untuk menyalin ssh key Anda ke server.
 
-1. Start a webserver in your VM by executing `python -m http.server 8888`. Access the VM webserver by navigating to `http://localhost:9999` in your machine.
+1. Jalankan webserver di VM Anda dengan menjalankan `python -m http.server 8888`. Akses webserver VM dengan membuka `http://localhost:9999` di mesin Anda.
 
-1. Edit your SSH server config by doing `sudo vim /etc/ssh/sshd_config` and disable password authentication by editing the value of `PasswordAuthentication`. Disable root login by editing the value of `PermitRootLogin`. Restart the `ssh` service with `sudo service sshd restart`. Try sshing in again.
+1. Edit konfigurasi server SSH Anda dengan menjalankan `sudo vim /etc/ssh/sshd_config` dan nonaktifkan autentikasi password dengan mengedit nilai `PasswordAuthentication`. Nonaktifkan login root dengan mengedit nilai `PermitRootLogin`. Restart layanan `ssh` dengan `sudo service sshd restart`. Cobalah ssh lagi.
 
-1. (Challenge) Install [`mosh`](https://mosh.org/) in the VM and establish a connection. Then disconnect the network adapter of the server/VM. Can mosh properly recover from it?
+1. (Tantangan) Instal [`mosh`](https://mosh.org/) di VM dan buat koneksi. Kemudian putuskan network adapter server/VM. Bisakah mosh pulih dengan baik dari hal tersebut?
 
-1. (Challenge) Look into what the `-N` and `-f` flags do in `ssh` and figure out a command to achieve background port forwarding.
+1. (Tantangan) Cari tahu apa yang dilakukan flag `-N` dan `-f` di `ssh` dan temukan perintah untuk mencapai port forwarding di background.

--- a/_2026/course-shell.md
+++ b/_2026/course-shell.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Course Overview + Introduction to the Shell"
 description: >
-  Learn about the motivation for this class, and get started with the shell.
+  Pelajari motivasi kelas ini, dan mulai menggunakan shell.
 thumbnail: /static/assets/thumbnails/2026/lec1.png
 date: 2026-01-12
 ready: true

--- a/_2026/course-shell.md
+++ b/_2026/course-shell.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Course Overview + Introduction to the Shell"
+title: "Ikhtisar Kursus + Pengantar Shell"
 description: >
   Pelajari motivasi kelas ini, dan mulai menggunakan shell.
 thumbnail: /static/assets/thumbnails/2026/lec1.png
@@ -11,156 +11,154 @@ video:
   id: MSgoeuMqUmU
 ---
 
-# Who are we?
+# Siapa kami?
 
-This class is co-taught by [Anish](https://anish.io/),
-[Jon](https://thesquareplanet.com/), and [Jose](http://josejg.com/). We
-are all ex-MIT students who started this MIT IAP class back when we were
-students. You can reach us collectively at
+Kelas ini diajarkan bersama oleh [Anish](https://anish.io/),
+[Jon](https://thesquareplanet.com/), dan [Jose](http://josejg.com/). Kami
+semuanya mantan mahasiswa MIT yang memulai kelas MIT IAP ini sejak kami masih
+menjadi mahasiswa. Anda dapat menghubungi kami secara kolektif di
 [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-We are not paid to teach this class, and do not monetize the class in
-any way. We make all the [course
-materials](https://missing.csail.mit.edu/) and [recordings of the
-lectures](https://www.youtube.com/@MissingSemester) freely available
-online. If you want to support our work, the best way to do so is to
-simply spread the word about the class. If you're a company, university,
-or other organization that runs this content past larger cohorts, please
-send us experience reports/testimonials by email so we get to hear about
-it :)
+Kami tidak dibayar untuk mengajar kelas ini, dan tidak memonetisasi kelas ini
+dengan cara apa pun. Kami menyediakan semua [materi
+kuliah](https://missing.csail.mit.edu/) dan [rekaman
+kuliah](https://www.youtube.com/@MissingSemester) secara gratis
+di internet. Jika Anda ingin mendukung pekerjaan kami, cara terbaik adalah
+dengan menyebarkan informasi tentang kelas ini. Jika Anda adalah perusahaan,
+universitas, atau organisasi lain yang menjalankan konten ini untuk kelompok
+yang lebih besar, silakan kirimkan laporan pengalaman/testimoni melalui email
+agar kami bisa mendengarnya :)
 
-# Motivation
+# Motivasi
 
-As computer scientists, we know that computers are great at aiding in
-repetitive tasks. However, far too often, we forget that this applies
-just as much to our _use_ of the computer as it does to the computations
-we want our programs to perform. We have a vast range of tools available
-at our fingertips that enable us to be more productive and solve more
-complex problems when working on any computer-related problem. Yet many
-of us utilize only a small fraction of those tools; we only know enough
-magical incantations by rote to get by, and blindly copy-paste commands
-from the internet when we get stuck.
+Sebagai ilmuwan komputer, kita tahu bahwa komputer sangat handal dalam membantu
+tugas-tugas berulang. Namun, terlalu sering kita lupa bahwa hal ini juga berlaku
+untuk _penggunaan_ komputer kita, bukan hanya komputasi yang ingin kita lakukan
+melalui program. Kita memiliki berbagai macam alat yang tersedia di ujung jari
+yang memungkinkan kita untuk lebih produktif dan menyelesaikan masalah yang lebih
+kompleks saat mengerjakan tugas apa pun yang berkaitan dengan komputer. Namun
+banyak dari kita hanya menggunakan sebagian kecil dari alat-alat tersebut; kita
+hanya tahu beberapa perintah ajaib secara hafalan untuk bertahan, dan
+copy-paste perintah dari internet secara membabi-buta ketika kita terjebak.
 
-This class is an attempt to [address this](/about/).
+Kelas ini adalah upaya untuk [mengatasi hal ini](/about/).
 
-We want to teach you how to make the most of the tools you know, show
-you new tools to add to your toolbox, and hopefully instill in you some
-excitement for exploring (and perhaps building) more tools on your own.
-This is what we believe to be the missing semester from most Computer
-Science curricula.
+Kami ingin mengajarkan Anda cara memaksimalkan alat-alat yang Anda ketahui,
+memperkenalkan alat-alat baru untuk ditambahkan ke kotak peralatan Anda, dan
+semoga menanamkan semangat untuk menjelajahi (dan mungkin membangun) lebih
+banyak alat sendiri. Inilah yang kami yakini sebagai semester yang hilang dari
+sebagian besar kurikulum Ilmu Komputer.
 
-# Class structure
+# Struktur kelas
 
-The not-for-credit class consists of nine 1-hour lectures, each one
-centering on a [particular topic](/2026/). The lectures are largely
-independent, though as the semester goes on we will presume that you are
-familiar with the content from the earlier lectures. We have lecture
-notes online, but there may be content covered in class (e.g. in the
-form of demos) that may not be in the notes. As for past years, we will
-be recording lectures and posting the recordings
-[online](https://www.youtube.com/@MissingSemester).
+Kelas tanpa kredit ini terdiri dari sembilan kuliah masing-masing 1 jam, setiap
+kuliah berfokus pada [topik tertentu](/2026/). Kuliah-kuliah ini sebagian besar
+berdiri sendiri, meskipun seiring berjalannya semester kami akan berasumsi bahwa
+Anda sudah familiar dengan materi dari kuliah-kuliah sebelumnya. Kami memiliki
+catatan kuliah di internet, tetapi mungkin ada konten yang dibahas di kelas
+(misalnya dalam bentuk demo) yang mungkin tidak ada di catatan. Seperti tahun-tahun
+sebelumnya, kami akan merekam kuliah dan mengunggah rekamannya
+[di internet](https://www.youtube.com/@MissingSemester).
 
-We are trying to cover a lot of ground over the course of just a few
-1-hour lectures, so the lectures are fairly dense. To allow you some
-time to get familiar with the content at your own pace, each lecture
-includes a set of exercises that guide you through the lecture's key
-points. We will not be running dedicated office hours, but we encourage
-you to ask questions on the [OSSU Discord](https://ossu.dev/#community),
-in `#missing-semester-forum`, or email us at
+Kami berusaha membahas banyak hal dalam waktu hanya beberapa kuliah 1 jam,
+sehingga kuliah-kuliah ini cukup padat. Untuk memberi Anda waktu mengenal
+kontennya dengan kecepatan Anda sendiri, setiap kuliah dilengkapi serangkaian
+latihan yang memandu Anda melalui poin-poin kunci kuliah. Kami tidak akan
+menjalankan jam kantor khusus, tetapi kami mendorong Anda untuk bertanya di
+[OSSU Discord](https://ossu.dev/#community),
+di `#missing-semester-forum`, atau kirim email kepada kami di
 [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-Due to the limited time we have, we won't be able to cover all the tools
-in the same level of detail a full-scale class might. Where possible, we
-will try to point you towards resources for digging further into a tool
-or topic, but if something particularly strikes your fancy, don't
-hesitate to reach out to us and ask for pointers!
+Karena waktu yang terbatas, kami tidak akan bisa membahas semua alat dengan
+tingkat detail yang sama seperti kelas berskala penuh. Jika memungkinkan, kami
+akan mengarahkan Anda ke sumber daya untuk menggali lebih dalam tentang suatu
+alat atau topik, tetapi jika ada yang menarik perhatian Anda, jangan ragu untuk
+menghubungi kami dan meminta petunjuk!
 
-Finally, if you have feedback about the class, please send it to us by
-email at [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+Terakhir, jika Anda memiliki umpan balik tentang kelas ini, silakan kirimkan
+kepada kami melalui email di [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-# Topic 1: The Shell
+# Topik 1: Shell
 
 {% comment %}
 lecturer: Jon
 {% endcomment %}
 
-## What is the shell?
+## Apa itu shell?
 
-Computers these days have a variety of interfaces for giving them
-commands; fanciful graphical user interfaces, voice interfaces, AR/VR,
-and more recently: LLMs. These are great for 80% of use-cases, but they
-are often fundamentally restricted in what they allow you to do — you
-cannot press a button that isn't there or give a voice command that
-hasn't been programmed. To take full advantage of the tools your
-computer provides, we have to go old-school and drop down to a textual
-interface: The Shell.
+Komputer saat ini memiliki berbagai macam antarmuka untuk memberikan perintah;
+antarmuka grafis yang mewah, antarmuka suara, AR/VR, dan baru-baru ini: LLM.
+Semua ini bagus untuk 80% kasus penggunaan, tetapi seringkali memiliki batasan
+mendasar dalam hal yang mereka izinkan — Anda tidak dapat menekan tombol yang
+tidak ada atau memberikan perintah suara yang belum diprogram. Untuk memanfaatkan
+secara penuh alat-alat yang disediakan komputer Anda, kita harus kembali ke cara
+lama dan beralih ke antarmuka tekstual: Shell.
 
-Nearly all platforms you can get your hands on have a shell in one form
-or another, and many of them have several shells for you to choose from.
-While they may vary in the details, at their core they are all roughly
-the same: they allow you to run programs, give them input, and inspect
-their output in a semi-structured way.
+Hampir semua platform yang bisa Anda gunakan memiliki shell dalam satu bentuk
+atau lainnya, dan banyak di antaranya memiliki beberapa shell untuk Anda pilih.
+Meskipun mungkin berbeda dalam detailnya, pada intinya semuanya kurang lebih
+sama: mereka memungkinkan Anda menjalankan program, memberikan input, dan
+memeriksa output mereka secara semi-terstruktur.
 
-To open a shell _prompt_ (where you can type commands), you first need a
-_terminal_, which is the visual interface to a shell. Your device
-probably shipped with one installed, or you can install one fairly
-easily:
+Untuk membuka _prompt_ shell (tempat Anda bisa mengetik perintah), Anda
+membutuhkan _terminal_, yaitu antarmuka visual ke shell. Perangkat Anda
+kemungkinan sudah terinstal salah satunya, atau Anda bisa menginstal dengan
+mudah:
 
 - **Linux:**
-  Press `Ctrl + Alt + T` (works on most distributions). Or search for
-  "Terminal" in your applications menu.
+  Tekan `Ctrl + Alt + T` (berfungsi di sebagian besar distribusi). Atau cari
+  "Terminal" di menu aplikasi Anda.
 - **Windows:**
-  Press `Win + R`, type `cmd` or `powershell`, and press Enter.
-  Alternatively, search "Terminal" or "Command Prompt" in the Start menu.
+  Tekan `Win + R`, ketik `cmd` atau `powershell`, lalu tekan Enter.
+  Atau cari "Terminal" atau "Command Prompt" di menu Start.
 - **macOS:**
-  Press `Cmd + Space` to open Spotlight, type "Terminal", and press Enter.
-  Or find it in Applications → Utilities → Terminal.
+  Tekan `Cmd + Space` untuk membuka Spotlight, ketik "Terminal", lalu tekan Enter.
+  Atau temukan di Applications → Utilities → Terminal.
 
-On Linux and macOS, this will usually open the Bourne Again SHell, or
-"bash" for short. This is one of the most widely used shells, and its
-syntax is similar to what you will see in many other shells. On Windows,
-you'll be greeted by the "batch" or "powershell" shells, depending on
-which command you ran. These are Windows-specific, and not what we'll be
-focusing on in this class, although it has analogues for most of what
-we'll be teaching. You'll instead want the [Windows Subsystem for
-Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-machine.
+Pada Linux dan macOS, ini biasanya akan membuka Bourne Again SHell, atau
+"bash" singkatnya. Ini adalah salah satu shell yang paling banyak digunakan,
+dan sintaksnya mirip dengan yang akan Anda lihat di banyak shell lainnya.
+Di Windows, Anda akan disambut oleh shell "batch" atau "powershell", tergantung
+pada perintah yang Anda jalankan. Keduanya spesifik untuk Windows, dan bukan
+yang akan kita fokuskan di kelas ini, meskipun keduanya memiliki analogi untuk
+sebagian besar yang akan kita ajarkan. Anda sebaiknya menggunakan [Windows
+Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau
+mesin virtual Linux.
 
-Other shells exist, often with many ergonomic improvements over bash
-(fish and zsh are among the most common). While these are very popular
-(all the instructors use one), they're nowhere near as ubiquitous as
-bash, and lean on many of the same concepts, so we won't be focusing on
-those in this lecture.
+Shell lain juga ada, seringkali dengan banyak peningkatan ergonomis dibanding
+bash (fish dan zsh adalah yang paling umum). Meskipun sangat populer (semua
+instruktur menggunakannya), mereka tidak sebanyak bash, dan mengandalkan banyak
+konsep yang sama, jadi kita tidak akan fokus pada mereka di kuliah ini.
 
-## Why should you care about it?
+## Mengapa Anda perlu mempedulikannya?
 
-The shell is not just (usually) much faster than "clicking around", it
-also comes with expressive power you can't easily find in any one
-graphical program. As we'll see, the shell gives you the ability to
-_combine_ programs in creative ways to automate nearly any task.
+Shell bukan hanya (biasanya) jauh lebih cepat daripada "mengklik-klik", shell
+juga hadir dengan kekuatan ekspresif yang tidak mudah ditemukan di satu program
+grafis mana pun. Seperti yang akan kita lihat, shell memberi Anda kemampuan untuk
+_menggabungkan_ program secara kreatif untuk mengotomatisasi hampir semua tugas.
 
-Knowing your way around a shell is also very useful to navigate the
-world of open-source software (which often come with install
-instructions that require the shell), building continuous integration
-for your software projects (as described in the [Code Quality
-lecture](/2026/code-quality/)), and debugging errors when other programs
-fail.
+Mengetahui cara menggunakan shell juga sangat berguna untuk menavigasi dunia
+perangkat lunak open-source (yang seringkali datang dengan instruksi instalasi
+yang membutuhkan shell), membangun integrasi berkelanjutan untuk proyek
+perangkat lunak Anda (seperti dijelaskan di [kuliah Code
+Quality](/2026/code-quality/)), dan men-debug kesalahan ketika program lain
+gagal.
 
-## Navigating in the shell
+## Navigasi di shell
 
-When you launch your terminal, you will see a _prompt_ that often looks
-a little like this:
+Ketika Anda membuka terminal, Anda akan melihat _prompt_ yang biasanya terlihat
+seperti ini:
 
 ```console
 missing:~$
 ```
 
-This is the main textual interface to the shell. It tells you that you
-are on the machine `missing` and that your "current working directory",
-or where you currently are, is `~` (short for "home"). The `$` tells you
-that you are not the root user (more on that later). At this prompt you
-can type a _command_, which will then be interpreted by the shell. The
-most basic command is to execute a program:
+Ini adalah antarmuka tekstual utama ke shell. Ini memberi tahu Anda bahwa Anda
+berada di mesin `missing` dan "direktori kerja saat ini" Anda, atau tempat Anda
+berada sekarang, adalah `~` (singkatan dari "home"). Tanda `$` memberi tahu Anda
+bahwa Anda bukan pengguna root (lebih lanjut tentang itu nanti). Di prompt ini
+Anda bisa mengetik _perintah_, yang kemudian akan diinterpretasikan oleh shell.
+Perintah paling dasar adalah menjalankan sebuah program:
 
 ```console
 missing:~$ date
@@ -168,43 +166,43 @@ Fri 10 Jan 2020 11:49:31 AM EST
 missing:~$
 ```
 
-Here, we executed the `date` program, which (perhaps unsurprisingly)
-prints the current date and time. The shell then asks us for another
-command to execute. We can also execute a command with _arguments_:
+Di sini, kita menjalankan program `date`, yang (mungkin tidak mengejutkan)
+mencetak tanggal dan waktu saat ini. Shell kemudian meminta kita perintah lain
+untuk dijalankan. Kita juga bisa menjalankan perintah dengan _argumen_:
 
 ```console
 missing:~$ echo hello
 hello
 ```
 
-In this case, we told the shell to execute the program `echo` with the
-argument `hello`. The `echo` program simply prints out its arguments.
-The shell parses the command by splitting it by whitespace, and then
-runs the program indicated by the first word, supplying each subsequent
-word as an argument that the program can access. If you want to provide
-an argument that contains spaces or other special characters (e.g., a
-directory named "My Photos"), you can either quote the argument with `'`
-or `"` (`"My Photos"`), or escape just the relevant characters with `\`
-(`My\ Photos`).
+Dalam kasus ini, kita menyuruh shell untuk menjalankan program `echo` dengan
+argumen `hello`. Program `echo` cukup mencetak argumennya. Shell mengurai
+perintah dengan memisahkannya berdasarkan spasi, lalu menjalankan program yang
+ditunjukkan oleh kata pertama, menyediakan setiap kata berikutnya sebagai
+argumen yang bisa diakses oleh program. Jika Anda ingin memberikan argumen yang
+mengandung spasi atau karakter khusus lainnya (misalnya, direktori bernama
+"My Photos"), Anda bisa mengutip argumen dengan `'` atau `"` (`"My Photos"`),
+atau meng-escape hanya karakter yang relevan dengan `\` (`My\ Photos`).
 
-Perhaps the most important command when you're starting out is `man`,
-short for "manual". The `man` program, among other things, lets you look
-up more information about any command on your system. For example, if
-you run `man date`, it'll explain what `date` is, and all of the various
-arguments you can pass it to alter its behavior. You can also usually
-get a short version of the help by passing `--help` as an argument to
-most commands.
+Mungkin perintah paling penting ketika Anda baru memulai adalah `man`,
+singkatan dari "manual". Program `man`, antara lain, memungkinkan Anda mencari
+informasi lebih lanjut tentang perintah apa pun di sistem Anda. Misalnya, jika
+Anda menjalankan `man date`, ini akan menjelaskan apa itu `date`, dan semua
+berbagai argumen yang bisa Anda berikan untuk mengubah perilakunya. Anda juga
+biasanya bisa mendapatkan versi singkat bantuan dengan memberikan `--help`
+sebagai argumen ke sebagian besar perintah.
 
-> Consider installing and using [`tldr`](https://tldr.sh/) in addition
-> to `man`, as it shows you common usage examples right there in the
-> terminal. LLMs are also usually very good at explaining how commands
-> work and how you can call them to achieve what you want to accomplish.
+> Pertimbangkan untuk menginstal dan menggunakan [`tldr`](https://tldr.sh/)
+> selain `man`, karena ini menampilkan contoh penggunaan umum langsung di
+> terminal. LLM juga biasanya sangat baik dalam menjelaskan cara kerja perintah
+> dan bagaimana Anda bisa menggunakannya untuk mencapai apa yang ingin Anda
+> lakukan.
 
-After `man`, the most important command to learn is `cd`, or "change
-directory". This command is actually built into the shell, and isn't a
-separate program (i.e., `which cd` will say "no cd found"). You pass it
-a path, and that path becomes your current working directory. You'll
-also see the working directory reflected in the shell prompt:
+Setelah `man`, perintah paling penting untuk dipelajari adalah `cd`, atau "change
+directory". Perintah ini sebenarnya sudah tertanam di dalam shell, dan bukan
+program terpisah (yaitu, `which cd` akan menampilkan "no cd found"). Anda
+memberikannya sebuah path, dan path tersebut menjadi direktori kerja saat ini
+Anda. Anda juga akan melihat direktori kerja tercermin di prompt shell:
 
 ```console
 missing:~$ cd /bin
@@ -213,23 +211,22 @@ missing:/$ cd ~
 missing:~$
 ```
 
-> Note that the shell comes with auto-completion, so you can often
-> complete paths faster by pressing `<TAB>`!
+> Perhatikan bahwa shell dilengkapi dengan auto-completion, sehingga Anda sering
+> bisa melengkapi path lebih cepat dengan menekan `<TAB>`!
 
-A lot of commands operate on the current working directory if nothing
-else is specified. If you're ever unsure where you are, you can run
-`pwd` or print the `$PWD` environment variable (with `echo $PWD`), both
-of which produce the current working directory.
+Banyak perintah beroperasi pada direktori kerja saat ini jika tidak ada yang
+dispesifikasikan. Jika Anda tidak yakin di mana Anda berada, Anda bisa
+menjalankan `pwd` atau mencetak variabel lingkungan `$PWD` (dengan `echo $PWD`),
+keduanya menghasilkan direktori kerja saat ini.
 
-The current working directory also comes in handy in that it allows us to
-use _relative_ paths. All the paths we've seen so far have been
-_absolute_ --- they start with `/` and give the full set of directories
-needed to navigate to some location from the root of the file system
-(`/`). In practice, you'll more commonly work with relative paths; so
-called because they are relative to the current working directory. In a
-relative path (anything _not_ starting with `/`), the first path
-component is looked up in the current working directory, and subsequent
-components traverse as usual. For example:
+Direktori kerja saat ini juga berguna karena memungkinkan kita menggunakan path
+_relatif_. Semua path yang telah kita lihat sejauh ini adalah _absolut_ ---
+mereka dimulai dengan `/` dan memberikan seluruh kumpulan direktori yang
+dibutuhkan untuk menavigasi ke suatu lokasi dari root sistem file (`/`). Dalam
+praktiknya, Anda lebih sering bekerja dengan path relatif; disebut demikian
+karena relatif terhadap direktori kerja saat ini. Dalam path relatif (apa pun
+yang _tidak_ dimulai dengan `/`), komponen path pertama dicari di direktori
+kerja saat ini, dan komponen berikutnya menelusuri seperti biasa. Misalnya:
 
 ```console
 missing:~$ cd /
@@ -237,9 +234,8 @@ missing:/$ cd bin
 missing:/bin$
 ```
 
-There are also two "special" components that exist in every directory:
-`.` and `..`. `.` is "this directory", and `..` is "the parent
-directory". So:
+Ada juga dua komponen "khusus" yang ada di setiap direktori: `.` dan `..`. `.`
+adalah "direktori ini", dan `..` adalah "direktori induk". Jadi:
 
 ```console
 missing:~$ cd /
@@ -247,21 +243,21 @@ missing:/$ cd bin/../bin/../bin/././../bin/..
 missing:/$
 ```
 
-You can usually use absolute and relative paths interchangeably for any
-command argument, just keep in mind what your current working directory
-is when using a relative one!
+Anda biasanya bisa menggunakan path absolut dan relatif secara bergantian untuk
+argumen perintah apa pun, cukup ingat apa direktori kerja saat ini Anda saat
+menggunakan path relatif!
 
-> Consider installing and using
-> [`zoxide`](https://github.com/ajeetdsouza/zoxide) to speed up your
-> `cd`ing --- `z` will remember the paths you frequently visit and let
-> you access with less typing.
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`zoxide`](https://github.com/ajeetdsouza/zoxide) untuk mempercepat `cd`
+> Anda --- `z` akan mengingat path yang sering Anda kunjungi dan memungkinkan
+> Anda mengaksesnya dengan lebih sedikit pengetikan.
 
-## What is available in the shell?
+## Apa yang tersedia di shell?
 
-But how does the shell know how to find programs like `date` or `echo`?
-If the shell is asked to execute a command, it consults an _environment
-variable_ called `$PATH` that lists which directories the shell should
-search for programs when it is given a command:
+Tapi bagaimana shell tahu cara menemukan program seperti `date` atau `echo`?
+Jika shell diminta menjalankan perintah, ia melihat _variabel lingkungan_
+bernama `$PATH` yang mencantumkan direktori mana yang harus dicari shell untuk
+program ketika diberikan perintah:
 
 ```console
 missing:~$ echo $PATH
@@ -272,122 +268,122 @@ missing:~$ /bin/echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
-When we run the `echo` command, the shell sees that it should execute
-the program `echo`, and then searches through the `:`-separated list of
-directories in `$PATH` for a file by that name. When it finds it, it
-runs it (assuming the file is _executable_; more on that later). We can
-find out which file is executed for a given program name using the
-`which` program. We can also bypass `$PATH` entirely by giving the
-_path_ to the file we want to execute.
+Ketika kita menjalankan perintah `echo`, shell melihat bahwa ia harus
+menjalankan program `echo`, lalu mencari melalui daftar direktori yang dipisahkan
+`:` di `$PATH` untuk file dengan nama tersebut. Ketika menemukannya, ia
+menjalankannya (dengan asumsi file tersebut _dapat dieksekusi_; lebih lanjut
+tentang itu nanti). Kita bisa mengetahui file mana yang dijalankan untuk nama
+program tertentu menggunakan program `which`. Kita juga bisa melewati `$PATH`
+sepenuhnya dengan memberikan _path_ ke file yang ingin kita eksekusi.
 
-This also gives a clue for how we can determine _all_ the programs we're
-able to execute in the shell: by listing the contents of all the
-directories on `$PATH`. We can do this by passing a given directory path
-to the `ls` program, which lists files:
+Ini juga memberikan petunjuk tentang bagaimana kita bisa menentukan _semua_
+program yang bisa kita jalankan di shell: dengan mendaftar isi dari semua
+direktori di `$PATH`. Kita bisa melakukan ini dengan memberikan path direktori
+tertentu ke program `ls`, yang mendaftar file:
 
 ```console
 missing:~$ ls /bin
 ```
 
-> Consider installing and using [`eza`](https://eza.rocks/) for a more
-> human-friendly `ls`.
+> Pertimbangkan untuk menginstal dan menggunakan [`eza`](https://eza.rocks/)
+> sebagai pengganti `ls` yang lebih ramah pengguna.
 
-This will, on most computers, print a _lot_ of programs, but we'll only
-focus on some of the most important ones here. First, some simple ones:
+Ini akan, di sebagian besar komputer, mencetak _sangat banyak_ program, tetapi
+kita hanya akan fokus pada beberapa yang paling penting di sini. Pertama,
+beberapa yang sederhana:
 
-- `cat file`, which prints the contents of `file`.
-- `sort file`, which prints out the lines of `file` in sorted order.
-- `uniq file`, which eliminates consecutive duplicate lines from `file`.
-- `head file` and `tail file`, which respectively print the first and
-  last few lines of `file`.
+- `cat file`, yang mencetak isi dari `file`.
+- `sort file`, yang mencetak baris-baris `file` dalam urutan terurut.
+- `uniq file`, yang menghilangkan baris duplikat yang berurutan dari `file`.
+- `head file` dan `tail file`, yang masing-masing mencetak beberapa baris
+  pertama dan terakhir dari `file`.
 
-> Consider installing and using [`bat`](https://github.com/sharkdp/bat)
-> over `cat` for syntax highlighting and scrolling.
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`bat`](https://github.com/sharkdp/bat) sebagai pengganti `cat` untuk
+> syntax highlighting dan scrolling.
 
-There's also `grep pattern file`, which finds lines matching `pattern`
-in `file`. This one deserves slightly more attention as it's both _very_
-useful and sports a wider array of features than one may expect.
-`pattern` is actually a _regular expression_ which can express very
-complex patterns --- we'll [cover
-those](/2026/code-quality/#regular-expressions)
-in the code quality lecture. You can also specify a directory instead of a
-file (or leave it off for `.`) and pass `-r` to recursively search all
-the files in a directory.
+Ada juga `grep pattern file`, yang mencari baris yang cocok dengan `pattern`
+di `file`. Yang satu ini patut mendapat perhatian lebih karena _sangat_ berguna
+dan memiliki berbagai fitur yang lebih luas dari yang mungkin diharapkan.
+`pattern` sebenarnya adalah _regular expression_ yang bisa mengekspresikan pola
+yang sangat kompleks --- kita akan [membahasnya](/2026/code-quality/#regular-expressions)
+di kuliah code quality. Anda juga bisa menentukan direktori sebagai ganti file
+(atau membiarkannya kosong untuk `.`) dan memberikan `-r` untuk mencari secara
+rekursif di semua file dalam direktori.
 
-> Consider installing and using
-> [`ripgrep`](https://github.com/BurntSushi/ripgrep) over `grep` for a
-> faster and more human-friendly (but less portable) alternative.
-> `ripgrep` will also recursively search the current working directory
-> by default!
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`ripgrep`](https://github.com/BurntSushi/ripgrep) sebagai pengganti `grep`
+> untuk alternatif yang lebih cepat dan lebih ramah pengguna (tetapi kurang
+> portabel). `ripgrep` juga akan mencari secara rekursif di direktori kerja
+> saat ini secara default!
 
-There are also some very useful tools with a slightly more complicated
-interface. First among those is `sed`, which is a programmatic file
-editor. It has its own programming language for making automated edits
-to files, but the most common use of it is:
+Ada juga beberapa alat yang sangat berguna dengan antarmuka yang sedikit lebih
+kompleks. Yang pertama adalah `sed`, yang merupakan editor file terprogram. Ia
+memiliki bahasa pemrograman sendiri untuk melakukan pengeditan otomatis pada
+file, tetapi penggunaan yang paling umum adalah:
 
 ```console
 missing:~$ sed -i 's/pattern/replacement/g' file
 ```
 
-This replaces all instances of `pattern` with `replacement` in `file`.
-The `-i` indicates that we want the substitutions to happen inline (as
-opposed to leaving `file` unmodified and printing the substituted
-contents). The `s/` is the way to express in the sed programming
-language that we want to do a substitution. The `/` separates the
-pattern from the replacement. And the trailing `/g` indicates that we
-want to replace _all_ occurrences on each line rather than just the
-first. As with `grep`, `pattern` here is a regular expression, which
-gives you significant expressive power. Regular expression substitutions
-also allow `replacement` to refer back to parts of the matched pattern;
-we'll see an example of that in a second.
+Ini mengganti semua kemunculan `pattern` dengan `replacement` di `file`.
+`-i` menunjukkan bahwa kita ingin substitusi terjadi secara inline (bukan
+membiarkan `file` tidak termodifikasi dan mencetak isi yang telah disubstitusi).
+`s/` adalah cara mengekspresikan dalam bahasa pemrograman sed bahwa kita ingin
+melakukan substitusi. `/` memisahkan pattern dari replacement. Dan `/g` di akhir
+menunjukkan bahwa kita ingin mengganti _semua_ kemunculan di setiap baris, bukan
+hanya yang pertama. Seperti `grep`, `pattern` di sini adalah regular expression,
+yang memberi Anda kekuatan ekspresif yang signifikan. Substitusi regular
+expression juga memungkinkan `replacement` merujuk kembali ke bagian-bagian dari
+pola yang dicocokkan; kita akan melihat contohnya sebentar lagi.
 
-Next, we have `find`, which lets you find files (recursively) that match
-certain conditions. For example:
+Selanjutnya, kita punya `find`, yang memungkinkan Anda mencari file (secara
+rekursif) yang cocok dengan kondisi tertentu. Misalnya:
 
 ```console
 missing:~$ find ~/Downloads -type f -name "*.zip" -mtime +30
 ```
 
-Finds ZIP files in the download directory that are older than 30 days.
+Mencari file ZIP di direktori unduhan yang lebih lama dari 30 hari.
 
 ```console
 missing:~$ find ~ -type f -size +100M -exec ls -lh {} \;
 ```
 
-Finds files larger than 100M in your home directory and lists them. Note
-that `-exec` takes a _command_ terminated with a stand-alone `;` (which
-we need to escape much like a space) where `{}` is replaced with each
-matching file path by `find`.
+Mencari file yang lebih besar dari 100M di direktori home Anda dan mendaftarkannya.
+Perhatikan bahwa `-exec` menerima _perintah_ yang diakhiri dengan `;` yang berdiri
+sendiri (yang perlu kita escape seperti spasi) di mana `{}` diganti dengan setiap
+path file yang cocok oleh `find`.
 
 ```console
 missing:~$ find . -name "*.py" -exec grep -l "TODO" {} \;
 ```
 
-Finds any `.py` files with TODO items in them.
+Mencari file `.py` apa pun yang memiliki item TODO di dalamnya.
 
-The syntax of `find` can be a little daunting, but hopefully this gives
-you a sense of how useful it can be!
+Sintaks `find` bisa sedikit menakutkan, tetapi semoga ini memberi Anda gambaran
+tentang betapa bergunanya alat ini!
 
-> Consider installing and using [`fd`](https://github.com/sharkdp/fd)
-> instead of `find` for a more human-friendly (but less portable!)
-> experience.
+> Pertimbangkan untuk menginstal dan menggunakan [`fd`](https://github.com/sharkdp/fd)
+> sebagai pengganti `find` untuk pengalaman yang lebih ramah pengguna (tetapi
+> kurang portabel!).
 
-Next on the docket is `awk`, which, like `sed`, has its own programming
-language. Where `sed` is built for editing files, `awk` is built for
-parsing them. By far the most common use of `awk` is for data files with
-a regular syntax (like CSV files) where you want to extract only certain
-parts of every record (i.e., line):
+Selanjutnya adalah `awk`, yang, seperti `sed`, memiliki bahasa pemrograman
+sendiri. Jika `sed` dibangun untuk mengedit file, `awk` dibangun untuk mengurai
+file. Penggunaan `awk` yang paling umum adalah untuk file data dengan sintaks
+reguler (seperti file CSV) di mana Anda hanya ingin mengekstrak bagian tertentu
+dari setiap record (yaitu, baris):
 
 ```console
 missing:~$ awk '{print $2}' file
 ```
 
-Prints the second whitespace-separated column of every line of `file`.
-If you add `-F,`, it'll print the second comma-separated column of every
-line. `awk` can do much more --- filtering rows, computing aggregates,
-and more --- see the exercises for a taste.
+Mencetak kolom kedua yang dipisahkan spasi dari setiap baris `file`. Jika Anda
+menambahkan `-F,`, ini akan mencetak kolom kedua yang dipisahkan koma dari setiap
+baris. `awk` bisa melakukan banyak hal --- memfilter baris, menghitung agregat,
+dan lainnya --- lihat latihan untuk contohnya.
 
-Putting these tools together, we can do fancy things like:
+Dengan menggabungkan alat-alat ini, kita bisa melakukan hal-hal canggih seperti:
 
 ```console
 missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
@@ -398,76 +394,75 @@ missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
 postgres,mysql,oracle,dell,ubuntu,inspur,test,admin,user,root
 ```
 
-This grabs SSH logs from a remote server (we'll talk more about `ssh` in
-the next lecture), searches for disconnect messages, extracts the
-username from each such message, and prints the top 10 usernames
-comma-separated. All in one command! We'll leave dissecting each step as
-an exercise.
+Ini mengambil log SSH dari server remote (kita akan membahas lebih lanjut tentang
+`ssh` di kuliah berikutnya), mencari pesan disconnect, mengekstrak nama pengguna
+dari setiap pesan tersebut, dan mencetak 10 nama pengguna teratas yang dipisahkan
+koma. Semua dalam satu perintah! Kita serahkan penguraian setiap langkah sebagai
+latihan.
 
-## The shell language (bash)
+## Bahasa shell (bash)
 
-The previous example introduced a new concept: pipes (`|`). These let
-you string together the output of one program with the input of another.
-This works because most command-line programs will operate on their
-"standard input" (where your keystrokes normally go) if no `file`
-argument is given. `|` takes the "standard output" (what normally gets
-printed to your terminal) of the program before the `|` and makes it be
-the standard input of the program after the `|`. This allows you to
-_compose_ shell programs, and it's part of what makes the shell such a
-productive environment to work in!
+Contoh sebelumnya memperkenalkan konsep baru: pipe (`|`). Ini memungkinkan Anda
+menghubungkan output dari satu program dengan input program lainnya. Ini berfungsi
+karena sebagian besar program baris perintah akan beroperasi pada "standard input"
+mereka (tempat ketukan keyboard Anda biasanya masuk) jika tidak ada argumen `file`
+yang diberikan. `|` mengambil "standard output" (yang biasanya dicetak ke terminal
+Anda) dari program sebelum `|` dan menjadikannya standard input dari program setelah
+`|`. Ini memungkinkan Anda _menggabungkan_ program shell, dan ini adalah bagian dari
+apa yang membuat shell menjadi lingkungan yang sangat produktif untuk bekerja!
 
-In fact, most shells implement a full programming language (like bash),
-just like Python or Ruby. It has variables, conditionals, loops, and
-functions. When you run commands in your shell, you are really writing a
-small bit of code that your shell interprets. We won't teach you all of
-bash today, but there are some bits you'll find particularly useful:
+Faktanya, sebagian besar shell mengimplementasikan bahasa pemrograman lengkap
+(sperti bash), seperti Python atau Ruby. Ia memiliki variabel, kondisional, loop,
+dan fungsi. Ketika Anda menjalankan perintah di shell, Anda sebenarnya menulis
+sedikit kode yang diinterpretasikan oleh shell Anda. Kami tidak akan mengajari
+Anda semua tentang bash hari ini, tetapi ada beberapa bagian yang akan Anda
+anggap sangat berguna:
 
-First, redirects: `>file` lets you take the standard output of a program
-and write it to `file` instead of to your terminal. This makes it easier
-to analyze after the fact. `>>file` will append to `file` rather than
-overwrite it. There's also `<file` which tells the shell to read from
-`file` instead of from your keyboard as the standard input to a program.
+Pertama, redirect: `>file` memungkinkan Anda mengambil standard output dari
+sebuah program dan menulisnya ke `file` alih-alih ke terminal Anda. Ini
+memudahkan analisis setelahnya. `>>file` akan menambahkan ke `file` alih-alih
+menimpanya. Ada juga `<file` yang menyuruh shell untuk membaca dari `file`
+alih-alih dari keyboard Anda sebagai standard input ke sebuah program.
 
-> This is a good time to mention the `tee` program. `tee` will print
-> standard input to standard output (just like `cat`!), but will _also_
-> write it to a file. So `verbose cmd | tee verbose.log | grep CRITICAL`
-> will preserve the full verbose log to a file while keeping your
-> terminal clean!
+> Ini saat yang tepat untuk menyebutkan program `tee`. `tee` akan mencetak
+> standard input ke standard output (seperti `cat`!), tetapi _juga_ akan
+> menulisnya ke file. Jadi `verbose cmd | tee verbose.log | grep CRITICAL`
+> akan menyimpan log verbose lengkap ke file sambil menjaga terminal Anda tetap
+> bersih!
 
-Next, conditionals: `if command1; then command2; command3; fi` will
-execute `command1`, and if it doesn't result in an error, will run
-`command2` and `command3`. You can also have an `else` branch if you
-wish. The most common command to use as `command1` is the `test`
-command, often abbreviated simply as `[`, which lets you evaluate
-conditions like "does a file exist" (`test -f file` / `[ -f file ]`) or
-"does a string equal another" (`[ "$var" = "string" ]`). In bash,
-there's also `[[ ]]`, which is a "safer" built-in version of `test` that
-has fewer odd behaviours around quoting.
+Selanjutnya, kondisional: `if command1; then command2; command3; fi` akan
+menjalankan `command1`, dan jika tidak menghasilkan error, akan menjalankan
+`command2` dan `command3`. Anda juga bisa memiliki cabang `else` jika Anda
+menginginkannya. Perintah yang paling umum digunakan sebagai `command1` adalah
+perintah `test`, sering disingkat hanya sebagai `[`, yang memungkinkan Anda
+mengevaluasi kondisi seperti "apakah file ada" (`test -f file` / `[ -f file ]`)
+atau "apakah string sama dengan yang lain" (`[ "$var" = "string" ]`). Dalam
+bash, ada juga `[[ ]]`, yang merupakan versi built-in `test` yang "lebih aman"
+dan memiliki lebih sedikit perilaku aneh seputar quoting.
 
-Bash also has two forms of loops, `while` and `for`. `while command1; do
-command2; command3; done` functions just like the equivalent `if`
-command, except that it will re-execute the whole thing over and over
-for as long as `command1` does not error. `for varname in a b c d; do
-command; done` executes `command` four times, each time with `$varname`
-set to one of `a`, `b`, `c`, and `d`. Instead of listing the items
-explicitly, you'll often use "command substitution", such as:
+Bash juga memiliki dua bentuk loop, `while` dan `for`. `while command1; do
+command2; command3; done` berfungsi persis seperti perintah `if` yang setara,
+kecuali ia akan mengeksekusi semuanya berulang-ulang selama `command1` tidak
+menghasilkan error. `for varname in a b c d; do command; done` menjalankan
+`command` empat kali, setiap kali dengan `$varname` diatur ke salah satu dari
+`a`, `b`, `c`, dan `d`. Alih-alih mendaftar item secara eksplisit, Anda sering
+akan menggunakan "command substitution", seperti:
 
 ```bash
 for i in $(seq 1 10); do
 ```
 
-This executes the command `seq 1 10` (which prints the numbers from 1 to
-10 inclusive) and then replaces the whole `$()` with that command's
-output, giving you a 10-iteration for loop. In older code you'll
-sometimes see literal backticks (like ``for i in `seq 1 10`; do``)
-instead of `$()`, but you should strongly prefer the `$()` form as it
-can be nested.
+Ini menjalankan perintah `seq 1 10` (yang mencetak angka dari 1 sampai 10
+inklusif) dan kemudian mengganti seluruh `$()` dengan output perintah tersebut,
+memberikan Anda loop for 10 iterasi. Di kode lama Anda terkadang akan melihat
+backtick literal (seperti ``for i in `seq 1 10`; do``) alih-alih `$()`, tetapi
+Anda sebaiknya lebih memilih bentuk `$()` karena bisa di-nest.
 
-While you _can_ write long shell scripts directly in your prompt, you'll
-usually want to write them into a `.sh` file instead. For example,
-here's a script that will run a program in a loop until it fails,
-printing the output only of the failed run, while stressing your CPU in
-the background (useful to reproduce flaky tests for example):
+Meskipun Anda _bisa_ menulis skrip shell panjang langsung di prompt Anda, Anda
+biasanya akan ingin menulisnya ke file `.sh` sebagai gantinya. Misalnya, berikut
+adalah skrip yang akan menjalankan program dalam loop sampai gagal, mencetak
+output hanya dari run yang gagal, sambil membebani CPU di latar belakang
+(berguna misalnya untuk mereproduksi tes yang tidak stabil):
 
 ```bash
 #!/bin/bash
@@ -496,161 +491,158 @@ tail -n 20 "$LOGFILE"
 echo "Full log: $LOGFILE"
 ```
 
-This has a number of new things in it that I recommend you spend some
-time diving into, as they're very useful in crafting useful shell
-invocations like background jobs (`&`) to run programs concurrently,
-trickier [shell
-redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html),
-and [arithmetic
+Ini memiliki beberapa hal baru yang saya sarankan Anda luangkan waktu untuk
+mempelajarinya, karena mereka sangat berguna dalam membuat pemanggilan shell
+yang berguna seperti background job (`&`) untuk menjalankan program secara
+bersamaan, [shell
+redirection](https://www.gnu.org/software/bash/manual/html_node/Redirections.html)
+yang lebih rumit, dan [arithmetic
 expansion](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html).
 
-It's worth spending a second on the first two lines of the program
-though. The first is the "shebang" -- you'll see this at the top of
-other files than shell scripts too. When a file that starts with the
-magic incantation `#!/path` is executed, the shell will start the
-program at `/path`, and pass it the contents of the file as input. In
-the case of a shell script, this means passing the contents of the shell
-script to `/bin/bash`, but you can also write Python scripts with a
-shebang line of `/usr/bin/python`!
+Perlu diperhatikan dua baris pertama program. Yang pertama adalah "shebang" --
+Anda akan melihat ini di bagian atas file selain skrip shell juga. Ketika file
+yang dimulai dengan mantra ajaib `#!/path` dieksekusi, shell akan memulai
+program di `/path`, dan memberikan isi file sebagai input. Dalam kasus skrip
+shell, ini berarti memberikan isi skrip shell ke `/bin/bash`, tetapi Anda juga
+bisa menulis skrip Python dengan baris shebang `/usr/bin/python`!
 
-The second line is a way to make bash "stricter", and mitigate a number
-of footguns when writing shell scripts. `set` can take a whole lot of
-arguments, but briefly: `-e` makes it so that if any command fails, the
-script exits early; `-u` makes it so that use of undefined variables
-crashes the script rather than just using an empty string; and `-o
-pipefail` makes it so that if programs in a `|` sequence fail, the
-shell script as a whole also exits early.
+Baris kedua adalah cara membuat bash "lebih ketat", dan mengurangi sejumlah
+masalah umum saat menulis skrip shell. `set` bisa menerima banyak argumen,
+tetapi secara singkat: `-e` membuatnya sehingga jika perintah mana pun gagal,
+skrip keluar lebih awal; `-u` membuatnya sehingga penggunaan variabel yang tidak
+terdefinisi membuat skrip crash alih-alih hanya menggunakan string kosong; dan
+`-o pipefail` membuatnya sehingga jika program dalam urutan `|` gagal, skrip
+shell secara keseluruhan juga keluar lebih awal.
 
-> Shell programming is a deep topic, just as any programming language
-> is, but be warned: bash has an unusual number of gotchas, to the point
-> that there are [multiple](https://tldp.org/LDP/abs/html/gotchas.html)
-> websites dedicated to [listing them](https://mywiki.wooledge.org/BashPitfalls).
-> I highly recommend making heavy use of
-> [shellcheck](https://www.shellcheck.net/) when writing them. LLMs are
-> also great at writing and debugging shell scripts, as well as
-> translating them to a "real" programming language (like Python) when
-> they've grown too unwieldy for bash (100+ lines).
+> Pemrograman shell adalah topik yang dalam, seperti bahasa pemrograman apa pun,
+> tetapi perlu diingat: bash memiliki jumlah gotcha yang tidak biasa, sampai-sampai
+> ada [beberapa](https://tldp.org/LDP/abs/html/gotchas.html) situs web yang
+> didedikasikan untuk [mendaftarkannya](https://mywiki.wooledge.org/BashPitfalls).
+> Saya sangat menyarankan untuk banyak menggunakan
+> [shellcheck](https://www.shellcheck.net/) saat menulisnya. LLM juga sangat
+> bagus dalam menulis dan men-debug skrip shell, serta menerjemahkannya ke bahasa
+> pemrograman "nyata" (seperti Python) ketika sudah terlalu rumit untuk bash
+> (100+ baris).
 
-# Next steps
+# Langkah selanjutnya
 
-At this point you know your way around a shell enough to accomplish
-basic tasks. You should be able to navigate around to find files of
-interest and use the basic functionality of most programs. In the next
-lecture, we will talk about how to perform and automate more complex
-tasks using the shell and the many handy command-line programs out
-there.
+Pada titik ini Anda sudah cukup mengenal shell untuk menyelesaikan tugas-tugas
+dasar. Anda seharusnya bisa menavigasi untuk menemukan file yang menarik dan
+menggunakan fungsionalitas dasar sebagian besar program. Di kuliah berikutnya,
+kita akan membahas cara melakukan dan mengotomatisasi tugas yang lebih kompleks
+menggunakan shell dan banyak program baris perintah yang berguna.
 
-# Exercises
+# Latihan
 
-All classes in this course are accompanied by a series of exercises.
-Some give you a specific task to do, while others are open-ended, like
-"try using X and Y programs". We highly encourage you to try them out.
+Semua kelas dalam kursus ini disertai serangkaian latihan. Beberapa memberi Anda
+tugas spesifik untuk dilakukan, sementara yang lain bersifat terbuka, seperti
+"coba gunakan program X dan Y". Kami sangat mendorong Anda untuk mencobanya.
 
-We have not written solutions for the exercises. If you are stuck on
-anything in particular, feel free to post in `#missing-semester-forum`
-on [Discord](https://ossu.dev/#community) or send us an email describing
-what you've tried so far, and we will try to help you out. These
-exercises will also likely work well as initial prompts in a
-conversation with an LLM where you can interactively dive into the
-topic. The real value in these exercises is the journey of discovering
-the answers, not the answer itself. We encourage you to follow tangents
-and ask "why" as you work through them, rather than just looking for the
-shortest path to the solution.
+Kami belum menulis solusi untuk latihan. Jika Anda terjebak pada sesuatu, jangan
+ragu untuk posting di `#missing-semester-forum` di
+[Discord](https://ossu.dev/#community) atau kirim email kepada kami yang
+menjelaskan apa yang sudah Anda coba, dan kami akan mencoba membantu Anda.
+Latihan ini juga kemungkinan besar akan berfungsi dengan baik sebagai prompt
+awal dalam percakapan dengan LLM di mana Anda bisa secara interaktif mendalami
+topiknya. Nilai nyata dari latihan ini adalah perjalanan menemukan jawaban,
+bukan jawabannya itu sendiri. Kami mendorong Anda untuk mengikuti alur yang
+berbeda dan bertanya "mengapa" saat Anda mengerjakannya, alih-alih hanya
+mencari jalan terpendek ke solusi.
 
-1. For this course, you need to be using a Unix shell like Bash or ZSH. If
-   you are on Linux or macOS, you don't have to do anything special. If you
-   are on Windows, you need to make sure you are not running cmd.exe or
-   PowerShell; you can use [Windows Subsystem for
-   Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-   machine to use Unix-style command-line tools. To make sure you're running
-   an appropriate shell, you can try the command `echo $SHELL`. If it says
-   something like `/bin/bash` or `/usr/bin/zsh`, that means you're running
-   the right program.
+1. Untuk kursus ini, Anda perlu menggunakan shell Unix seperti Bash atau ZSH. Jika
+   Anda berada di Linux atau macOS, Anda tidak perlu melakukan apa-apa. Jika Anda
+   berada di Windows, Anda perlu memastikan Anda tidak menjalankan cmd.exe atau
+   PowerShell; Anda bisa menggunakan [Windows Subsystem for
+   Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau mesin virtual Linux
+   untuk menggunakan alat baris perintah bergaya Unix. Untuk memastikan Anda
+   menjalankan shell yang sesuai, Anda bisa mencoba perintah `echo $SHELL`. Jika
+   menampilkan sesuatu seperti `/bin/bash` atau `/usr/bin/zsh`, itu berarti Anda
+   menjalankan program yang benar.
 
-1. What does the `-l` flag to `ls` do? Run `ls -l /` and examine the output.
-   What do the first 10 characters of each line mean? (Hint: `man ls`)
+1. Apa yang dilakukan flag `-l` pada `ls`? Jalankan `ls -l /` dan periksa
+   outputnya. Apa arti 10 karakter pertama dari setiap baris? (Petunjuk: `man ls`)
 
-1. In the command `find ~/Downloads -type f -name "*.zip" -mtime +30`, the
-   `*.zip` is a "glob". What is a glob? Create a test directory with some
-   files and experiment with patterns like `ls *.txt`, `ls file?.txt`, and
-   `ls {a,b,c}.txt`. See [Pattern
+1. Dalam perintah `find ~/Downloads -type f -name "*.zip" -mtime +30`,
+   `*.zip` adalah "glob". Apa itu glob? Buat direktori uji dengan beberapa file
+   dan bereksperimenlah dengan pola seperti `ls *.txt`, `ls file?.txt`, dan
+   `ls {a,b,c}.txt`. Lihat [Pattern
    Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)
-   in the Bash manual.
+   di manual Bash.
 
-1. What's the difference between `'single quotes'`, `"double quotes"`, and
-   `$'ANSI quotes'`? Write a command that echoes a string containing a
-   literal `$`, a `!`, and a newline character. See
+1. Apa perbedaan antara `'single quotes'`, `"double quotes"`, dan
+   `$'ANSI quotes'`? Tulis perintah yang meng-echo string yang mengandung
+   literal `$`, `!`, dan karakter newline. Lihat
    [Quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html).
 
-1. The shell has three standard streams: stdin (0), stdout (1), and stderr
-   (2). Run `ls /nonexistent /tmp` and redirect stdout to one file and
-   stderr to another. How would you redirect both to the same file? See
+1. Shell memiliki tiga stream standar: stdin (0), stdout (1), dan stderr
+   (2). Jalankan `ls /nonexistent /tmp` dan redirect stdout ke satu file dan
+   stderr ke file lainnya. Bagaimana Anda akan redirect keduanya ke file yang
+   sama? Lihat
    [Redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html).
 
-1. `$?` holds the exit status of the last command (0 = success). `&&` runs
-   the next command only if the previous succeeded; `||` runs it only if
-   the previous failed. Write a one-liner that creates `/tmp/mydir` only if
-   it doesn't already exist. See [Exit
+1. `$?` menyimpan status exit dari perintah terakhir (0 = sukses). `&&` menjalankan
+   perintah berikutnya hanya jika yang sebelumnya sukses; `||` menjalankannya hanya
+   jika yang sebelumnya gagal. Tulis satu baris perintah yang membuat `/tmp/mydir`
+   hanya jika belum ada. Lihat [Exit
    Status](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html).
 
-1. Why does `cd` have to be built into the shell itself rather than a
-   standalone program? (Hint: think about what a child process can and
-   cannot affect in its parent.)
+1. Mengapa `cd` harus tertanam di dalam shell itu sendiri alih-alih menjadi program
+   terpisah? (Petunjuk: pikirkan apa yang bisa dan tidak bisa dipengaruhi oleh
+   proses anak pada induknya.)
 
-1. Write a script that takes a filename as an argument (`$1`) and checks
-   whether the file exists using `test -f` or `[ -f ... ]`. It should print
-   different messages depending on whether the file exists. See [Bash
+1. Tulis skrip yang menerima nama file sebagai argumen (`$1`) dan memeriksa
+   apakah file tersebut ada menggunakan `test -f` atau `[ -f ... ]`. Skrip harus
+   mencetak pesan berbeda tergantung pada apakah file tersebut ada. Lihat [Bash
    Conditional
    Expressions](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html).
 
-1. Save the script from the previous exercise to a file (e.g., `check.sh`).
-   Try running it with `./check.sh somefile`. What happens? Now run
-   `chmod +x check.sh` and try again. Why is this step necessary? (Hint:
-   look at `ls -l check.sh` before and after the `chmod`.)
+1. Simpan skrip dari latihan sebelumnya ke file (misalnya, `check.sh`).
+   Coba jalankan dengan `./check.sh somefile`. Apa yang terjadi? Sekarang jalankan
+   `chmod +x check.sh` dan coba lagi. Mengapa langkah ini diperlukan? (Petunjuk:
+   lihat `ls -l check.sh` sebelum dan sesudah `chmod`.)
 
-1. What happens if you add `-x` to the `set` flags in a script? Try it with
-    a simple script and observe the output. See [The Set
+1. Apa yang terjadi jika Anda menambahkan `-x` ke flag `set` dalam skrip? Cobalah
+    dengan skrip sederhana dan amati outputnya. Lihat [The Set
     Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
 
-1. Write a command that copies a file to a backup with today's date in the
-    filename (e.g., `notes.txt` → `notes_2026-01-12.txt`). (Hint: `$(date
-    +%Y-%m-%d)`). See [Command
+1. Tulis perintah yang menyalin file ke cadangan dengan tanggal hari ini di nama
+    file (misalnya, `notes.txt` → `notes_2026-01-12.txt`). (Petunjuk: `$(date
+    +%Y-%m-%d)`). Lihat [Command
     Substitution](https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html).
 
-1. Modify the flaky test script from the lecture to accept the test command
-    as an argument instead of hardcoding `cargo test my_test`. (Hint: `$1`
-    or `$@`). See [Special
+1. Modifikasi skrip tes tidak stabil dari kuliah untuk menerima perintah tes
+    sebagai argumen alih-alih menggunakan `cargo test my_test` secara langsung.
+    (Petunjuk: `$1` atau `$@`). Lihat [Special
     Parameters](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html).
 
-1. Use pipes to find the 5 most common file extensions in your home
-    directory. (Hint: combine `find`, `grep` or `sed` or `awk`, `sort`,
-    `uniq -c`, and `head`.)
+1. Gunakan pipe untuk menemukan 5 ekstensi file paling umum di direktori home
+    Anda. (Petunjuk: gabungkan `find`, `grep` atau `sed` atau `awk`, `sort`,
+    `uniq -c`, dan `head`.)
 
-1. `xargs` converts lines from stdin into command arguments. Use `find` and
-    `xargs` together (not `find -exec`) to find all `.sh` files in a
-    directory and count the lines in each with `wc -l`. Bonus: make it
-    handle filenames with spaces. (Hint: `-print0` and `-0`). See `man
+1. `xargs` mengubah baris dari stdin menjadi argumen perintah. Gunakan `find` dan
+    `xargs` bersama-sama (bukan `find -exec`) untuk mencari semua file `.sh` dalam
+    direktori dan hitung baris di masing-masing dengan `wc -l`. Bonus: buat agar
+    bisa menangani nama file dengan spasi. (Petunjuk: `-print0` dan `-0`). Lihat `man
     xargs`.
 
-1. Use `curl` to fetch the HTML of the course website
-    (`https://missing.csail.mit.edu/`) and pipe it to `grep` to count how
-    many lectures are listed. (Hint: look for a pattern that appears once
-    per lecture; use `curl -s` to silence the progress output.)
+1. Gunakan `curl` untuk mengambil HTML dari situs web kursus
+    (`https://missing.csail.mit.edu/`) dan pipe ke `grep` untuk menghitung berapa
+    banyak kuliah yang terdaftar. (Petunjuk: cari pola yang muncul sekali per
+    kuliah; gunakan `curl -s` untuk menghilangkan output progress.)
 
-1. [`jq`](https://jqlang.github.io/jq/) is a powerful tool for processing
-    JSON data. Fetch the sample data at
-    `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` with
-    `curl` and use `jq` to extract just the names of people whose version
-    is greater than 6. (Hint: pipe to `jq .` first to see the structure;
-    then try `jq '.[] | select(...) | .name'`)
+1. [`jq`](https://jqlang.github.io/jq/) adalah alat yang kuat untuk memproses
+    data JSON. Ambil data contoh di
+    `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` dengan
+    `curl` dan gunakan `jq` untuk mengekstrak hanya nama-nama orang yang
+    versinya lebih besar dari 6. (Petunjuk: pipe ke `jq .` terlebih dahulu untuk
+    melihat strukturnya; lalu coba `jq '.[] | select(...) | .name'`)
 
-1. `awk` can filter lines based on column values and manipulate output.
-    For example, `awk '$3 ~ /pattern/ {$4=""; print}'` prints only lines
-    where the third column matches `pattern`, while omitting the fourth
-    column. Write an `awk` command that prints only lines where the second
-    column is greater than 100, and swaps the first and third columns. Test
-    with: `printf 'a 50 x\nb 150 y\nc 200 z\n'`
+1. `awk` bisa memfilter baris berdasarkan nilai kolom dan memanipulasi output.
+    Misalnya, `awk '$3 ~ /pattern/ {$4=""; print}'` mencetak hanya baris di mana
+    kolom ketiga cocok dengan `pattern`, sambil menghilangkan kolom keempat. Tulis
+    perintah `awk` yang mencetak hanya baris di mana kolom kedua lebih besar dari
+    100, dan menukar kolom pertama dan ketiga. Uji dengan: `printf 'a 50 x\nb 150 y\nc 200 z\n'`
 
-1. Dissect the SSH log pipeline from the lecture: what does each step do?
-    Then build something similar to find your most-used shell commands from
-    `~/.bash_history` (or `~/.zsh_history`).
+1. Bedah pipeline log SSH dari kuliah: apa yang dilakukan setiap langkah?
+    Kemudian buat sesuatu yang serupa untuk menemukan perintah shell yang paling
+    sering Anda gunakan dari `~/.bash_history` (atau `~/.zsh_history`).

--- a/_2026/course-shell.md
+++ b/_2026/course-shell.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Course Overview + Introduction to the Shell"
+title: "Gambaran Kursus + Pengantar Shell"
 description: >
-  Learn about the motivation for this class, and get started with the shell.
+  Pelajari motivasi kelas ini, dan mulai gunakan shell.
 thumbnail: /static/assets/thumbnails/2026/lec1.png
 date: 2026-01-12
 ready: true
@@ -11,156 +11,158 @@ video:
   id: MSgoeuMqUmU
 ---
 
-# Who are we?
+# Siapa kami?
 
-This class is co-taught by [Anish](https://anish.io/),
-[Jon](https://thesquareplanet.com/), and [Jose](http://josejg.com/). We
-are all ex-MIT students who started this MIT IAP class back when we were
-students. You can reach us collectively at
+Kelas ini diajarkan bersama oleh [Anish](https://anish.io/),
+[Jon](https://thesquareplanet.com/), dan [Jose](http://josejg.com/). Kami
+semuanya mantan mahasiswa MIT yang memulai kelas MIT IAP ini sejak kami masih
+menjadi mahasiswa. Anda dapat menghubungi kami di
 [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-We are not paid to teach this class, and do not monetize the class in
-any way. We make all the [course
-materials](https://missing.csail.mit.edu/) and [recordings of the
-lectures](https://www.youtube.com/@MissingSemester) freely available
-online. If you want to support our work, the best way to do so is to
-simply spread the word about the class. If you're a company, university,
-or other organization that runs this content past larger cohorts, please
-send us experience reports/testimonials by email so we get to hear about
-it :)
+Kami tidak dibayar untuk mengajar kelas ini, dan tidak
+memperdagangkan kelas ini dengan cara apa pun. Kami menyediakan semua
+[materi kursus](https://missing.csail.mit.edu/) dan [rekaman
+kuliah](https://www.youtube.com/@MissingSemester) secara gratis
+daring. Jika Anda ingin mendukung pekerjaan kami, cara terbaik adalah
+dengan menyebarkan informasi tentang kelas ini. Jika Anda adalah perusahaan,
+universitas, atau organisasi lain yang menjalankan konten ini untuk kelompok
+yang lebih besar, silakan kirimkan laporan pengalaman/testimoni melalui email
+agar kami dapat mengetahuinya :)
 
-# Motivation
+# Motivasi
 
-As computer scientists, we know that computers are great at aiding in
-repetitive tasks. However, far too often, we forget that this applies
-just as much to our _use_ of the computer as it does to the computations
-we want our programs to perform. We have a vast range of tools available
-at our fingertips that enable us to be more productive and solve more
-complex problems when working on any computer-related problem. Yet many
-of us utilize only a small fraction of those tools; we only know enough
-magical incantations by rote to get by, and blindly copy-paste commands
-from the internet when we get stuck.
+Sebagai ilmuwan komputer, kita tahu bahwa komputer sangat hebat dalam
+membantu tugas-tugas berulang. Namun, terlalu sering kita lupa bahwa hal ini
+juga berlaku untuk _penggunaan_ komputer kita, bukan hanya perhitungan yang
+ingin kita lakukan oleh program kita. Kita memiliki berbagai macam alat yang
+siap di ujung jari yang memungkinkan kita lebih produktif dan menyelesaikan
+masalah yang lebih kompleks saat mengerjakan masalah terkait komputer apa pun.
+Namun banyak dari kita hanya menggunakan sebagian kecil dari alat-alat
+tersebut; kita hanya tahu cukup banyak mantra ajaib secara hafalan untuk
+bertahan, dan membabi-buta menyalin-tempel perintah dari internet saat kita
+macet.
 
-This class is an attempt to [address this](/about/).
+Kelas ini adalah upaya untuk [mengatasi hal ini](/about/).
 
-We want to teach you how to make the most of the tools you know, show
-you new tools to add to your toolbox, and hopefully instill in you some
-excitement for exploring (and perhaps building) more tools on your own.
-This is what we believe to be the missing semester from most Computer
-Science curricula.
+Kami ingin mengajarkan Anda cara memaksimalkan alat yang Anda tahu,
+memperkenalkan alat-alat baru untuk ditambahkan ke kotak peralatan Anda, dan
+mudah-mudahan menanamkan semangat untuk menjelajahi (dan mungkin membangun)
+lebih banyak alat sendiri. Inilah yang kami yakini sebagai semester yang
+hilang dari sebagian besar kurikulum Ilmu Komputer.
 
-# Class structure
+# Struktur kelas
 
-The not-for-credit class consists of nine 1-hour lectures, each one
-centering on a [particular topic](/2026/). The lectures are largely
-independent, though as the semester goes on we will presume that you are
-familiar with the content from the earlier lectures. We have lecture
-notes online, but there may be content covered in class (e.g. in the
-form of demos) that may not be in the notes. As for past years, we will
-be recording lectures and posting the recordings
-[online](https://www.youtube.com/@MissingSemester).
+Kelas tanpa kredit ini terdiri dari sembilan kuliah 1 jam, masing-masing
+berpusat pada [topik tertentu](/2026/). Kuliah-kuliah ini sebagian besar
+independen, meskipun seiring berjalannya semester kami akan berasumsi bahwa
+Anda sudah terbiasa dengan materi dari kuliah-kuliah sebelumnya. Kami
+memiliki catatan kuliah daring, tetapi mungkin ada konten yang dibahas di
+kelas (misalnya dalam bentuk demo) yang tidak ada dalam catatan. Seperti tahun-tahun
+sebelumnya, kami akan merekam kuliah dan mengunggah rekamannya
+[secara daring](https://www.youtube.com/@MissingSemester).
 
-We are trying to cover a lot of ground over the course of just a few
-1-hour lectures, so the lectures are fairly dense. To allow you some
-time to get familiar with the content at your own pace, each lecture
-includes a set of exercises that guide you through the lecture's key
-points. We will not be running dedicated office hours, but we encourage
-you to ask questions on the [OSSU Discord](https://ossu.dev/#community),
-in `#missing-semester-forum`, or email us at
+Kami berusaha mencakup banyak hal hanya dalam beberapa kuliah 1 jam, jadi
+kuliah-kuliahnya cukup padat. Untuk memberi Anda waktu membiasakan diri
+dengan materi sesuai kecepatan Anda sendiri, setiap kuliah mencakup
+serangkaian latihan yang memandu Anda melalui poin-poin kunci kuliah. Kami
+tidak menjalankan jam kantor khusus, tetapi kami mendorong Anda untuk
+bertanya di [OSSU Discord](https://ossu.dev/#community),
+di `#missing-semester-forum`, atau kirimkan email kepada kami di
 [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-Due to the limited time we have, we won't be able to cover all the tools
-in the same level of detail a full-scale class might. Where possible, we
-will try to point you towards resources for digging further into a tool
-or topic, but if something particularly strikes your fancy, don't
-hesitate to reach out to us and ask for pointers!
+Karena waktu yang terbatas, kami tidak akan dapat mencakup semua alat
+dengan tingkat detail yang sama seperti kelas skala penuh. Jika memungkinkan,
+kami akan mencoba mengarahkan Anda ke sumber daya untuk menggali lebih dalam
+tentang alat atau topik tertentu, tetapi jika ada yang menarik perhatian Anda,
+jangan ragu untuk menghubungi kami dan meminta petunjuk!
 
-Finally, if you have feedback about the class, please send it to us by
-email at [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
+Terakhir, jika Anda memiliki umpan balik tentang kelas ini, silakan kirimkan
+kepada kami melalui email di [missing-semester@mit.edu](mailto:missing-semester@mit.edu).
 
-# Topic 1: The Shell
+# Topik 1: Shell
 
 {% comment %}
 lecturer: Jon
 {% endcomment %}
 
-## What is the shell?
+## Apa itu shell?
 
-Computers these days have a variety of interfaces for giving them
-commands; fanciful graphical user interfaces, voice interfaces, AR/VR,
-and more recently: LLMs. These are great for 80% of use-cases, but they
-are often fundamentally restricted in what they allow you to do — you
-cannot press a button that isn't there or give a voice command that
-hasn't been programmed. To take full advantage of the tools your
-computer provides, we have to go old-school and drop down to a textual
-interface: The Shell.
+Komputer saat ini memiliki berbagai antarmuka untuk memberikan perintah;
+antarmuka grafis yang mewah, antarmuka suara, AR/VR, dan baru-baru ini: LLM.
+Ini sangat bagus untuk 80% kasus penggunaan, tetapi sering kali mereka
+secara mendasar terbatas dalam apa yang mereka izinkan untuk Anda lakukan —
+Anda tidak dapat menekan tombol yang tidak ada atau memberikan perintah suara
+yang belum diprogram. Untuk memanfaatkan sepenuhnya alat yang disediakan
+komputer Anda, kita harus kembali ke cara lama dan beralih ke antarmuka
+tekstual: Shell.
 
-Nearly all platforms you can get your hands on have a shell in one form
-or another, and many of them have several shells for you to choose from.
-While they may vary in the details, at their core they are all roughly
-the same: they allow you to run programs, give them input, and inspect
-their output in a semi-structured way.
+Hampir semua platform yang bisa Anda dapatkan memiliki shell dalam satu bentuk
+atau lainnya, dan banyak dari mereka memiliki beberapa shell yang bisa Anda
+pilih. Meskipun mereka mungkin berbeda dalam detail, pada intinya mereka semua
+kurang lebih sama: mereka memungkinkan Anda menjalankan program, memberikan
+input, dan memeriksa output mereka secara semi-terstruktur.
 
-To open a shell _prompt_ (where you can type commands), you first need a
-_terminal_, which is the visual interface to a shell. Your device
-probably shipped with one installed, or you can install one fairly
-easily:
+Untuk membuka _prompt_ shell (tempat Anda dapat mengetik perintah), Anda
+terlebih dahulu membutuhkan _terminal_, yang merupakan antarmuka visual ke
+shell. Perangkat Anda mungkin sudah terinstal satu, atau Anda dapat
+menginstalnya dengan cukup mudah:
 
 - **Linux:**
-  Press `Ctrl + Alt + T` (works on most distributions). Or search for
-  "Terminal" in your applications menu.
+  Tekan `Ctrl + Alt + T` (berlaku di sebagian besar distribusi). Atau cari
+  "Terminal" di menu aplikasi Anda.
 - **Windows:**
-  Press `Win + R`, type `cmd` or `powershell`, and press Enter.
-  Alternatively, search "Terminal" or "Command Prompt" in the Start menu.
+  Tekan `Win + R`, ketik `cmd` atau `powershell`, dan tekan Enter.
+  Alternatifnya, cari "Terminal" atau "Command Prompt" di menu Start.
 - **macOS:**
-  Press `Cmd + Space` to open Spotlight, type "Terminal", and press Enter.
-  Or find it in Applications → Utilities → Terminal.
+  Tekan `Cmd + Space` untuk membuka Spotlight, ketik "Terminal", dan tekan Enter.
+  Atau temukan di Applications → Utilities → Terminal.
 
-On Linux and macOS, this will usually open the Bourne Again SHell, or
-"bash" for short. This is one of the most widely used shells, and its
-syntax is similar to what you will see in many other shells. On Windows,
-you'll be greeted by the "batch" or "powershell" shells, depending on
-which command you ran. These are Windows-specific, and not what we'll be
-focusing on in this class, although it has analogues for most of what
-we'll be teaching. You'll instead want the [Windows Subsystem for
-Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-machine.
+Di Linux dan macOS, ini biasanya akan membuka Bourne Again SHell, atau
+"bash" singkatnya. Ini adalah salah satu shell yang paling banyak digunakan, dan
+sintaksisnya mirip dengan apa yang akan Anda lihat di banyak shell lainnya. Di
+Windows, Anda akan disambut oleh shell "batch" atau "powershell", tergantung
+pada perintah mana yang Anda jalankan. Ini khusus untuk Windows, dan bukan yang
+akan kami fokuskan di kelas ini, meskipun mereka memiliki analog untuk
+sebagian besar yang akan kami ajarkan. Anda sebaiknya menggunakan [Windows
+Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau
+mesin virtual Linux.
 
-Other shells exist, often with many ergonomic improvements over bash
-(fish and zsh are among the most common). While these are very popular
-(all the instructors use one), they're nowhere near as ubiquitous as
-bash, and lean on many of the same concepts, so we won't be focusing on
-those in this lecture.
+Shell lain juga ada, sering kali dengan banyak peningkatan ergonomis
+dibandingkan bash (fish dan zsh adalah yang paling umum). Meskipun ini sangat
+populer (semua instruktur menggunakannya), mereka tidak tersebar luas seperti
+bash, dan bergantung pada banyak konsep yang sama, jadi kami tidak akan
+memfokuskan pada mereka dalam kuliah ini.
 
-## Why should you care about it?
+## Mengapa Anda harus peduli?
 
-The shell is not just (usually) much faster than "clicking around", it
-also comes with expressive power you can't easily find in any one
-graphical program. As we'll see, the shell gives you the ability to
-_combine_ programs in creative ways to automate nearly any task.
+Shell bukan hanya (biasanya) jauh lebih cepat daripada "mengklik-klik",
+tetapi juga dilengkapi dengan kekuatan ekspresif yang tidak dapat Anda temukan
+dengan mudah di satu program grafis. Seperti yang akan kita lihat, shell
+memberi Anda kemampuan untuk _menggabungkan_ program secara kreatif untuk
+mengotomatiskan hampir semua tugas.
 
-Knowing your way around a shell is also very useful to navigate the
-world of open-source software (which often come with install
-instructions that require the shell), building continuous integration
-for your software projects (as described in the [Code Quality
-lecture](/2026/code-quality/)), and debugging errors when other programs
-fail.
+Mengetahui cara menggunakan shell juga sangat berguna untuk menavigasi
+dunia perangkat lunak sumber terbuka (yang sering kali dilengkapi dengan
+petunjuk instalasi yang membutuhkan shell), membangun integrasi berkelanjutan
+untuk proyek perangkat lunak Anda (seperti dijelaskan dalam [kuliah Code
+Quality](/2026/code-quality/)), dan men-debug kesalahan saat program lain
+gagal.
 
-## Navigating in the shell
+## Navigasi di shell
 
-When you launch your terminal, you will see a _prompt_ that often looks
-a little like this:
+Saat Anda membuka terminal, Anda akan melihat _prompt_ yang sering terlihat
+seperti ini:
 
 ```console
 missing:~$
 ```
 
-This is the main textual interface to the shell. It tells you that you
-are on the machine `missing` and that your "current working directory",
-or where you currently are, is `~` (short for "home"). The `$` tells you
-that you are not the root user (more on that later). At this prompt you
-can type a _command_, which will then be interpreted by the shell. The
-most basic command is to execute a program:
+Ini adalah antarmuka tekstual utama ke shell. Ini memberi tahu Anda bahwa
+Anda berada di mesin `missing` dan bahwa "direktori kerja Anda saat ini",
+atau tempat Anda berada saat ini, adalah `~` (singkatan dari "home"). `$`
+memberi tahu Anda bahwa Anda bukan pengguna root (lebih lanjut tentang itu
+nanti). Pada prompt ini Anda dapat mengetik _perintah_, yang kemudian akan
+diterjemahkan oleh shell. Perintah paling dasar adalah menjalankan program:
 
 ```console
 missing:~$ date
@@ -168,43 +170,43 @@ Fri 10 Jan 2020 11:49:31 AM EST
 missing:~$
 ```
 
-Here, we executed the `date` program, which (perhaps unsurprisingly)
-prints the current date and time. The shell then asks us for another
-command to execute. We can also execute a command with _arguments_:
+Di sini, kita menjalankan program `date`, yang (mungkin tidak mengejutkan)
+mencetak tanggal dan waktu saat ini. Shell kemudian meminta kita perintah lain
+untuk dijalankan. Kita juga dapat menjalankan perintah dengan _argumen_:
 
 ```console
 missing:~$ echo hello
 hello
 ```
 
-In this case, we told the shell to execute the program `echo` with the
-argument `hello`. The `echo` program simply prints out its arguments.
-The shell parses the command by splitting it by whitespace, and then
-runs the program indicated by the first word, supplying each subsequent
-word as an argument that the program can access. If you want to provide
-an argument that contains spaces or other special characters (e.g., a
-directory named "My Photos"), you can either quote the argument with `'`
-or `"` (`"My Photos"`), or escape just the relevant characters with `\`
-(`My\ Photos`).
+Dalam kasus ini, kita memberi tahu shell untuk menjalankan program `echo`
+dengan argumen `hello`. Program `echo` cukup mencetak argumennya. Shell
+mengurai perintah dengan memisahnya berdasarkan spasi, dan kemudian menjalankan
+program yang ditunjukkan oleh kata pertama, menyediakan setiap kata berikutnya
+sebagai argumen yang dapat diakses oleh program. Jika Anda ingin memberikan
+argumen yang mengandung spasi atau karakter khusus lainnya (misalnya, direktori
+bernama "My Photos"), Anda dapat mengutip argumen dengan `'` atau `"` (`"My
+Photos"`), atau melepaskan karakter yang relevan dengan `\` (`My\ Photos`).
 
-Perhaps the most important command when you're starting out is `man`,
-short for "manual". The `man` program, among other things, lets you look
-up more information about any command on your system. For example, if
-you run `man date`, it'll explain what `date` is, and all of the various
-arguments you can pass it to alter its behavior. You can also usually
-get a short version of the help by passing `--help` as an argument to
-most commands.
+Mungkin perintah paling penting saat Anda baru memulai adalah `man`,
+singkatan dari "manual". Program `man`, antara lain, memungkinkan Anda mencari
+informasi lebih lanjut tentang perintah apa pun di sistem Anda. Misalnya, jika
+Anda menjalankan `man date`, ini akan menjelaskan apa itu `date`, dan semua
+berbagai argumen yang dapat Anda berikan untuk mengubah perilakunya. Anda juga
+biasanya bisa mendapatkan versi singkat bantuan dengan memberikan `--help`
+sebagai argumen ke sebagian besar perintah.
 
-> Consider installing and using [`tldr`](https://tldr.sh/) in addition
-> to `man`, as it shows you common usage examples right there in the
-> terminal. LLMs are also usually very good at explaining how commands
-> work and how you can call them to achieve what you want to accomplish.
+> Pertimbangkan untuk menginstal dan menggunakan [`tldr`](https://tldr.sh/)
+> selain `man`, karena ini menunjukkan contoh penggunaan umum langsung di
+> terminal. LLM juga biasanya sangat baik dalam menjelaskan cara kerja perintah
+> dan bagaimana Anda dapat memanggilnya untuk mencapai apa yang ingin Anda
+> lakukan.
 
-After `man`, the most important command to learn is `cd`, or "change
-directory". This command is actually built into the shell, and isn't a
-separate program (i.e., `which cd` will say "no cd found"). You pass it
-a path, and that path becomes your current working directory. You'll
-also see the working directory reflected in the shell prompt:
+Setelah `man`, perintah paling penting untuk dipelajari adalah `cd`, atau
+"change directory". Perintah ini sebenarnya dibangun ke dalam shell, dan bukan
+program terpisah (yaitu, `which cd` akan mengatakan "no cd found"). Anda
+memberikannya jalur, dan jalur itu menjadi direktori kerja Anda saat ini. Anda
+juga akan melihat direktori kerja tercermin di prompt shell:
 
 ```console
 missing:~$ cd /bin
@@ -213,23 +215,23 @@ missing:/$ cd ~
 missing:~$
 ```
 
-> Note that the shell comes with auto-completion, so you can often
-> complete paths faster by pressing `<TAB>`!
+> Perhatikan bahwa shell dilengkapi dengan pelengkapan otomatis, jadi Anda
+> sering dapat melengkapi jalur lebih cepat dengan menekan `<TAB>`!
 
-A lot of commands operate on the current working directory if nothing
-else is specified. If you're ever unsure where you are, you can run
-`pwd` or print the `$PWD` environment variable (with `echo $PWD`), both
-of which produce the current working directory.
+Banyak perintah beroperasi pada direktori kerja saat ini jika tidak ada
+yang ditentukan. Jika Anda tidak yakin di mana Anda berada, Anda dapat
+menjalankan `pwd` atau mencetak variabel lingkungan `$PWD` (dengan `echo
+$PWD`), keduanya menghasilkan direktori kerja saat ini.
 
-The current working directory also comes in handy in that it allows us to
-use _relative_ paths. All the paths we've seen so far have been
-_absolute_ --- they start with `/` and give the full set of directories
-needed to navigate to some location from the root of the file system
-(`/`). In practice, you'll more commonly work with relative paths; so
-called because they are relative to the current working directory. In a
-relative path (anything _not_ starting with `/`), the first path
-component is looked up in the current working directory, and subsequent
-components traverse as usual. For example:
+Direktori kerja saat ini juga berguna karena memungkinkan kita menggunakan
+jalur _relatif_. Semua jalur yang telah kita lihat sejauh ini adalah
+_absolut_ --- mereka dimulai dengan `/` dan memberikan kumpulan direktori
+lengkap yang diperlukan untuk menavigasi ke suatu lokasi dari root sistem file
+(`/`). Dalam praktiknya, Anda akan lebih sering bekerja dengan jalur relatif;
+disebut demikian karena relatif terhadap direktori kerja saat ini. Dalam jalur
+relatif (apa pun yang _tidak_ dimulai dengan `/`), komponen jalur pertama
+dicari di direktori kerja saat ini, dan komponen berikutnya melintasi seperti
+biasa. Misalnya:
 
 ```console
 missing:~$ cd /
@@ -237,9 +239,8 @@ missing:/$ cd bin
 missing:/bin$
 ```
 
-There are also two "special" components that exist in every directory:
-`.` and `..`. `.` is "this directory", and `..` is "the parent
-directory". So:
+Ada juga dua komponen "khusus" yang ada di setiap direktori: `.` dan `..`.
+`.` adalah "direktori ini", dan `..` adalah "direktori induk". Jadi:
 
 ```console
 missing:~$ cd /
@@ -247,21 +248,21 @@ missing:/$ cd bin/../bin/../bin/././../bin/..
 missing:/$
 ```
 
-You can usually use absolute and relative paths interchangeably for any
-command argument, just keep in mind what your current working directory
-is when using a relative one!
+Anda biasanya dapat menggunakan jalur absolut dan relatif secara bergantian
+untuk argumen perintah apa pun, ingat saja apa direktori kerja Anda saat ini
+saat menggunakan jalur relatif!
 
-> Consider installing and using
-> [`zoxide`](https://github.com/ajeetdsouza/zoxide) to speed up your
-> `cd`ing --- `z` will remember the paths you frequently visit and let
-> you access with less typing.
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`zoxide`](https://github.com/ajeetdsouza/zoxide) untuk mempercepat `cd`
+> Anda --- `z` akan mengingat jalur yang sering Anda kunjungi dan membiarkan
+> Anda mengaksesnya dengan lebih sedikit pengetikan.
 
-## What is available in the shell?
+## Apa yang tersedia di shell?
 
-But how does the shell know how to find programs like `date` or `echo`?
-If the shell is asked to execute a command, it consults an _environment
-variable_ called `$PATH` that lists which directories the shell should
-search for programs when it is given a command:
+Tetapi bagaimana shell tahu cara menemukan program seperti `date` atau
+`echo`? Jika shell diminta untuk menjalankan perintah, ia berkonsultasi dengan
+_variabel lingkungan_ yang disebut `$PATH` yang mencantumkan direktori mana
+yang harus dicari shell untuk program saat diberikan perintah:
 
 ```console
 missing:~$ echo $PATH
@@ -272,122 +273,124 @@ missing:~$ /bin/echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
-When we run the `echo` command, the shell sees that it should execute
-the program `echo`, and then searches through the `:`-separated list of
-directories in `$PATH` for a file by that name. When it finds it, it
-runs it (assuming the file is _executable_; more on that later). We can
-find out which file is executed for a given program name using the
-`which` program. We can also bypass `$PATH` entirely by giving the
-_path_ to the file we want to execute.
+Saat kita menjalankan perintah `echo`, shell melihat bahwa ia harus
+menjalankan program `echo`, dan kemudian mencari melalui daftar direktori yang
+dipisahkan oleh `:` di `$PATH` untuk file dengan nama tersebut. Ketika
+menemukannya, ia menjalankannya (dengan asumsi file tersebut _dapat
+dieksekusi_; lebih lanjut tentang itu nanti). Kita dapat mengetahui file mana
+yang dijalankan untuk nama program tertentu menggunakan program `which`. Kita
+juga dapat mengabaikan `$PATH` sepenuhnya dengan memberikan _jalur_ ke file
+yang ingin kita eksekusi.
 
-This also gives a clue for how we can determine _all_ the programs we're
-able to execute in the shell: by listing the contents of all the
-directories on `$PATH`. We can do this by passing a given directory path
-to the `ls` program, which lists files:
+Ini juga memberikan petunjuk tentang bagaimana kita dapat menentukan _semua_
+program yang dapat kita jalankan di shell: dengan mendaftar isi semua
+direktori di `$PATH`. Kita dapat melakukan ini dengan memberikan jalur
+direktori tertentu ke program `ls`, yang mendaftarkan file:
 
 ```console
 missing:~$ ls /bin
 ```
 
-> Consider installing and using [`eza`](https://eza.rocks/) for a more
-> human-friendly `ls`.
+> Pertimbangkan untuk menginstal dan menggunakan [`eza`](https://eza.rocks/)
+> untuk `ls` yang lebih ramah manusia.
 
-This will, on most computers, print a _lot_ of programs, but we'll only
-focus on some of the most important ones here. First, some simple ones:
+Ini akan, di sebagian besar komputer, mencetak _banyak_ program, tetapi kita
+hanya akan fokus pada beberapa yang paling penting di sini. Pertama, beberapa
+yang sederhana:
 
-- `cat file`, which prints the contents of `file`.
-- `sort file`, which prints out the lines of `file` in sorted order.
-- `uniq file`, which eliminates consecutive duplicate lines from `file`.
-- `head file` and `tail file`, which respectively print the first and
-  last few lines of `file`.
+- `cat file`, yang mencetak isi `file`.
+- `sort file`, yang mencetak baris-baris `file` dalam urutan yang diurutkan.
+- `uniq file`, yang menghilangkan baris duplikat yang berurutan dari `file`.
+- `head file` dan `tail file`, yang masing-masing mencetak beberapa baris
+  pertama dan terakhir dari `file`.
 
-> Consider installing and using [`bat`](https://github.com/sharkdp/bat)
-> over `cat` for syntax highlighting and scrolling.
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`bat`](https://github.com/sharkdp/bat) daripada `cat` untuk penyorotan
+> sintaksis dan pengguliran.
 
-There's also `grep pattern file`, which finds lines matching `pattern`
-in `file`. This one deserves slightly more attention as it's both _very_
-useful and sports a wider array of features than one may expect.
-`pattern` is actually a _regular expression_ which can express very
-complex patterns --- we'll [cover
-those](/2026/code-quality/#regular-expressions)
-in the code quality lecture. You can also specify a directory instead of a
-file (or leave it off for `.`) and pass `-r` to recursively search all
-the files in a directory.
+Ada juga `grep pattern file`, yang menemukan baris yang cocok dengan
+`pattern` di `file`. Yang satu ini patut mendapat perhatian lebih karena
+sangat _berguna_ dan memiliki rangkaian fitur yang lebih luas dari yang
+diharapkan. `pattern` sebenarnya adalah _ekspresi reguler_ yang dapat
+menyatakan pola yang sangat kompleks --- kita akan [membahasnya](/2026/code-quality/#regular-expressions)
+dalam kuliah code quality. Anda juga dapat menentukan direktori alih-alih file
+(atau membiarkannya untuk `.`) dan memberikan `-r` untuk mencari secara rekursif
+semua file di direktori.
 
-> Consider installing and using
-> [`ripgrep`](https://github.com/BurntSushi/ripgrep) over `grep` for a
-> faster and more human-friendly (but less portable) alternative.
-> `ripgrep` will also recursively search the current working directory
-> by default!
+> Pertimbangkan untuk menginstal dan menggunakan
+> [`ripgrep`](https://github.com/BurntSushi/ripgrep) daripada `grep` untuk
+> alternatif yang lebih cepat dan lebih ramah manusia (tetapi kurang portabel).
+> `ripgrep` juga akan mencari secara rekursif di direktori kerja saat ini
+> secara default!
 
-There are also some very useful tools with a slightly more complicated
-interface. First among those is `sed`, which is a programmatic file
-editor. It has its own programming language for making automated edits
-to files, but the most common use of it is:
+Ada juga beberapa alat yang sangat berguna dengan antarmuka yang sedikit
+lebih rumit. Yang pertama di antaranya adalah `sed`, yang merupakan editor
+file terprogram. Ia memiliki bahasa pemrograman sendiri untuk membuat edit
+otomatis ke file, tetapi penggunaan yang paling umum adalah:
 
 ```console
 missing:~$ sed -i 's/pattern/replacement/g' file
 ```
 
-This replaces all instances of `pattern` with `replacement` in `file`.
-The `-i` indicates that we want the substitutions to happen inline (as
-opposed to leaving `file` unmodified and printing the substituted
-contents). The `s/` is the way to express in the sed programming
-language that we want to do a substitution. The `/` separates the
-pattern from the replacement. And the trailing `/g` indicates that we
-want to replace _all_ occurrences on each line rather than just the
-first. As with `grep`, `pattern` here is a regular expression, which
-gives you significant expressive power. Regular expression substitutions
-also allow `replacement` to refer back to parts of the matched pattern;
-we'll see an example of that in a second.
+Ini menggantikan semua instance `pattern` dengan `replacement` di `file`.
+`-i` menunjukkan bahwa kita ingin substitusi terjadi secara inline (sebaliknya
+dari membiarkan `file` tidak dimodifikasi dan mencetak isi yang telah
+disubstitusi). `s/` adalah cara untuk menyatakan dalam bahasa pemrograman sed
+bahwa kita ingin melakukan substitusi. `/` memisahkan pola dari pengganti. Dan
+`/g` di akhir menunjukkan bahwa kita ingin menggantikan _semua_ kemunculan
+pada setiap baris, bukan hanya yang pertama. Seperti `grep`, `pattern` di sini
+adalah ekspresi reguler, yang memberi Anda kekuatan ekspresif yang signifikan.
+Substitusi ekspresi reguler juga mengizinkan `replacement` untuk merujuk
+kembali ke bagian dari pola yang cocok; kita akan melihat contohnya sebentar
+lagi.
 
-Next, we have `find`, which lets you find files (recursively) that match
-certain conditions. For example:
+Selanjutnya, kita memiliki `find`, yang memungkinkan Anda mencari file
+(secara rekursif) yang memenuhi kondisi tertentu. Misalnya:
 
 ```console
 missing:~$ find ~/Downloads -type f -name "*.zip" -mtime +30
 ```
 
-Finds ZIP files in the download directory that are older than 30 days.
+Mencari file ZIP di direktori unduhan yang lebih tua dari 30 hari.
 
 ```console
 missing:~$ find ~ -type f -size +100M -exec ls -lh {} \;
 ```
 
-Finds files larger than 100M in your home directory and lists them. Note
-that `-exec` takes a _command_ terminated with a stand-alone `;` (which
-we need to escape much like a space) where `{}` is replaced with each
-matching file path by `find`.
+Mencari file yang lebih besar dari 100M di direktori home Anda dan
+mendaftarkannya. Perhatikan bahwa `-exec` mengambil _perintah_ yang diakhiri
+dengan `;` yang berdiri sendiri (yang perlu kita lepaskan seperti spasi) di
+mana `{}` diganti dengan setiap jalur file yang cocok oleh `find`.
 
 ```console
 missing:~$ find . -name "*.py" -exec grep -l "TODO" {} \;
 ```
 
-Finds any `.py` files with TODO items in them.
+Mencari file `.py` apa pun yang memiliki item TODO di dalamnya.
 
-The syntax of `find` can be a little daunting, but hopefully this gives
-you a sense of how useful it can be!
+Sintaksis `find` bisa sedikit menakutkan, tetapi semoga ini memberi Anda
+gambaran tentang betapa bergunanya alat ini!
 
-> Consider installing and using [`fd`](https://github.com/sharkdp/fd)
-> instead of `find` for a more human-friendly (but less portable!)
-> experience.
+> Pertimbangkan untuk menginstal dan menggunakan [`fd`](https://github.com/sharkdp/fd)
+> daripada `find` untuk pengalaman yang lebih ramah manusia (tetapi kurang
+> portabel!).
 
-Next on the docket is `awk`, which, like `sed`, has its own programming
-language. Where `sed` is built for editing files, `awk` is built for
-parsing them. By far the most common use of `awk` is for data files with
-a regular syntax (like CSV files) where you want to extract only certain
-parts of every record (i.e., line):
+Selanjutnya adalah `awk`, yang, seperti `sed`, memiliki bahasa pemrograman
+sendiri. Jika `sed` dibangun untuk mengedit file, `awk` dibangun untuk
+menguraikannya. Penggunaan `awk` yang paling umum adalah untuk file data
+dengan sintaksis reguler (seperti file CSV) di mana Anda hanya ingin
+mengekstrak bagian tertentu dari setiap catatan (yaitu, baris):
 
 ```console
 missing:~$ awk '{print $2}' file
 ```
 
-Prints the second whitespace-separated column of every line of `file`.
-If you add `-F,`, it'll print the second comma-separated column of every
-line. `awk` can do much more --- filtering rows, computing aggregates,
-and more --- see the exercises for a taste.
+Mencetak kolom kedua yang dipisahkan spasi dari setiap baris `file`. Jika
+Anda menambahkan `-F,`, ini akan mencetak kolom kedua yang dipisahkan koma
+dari setiap baris. `awk` dapat melakukan lebih banyak --- memfilter baris,
+menghitung agregat, dan lainnya --- lihat latihan untuk rasanya.
 
-Putting these tools together, we can do fancy things like:
+Menggabungkan alat-alat ini, kita dapat melakukan hal-hal mewah seperti:
 
 ```console
 missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
@@ -398,76 +401,76 @@ missing:~$ ssh myserver 'journalctl -u sshd -b-1 | grep "Disconnected from"' \
 postgres,mysql,oracle,dell,ubuntu,inspur,test,admin,user,root
 ```
 
-This grabs SSH logs from a remote server (we'll talk more about `ssh` in
-the next lecture), searches for disconnect messages, extracts the
-username from each such message, and prints the top 10 usernames
-comma-separated. All in one command! We'll leave dissecting each step as
-an exercise.
+Ini mengambil log SSH dari server jarak jauh (kita akan membahas lebih
+lanjut tentang `ssh` di kuliah berikutnya), mencari pesan pemutusan, mengekstrak
+nama pengguna dari setiap pesan tersebut, dan mencetak 10 nama pengguna
+teratas yang dipisahkan koma. Semua dalam satu perintah! Kita akan meninggalkan
+pembedahan setiap langkah sebagai latihan.
 
-## The shell language (bash)
+## Bahasa shell (bash)
 
-The previous example introduced a new concept: pipes (`|`). These let
-you string together the output of one program with the input of another.
-This works because most command-line programs will operate on their
-"standard input" (where your keystrokes normally go) if no `file`
-argument is given. `|` takes the "standard output" (what normally gets
-printed to your terminal) of the program before the `|` and makes it be
-the standard input of the program after the `|`. This allows you to
-_compose_ shell programs, and it's part of what makes the shell such a
-productive environment to work in!
+Contoh sebelumnya memperkenalkan konsep baru: pipe (`|`). Ini memungkinkan
+Anda merangkai output satu program dengan input program lain. Ini berfungsi
+karena sebagian besar program baris perintah akan beroperasi pada "standard
+input" mereka (tempat ketukan tombol Anda biasanya pergi) jika tidak ada
+argumen `file` yang diberikan. `|` mengambil "standard output" (yang biasanya
+dicetak ke terminal Anda) dari program sebelum `|` dan menjadikannya input
+standar dari program setelah `|`. Ini memungkinkan Anda untuk
+_mengkomposisikan_ program shell, dan ini adalah bagian dari apa yang membuat
+shell menjadi lingkungan yang produktif untuk bekerja!
 
-In fact, most shells implement a full programming language (like bash),
-just like Python or Ruby. It has variables, conditionals, loops, and
-functions. When you run commands in your shell, you are really writing a
-small bit of code that your shell interprets. We won't teach you all of
-bash today, but there are some bits you'll find particularly useful:
+Faktanya, sebagian besar shell mengimplementasikan bahasa pemrograman
+lengkap (seperti bash), seperti Python atau Ruby. Ia memiliki variabel,
+kondisional, loop, dan fungsi. Saat Anda menjalankan perintah di shell Anda,
+Anda sebenarnya menulis sedikit kode yang diterjemahkan oleh shell Anda. Kami
+tidak akan mengajarkan semua bash hari ini, tetapi ada beberapa bagian yang
+akan Anda temukan sangat berguna:
 
-First, redirects: `>file` lets you take the standard output of a program
-and write it to `file` instead of to your terminal. This makes it easier
-to analyze after the fact. `>>file` will append to `file` rather than
-overwrite it. There's also `<file` which tells the shell to read from
-`file` instead of from your keyboard as the standard input to a program.
+Pertama, redirect: `>file` memungkinkan Anda mengambil output standar
+program dan menulisnya ke `file` alih-alih ke terminal Anda. Ini memudahkan
+untuk dianalisis setelahnya. `>>file` akan menambahkan ke `file` alih-alih
+menimpanya. Ada juga `<file` yang memberi tahu shell untuk membaca dari `file`
+alih-alih dari keyboard Anda sebagai input standar ke program.
 
-> This is a good time to mention the `tee` program. `tee` will print
-> standard input to standard output (just like `cat`!), but will _also_
-> write it to a file. So `verbose cmd | tee verbose.log | grep CRITICAL`
-> will preserve the full verbose log to a file while keeping your
-> terminal clean!
+> Ini adalah waktu yang baik untuk menyebutkan program `tee`. `tee` akan
+> mencetak input standar ke output standar (seperti `cat`!), tetapi juga akan
+> menulisnya ke file. Jadi `verbose cmd | tee verbose.log | grep CRITICAL`
+> akan menyimpan log verbose lengkap ke file sambil menjaga terminal Anda
+> tetap bersih!
 
-Next, conditionals: `if command1; then command2; command3; fi` will
-execute `command1`, and if it doesn't result in an error, will run
-`command2` and `command3`. You can also have an `else` branch if you
-wish. The most common command to use as `command1` is the `test`
-command, often abbreviated simply as `[`, which lets you evaluate
-conditions like "does a file exist" (`test -f file` / `[ -f file ]`) or
-"does a string equal another" (`[ "$var" = "string" ]`). In bash,
-there's also `[[ ]]`, which is a "safer" built-in version of `test` that
-has fewer odd behaviours around quoting.
+Selanjutnya, kondisional: `if command1; then command2; command3; fi` akan
+menjalankan `command1`, dan jika tidak menghasilkan kesalahan, akan menjalankan
+`command2` dan `command3`. Anda juga dapat memiliki cabang `else` jika Anda
+inginkan. Perintah yang paling umum untuk digunakan sebagai `command1` adalah
+perintah `test`, sering disingkat hanya sebagai `[`, yang memungkinkan Anda
+mengevaluasi kondisi seperti "apakah file ada" (`test -f file` / `[ -f file ]`)
+atau "apakah string sama dengan yang lain" (`[ "$var" = "string" ]`). Dalam
+bash, ada juga `[[ ]]`, yang merupakan versi built-in `test` yang "lebih aman"
+yang memiliki lebih sedikit perilaku aneh di sekitar pengutipan.
 
-Bash also has two forms of loops, `while` and `for`. `while command1; do
-command2; command3; done` functions just like the equivalent `if`
-command, except that it will re-execute the whole thing over and over
-for as long as `command1` does not error. `for varname in a b c d; do
-command; done` executes `command` four times, each time with `$varname`
-set to one of `a`, `b`, `c`, and `d`. Instead of listing the items
-explicitly, you'll often use "command substitution", such as:
+Bash juga memiliki dua bentuk loop, `while` dan `for`. `while command1; do
+command2; command3; done` berfungsi persis seperti perintah `if` yang setara,
+kecuali bahwa ia akan menjalankan ulang semuanya berulang-ulang selama
+`command1` tidak error. `for varname in a b c d; do command; done` menjalankan
+`command` empat kali, setiap kali dengan `$varname` diatur ke salah satu dari
+`a`, `b`, `c`, dan `d`. Alih-alih mendaftar item secara eksplisit, Anda akan
+sering menggunakan "command substitution", seperti:
 
 ```bash
 for i in $(seq 1 10); do
 ```
 
-This executes the command `seq 1 10` (which prints the numbers from 1 to
-10 inclusive) and then replaces the whole `$()` with that command's
-output, giving you a 10-iteration for loop. In older code you'll
-sometimes see literal backticks (like ``for i in `seq 1 10`; do``)
-instead of `$()`, but you should strongly prefer the `$()` form as it
-can be nested.
+Ini menjalankan perintah `seq 1 10` (yang mencetak angka dari 1 hingga 10
+inklusif) dan kemudian mengganti seluruh `$()` dengan output perintah tersebut,
+memberi Anda loop for 10 iterasi. Dalam kode lama Anda terkadang akan melihat
+backtick literal (seperti ``for i in `seq 1 10`; do``) alih-alih `$()`, tetapi
+Anda sebaiknya lebih memilih bentuk `$()` karena dapat disarangkan.
 
-While you _can_ write long shell scripts directly in your prompt, you'll
-usually want to write them into a `.sh` file instead. For example,
-here's a script that will run a program in a loop until it fails,
-printing the output only of the failed run, while stressing your CPU in
-the background (useful to reproduce flaky tests for example):
+Meskipun Anda _bisa_ menulis skrip shell panjang langsung di prompt Anda,
+Anda biasanya akan ingin menulisnya ke file `.sh` sebagai gantinya. Misalnya,
+berikut adalah skrip yang akan menjalankan program dalam loop sampai gagal,
+mencetak hanya output dari jalanan yang gagal, sambil membebani CPU Anda di
+latar belakang (berguna untuk mereproduksi tes yang tidak stabil misalnya):
 
 ```bash
 #!/bin/bash
@@ -496,161 +499,160 @@ tail -n 20 "$LOGFILE"
 echo "Full log: $LOGFILE"
 ```
 
-This has a number of new things in it that I recommend you spend some
-time diving into, as they're very useful in crafting useful shell
-invocations like background jobs (`&`) to run programs concurrently,
-trickier [shell
-redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html),
-and [arithmetic
-expansion](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html).
+Ini memiliki sejumlah hal baru yang saya sarankan Anda luangkan waktu untuk
+mendalaminya, karena mereka sangat berguna dalam menyusun pemanggilan shell
+yang berguna seperti pekerjaan latar belakang (`&`) untuk menjalankan program
+secara bersamaan, [pengalihan
+shell](https://www.gnu.org/software/bash/manual/html_node/Redirections.html)
+yang lebih rumit, dan [ekspansi
+aritmatika](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html).
 
-It's worth spending a second on the first two lines of the program
-though. The first is the "shebang" -- you'll see this at the top of
-other files than shell scripts too. When a file that starts with the
-magic incantation `#!/path` is executed, the shell will start the
-program at `/path`, and pass it the contents of the file as input. In
-the case of a shell script, this means passing the contents of the shell
-script to `/bin/bash`, but you can also write Python scripts with a
-shebang line of `/usr/bin/python`!
+Perlu menghabiskan sebentar pada dua baris pertama program. Yang pertama
+adalah "shebang" --- Anda akan melihat ini di bagian atas file selain skrip
+shell. Ketika file yang dimulai dengan mantra ajaib `#!/path` dijalankan,
+shell akan memulai program di `/path`, dan memberikan isi file sebagai input.
+Dalam kasus skrip shell, ini berarti memberikan isi skrip shell ke `/bin/bash`,
+tetapi Anda juga dapat menulis skrip Python dengan baris shebang
+`/usr/bin/python`!
 
-The second line is a way to make bash "stricter", and mitigate a number
-of footguns when writing shell scripts. `set` can take a whole lot of
-arguments, but briefly: `-e` makes it so that if any command fails, the
-script exits early; `-u` makes it so that use of undefined variables
-crashes the script rather than just using an empty string; and `-o
-pipefail` makes it so that if programs in a `|` sequence fail, the
-shell script as a whole also exits early.
+Baris kedua adalah cara untuk membuat bash "lebih ketat", dan mengurangi
+sejumlah jebakan saat menulis skrip shell. `set` dapat mengambil banyak
+argumen, tetapi secara singkat: `-e` membuatnya sehingga jika perintah apa
+pun gagal, skrip keluar lebih awal; `-u` membuatnya sehingga penggunaan
+variabel yang tidak terdefinisi membuat skrip crash alih-alih hanya menggunakan
+string kosong; dan `-o pipefail` membuatnya sehingga jika program dalam urutan
+`|` gagal, skrip shell secara keseluruhan juga keluar lebih awal.
 
-> Shell programming is a deep topic, just as any programming language
-> is, but be warned: bash has an unusual number of gotchas, to the point
-> that there are [multiple](https://tldp.org/LDP/abs/html/gotchas.html)
-> websites dedicated to [listing them](https://mywiki.wooledge.org/BashPitfalls).
-> I highly recommend making heavy use of
-> [shellcheck](https://www.shellcheck.net/) when writing them. LLMs are
-> also great at writing and debugging shell scripts, as well as
-> translating them to a "real" programming language (like Python) when
-> they've grown too unwieldy for bash (100+ lines).
+> Pemrograman shell adalah topik yang mendalam, seperti bahasa pemrograman
+> apa pun, tetapi perlu diingat: bash memiliki jumlah jebakan yang tidak biasa,
+> sampai-sampai ada [beberapa](https://tldp.org/LDP/abs/html/gotchas.html) situs
+> web yang didedikasikan untuk [mendaftarkannya](https://mywiki.wooledge.org/BashPitfalls).
+> Saya sangat merekomendasikan untuk banyak menggunakan
+> [shellcheck](https://www.shellcheck.net/) saat menulisnya. LLM juga bagus
+> dalam menulis dan men-debug skrip shell, serta menerjemahkannya ke bahasa
+> pemrograman "nyata" (seperti Python) ketika mereka telah tumbuh terlalu rumit
+> untuk bash (100+ baris).
 
-# Next steps
+# Langkah selanjutnya
 
-At this point you know your way around a shell enough to accomplish
-basic tasks. You should be able to navigate around to find files of
-interest and use the basic functionality of most programs. In the next
-lecture, we will talk about how to perform and automate more complex
-tasks using the shell and the many handy command-line programs out
-there.
+Pada titik ini Anda sudah cukup tahu cara menggunakan shell untuk
+menyelesaikan tugas-tugas dasar. Anda seharusnya dapat menavigasi untuk
+menemukan file yang menarik dan menggunakan fungsionalitas dasar sebagian
+besar program. Di kuliah berikutnya, kita akan membahas cara melakukan dan
+mengotomatiskan tugas yang lebih kompleks menggunakan shell dan banyak program
+baris perintah yang berguna di luar sana.
 
-# Exercises
+# Latihan
 
-All classes in this course are accompanied by a series of exercises.
-Some give you a specific task to do, while others are open-ended, like
-"try using X and Y programs". We highly encourage you to try them out.
+Semua kelas dalam kursus ini disertai dengan serangkaian latihan. Beberapa
+memberi Anda tugas tertentu untuk dilakukan, sementara yang lain terbuka,
+seperti "coba gunakan program X dan Y". Kami sangat mendorong Anda untuk
+mencobanya.
 
-We have not written solutions for the exercises. If you are stuck on
-anything in particular, feel free to post in `#missing-semester-forum`
-on [Discord](https://ossu.dev/#community) or send us an email describing
-what you've tried so far, and we will try to help you out. These
-exercises will also likely work well as initial prompts in a
-conversation with an LLM where you can interactively dive into the
-topic. The real value in these exercises is the journey of discovering
-the answers, not the answer itself. We encourage you to follow tangents
-and ask "why" as you work through them, rather than just looking for the
-shortest path to the solution.
+Kami belum menulis solusi untuk latihan. Jika Anda macet pada sesuatu,
+jangan ragu untuk posting di `#missing-semester-forum` di
+[Discord](https://ossu.dev/#community) atau kirimkan email kepada kami yang
+menjelaskan apa yang telah Anda coba sejauh ini, dan kami akan mencoba membantu
+Anda. Latihan ini juga mungkin bekerja dengan baik sebagai prompt awal dalam
+percakapan dengan LLM di mana Anda dapat secara interaktif mendalami topik.
+Nilai nyata dari latihan ini adalah perjalanan menemukan jawaban, bukan
+jawabannya itu sendiri. Kami mendorong Anda untuk mengikuti cabang dan bertanya
+"mengapa" saat Anda mengerjakannya, daripada hanya mencari jalur terpendek ke
+solusi.
 
-1. For this course, you need to be using a Unix shell like Bash or ZSH. If
-   you are on Linux or macOS, you don't have to do anything special. If you
-   are on Windows, you need to make sure you are not running cmd.exe or
-   PowerShell; you can use [Windows Subsystem for
-   Linux](https://docs.microsoft.com/en-us/windows/wsl/) or a Linux virtual
-   machine to use Unix-style command-line tools. To make sure you're running
-   an appropriate shell, you can try the command `echo $SHELL`. If it says
-   something like `/bin/bash` or `/usr/bin/zsh`, that means you're running
-   the right program.
+1. Untuk kursus ini, Anda perlu menggunakan shell Unix seperti Bash atau ZSH. Jika
+   Anda di Linux atau macOS, Anda tidak perlu melakukan apa-apa yang istimewa. Jika
+   Anda di Windows, Anda perlu memastikan Anda tidak menjalankan cmd.exe atau
+   PowerShell; Anda dapat menggunakan [Windows Subsystem for
+   Linux](https://docs.microsoft.com/en-us/windows/wsl/) atau mesin virtual Linux
+   untuk menggunakan alat baris perintah gaya Unix. Untuk memastikan Anda menjalankan
+   shell yang sesuai, Anda dapat mencoba perintah `echo $SHELL`. Jika ini mengatakan
+   sesuatu seperti `/bin/bash` atau `/usr/bin/zsh`, itu berarti Anda menjalankan
+   program yang benar.
 
-1. What does the `-l` flag to `ls` do? Run `ls -l /` and examine the output.
-   What do the first 10 characters of each line mean? (Hint: `man ls`)
+1. Apa yang dilakukan flag `-l` pada `ls`? Jalankan `ls -l /` dan periksa outputnya.
+   Apa arti 10 karakter pertama dari setiap baris? (Petunjuk: `man ls`)
 
-1. In the command `find ~/Downloads -type f -name "*.zip" -mtime +30`, the
-   `*.zip` is a "glob". What is a glob? Create a test directory with some
-   files and experiment with patterns like `ls *.txt`, `ls file?.txt`, and
-   `ls {a,b,c}.txt`. See [Pattern
+1. Dalam perintah `find ~/Downloads -type f -name "*.zip" -mtime +30`, `*.zip`
+   adalah "glob". Apa itu glob? Buat direktori uji dengan beberapa file dan
+   bereksperimenlah dengan pola seperti `ls *.txt`, `ls file?.txt`, dan `ls
+   {a,b,c}.txt`. Lihat [Pattern
    Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)
-   in the Bash manual.
+   di manual Bash.
 
-1. What's the difference between `'single quotes'`, `"double quotes"`, and
-   `$'ANSI quotes'`? Write a command that echoes a string containing a
-   literal `$`, a `!`, and a newline character. See
+1. Apa perbedaan antara `'single quotes'`, `"double quotes"`, dan `$'ANSI
+   quotes'`? Tulis perintah yang meng-echo string yang mengandung `$` literal,
+   `!`, dan karakter newline. Lihat
    [Quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html).
 
-1. The shell has three standard streams: stdin (0), stdout (1), and stderr
-   (2). Run `ls /nonexistent /tmp` and redirect stdout to one file and
-   stderr to another. How would you redirect both to the same file? See
+1. Shell memiliki tiga stream standar: stdin (0), stdout (1), dan stderr (2).
+   Jalankan `ls /nonexistent /tmp` dan arahkan stdout ke satu file dan stderr ke
+   file lain. Bagaimana Anda akan mengarahkan keduanya ke file yang sama? Lihat
    [Redirections](https://www.gnu.org/software/bash/manual/html_node/Redirections.html).
 
-1. `$?` holds the exit status of the last command (0 = success). `&&` runs
-   the next command only if the previous succeeded; `||` runs it only if
-   the previous failed. Write a one-liner that creates `/tmp/mydir` only if
-   it doesn't already exist. See [Exit
+1. `$?` menyimpan status keluar dari perintah terakhir (0 = sukses). `&&`
+   menjalankan perintah berikutnya hanya jika yang sebelumnya berhasil; `||`
+   menjalankannya hanya jika yang sebelumnya gagal. Tulis satu baris yang membuat
+   `/tmp/mydir` hanya jika belum ada. Lihat [Exit
    Status](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html).
 
-1. Why does `cd` have to be built into the shell itself rather than a
-   standalone program? (Hint: think about what a child process can and
-   cannot affect in its parent.)
+1. Mengapa `cd` harus dibangun ke dalam shell itu sendiri daripada program
+   mandiri? (Petunjuk: pikirkan tentang apa yang dapat dan tidak dapat dipengaruhi
+   oleh proses anak di induknya.)
 
-1. Write a script that takes a filename as an argument (`$1`) and checks
-   whether the file exists using `test -f` or `[ -f ... ]`. It should print
-   different messages depending on whether the file exists. See [Bash
-   Conditional
+1. Tulis skrip yang mengambil nama file sebagai argumen (`$1`) dan memeriksa
+   apakah file ada menggunakan `test -f` atau `[ -f ... ]`. Ini harus mencetak
+   pesan yang berbeda tergantung pada apakah file ada. Lihat [Bash Conditional
    Expressions](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html).
 
-1. Save the script from the previous exercise to a file (e.g., `check.sh`).
-   Try running it with `./check.sh somefile`. What happens? Now run
-   `chmod +x check.sh` and try again. Why is this step necessary? (Hint:
-   look at `ls -l check.sh` before and after the `chmod`.)
+1. Simpan skrip dari latihan sebelumnya ke file (misalnya, `check.sh`). Coba
+   jalankan dengan `./check.sh somefile`. Apa yang terjadi? Sekarang jalankan
+   `chmod +x check.sh` dan coba lagi. Mengapa langkah ini diperlukan? (Petunjuk:
+   lihat `ls -l check.sh` sebelum dan sesudah `chmod`.)
 
-1. What happens if you add `-x` to the `set` flags in a script? Try it with
-    a simple script and observe the output. See [The Set
+1. Apa yang terjadi jika Anda menambahkan `-x` ke flag `set` dalam skrip? Cobalah
+    dengan skrip sederhana dan amati outputnya. Lihat [The Set
     Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
 
-1. Write a command that copies a file to a backup with today's date in the
-    filename (e.g., `notes.txt` → `notes_2026-01-12.txt`). (Hint: `$(date
-    +%Y-%m-%d)`). See [Command
+1. Tulis perintah yang menyalin file ke cadangan dengan tanggal hari ini di nama
+    file (misalnya, `notes.txt` → `notes_2026-01-12.txt`). (Petunjuk: `$(date
+    +%Y-%m-%d)`). Lihat [Command
     Substitution](https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html).
 
-1. Modify the flaky test script from the lecture to accept the test command
-    as an argument instead of hardcoding `cargo test my_test`. (Hint: `$1`
-    or `$@`). See [Special
+1. Modifikasi skrip tes tidak stabil dari kuliah untuk menerima perintah tes
+    sebagai argumen alih-alih meng-hardcode `cargo test my_test`. (Petunjuk: `$1`
+    atau `$@`). Lihat [Special
     Parameters](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html).
 
-1. Use pipes to find the 5 most common file extensions in your home
-    directory. (Hint: combine `find`, `grep` or `sed` or `awk`, `sort`,
-    `uniq -c`, and `head`.)
+1. Gunakan pipe untuk menemukan 5 ekstensi file paling umum di direktori home
+    Anda. (Petunjuk: gabungkan `find`, `grep` atau `sed` atau `awk`, `sort`, `uniq
+    -c`, dan `head`.)
 
-1. `xargs` converts lines from stdin into command arguments. Use `find` and
-    `xargs` together (not `find -exec`) to find all `.sh` files in a
-    directory and count the lines in each with `wc -l`. Bonus: make it
-    handle filenames with spaces. (Hint: `-print0` and `-0`). See `man
+1. `xargs` mengubah baris dari stdin menjadi argumen perintah. Gunakan `find` dan
+    `xargs` bersama-sama (bukan `find -exec`) untuk menemukan semua file `.sh` di
+    direktori dan hitung baris di masing-masing dengan `wc -l`. Bonus: buat ini
+    menangani nama file dengan spasi. (Petunjuk: `-print0` dan `-0`). Lihat `man
     xargs`.
 
-1. Use `curl` to fetch the HTML of the course website
-    (`https://missing.csail.mit.edu/`) and pipe it to `grep` to count how
-    many lectures are listed. (Hint: look for a pattern that appears once
-    per lecture; use `curl -s` to silence the progress output.)
+1. Gunakan `curl` untuk mengambil HTML dari situs web kursus
+    (`https://missing.csail.mit.edu/`) dan arahkan ke `grep` untuk menghitung
+    berapa banyak kuliah yang terdaftar. (Petunjuk: cari pola yang muncul sekali
+    per kuliah; gunakan `curl -s` untuk membisukan output kemajuan.)
 
-1. [`jq`](https://jqlang.github.io/jq/) is a powerful tool for processing
-    JSON data. Fetch the sample data at
-    `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` with
-    `curl` and use `jq` to extract just the names of people whose version
-    is greater than 6. (Hint: pipe to `jq .` first to see the structure;
-    then try `jq '.[] | select(...) | .name'`)
+1. [`jq`](https://jqlang.github.io/jq/) adalah alat yang kuat untuk memproses
+    data JSON. Ambil data sampel di
+    `https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json` dengan `curl`
+    dan gunakan `jq` untuk mengekstrak hanya nama orang yang versinya lebih besar
+    dari 6. (Petunjuk: arahkan ke `jq .` terlebih dahulu untuk melihat strukturnya;
+    lalu coba `jq '.[] | select(...) | .name'`)
 
-1. `awk` can filter lines based on column values and manipulate output.
-    For example, `awk '$3 ~ /pattern/ {$4=""; print}'` prints only lines
-    where the third column matches `pattern`, while omitting the fourth
-    column. Write an `awk` command that prints only lines where the second
-    column is greater than 100, and swaps the first and third columns. Test
-    with: `printf 'a 50 x\nb 150 y\nc 200 z\n'`
+1. `awk` dapat memfilter baris berdasarkan nilai kolom dan memanipulasi output.
+    Misalnya, `awk '$3 ~ /pattern/ {$4=""; print}'` hanya mencetak baris di mana
+    kolom ketiga cocok dengan `pattern`, sambil menghilangkan kolom keempat. Tulis
+    perintah `awk` yang hanya mencetak baris di mana kolom kedua lebih besar dari
+    100, dan menukar kolom pertama dan ketiga. Uji dengan: `printf 'a 50 x\nb 150
+    y\nc 200 z\n'`
 
-1. Dissect the SSH log pipeline from the lecture: what does each step do?
-    Then build something similar to find your most-used shell commands from
-    `~/.bash_history` (or `~/.zsh_history`).
+1. Bedah pipeline log SSH dari kuliah: apa yang dilakukan setiap langkah? Kemudian
+    bangun sesuatu yang mirip untuk menemukan perintah shell yang paling sering Anda
+    gunakan dari `~/.bash_history` (atau `~/.zsh_history`).

--- a/_2026/debugging-profiling.md
+++ b/_2026/debugging-profiling.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Debugging and Profiling"
+title: "Debugging dan Profiling"
 description: >
-  Learn how to debug programs using logging and debuggers, and how to profile code for performance.
+  Pelajari cara men-debug program menggunakan logging dan debugger, serta cara melakukan profiling kode untuk performa.
 thumbnail: /static/assets/thumbnails/2026/lec4.png
 date: 2026-01-15
 ready: true
@@ -12,69 +12,68 @@ video:
   id: 8VYT9TcUmKs
 ---
 
-A golden rule in programming is that code does not do what you expect it to do, but what you tell it to do. Bridging that gap can sometimes be a quite difficult feat. In this lecture we are going to cover useful techniques for dealing with buggy and resource hungry code: debugging and profiling.
+Sebuah aturan emas dalam pemrograman adalah bahwa kode tidak melakukan apa yang Anda harapkan, melainkan apa yang Anda perintahkan. Menjembatani kesenjangan tersebut terkadang bisa menjadi hal yang cukup sulit. Dalam kuliah ini kita akan membahas teknik-teknik berguna untuk menangani kode yang bermasalah dan rakus sumber daya: debugging dan profiling.
 
 # Debugging
 
-## Printf Debugging and Logging
+## Printf Debugging dan Logging
 
-> "The most effective debugging tool is still careful thought, coupled with judiciously placed print statements" — Brian Kernighan, _Unix for Beginners_.
+> "Alat debugging yang paling efektif tetaplah pemikiran yang hati-hati, dipadukan dengan pernyataan print yang ditempatkan secara bijaksana" — Brian Kernighan, _Unix for Beginners_.
 
-A first approach to debug a program is to add print statements around where you have detected the problem, and keep iterating until you have extracted enough information to understand what is responsible for the issue.
+Pendekatan pertama untuk men-debug sebuah program adalah dengan menambahkan pernyataan print di sekitar area yang terdeteksi bermasalah, lalu terus beriterasi hingga Anda berhasil mengekstrak cukup informasi untuk memahami apa yang menyebabkan masalah tersebut.
 
-A second approach is to use logging in your program, instead of ad hoc print statements. Logging is essentially "printing with more care", and is usually done through a logging framework that includes built-in support for things like:
+Pendekatan kedua adalah menggunakan logging dalam program Anda, alih-alih pernyataan print yang bersifat ad hoc. Logging pada dasarnya adalah "mencetak dengan lebih terarah", dan biasanya dilakukan melalui framework logging yang memiliki dukungan bawaan untuk hal-hal seperti:
 
-- the ability to direct the logs (or subsets of the logs) to other output locations;
-- setting severity levels (such as INFO, DEBUG, WARN, ERROR, etc.) and allow you to filter the output according to those; and
-- support for structured logging of data related to the log entries, which can then be extracted more easily after the fact.
+- kemampuan untuk mengarahkan log (atau subset dari log) ke lokasi output lain;
+- pengaturan level keparahan (seperti INFO, DEBUG, WARN, ERROR, dll.) dan memungkinkan Anda memfilter output berdasarkan level tersebut; dan
+- dukungan untuk logging terstruktur dari data yang terkait dengan entri log, yang kemudian dapat diekstrak lebih mudah setelahnya.
 
-Logging statements you'll also usually proactively put in while
-programming so that the data you need to debug may already be there!
-And indeed, once you've found and fixed a problem using print
-statements, it's often worthwhile to convert those prints into proper
-log statements before removing them. This way, if similar bugs occur
-in the future, you'll already have the diagnostic information you need
-without modifying the code.
+Pernyataan logging juga biasanya akan Anda proaktif tambahkan saat
+pemrograman sehingga data yang Anda butuhkan untuk debugging mungkin sudah tersedia! Dan memang, setelah Anda menemukan dan memperbaiki masalah menggunakan pernyataan
+print, seringkali bermanfaat untuk mengonversi print tersebut menjadi
+pernyataan log yang proper sebelum menghapusnya. Dengan cara ini, jika bug serupa terjadi
+di masa depan, Anda sudah memiliki informasi diagnostik yang Anda butuhkan
+tanpa perlu memodifikasi kode.
 
-> **Third-party logs**: Many programs support the `-v` or `--verbose` flag to print more information when they run. This can be useful for discovering why a given command fails. Some even allow repeating the flag for more details. When debugging issues with services (databases, web servers, etc.), check their logs—often in `/var/log/` on Linux. Use `journalctl -u <service>` to view logs for systemd services. For third-party libraries, check if they support debug logging via environment variables or configuration.
+> **Log pihak ketiga**: Banyak program mendukung flag `-v` atau `--verbose` untuk mencetak lebih banyak informasi saat dijalankan. Ini bisa berguna untuk mengetahui mengapa suatu perintah gagal. Beberapa bahkan memungkinkan pengulangan flag untuk detail lebih lanjut. Saat men-debug masalah dengan layanan (database, web server, dll.), periksa log mereka—seringkali di `/var/log/` pada Linux. Gunakan `journalctl -u <service>` untuk melihat log layanan systemd. Untuk pustaka pihak ketiga, periksa apakah mereka mendukung debug logging melalui variabel lingkungan atau konfigurasi.
 
-## Debuggers
+## Debugger
 
-Print debugging works well when you know what to print and can easily modify and re-run your code. Debuggers become valuable when you're not sure what information you need, when the bug only manifests in hard-to-reproduce conditions, or when modifying and restarting the program is expensive (long startup times, complex state to recreate, etc.).
+Print debugging bekerja dengan baik ketika Anda tahu apa yang harus dicetak dan dapat dengan mudah memodifikasi serta menjalankan ulang kode Anda. Debugger menjadi berharga ketika Anda tidak yakin informasi apa yang Anda butuhkan, ketika bug hanya muncul dalam kondisi yang sulit direproduksi, atau ketika memodifikasi dan memulai ulang program membutuhkan biaya tinggi (waktu startup yang lama, state yang kompleks untuk dibuat ulang, dll.).
 
-Debuggers are programs that let you interact with the execution of a program as it happens, allowing you to:
+Debugger adalah program yang memungkinkan Anda berinteraksi dengan eksekusi suatu program saat terjadi, memungkinkan Anda untuk:
 
-- Halt execution when it reaches a certain line.
-- Step through one instruction at a time.
-- Inspect values of variables after a crash.
-- Conditionally halt execution when a given condition is met.
-- And many more advanced features.
+- Menghentikan eksekusi ketika mencapai baris tertentu.
+- Melangkah melalui satu instruksi pada satu waktu.
+- Memeriksa nilai variabel setelah crash.
+- Menghentikan eksekusi secara kondisional ketika suatu kondisi terpenuhi.
+- Dan banyak fitur lanjutan lainnya.
 
-Most programming languages support (or come with) some form of debugger. The most versatile are **general-purpose debuggers** like [`gdb`](https://www.gnu.org/software/gdb/) (GNU Debugger) and [`lldb`](https://lldb.llvm.org/) (LLVM Debugger), which can debug any native binary. Many languages also have **language-specific debuggers** that integrate more tightly with the runtime (like Python's pdb or Java's jdb).
+Sebagian besar bahasa pemrograman mendukung (atau menyediakan) beberapa bentuk debugger. Yang paling serbaguna adalah **debugger serbaguna** seperti [`gdb`](https://www.gnu.org/software/gdb/) (GNU Debugger) dan [`lldb`](https://lldb.llvm.org/) (LLVM Debugger), yang dapat men-debug binary native apa pun. Banyak bahasa juga memiliki **debugger khusus bahasa** yang terintegrasi lebih erat dengan runtime (seperti pdb milik Python atau jdb milik Java).
 
-`gdb` is the de-facto standard debugger for C, C++, Rust, and other compiled languages. It lets you probe pretty much any process and get its current machine state: registers, stack, program counter, and more.
+`gdb` adalah debugger standar de-facto untuk C, C++, Rust, dan bahasa terkompilasi lainnya. Debugger ini memungkinkan Anda memeriksa hampir semua proses dan mendapatkan state mesin saat ini: register, stack, program counter, dan lainnya.
 
-Some useful GDB commands:
+Beberapa perintah GDB yang berguna:
 
-- `run` - Start the program
-- `b {function}` or `b {file}:{line}` - Set a breakpoint
-- `c` - Continue execution
+- `run` - Memulai program
+- `b {function}` atau `b {file}:{line}` - Mengatur breakpoint
+- `c` - Melanjutkan eksekusi
 - `step` / `next` / `finish` - Step in / step over / step out
-- `p {variable}` - Print value of variable
-- `bt` - Show backtrace (call stack)
-- `watch {expression}` - Break when the value changes
+- `p {variable}` - Mencetak nilai variabel
+- `bt` - Menampilkan backtrace (call stack)
+- `watch {expression}` - Break ketika nilai berubah
 
-> Consider using GDB's TUI mode (`gdb -tui` or press `Ctrl-x a` inside GDB) for a split-screen view showing source code alongside the command prompt.
+> Pertimbangkan untuk menggunakan mode TUI GDB (`gdb -tui` atau tekan `Ctrl-x a` di dalam GDB) untuk tampilan split-screen yang menampilkan source code di samping command prompt.
 
 ### Record-Replay Debugging
 
-Some of the most frustrating bugs are _Heisenbugs_: bugs that seem to disappear or change behavior when you try to observe them. Race conditions, timing-dependent bugs, and issues that only appear under certain system conditions fall into this category. Traditional debugging is often useless here because running the program again produces different behavior (e.g., print statements may slow down the code sufficiently that the race no longer happens).
+Beberapa bug yang paling membuat frustrasi adalah _Heisenbug_: bug yang sepertinya menghilang atau berubah perilaku ketika Anda mencoba mengamatinya. Race condition, bug yang bergantung pada timing, dan masalah yang hanya muncul di bawah kondisi sistem tertentu termasuk dalam kategori ini. Debugging tradisional seringkali tidak berguna di sini karena menjalankan program lagi menghasilkan perilaku yang berbeda (misalnya, pernyataan print mungkin memperlambat kode cukup sehingga race tidak lagi terjadi).
 
-**Record-replay debugging** solves this by recording a program's execution and allowing you to replay it deterministically as many times as you need. Even better, you can _reverse_ through the execution to find exactly where things went wrong.
+**Record-replay debugging** menyelesaikan ini dengan merekam eksekusi program dan memungkinkan Anda memutar ulangnya secara deterministik sebanyak yang Anda butuhkan. Lebih baik lagi, Anda dapat _mundur_ melalui eksekusi untuk menemukan secara tepat di mana segala sesuatunya menjadi salah.
 
-[rr](https://rr-project.org/) is a powerful tool for Linux that records program execution and allows deterministic replay with full debugging capabilities. It works with GDB, so you already know the interface.
+[rr](https://rr-project.org/) adalah alat yang powerful untuk Linux yang merekam eksekusi program dan memungkinkan replay deterministik dengan kemampuan debugging penuh. Alat ini bekerja dengan GDB, jadi Anda sudah familiar dengan antarmukanya.
 
-Basic usage:
+Penggunaan dasar:
 
 ```bash
 # Record a program execution
@@ -84,37 +83,37 @@ rr record ./my_program
 rr replay
 ```
 
-The magic happens during replay. Because the execution is deterministic, you can use **reverse debugging** commands:
+Keajaiban terjadi saat replay. Karena eksekusinya deterministik, Anda dapat menggunakan perintah **reverse debugging**:
 
-- `reverse-continue` (`rc`) - Run backwards until hitting a breakpoint
-- `reverse-step` (`rs`) - Step backwards one line
-- `reverse-next` (`rn`) - Step backwards, skipping function calls
-- `reverse-finish` - Run backwards until entering the current function
+- `reverse-continue` (`rc`) - Jalankan mundur hingga mencapai breakpoint
+- `reverse-step` (`rs`) - Mundur satu baris
+- `reverse-next` (`rn`) - Mundur, melewati function call
+- `reverse-finish` - Jalankan mundur hingga memasuki fungsi saat ini
 
-This is incredibly powerful for debugging. Say you have a crash—instead of guessing where the bug is and setting breakpoints, you can:
+Ini sangat powerful untuk debugging. Misalkan Anda memiliki crash—alih-alih menebak di mana bug berada dan mengatur breakpoint, Anda dapat:
 
-1. Run to the crash
-2. Inspect the corrupted state
-3. Set a watchpoint on the corrupted variable
-4. `reverse-continue` to find exactly where it was corrupted
+1. Jalankan hingga crash
+2. Periksa state yang rusak
+3. Atur watchpoint pada variabel yang rusak
+4. `reverse-continue` untuk menemukan secara tepat di mana kerusakan terjadi
 
-**When to use rr:**
-- Flaky tests that fail intermittently
-- Race conditions and threading bugs
-- Crashes that are hard to reproduce
-- Any bug where you wish you could "go back in time"
+**Kapan menggunakan rr:**
+- Test yang flaky yang gagal secara intermiten
+- Race condition dan bug threading
+- Crash yang sulit direproduksi
+- Bug apa pun di mana Anda berharap bisa "mundur ke masa lalu"
 
-> Note: rr only works on Linux and requires hardware performance counters. It doesn't work in VMs that don't expose these counters, such as on most AWS EC2 instances, and it doesn't support GPU access. For macOS, check out [Warpspeed](https://warpspeed.dev/).
+> Catatan: rr hanya bekerja di Linux dan memerlukan hardware performance counter. Tidak bekerja di VM yang tidak mengekspos counter ini, seperti pada sebagian besar instance AWS EC2, dan tidak mendukung akses GPU. Untuk macOS, lihat [Warpspeed](https://warpspeed.dev/).
 
-> **rr and concurrency**: Because rr records execution deterministically, it serializes thread scheduling. This means some race conditions may not manifest under rr if they depend on specific timing. rr is still useful for debugging races—once you capture a failing run, you can replay it reliably—but you may need multiple recording attempts to catch an intermittent bug. For bugs that don't involve concurrency, rr shines brightest: you can always reproduce the exact execution and use reverse debugging to hunt down corruption.
+> **rr dan konkurensi**: Karena rr merekam eksekusi secara deterministik, rr menserialisasi penjadwalan thread. Ini berarti beberapa race condition mungkin tidak muncul di bawah rr jika mereka bergantung pada timing tertentu. rr tetap berguna untuk men-debug race—setelah Anda menangkap run yang gagal, Anda dapat memutar ulangnya secara andal—tetapi Anda mungkin memerlukan beberapa kali percobaan perekaman untuk menangkap bug intermiten. Untuk bug yang tidak melibatkan konkurensi, rr bersinar paling terang: Anda selalu dapat mereproduksi eksekusi yang persis sama dan menggunakan reverse debugging untuk melacak kerusakan.
 
 ## System Call Tracing
 
-Sometimes you need to understand how your program interacts with the operating system. Programs make [system calls](https://en.wikipedia.org/wiki/System_call) to request services from the kernel—opening files, allocating memory, creating processes, and more. Tracing these calls can reveal why a program is hanging, what files it's trying to access, or where it's spending time waiting.
+Terkadang Anda perlu memahami bagaimana program Anda berinteraksi dengan sistem operasi. Program membuat [system call](https://en.wikipedia.org/wiki/System_call) untuk meminta layanan dari kernel—membuka file, mengalokasikan memori, membuat proses, dan lainnya. Melacak panggilan ini dapat mengungkap mengapa program hang, file apa yang coba diakses, atau di mana program menghabiskan waktu menunggu.
 
-### strace (Linux) and dtruss (macOS)
+### strace (Linux) dan dtruss (macOS)
 
-[`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) lets you observe every system call a program makes:
+[`strace`](https://www.man7.org/linux/man-pages/man1/strace.1.html) memungkinkan Anda mengamati setiap system call yang dibuat oleh sebuah program:
 
 ```bash
 # Trace all system calls
@@ -133,13 +132,13 @@ strace -p <PID>
 strace -T ./my_program
 ```
 
-> On macOS and BSD, use [`dtruss`](https://www.manpagez.com/man/1/dtruss/) (which wraps `dtrace`) for similar functionality:
+> Di macOS dan BSD, gunakan [`dtruss`](https://www.manpagez.com/man/1/dtruss/) (yang membungkus `dtrace`) untuk fungsionalitas serupa:
 
-> For deeper dives into `strace`, check out Julia Evans' excellent [strace zine](https://jvns.ca/strace-zine-unfolded.pdf).
+> Untuk pembahasan lebih mendalam tentang `strace`, lihat [strace zine](https://jvns.ca/strace-zine-unfolded.pdf) yang luar biasa dari Julia Evans.
 
-### bpftrace and eBPF
+### bpftrace dan eBPF
 
-[eBPF](https://ebpf.io/) (extended Berkeley Packet Filter) is a powerful Linux technology that allows running sandboxed programs in the kernel. [`bpftrace`](https://github.com/iovisor/bpftrace) provides a high-level syntax for writing eBPF programs. These are arbitrary programs running in the kernel, and thus have huge expressive power (though also a somewhat clumsy awk-like syntax). The most common use-case for them is to investigate what system calls are being invoked, including aggregations (like counts or latency statistics) or introspecting (or even filtering on) system call arguments.
+[eBPF](https://ebpf.io/) (extended Berkeley Packet Filter) adalah teknologi Linux yang powerful yang memungkinkan menjalankan program yang di-sandbox di dalam kernel. [`bpftrace`](https://github.com/iovisor/bpftrace) menyediakan sintaks tingkat tinggi untuk menulis program eBPF. Ini adalah program arbitrer yang berjalan di kernel, dan dengan demikian memiliki kekuatan ekspresif yang besar (meskipun juga memiliki sintaks yang agak canggung mirip awk). Kasus penggunaan yang paling umum adalah untuk menyelidiki system call apa yang dipanggil, termasuk agregasi (seperti hitungan atau statistik latensi) atau introspeksi (atau bahkan memfilter) argumen system call.
 
 ```bash
 # Trace file opens system-wide (prints immediately)
@@ -149,9 +148,9 @@ sudo bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm,
 sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* { @[probe] = count(); }'
 ```
 
-However, you can also write eBPF programs directly in C using a toolchain like [`bcc`](https://github.com/iovisor/bcc), which also ships with [many handy tools](https://www.brendangregg.com/blog/2015-09-22/bcc-linux-4.3-tracing.html) like `biosnoop` for printing latency distributions for disk operations or `opensnoop` for printing all open files.
+Namun, Anda juga dapat menulis program eBPF langsung dalam C menggunakan toolchain seperti [`bcc`](https://github.com/iovisor/bcc), yang juga dilengkapi dengan [banyak alat yang berguna](https://www.brendangregg.com/blog/2015-09-22/bcc-linux-4.3-tracing.html) seperti `biosnoop` untuk mencetak distribusi latensi untuk operasi disk atau `opensnoop` untuk mencetak semua file yang dibuka.
 
-Where `strace` is useful because it's easy to "just get up and running", `bpftrace` is what you should reach for when you need lower overhead, want to trace through kernel functions, need to do any kind of aggregation, etc. Note that `bpftrace` has to run as `root` though, and that it generally monitors the entire kernel, not just a particular process. To target a specific program, you can filter by command name or PID:
+Jika `strace` berguna karena mudah untuk "langsung dijalankan", `bpftrace` adalah yang harus Anda gunakan ketika Anda membutuhkan overhead yang lebih rendah, ingin men-trace melalui fungsi kernel, perlu melakukan agregasi, dll. Perhatikan bahwa `bpftrace` harus dijalankan sebagai `root`, dan secara umum memonitor seluruh kernel, bukan hanya proses tertentu. Untuk menargetkan program spesifik, Anda dapat memfilter berdasarkan nama perintah atau PID:
 
 ```bash
 # Filter by command name (prints summary on Ctrl-C)
@@ -161,11 +160,11 @@ sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* /comm == "bash"/ { @[probe] = 
 sudo bpftrace -e 'tracepoint:syscalls:sys_enter_* /pid == cpid/ { @[probe] = count(); }' -c 'ls -la'
 ```
 
-The `-c` flag runs the specified command and sets `cpid` to its PID, which is useful for tracing a program from the moment it starts. When the traced command exits, bpftrace prints the aggregated results.
+Flag `-c` menjalankan perintah yang ditentukan dan mengatur `cpid` ke PID-nya, yang berguna untuk men-trace program sejak awal dimulai. Ketika perintah yang di-trace keluar, bpftrace mencetak hasil agregat.
 
 ### Network Debugging
 
-For network issues, [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) and [Wireshark](https://www.wireshark.org/) let you capture and analyze network packets:
+Untuk masalah jaringan, [`tcpdump`](https://www.man7.org/linux/man-pages/man1/tcpdump.1.html) dan [Wireshark](https://www.wireshark.org/) memungkinkan Anda menangkap dan menganalisis paket jaringan:
 
 ```bash
 # Capture packets on port 80
@@ -175,19 +174,19 @@ sudo tcpdump -i any port 80
 sudo tcpdump -i any -w capture.pcap
 ```
 
-For HTTPS traffic, the encryption makes tcpdump less useful. Tools like [mitmproxy](https://mitmproxy.org/) can act as an intercepting proxy to inspect encrypted traffic. Browser developer tools (Network tab) are often the easiest way to debug HTTPS requests from web applications—they show decrypted request/response data, headers, and timing.
+Untuk traffic HTTPS, enkripsi membuat tcpdump kurang berguna. Alat seperti [mitmproxy](https://mitmproxy.org/) dapat bertindak sebagai intercepting proxy untuk memeriksa traffic terenkripsi. Browser developer tools (tab Network) seringkali merupakan cara termudah untuk men-debug permintaan HTTPS dari aplikasi web—mereka menampilkan data request/response yang didekripsi, header, dan timing.
 
 ## Memory Debugging
 
-Memory bugs—buffer overflows, use-after-free, memory leaks—are among the most dangerous and difficult to debug. They often don't crash immediately but corrupt memory in ways that cause problems much later.
+Bug memori—buffer overflow, use-after-free, memory leak—termasuk yang paling berbahaya dan sulit untuk di-debug. Seringkali mereka tidak langsung crash tetapi merusak memori dengan cara yang menyebabkan masalah jauh di kemudian hari.
 
-### Sanitizers
+### Sanitizer
 
-One approach to finding memory bugs is to use **sanitizers**, which are compiler features that instrument your code to detect errors at runtime. For example, the widely used **AddressSanitizer (ASan)** detects:
-- Buffer overflows (stack, heap, and global)
+Salah satu pendekatan untuk menemukan bug memori adalah menggunakan **sanitizer**, yang merupakan fitur compiler yang menginstrumen kode Anda untuk mendeteksi error saat runtime. Misalnya, **AddressSanitizer (ASan)** yang banyak digunakan mendeteksi:
+- Buffer overflow (stack, heap, dan global)
 - Use-after-free
 - Use-after-return
-- Memory leaks
+- Memory leak
 
 ```bash
 # Compile with AddressSanitizer
@@ -195,66 +194,66 @@ gcc -fsanitize=address -g program.c -o program
 ./program
 ```
 
-There are a variety of useful sanitizers:
+Terdapat berbagai sanitizer yang berguna:
 
-- **ThreadSanitizer (TSan)**: Detects data races in multithreaded code (`-fsanitize=thread`)
-- **MemorySanitizer (MSan)**: Detects reads of uninitialized memory (`-fsanitize=memory`)
-- **UndefinedBehaviorSanitizer (UBSan)**: Detects undefined behavior like integer overflow (`-fsanitize=undefined`)
+- **ThreadSanitizer (TSan)**: Mendeteksi data race di kode multithreaded (`-fsanitize=thread`)
+- **MemorySanitizer (MSan)**: Mendeteksi pembacaan memori yang belum diinisialisasi (`-fsanitize=memory`)
+- **UndefinedBehaviorSanitizer (UBSan)**: Mendeteksi perilaku undefined seperti integer overflow (`-fsanitize=undefined`)
 
-Sanitizers require recompilation but are fast enough to use in CI pipelines and during regular development.
+Sanitizer memerlukan kompilasi ulang tetapi cukup cepat untuk digunakan di pipeline CI dan selama pengembangan reguler.
 
-### Valgrind: When You Can't Recompile
+### Valgrind: Ketika Anda Tidak Bisa Mengkompilasi Ulang
 
-[Valgrind](https://valgrind.org/) instead runs your program in something akin to a virtual machine to detect memory errors. It's slower than sanitizers but doesn't require recompilation:
+[Valgrind](https://valgrind.org/) sebaliknya menjalankan program Anda di semacam mesin virtual untuk mendeteksi error memori. Lebih lambat daripada sanitizer tetapi tidak memerlukan kompilasi ulang:
 
 ```bash
 valgrind --leak-check=full ./my_program
 ```
 
-Use Valgrind when:
-- You don't have source code
-- You can't recompile (third-party libraries)
-- You need specific tools not available as sanitizers
+Gunakan Valgrind ketika:
+- Anda tidak memiliki source code
+- Anda tidak bisa mengkompilasi ulang (pustaka pihak ketiga)
+- Anda membutuhkan alat spesifik yang tidak tersedia sebagai sanitizer
 
-Valgrind is actually a really powerful controlled execution environment, and we'll see more of it later when we get to profiling!
+Valgrind sebenarnya adalah lingkungan eksekusi terkontrol yang sangat powerful, dan kita akan melihat lebih banyak tentang ini nanti saat masuk ke profiling!
 
-## AI for Debugging
+## AI untuk Debugging
 
-Large language models have become surprisingly useful debugging assistants. They excel at certain debugging tasks that complement traditional tools.
+Model bahasa besar telah menjadi asisten debugging yang secara mengejutkan berguna. Mereka unggul dalam tugas-tugas debugging tertentu yang melengkapi alat tradisional.
 
-**Where LLMs shine:**
+**Di mana LLM bersinar:**
 
-- **Explaining cryptic error messages**: Compiler errors, especially from C++ templates or Rust's borrow checker, can be notoriously cryptic. LLMs can translate them into plain English and suggest fixes.
+- **Menjelaskan pesan error yang misterius**: Error compiler, terutama dari template C++ atau borrow checker Rust, bisa sangat misterius. LLM dapat menerjemahkannya ke bahasa Inggris yang sederhana dan menyarankan perbaikan.
 
-- **Traversing language and abstraction boundaries**: If you're debugging a problem that spans multiple languages (say, a bug in a C library that manifests through a Python binding), LLMs can help navigate the different layers. They're particularly good at understanding FFI boundaries, build system issues, and cross-language debugging (e.g., my program errors, but I believe it is because of a bug in one of my dependencies).
+- **Menelusuri batas bahasa dan abstraksi**: Jika Anda men-debug masalah yang mencakup beberapa bahasa (misalnya, bug di pustaka C yang muncul melalui binding Python), LLM dapat membantu menavigasi lapisan-lapisan yang berbeda. Mereka sangat baik dalam memahami batas FFI, masalah build system, dan debugging lintas bahasa (misalnya, program saya error, tetapi saya percaya itu karena bug di salah satu dependensi saya).
 
-- **Correlating symptoms with root causes**: "My program works fine but uses 10x more memory than expected" is the kind of vague symptom that LLMs can help investigate, suggesting likely causes and what to look for.
+- **Mengorelasikan gejala dengan akar penyebab**: "Program saya berjalan baik tetapi menggunakan memori 10x lebih banyak dari yang diharapkan" adalah jenis gejala samar yang dapat dibantu investigasi oleh LLM, dengan menyarankan penyebab yang mungkin dan apa yang harus dicari.
 
-- **Analyzing crash dumps and stack traces**: Paste a stack trace and ask what might have caused it.
+- **Menganalisis crash dump dan stack trace**: Tempelkan stack trace dan tanyakan apa yang mungkin menyebabkannya.
 
-> **Note on debug symbols**: For meaningful stack traces and debugging, ensure your binaries (and any linked libraries) are compiled with debug symbols (`-g` flag). Debug information is typically stored in DWARF format. Additionally, compiling with frame pointers (`-fno-omit-frame-pointer`) makes stack traces more reliable, especially for profiling tools. Without these, stack traces may show only memory addresses or be incomplete. This matters more for natively compiled programs (C++, Rust) than Python or Java.
+> **Catatan tentang debug symbol**: Untuk stack trace dan debugging yang bermakna, pastikan binary Anda (dan pustaka yang ditautkan) dikompilasi dengan debug symbol (flag `-g`). Informasi debug biasanya disimpan dalam format DWARF. Selain itu, kompilasi dengan frame pointer (`-fno-omit-frame-pointer`) membuat stack trace lebih andal, terutama untuk alat profiling. Tanpa ini, stack trace mungkin hanya menampilkan alamat memori atau tidak lengkap. Ini lebih penting untuk program yang dikompilasi secara native (C++, Rust) daripada Python atau Java.
 
-**Limitations to keep in mind:**
-- LLMs can hallucinate plausible-sounding but wrong explanations
-- They may suggest fixes that mask the bug rather than fix it
-- Always verify suggestions with actual debugging tools
-- They work best as a complement to, not replacement for, understanding your code
+**Keterbatasan yang perlu diingat:**
+- LLM dapat berhalusinasi dengan penjelasan yang terdengar masuk akal tetapi salah
+- Mereka mungkin menyarankan perbaikan yang menutupi bug alih-alih memperbaikinya
+- Selalu verifikasi saran dengan alat debugging yang sebenarnya
+- Mereka bekerja paling baik sebagai pelengkap, bukan pengganti, untuk memahami kode Anda
 
-> This is distinct from the [general AI coding capabilities](/2026/development-environment/#ai-powered-development) covered in the Development Environment lecture. Here we're specifically talking about using LLMs as a debugging aid.
+> Ini berbeda dari [kemampuan coding AI umum](/2026/development-environment/#ai-powered-development) yang dibahas dalam kuliah Development Environment. Di sini kita secara khusus berbicara tentang menggunakan LLM sebagai bantuan debugging.
 
 # Profiling
 
-Even if your code functionally behaves as you would expect, that might not be good enough if it takes all your CPU or memory in the process. Algorithms classes often teach big _O_ notation but not how to find hot spots in your programs. Since [premature optimization is the root of all evil](https://wiki.c2.com/?PrematureOptimization), you should learn about profilers and monitoring tools. They will help you understand which parts of your program are taking most of the time and/or resources so you can focus on optimizing those parts.
+Bahkan jika kode Anda secara fungsional berperilaku seperti yang Anda harapkan, itu mungkin tidak cukup baik jika membutuhkan semua CPU atau memori Anda dalam prosesnya. Kelas algoritma sering mengajarkan notasi big _O_ tetapi tidak cara menemukan titik panas dalam program Anda. Karena [optimasi prematur adalah akar dari segala kejahatan](https://wiki.c2.com/?PrematureOptimization), Anda harus mempelajari profiler dan alat monitoring. Mereka akan membantu Anda memahami bagian mana dari program Anda yang menghabiskan sebagian besar waktu dan/atau sumber daya sehingga Anda dapat fokus mengoptimalkan bagian-bagian tersebut.
 
 ## Timing
 
-The simplest way to measure performance is to time things. In many scenarios it can be enough to just print the time it took your code between two points.
+Cara paling sederhana untuk mengukur performa adalah dengan mengukur waktu. Dalam banyak skenario, cukup dengan mencetak waktu yang dibutuhkan kode Anda antara dua titik.
 
-However, wall clock time can be misleading since your computer might be running other processes at the same time or waiting for events to happen. The `time` command distinguishes between _Real_, _User_, and _Sys_ time:
+Namun, waktu wall clock bisa menyesatkan karena komputer Anda mungkin menjalankan proses lain pada saat yang sama atau menunggu peristiwa terjadi. Perintah `time` membedakan antara waktu _Real_, _User_, dan _Sys_:
 
-- **Real** - Wall clock time from start to finish, including time spent waiting
-- **User** - Time spent in the CPU running user code
-- **Sys** - Time spent in the CPU running kernel code
+- **Real** - Waktu wall clock dari awal hingga akhir, termasuk waktu yang dihabiskan untuk menunggu
+- **User** - Waktu yang dihabiskan di CPU untuk menjalankan kode user
+- **Sys** - Waktu yang dihabiskan di CPU untuk menjalankan kode kernel
 
 ```bash
 $ time curl https://missing.csail.mit.edu &> /dev/null
@@ -263,58 +262,58 @@ user	0m0.079s
 sys	    0m0.028s
 ```
 
-Here the request took nearly 300 milliseconds (real time) but only 107ms of CPU time (user + sys). The rest was waiting for the network.
+Di sini permintaan membutuhkan hampir 300 milidetik (waktu real) tetapi hanya 107ms waktu CPU (user + sys). Sisanya adalah menunggu jaringan.
 
 ## Resource Monitoring
 
-Sometimes the first step towards analyzing the performance of your program is to understand what its actual resource consumption is. Programs often run slowly when they are resource constrained.
+Terkadang langkah pertama menuju menganalisis performa program Anda adalah memahami konsumsi sumber daya aktualnya. Program sering berjalan lambat ketika mereka dibatasi sumber dayanya.
 
-- **General Monitoring**: [`htop`](https://htop.dev/) is an improved version of `top` that presents various statistics for currently running processes. Useful keybinds: `<F6>` to sort processes, `t` to show tree hierarchy, `h` to toggle threads. There's also [`btop`](https://github.com/aristocratos/btop) which monitors _way_ more things.
+- **Monitoring Umum**: [`htop`](https://htop.dev/) adalah versi peningkatan dari `top` yang menyajikan berbagai statistik untuk proses yang sedang berjalan. Keybind yang berguna: `<F6>` untuk mengurutkan proses, `t` untuk menampilkan hierarki tree, `h` untuk menampilkan thread. Ada juga [`btop`](https://github.com/aristocratos/btop) yang memonitor _jauh_ lebih banyak hal.
 
-- **I/O Operations**: [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) displays live I/O usage information.
+- **Operasi I/O**: [`iotop`](https://www.man7.org/linux/man-pages/man8/iotop.8.html) menampilkan informasi penggunaan I/O secara langsung.
 
-- **Memory Usage**: [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) displays total free and used memory.
+- **Penggunaan Memori**: [`free`](https://www.man7.org/linux/man-pages/man1/free.1.html) menampilkan total memori yang bebas dan yang digunakan.
 
-- **Open Files**: [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) lists file information about files opened by processes. Useful for checking which process has opened a specific file.
+- **File Terbuka**: [`lsof`](https://www.man7.org/linux/man-pages/man8/lsof.8.html) mencantumkan informasi tentang file yang dibuka oleh proses. Berguna untuk memeriksa proses mana yang telah membuka file tertentu.
 
-- **Network Connections**: [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) lets you monitor network connections. A common use case is figuring out what process is using a given port: `ss -tlnp | grep :8080`.
+- **Koneksi Jaringan**: [`ss`](https://www.man7.org/linux/man-pages/man8/ss.8.html) memungkinkan Anda memonitor koneksi jaringan. Kasus penggunaan yang umum adalah mencari tahu proses mana yang menggunakan port tertentu: `ss -tlnp | grep :8080`.
 
-- **Network Usage**: [`nethogs`](https://github.com/raboof/nethogs) and [`iftop`](https://pdw.ex-parrot.com/iftop/) are good interactive CLI tools for monitoring network usage per process.
+- **Penggunaan Jaringan**: [`nethogs`](https://github.com/raboof/nethogs) dan [`iftop`](https://pdw.ex-parrot.com/iftop/) adalah alat CLI interaktif yang baik untuk memonitor penggunaan jaringan per proses.
 
-## Visualizing Performance Data
+## Visualisasi Data Performa
 
-Humans spot patterns in graphs much faster than in tables of numbers. When analyzing performance, plotting your data often reveals trends, spikes, and anomalies that would be invisible in raw numbers.
+Manusia lebih cepat menemukan pola dalam grafik daripada dalam tabel angka. Saat menganalisis performa, memplot data Anda sering mengungkap tren, lonjakan, dan anomali yang tidak terlihat dalam angka mentah.
 
-**Making data plottable**: When adding print or log statements for debugging, consider formatting the output so it can be easily graphed later. A simple timestamp and value in CSV format (`1705012345,42.5`) is much easier to plot than a prose sentence. JSON-structured logs can also be parsed and plotted with minimal effort. In other words, log your data [in a tidy way](https://vita.had.co.nz/papers/tidy-data.pdf).
+**Membuat data dapat diplot**: Saat menambahkan pernyataan print atau log untuk debugging, pertimbangkan untuk memformat output sehingga dapat dengan mudah dibuat grafiknya nanti. Timestamp dan nilai sederhana dalam format CSV (`1705012345,42.5`) jauh lebih mudah diplot daripada kalimat prosa. Log terstruktur JSON juga dapat diurai dan diplot dengan usaha minimal. Dengan kata lain, log data Anda [dengan cara yang rapi](https://vita.had.co.nz/papers/tidy-data.pdf).
 
-**Quick plotting with gnuplot**: For simple command-line plotting, [`gnuplot`](http://www.gnuplot.info/) can generate graphs directly from data files:
+**Plot cepat dengan gnuplot**: Untuk plotting command-line sederhana, [`gnuplot`](http://www.gnuplot.info/) dapat menghasilkan grafik langsung dari file data:
 
 ```bash
 # Plot a simple CSV with timestamp,value
 gnuplot -e "set datafile separator ','; plot 'latency.csv' using 1:2 with lines"
 ```
 
-**Iterative exploration with matplotlib and ggplot2**: For deeper analysis, Python's [`matplotlib`](https://matplotlib.org/) and R's [`ggplot2`](https://ggplot2.tidyverse.org/) enable iterative exploration. Unlike one-off plotting, these tools let you quickly slice and transform data to investigate hypotheses. ggplot2's facet plots are particularly powerful—you can split a single dataset across multiple subplots by category (e.g., faceting request latency by endpoint or time-of-day) to tease out patterns that would otherwise be hidden.
+**Eksplorasi iteratif dengan matplotlib dan ggplot2**: Untuk analisis yang lebih mendalam, [`matplotlib`](https://matplotlib.org/) milik Python dan [`ggplot2`](https://ggplot2.tidyverse.org/) milik R memungkinkan eksplorasi iteratif. Berbeda dengan plotting sekali pakai, alat ini memungkinkan Anda dengan cepat memotong dan mentransformasi data untuk menyelidiki hipotesis. Facet plot ggplot2 sangat powerful—Anda dapat membagi satu dataset menjadi beberapa subplot berdasarkan kategori (misalnya, memfaset latensi permintaan berdasarkan endpoint atau waktu dalam sehari) untuk mengungkap pola yang jika tidak akan tersembunyi.
 
-**Example use cases:**
-- Plotting request latency over time reveals periodic slowdowns (garbage collection, cron jobs, traffic patterns) that raw percentiles obscure
-- Visualizing insert times for a growing data structure can expose algorithmic complexity issues—a plot of vector insertions will show characteristic spikes when the backing array doubles in size
-- Faceting metrics by different dimensions (request type, user cohort, server) often reveals that a "system-wide" problem is actually isolated to one category
+**Contoh kasus penggunaan:**
+- Memplot latensi permintaan dari waktu ke waktu mengungkap perlambatan periodik (garbage collection, cron job, pola traffic) yang disembunyikan oleh persentil mentah
+- Memvisualisasikan waktu insert untuk struktur data yang berkembang dapat mengungkap masalah kompleksitas algoritmik—plot insert vektor akan menunjukkan lonjakan khas ketika array pendukungnya bertambah dua kali lipat ukurannya
+- Memfaset metrik berdasarkan dimensi berbeda (jenis permintaan, kohort pengguna, server) sering mengungkap bahwa masalah "seluruh sistem" sebenarnya terisolasi pada satu kategori
 
-## CPU Profilers
+## CPU Profiler
 
-Most of the time when people refer to _profilers_ they mean _CPU profilers_. There are two main types:
+Sebagian besar waktu ketika orang merujuk ke _profiler_ mereka berarti _CPU profiler_. Ada dua jenis utama:
 
-- **Tracing profilers** keep a record of every function call your program makes
-- **Sampling profilers** probe your program periodically (commonly every millisecond) and record the program's stack
+- **Tracing profiler** menyimpan catatan dari setiap pemanggilan fungsi yang dibuat program Anda
+- **Sampling profiler** memeriksa program Anda secara berkala (biasanya setiap milidetik) dan merekam stack program
 
-Sampling profilers have lower overhead and are generally preferred for production use.
+Sampling profiler memiliki overhead yang lebih rendah dan umumnya lebih disukai untuk penggunaan produksi.
 
-### perf: the sampling profiler
+### perf: sampling profiler
 
-[`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) is the standard Linux profiler. It can profile any program without recompilation:
+[`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) adalah profiler Linux standar. Dapat memprofilkan program apa pun tanpa kompilasi ulang:
 
-`perf stat` gives you a quick overview of where time is spent:
+`perf stat` memberi Anda gambaran singkat tentang di mana waktu dihabiskan:
 
 ```bash
 $ perf stat ./slow_program
@@ -331,13 +330,13 @@ $ perf stat ./slow_program
        12,345,678      branch-misses             #    1.00% of all branches
 ```
 
-Profiler output for real world programs will contain large amounts of information. Humans are visual creatures and are quite terrible at reading large amounts of numbers. [Flame graphs](https://www.brendangregg.com/flamegraphs.html) are a visualization that makes profiling data much easier to understand.
+Output profiler untuk program dunia nyata akan berisi sejumlah besar informasi. Manusia adalah makhluk visual dan cukup buruk dalam membaca sejumlah besar angka. [Flame graph](https://www.brendangregg.com/flamegraphs.html) adalah visualisasi yang membuat data profiling jauh lebih mudah dipahami.
 
-A flame graph displays a hierarchy of function calls across the Y axis and time taken proportional to the X axis. They're interactive—you can click to zoom into specific parts of the program.
+Flame graph menampilkan hierarki pemanggilan fungsi pada sumbu Y dan waktu yang dihabiskan sebanding dengan sumbu X. Mereka interaktif—Anda dapat mengklik untuk memperbesar bagian tertentu dari program.
 
 [![FlameGraph](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg)
 
-To generate a flame graph from `perf` data:
+Untuk menghasilkan flame graph dari data `perf`:
 
 ```bash
 # Record profile
@@ -347,11 +346,11 @@ perf record -g ./my_program
 perf script | stackcollapse-perf.pl | flamegraph.pl > flamegraph.svg
 ```
 
-> Consider using [Speedscope](https://www.speedscope.app/) for an interactive web-based flame graph viewer, or [Perfetto](https://perfetto.dev/) for comprehensive system-level analysis.
+> Pertimbangkan untuk menggunakan [Speedscope](https://www.speedscope.app/) untuk penampil flame graph berbasis web interaktif, atau [Perfetto](https://perfetto.dev/) untuk analisis komprehensif tingkat sistem.
 
-### Valgrind's Callgrind: the tracing profiler
+### Callgrind milik Valgrind: tracing profiler
 
-[`callgrind`](https://valgrind.org/docs/manual/cl-manual.html) is a profiling tool that records the call history and instruction counts of your program. Unlike sampling profilers, it provides exact call counts and can show the relationship between callers and callees:
+[`callgrind`](https://valgrind.org/docs/manual/cl-manual.html) adalah alat profiling yang merekam riwayat panggilan dan hitungan instruksi program Anda. Berbeda dengan sampling profiler, alat ini memberikan hitungan panggilan yang tepat dan dapat menunjukkan hubungan antara pemanggil dan yang dipanggil:
 
 ```bash
 # Run with callgrind
@@ -362,30 +361,30 @@ callgrind_annotate callgrind.out.<pid>
 kcachegrind callgrind.out.<pid>
 ```
 
-Callgrind is slower than sampling profilers but provides precise call counts and can optionally simulate cache behavior (with `--cache-sim=yes`) if you need that information.
+Callgrind lebih lambat daripada sampling profiler tetapi memberikan hitungan panggilan yang tepat dan secara opsional dapat mensimulasikan perilaku cache (dengan `--cache-sim=yes`) jika Anda membutuhkan informasi tersebut.
 
-> If you're using a particular language, there may be more specialized profilers. For example, Python has [`cProfile`](https://docs.python.org/3/library/profile.html) and [`py-spy`](https://github.com/benfred/py-spy), Go has [`go tool pprof`](https://pkg.go.dev/cmd/pprof), and Rust has [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph) (which actually works for any compiled program!).
+> Jika Anda menggunakan bahasa tertentu, mungkin ada profiler yang lebih khusus. Misalnya, Python memiliki [`cProfile`](https://docs.python.org/3/library/profile.html) dan [`py-spy`](https://github.com/benfred/py-spy), Go memiliki [`go tool pprof`](https://pkg.go.dev/cmd/pprof), dan Rust memiliki [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph) (yang sebenarnya bekerja untuk program terkompilasi apa pun!).
 
-## Memory Profilers
+## Memory Profiler
 
-Memory profilers help you understand how your program uses memory over time and find memory leaks.
+Memory profiler membantu Anda memahami bagaimana program Anda menggunakan memori dari waktu ke waktu dan menemukan memory leak.
 
-### Valgrind's Massif
+### Massif milik Valgrind
 
-[`massif`](https://valgrind.org/docs/manual/ms-manual.html) profiles heap memory usage:
+[`massif`](https://valgrind.org/docs/manual/ms-manual.html) memprofilkan penggunaan heap memory:
 
 ```bash
 valgrind --tool=massif ./my_program
 ms_print massif.out.<pid>
 ```
 
-This shows you heap usage over time, helping identify memory leaks and excessive allocation.
+Ini menampilkan penggunaan heap dari waktu ke waktu, membantu mengidentifikasi memory leak dan alokasi yang berlebihan.
 
-> For Python, [`memory-profiler`](https://pypi.org/project/memory-profiler/) provides line-by-line memory usage information.
+> Untuk Python, [`memory-profiler`](https://pypi.org/project/memory-profiler/) menyediakan informasi penggunaan memori baris per baris.
 
 ## Benchmarking
 
-When you need to compare the performance of different implementations or tools, [`hyperfine`](https://github.com/sharkdp/hyperfine) is excellent for benchmarking command-line programs:
+Ketika Anda perlu membandingkan performa dari implementasi atau alat yang berbeda, [`hyperfine`](https://github.com/sharkdp/hyperfine) sangat baik untuk benchmarking program command-line:
 
 ```bash
 $ hyperfine --warmup 3 'fd -e jpg' 'find . -iname "*.jpg"'
@@ -402,13 +401,13 @@ Summary
    21.89 ± 2.33 times faster than 'find . -iname "*.jpg"'
 ```
 
-> For web development, browser developer tools include excellent profilers. See the [Firefox Profiler](https://profiler.firefox.com/docs/) and [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/rendering-tools) documentation.
+> Untuk pengembangan web, browser developer tools menyertakan profiler yang sangat baik. Lihat dokumentasi [Firefox Profiler](https://profiler.firefox.com/docs/) dan [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/rendering-tools).
 
-# Exercises
+# Latihan
 
 ## Debugging
 
-1. **Debug a sorting algorithm**: The following pseudocode implements merge sort but contains a bug. Implement it in a language of your choice, then use a debugger (gdb, lldb, pdb, or your IDE's debugger) to find and fix the bug.
+1. **Debug algoritma sorting**: Pseudocode berikut mengimplementasikan merge sort tetapi mengandung bug. Implementasikan dalam bahasa pilihan Anda, lalu gunakan debugger (gdb, lldb, pdb, atau debugger IDE Anda) untuk menemukan dan memperbaiki bug tersebut.
 
    ```
    function merge_sort(arr):
@@ -433,9 +432,9 @@ Summary
        return result
    ```
 
-   Test vector: `merge_sort([3, 1, 4, 1, 5, 9, 2, 6])` should return `[1, 1, 2, 3, 4, 5, 6, 9]`. Use breakpoints and step through the merge function to find where the incorrect element is being selected.
+   Test vector: `merge_sort([3, 1, 4, 1, 5, 9, 2, 6])` seharusnya mengembalikan `[1, 1, 2, 3, 4, 5, 6, 9]`. Gunakan breakpoint dan telusuri fungsi merge untuk menemukan di mana elemen yang salah dipilih.
 
-1. Install [`rr`](https://rr-project.org/) and use reverse debugging to find a corruption bug. Save this program as `corruption.c`:
+1. Install [`rr`](https://rr-project.org/) dan gunakan reverse debugging untuk menemukan bug korupsi. Simpan program ini sebagai `corruption.c`:
 
    ```c
    #include <stdio.h>
@@ -486,9 +485,9 @@ Summary
    }
    ```
 
-   Compile with `gcc -g corruption.c -o corruption` and run it. Student 1's ID gets corrupted, but the corruption happens in a function that only touches student 0. Use `rr record ./corruption` and `rr replay` to find the culprit. Set a watchpoint on `students[1].id` and use `reverse-continue` after the corruption to find exactly which line of code overwrote it.
+   Kompilasi dengan `gcc -g corruption.c -o corruption` dan jalankan. ID Student 1 menjadi rusak, tetapi korupsi terjadi di fungsi yang hanya menyentuh student 0. Gunakan `rr record ./corruption` dan `rr replay` untuk menemukan pelakunya. Atur watchpoint pada `students[1].id` dan gunakan `reverse-continue` setelah korupsi untuk menemukan secara tepat baris kode mana yang menimpanya.
 
-1. Debug a memory error with AddressSanitizer. Save this as `uaf.c`:
+1. Debug error memori dengan AddressSanitizer. Simpan ini sebagai `uaf.c`:
 
    ```c
    #include <stdlib.h>
@@ -509,17 +508,17 @@ Summary
    }
    ```
 
-   First compile and run without sanitizers: `gcc uaf.c -o uaf && ./uaf`. It may appear to work. Now compile with AddressSanitizer: `gcc -fsanitize=address -g uaf.c -o uaf && ./uaf`. Read the error report. What bug does ASan find? Fix the issue it identifies.
+   Pertama kompilasi dan jalankan tanpa sanitizer: `gcc uaf.c -o uaf && ./uaf`. Mungkin terlihat berfungsi. Sekarang kompilasi dengan AddressSanitizer: `gcc -fsanitize=address -g uaf.c -o uaf && ./uaf`. Baca laporan error. Bug apa yang ditemukan ASan? Perbaiki masalah yang diidentifikasinya.
 
-1. Use `strace` (Linux) or `dtruss` (macOS) to trace the system calls made by a command like `ls -l`. What system calls is it making? Try tracing a more complex program and see what files it opens.
+1. Gunakan `strace` (Linux) atau `dtruss` (macOS) untuk men-trace system call yang dibuat oleh perintah seperti `ls -l`. System call apa saja yang dibuatnya? Coba trace program yang lebih kompleks dan lihat file apa yang dibukanya.
 
-1. Use an LLM to help debug a cryptic error message. Try copying a compiler error (especially from C++ templates or Rust) and asking for an explanation and fix. Try putting some of the output from `strace` or the address sanitizer into it.
+1. Gunakan LLM untuk membantu men-debug pesan error yang misterius. Coba salin error compiler (terutama dari template C++ atau Rust) dan minta penjelasan serta perbaikan. Coba masukkan beberapa output dari `strace` atau address sanitizer ke dalamnya.
 
 ## Profiling
 
-1. Use `perf stat` to get basic performance statistics for a program of your choice. What do the different counters mean?
+1. Gunakan `perf stat` untuk mendapatkan statistik performa dasar untuk program pilihan Anda. Apa arti dari masing-masing counter?
 
-1. Profile with `perf record`. Save this as `slow.c`:
+1. Profil dengan `perf record`. Simpan ini sebagai `slow.c`:
 
    ```c
    #include <math.h>
@@ -545,10 +544,10 @@ Summary
    }
    ```
 
-   Compile with debug symbols: `gcc -g -O2 slow.c -o slow -lm`. Run `perf record -g ./slow`, then `perf report` to see where time is spent. Try generating a flame graph using the flamegraph scripts.
+   Kompilasi dengan debug symbol: `gcc -g -O2 slow.c -o slow -lm`. Jalankan `perf record -g ./slow`, lalu `perf report` untuk melihat di mana waktu dihabiskan. Coba hasilkan flame graph menggunakan skrip flamegraph.
 
-1. Use `hyperfine` to benchmark two different implementations of the same task (e.g., `find` vs `fd`, `grep` vs `ripgrep`, or two versions of your own code).
+1. Gunakan `hyperfine` untuk membenchmark dua implementasi berbeda dari tugas yang sama (misalnya, `find` vs `fd`, `grep` vs `ripgrep`, atau dua versi kode Anda sendiri).
 
-1. Use `htop` to monitor your system while running a resource-intensive program. Try using `taskset` to limit which CPUs a process can use: `taskset --cpu-list 0,2 stress -c 3`. Why doesn't `stress` use three CPUs?
+1. Gunakan `htop` untuk memonitor sistem Anda saat menjalankan program yang intensif sumber daya. Coba gunakan `taskset` untuk membatasi CPU mana yang dapat digunakan oleh suatu proses: `taskset --cpu-list 0,2 stress -c 3`. Mengapa `stress` tidak menggunakan tiga CPU?
 
-1. A common issue is that a port you want to listen on is already taken by another process. Learn how to discover that process: First execute `python -m http.server 4444` to start a minimal web server on port 4444. On a separate terminal run `ss -tlnp | grep 4444` to find the process. Terminate it with `kill <PID>`.
+1. Masalah umum adalah port yang ingin Anda gunakan untuk mendengarkan sudah diambil oleh proses lain. Pelajari cara menemukan proses tersebut: Pertama jalankan `python -m http.server 4444` untuk memulai web server minimal di port 4444. Di terminal terpisah jalankan `ss -tlnp | grep 4444` untuk menemukan prosesnya. Hentikan dengan `kill <PID>`.

--- a/_2026/debugging-profiling.md
+++ b/_2026/debugging-profiling.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Debugging and Profiling"
 description: >
-  Learn how to debug programs using logging and debuggers, and how to profile code for performance.
+  Pelajari cara men-debug program menggunakan logging dan debugger, serta cara melakukan profiling kode untuk performa.
 thumbnail: /static/assets/thumbnails/2026/lec4.png
 date: 2026-01-15
 ready: true

--- a/_2026/development-environment.md
+++ b/_2026/development-environment.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Development Environment and Tools"
 description: >
-  Learn about IDEs, Vim, language servers, and AI-powered development tools.
+  Pelajari tentang IDE, Vim, language server, dan tools pengembangan berbasis AI.
 thumbnail: /static/assets/thumbnails/2026/lec3.png
 date: 2026-01-14
 ready: true

--- a/_2026/development-environment.md
+++ b/_2026/development-environment.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Development Environment and Tools"
+title: "Environment dan Alat Pengembangan"
 description: >
-  Learn about IDEs, Vim, language servers, and AI-powered development tools.
+  Pelajari tentang IDE, Vim, language server, dan alat pengembangan berbasis AI.
 thumbnail: /static/assets/thumbnails/2026/lec3.png
 date: 2026-01-14
 ready: true
@@ -11,121 +11,121 @@ video:
   id: QnM1nVzrkx8
 ---
 
-A _development environment_ is a set of tools for developing software. At the heart of a development environment is text editing functionality, along with accompanying features such as syntax highlighting, type checking, code formatting, and autocomplete. _Integrated development environments_ (IDEs) such as [VS Code][vs-code] bring together all of this functionality into a single application. Terminal-based development workflows combine tools such as [tmux](https://github.com/tmux/tmux) (a terminal multiplexer), [Vim](https://www.vim.org/) (a text editor), [Zsh](https://www.zsh.org/) (a shell), and language-specific command-line tools, such as [Ruff](https://docs.astral.sh/ruff/) (a Python linter and code formatter) and [Mypy](https://mypy-lang.org/) (a Python type checker).
+_Environment pengembangan_ (_development environment_) adalah sekumpulan alat untuk mengembangkan perangkat lunak. Di jantung environment pengembangan terdapat fungsionalitas penyuntingan teks, beserta fitur-fitur pendukung seperti penyorotan sintaks, pemeriksaan tipe, pemformatan kode, dan autocomplete. _Integrated development environment_ (IDE) seperti [VS Code][vs-code] menggabungkan semua fungsionalitas ini ke dalam satu aplikasi. Alur kerja pengembangan berbasis terminal menggabungkan alat-alat seperti [tmux](https://github.com/tmux/tmux) (terminal multiplexer), [Vim](https://www.vim.org/) (penyunting teks), [Zsh](https://www.zsh.org/) (shell), dan alat baris perintah khusus bahasa pemrograman, seperti [Ruff](https://docs.astral.sh/ruff/) (linter dan pemformat kode Python) dan [Mypy](https://mypy-lang.org/) (pemeriksa tipe Python).
 
-IDEs and terminal-based workflows each have their strengths and weaknesses. For example, graphical IDEs can be easier to learn, and today's IDEs generally have better out-of-the-box AI integrations like AI autocomplete; on the other hand, terminal-based workflows are lightweight, and they may be your only option in environments where you don't have a GUI or can't install software. We recommend you develop basic familiarity with both and develop mastery of at least one. If you don't already have a preferred IDE, we recommend starting with [VS Code][vs-code].
+IDE dan alur kerja berbasis terminal masing-masing memiliki kelebihan dan kekurangan. Sebagai contoh, IDE grafis mungkin lebih mudah dipelajari, dan IDE saat ini umumnya memiliki integrasi AI bawaan yang lebih baik seperti autocomplete AI; di sisi lain, alur kerja berbasis terminal bersifat ringan, dan mungkin menjadi satu-satunya pilihan Anda di environment yang tidak memiliki GUI atau tidak mengizinkan pemasangan perangkat lunak. Kami menyarankan Anda untuk membangun dasar familiaritas dengan keduanya dan menguasai setidaknya salah satunya. Jika Anda belum memiliki IDE pilihan, kami menyarankan untuk memulai dengan [VS Code][vs-code].
 
-In this lecture, we'll cover:
+Dalam kuliah ini, kita akan membahas:
 
-- [Text editing and Vim](#text-editing-and-vim)
-- [Code intelligence and language servers](#code-intelligence-and-language-servers)
-- [AI-powered development](#ai-powered-development)
-- [Extensions and other IDE functionality](#extensions-and-other-ide-functionality)
+- [Penyuntingan teks dan Vim](#penyuntingan-teks-dan-vim)
+- [Kecerdasan kode dan language server](#kecerdasan-kode-dan-language-server)
+- [Pengembangan berbasis AI](#pengembangan-berbasis-ai)
+- [Ekstensi dan fungsionalitas IDE lainnya](#ekstensi-dan-fungsionalitas-ide-lainnya)
 
 [vs-code]: https://code.visualstudio.com/
 
-# Text editing and Vim
+# Penyuntingan teks dan Vim
 
-When programming, you spend most of your time navigating through code, reading snippets of code, and making edits to code, rather than writing long streams or reading files top-to-bottom. [Vim] is a text editor that is optimized for this distribution of tasks.
+Saat pemrograman, Anda menghabiskan sebagian besar waktu untuk menavigasi kode, membaca potongan kode, dan melakukan perubahan pada kode, daripada menulis aliran kode panjang atau membaca file dari atas ke bawah. [Vim] adalah penyunting teks yang dioptimalkan untuk distribusi tugas ini.
 
-**The philosophy of Vim.** Vim has a beautiful idea as its foundation: its interface is itself a programming language, designed for navigating and editing text. Keystrokes (with mnemonic names) are commands, and these commands are composable. Vim avoids the use of the mouse, because it's too slow; Vim even avoids use of the arrow keys because it requires too much movement. The result: an editor that feels like a brain-computer interface and matches the speed at which you think.
+**Filosofi Vim.** Vim memiliki ide yang indah sebagai fondasinya: antarmukanya sendiri adalah sebuah bahasa pemrograman, yang dirancang untuk menavigasi dan menyunting teks. Tekanan tombol (dengan nama mnemonik) adalah perintah-perintah, dan perintah-perintah ini dapat dikomposisikan. Vim menghindari penggunaan mouse, karena terlalu lambat; Vim bahkan menghindari penggunaan tombol panah karena memerlukan terlalu banyak pergerakan. Hasilnya: sebuah penyunting yang terasa seperti antarmuka otak-komputer dan mengikuti kecepatan berpikir Anda.
 
-**Vim support in other software.** You don't have to use [Vim] itself to benefit from the ideas at its core. Many programs that involve any kind of text editing support "Vim mode", either as built-in functionality or as a plugin. For example, VS Code has the [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) plugin, Zsh has [built-in support](https://zsh.sourceforge.io/Guide/zshguide04.html) for Vim emulation, and even Claude Code has [built-in support](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) for Vim editor mode. Chances are that any tool you use that involves text editing supports Vim mode in one way or another.
+**Dukungan Vim di perangkat lunak lain.** Anda tidak harus menggunakan [Vim] itu sendiri untuk memanfaatkan ide-ide intinya. Banyak program yang melibatkan penyuntingan teks mendukung "mode Vim", baik sebagai fungsionalitas bawaan maupun sebagai plugin. Sebagai contoh, VS Code memiliki plugin [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim), Zsh memiliki [dukungan bawaan](https://zsh.sourceforge.io/Guide/zshguide04.html) untuk emulasi Vim, dan bahkan Claude Code memiliki [dukungan bawaan](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) untuk mode penyunting Vim. Kemungkinan besar, alat apa pun yang Anda gunakan yang melibatkan penyuntingan teks mendukung mode Vim dengan satu cara atau lainnya.
 
-## Modal editing
+## Penyuntingan modal
 
-Vim is a _modal editor_: it has different operating modes for different classes of tasks.
+Vim adalah _penyunting modal_: ia memiliki mode operasi yang berbeda untuk kelas tugas yang berbeda.
 
-- **Normal**: for moving around a file and making edits
-- **Insert**: for inserting text
-- **Replace**: for replacing text
-- **Visual** (plain, line, or block): for selecting blocks of text
-- **Command-line**: for running a command
+- **Normal**: untuk berpindah-pindah dalam file dan melakukan perubahan
+- **Insert**: untuk menyisipkan teks
+- **Replace**: untuk mengganti teks
+- **Visual** (biasa, baris, atau blok): untuk memilih blok teks
+- **Command-line**: untuk menjalankan perintah
 
-Keystrokes have different meanings in different operating modes. For example, the letter `x` in Insert mode will just insert a literal character "x", but in Normal mode, it will delete the character under the cursor, and in Visual mode, it will delete the selection.
+Tekanan tombol memiliki arti yang berbeda di mode operasi yang berbeda. Sebagai contoh, huruf `x` di mode Insert hanya akan menyisipkan karakter literal "x", tetapi di mode Normal, ia akan menghapus karakter di bawah kursor, dan di mode Visual, ia akan menghapus seleksi.
 
-In its default configuration, Vim shows the current mode in the bottom left. The initial/default mode is Normal mode. You'll generally spend most of your time between Normal mode and Insert mode.
+Dalam konfigurasi default, Vim menampilkan mode saat ini di kiri bawah. Mode awal/default adalah mode Normal. Anda umumnya akan menghabiskan sebagian besar waktu antara mode Normal dan mode Insert.
 
-You change modes by pressing `<ESC>` (the escape key) to switch from any mode back to Normal mode. From Normal mode, enter Insert mode with `i`, Replace mode with `R`, Visual mode with `v`, Visual Line mode with `V`, Visual Block mode with `<C-v>` (Ctrl-V, sometimes also written `^V`), and Command-line mode with `:`.
+Anda berpindah mode dengan menekan `<ESC>` (tombol escape) untuk beralih dari mode mana pun kembali ke mode Normal. Dari mode Normal, masuk ke mode Insert dengan `i`, mode Replace dengan `R`, mode Visual dengan `v`, mode Visual Line dengan `V`, mode Visual Block dengan `<C-v>` (Ctrl-V, terkadang juga ditulis `^V`), dan mode Command-line dengan `:`.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to Escape ([macOS instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)) or create an [alternative mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) for `<ESC>` with a simple key sequence.
+Anda banyak menggunakan tombol `<ESC>` saat menggunakan Vim: pertimbangkan untuk memetakan ulang Caps Lock ke Escape ([instruksi macOS](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)) atau buat [pemetaan alternatif](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) untuk `<ESC>` dengan urutan tombol sederhana.
 
-## Basics: inserting text
+## Dasar-dasar: menyisipkan teks
 
-From Normal mode, press `i` to enter Insert mode. Now, Vim behaves like any other text editor, until you press `<ESC>` to return to Normal mode. This, along with the basics explained above, are all you need to start editing files using Vim (though not particularly efficiently, if you're spending all your time editing from Insert mode).
+Dari mode Normal, tekan `i` untuk masuk ke mode Insert. Sekarang, Vim berperilaku seperti penyunting teks lainnya, sampai Anda menekan `<ESC>` untuk kembali ke mode Normal. Ini, bersama dengan dasar-dasar yang dijelaskan di atas, adalah semua yang Anda butuhkan untuk mulai menyunting file menggunakan Vim (meskipun tidak terlalu efisien, jika Anda menghabiskan seluruh waktu menyunting dari mode Insert).
 
-## Vim's interface is a programming language
+## Antarmuka Vim adalah bahasa pemrograman
 
-Vim's interface is a programming language. Keystrokes (with mnemonic names) are commands, and these commands _compose_. This enables efficient movement and edits, especially once the commands become muscle memory, just like typing becomes super efficient once you've learned your keyboard layout.
+Antarmuka Vim adalah bahasa pemrograman. Tekanan tombol (dengan nama mnemonik) adalah perintah-perintah, dan perintah-perintah ini dapat _dikomposisikan_. Hal ini memungkinkan pergerakan dan penyuntingan yang efisien, terutama setelah perintah-perintah tersebut menjadi memori otot, sama seperti mengetik menjadi sangat efisien setelah Anda menguasai tata letak keyboard.
 
-### Movement
+### Pergerakan
 
-You should spend most of your time in Normal mode, using movement commands to navigate the file. Movements in Vim are also called "nouns", because they refer to chunks of text.
+Anda harus menghabiskan sebagian besar waktu di mode Normal, menggunakan perintah pergerakan untuk menavigasi file. Pergerakan di Vim juga disebut "kata benda" (_nouns_), karena merujuk pada bagian-bagian teks.
 
-- Basic movement: `hjkl` (left, down, up, right)
-- Words: `w` (next word), `b` (beginning of word), `e` (end of word)
-- Lines: `0` (beginning of line), `^` (first non-blank character), `$` (end of line)
-- Screen: `H` (top of screen), `M` (middle of screen), `L` (bottom of screen)
-- Scroll: `Ctrl-u` (up), `Ctrl-d` (down)
-- File: `gg` (beginning of file), `G` (end of file)
-- Line numbers: `:{number}<CR>` or `{number}G` (line {number})
-    - `<CR>` refers to the carriage return / enter key
-- Misc: `%` (matching item, like parenthesis or brace)
-- Find: `f{character}`, `t{character}`, `F{character}`, `T{character}`
-    - find/to forward/backward {character} on the current line
-    - `,` / `;` for navigating matches
-- Search: `/{regex}`, `n` / `N` for navigating matches
+- Pergerakan dasar: `hjkl` (kiri, bawah, atas, kanan)
+- Kata: `w` (kata berikutnya), `b` (awal kata), `e` (akhir kata)
+- Baris: `0` (awal baris), `^` (karakter non-kosong pertama), `$` (akhir baris)
+- Layar: `H` (atas layar), `M` (tengah layar), `L` (bawah layar)
+- Gulir: `Ctrl-u` (atas), `Ctrl-d` (bawah)
+- File: `gg` (awal file), `G` (akhir file)
+- Nomor baris: `:{number}<CR>` atau `{number}G` (baris ke-{number})
+    - `<CR>` merujuk pada carriage return / tombol enter
+- Lain-lain: `%` (item yang cocok, seperti tanda kurung atau kurung kurawal)
+- Cari: `f{character}`, `t{character}`, `F{character}`, `T{character}`
+    - cari/menuju maju/mundur {character} pada baris saat ini
+    - `,` / `;` untuk menavigasi hasil pencarian
+- Pencarian: `/{regex}`, `n` / `N` untuk menavigasi hasil pencarian
 
-### Selection
+### Seleksi
 
-Visual modes:
+Mode Visual:
 
 - Visual: `v`
 - Visual Line: `V`
 - Visual Block: `Ctrl-v`
 
-Can use movement keys to make selection.
+Dapat menggunakan tombol pergerakan untuk membuat seleksi.
 
-### Edits
+### Penyuntingan
 
-Everything that you used to do with the mouse, you now do with the keyboard using editing commands that compose with movement commands. Here's where Vim's interface starts to look like a programming language. Vim's editing commands are also called "verbs", because verbs act on nouns.
+Semua yang sebelumnya Anda lakukan dengan mouse, sekarang Anda lakukan dengan keyboard menggunakan perintah penyuntingan yang dapat dikomposisikan dengan perintah pergerakan. Di sinilah antarmuka Vim mulai terlihat seperti bahasa pemrograman. Perintah penyuntingan Vim juga disebut "kata kerja" (_verbs_), karena kata kerja bekerja pada kata benda.
 
-- `i` enter Insert mode
-    - but for manipulating/deleting text, want to use something more than backspace
-- `o` / `O` insert line below / above
-- `d{motion}` delete {motion}
-    - e.g. `dw` is delete word, `d$` is delete to end of line, `d0` is delete to beginning of line
-- `c{motion}` change {motion}
-    - e.g. `cw` is change word
-    - like `d{motion}` followed by `i`
-- `x` delete character (equivalent to `dl`)
-- `s` substitute character (equivalent to `cl`)
-- Visual mode + manipulation
-    - select text, `d` to delete it or `c` to change it
-- `u` to undo, `<C-r>` to redo
-- `y` to copy / "yank" (some other commands like `d` also copy)
-- `p` to paste
-- Lots more to learn: for example, `~` flips the case of a character, and `J` joins together lines
+- `i` masuk mode Insert
+    - tetapi untuk memanipulasi/menghapus teks, Anda ingin menggunakan sesuatu selain backspace
+- `o` / `O` sisipkan baris di bawah / di atas
+- `d{motion}` hapus {motion}
+    - contoh: `dw` adalah hapus kata, `d$` adalah hapus sampai akhir baris, `d0` adalah hapus sampai awal baris
+- `c{motion}` ubah {motion}
+    - contoh: `cw` adalah ubah kata
+    - seperti `d{motion}` diikuti oleh `i`
+- `x` hapus karakter (setara dengan `dl`)
+- `s` ganti karakter (setara dengan `cl`)
+- Mode Visual + manipulasi
+    - pilih teks, `d` untuk menghapusnya atau `c` untuk mengubahnya
+- `u` untuk undo, `<C-r>` untuk redo
+- `y` untuk menyalin / "yank" (beberapa perintah lain seperti `d` juga menyalin)
+- `p` untuk menempel (paste)
+- Masih banyak yang bisa dipelajari: sebagai contoh, `~` membalik huruf besar/kecil karakter, dan `J` menggabungkan baris-baris
 
-### Counts
+### Jumlah (_Counts_)
 
-You can combine nouns and verbs with a count, which will perform a given action a number of times.
+Anda dapat menggabungkan kata benda dan kata kerja dengan jumlah, yang akan melakukan tindakan tertentu sebanyak beberapa kali.
 
-- `3w` move 3 words forward
-- `5j` move 5 lines down
-- `7dw` delete 7 words
+- `3w` pindah 3 kata ke depan
+- `5j` pindah 5 baris ke bawah
+- `7dw` hapus 7 kata
 
-### Modifiers
+### Modifier
 
-You can use modifiers to change the meaning of a noun. Some modifiers are `i`, which means "inner" or "inside", and `a`, which means "around".
+Anda dapat menggunakan modifier untuk mengubah arti dari kata benda. Beberapa modifier adalah `i`, yang berarti "inner" atau "di dalam", dan `a`, yang berarti "around" atau "di sekitar".
 
-- `ci(` change the contents inside the current pair of parentheses
-- `ci[` change the contents inside the current pair of square brackets
-- `da'` delete a single-quoted string, including the surrounding single quotes
+- `ci(` ubah konten di dalam tanda kurung saat ini
+- `ci[` ubah konten di dalam tanda kurung siku saat ini
+- `da'` hapus string bertanda kutip tunggal, termasuk tanda kutip tunggal di sekitarnya
 
-## Putting it all together
+## Menggabungkan semuanya
 
-Here is a broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) implementation:
+Berikut adalah implementasi [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) yang salah:
 
 ```python
 def fizz_buzz(limit):
@@ -142,73 +142,73 @@ def main():
     fizz_buzz(20)
 ```
 
-We use the following sequence of commands to fix the issues, beginning in Normal mode:
+Kita menggunakan urutan perintah berikut untuk memperbaiki masalah-masalahnya, dimulai dari mode Normal:
 
-- Main is never called
-    - `G` to jump to the end of the file
-    - `o` to **o**pen a new line below
-    - Type in `if __name__ == "__main__": main()`
-        - If your editor has Python language support, it might do some auto-indentation for you in Insert mode
-    - `<ESC>` to go back to Normal mode
-- Starts at 0 instead of 1
-    - `/` followed by `range` and `<CR>` to search for "range"
-    - `ww` to move forward two **w**ords (you could also use `2w`, but in practice, for small counts it's common to repeat the key instead of using the count functionality)
-    - `i` to switch to **i**nsert mode, and add `1,`
-    - `<ESC>` to go back to Normal mode
-    - `e` to jump to the **e**nd of the next word
-    - `a` to start **a**ppending text, and add `+ 1`
-    - `<ESC>` to go back to Normal mode
-- Prints "fizz" for multiples of 5
-    - `:6<CR>` to go to line 6
-    - `ci"` to **c**hange **i**nside the '**"**', change to `"buzz"`
-    - `<ESC>` to go back to Normal mode
+- Main tidak pernah dipanggil
+    - `G` untuk melompat ke akhir file
+    - `o` untuk memb**o**ka baris baru di bawah
+    - Ketik `if __name__ == "__main__": main()`
+        - Jika penyunting Anda memiliki dukungan bahasa Python, ia mungkin melakukan indentasi otomatis untuk Anda di mode Insert
+    - `<ESC>` untuk kembali ke mode Normal
+- Dimulai dari 0, bukan 1
+    - `/` diikuti oleh `range` dan `<CR>` untuk mencari "range"
+    - `ww` untuk maju dua **w** kata (Anda juga bisa menggunakan `2w`, tetapi dalam praktiknya, untuk jumlah kecil lebih umum mengulang tombol daripada menggunakan fungsionalitas jumlah)
+    - `i` untuk beralih ke mode **i**nsert, dan tambahkan `1,`
+    - `<ESC>` untuk kembali ke mode Normal
+    - `e` untuk melompat ke **e**nd (akhir) kata berikutnya
+    - `a` untuk mulai **a**ppend (menambahkan) teks, dan tambahkan `+ 1`
+    - `<ESC>` untuk kembali ke mode Normal
+- Mencetak "fizz" untuk kelipatan 5
+    - `:6<CR>` untuk pergi ke baris 6
+    - `ci"` untuk **c**hange **i**nside '**"**', ubah menjadi `"buzz"`
+    - `<ESC>` untuk kembali ke mode Normal
 
-## Learning Vim
+## Belajar Vim
 
-The best way to learn Vim is to learn the fundamentals (what we've covered so far) and then just enable Vim mode in all your software and start using it in practice. Avoid the temptation to use the mouse or the arrow keys; in some editors, you can unbind the arrow keys to force yourself to build good habits.
+Cara terbaik belajar Vim adalah mempelajari dasar-dasarnya (apa yang telah kita bahas sejauh ini) dan kemudian mengaktifkan mode Vim di semua perangkat lunak Anda dan mulai menggunakannya dalam praktik. Hindari godaan untuk menggunakan mouse atau tombol panah; di beberapa penyunting, Anda dapat melepas pemetaan tombol panah untuk memaksa diri Anda membangun kebiasaan yang baik.
 
-### Additional resources
+### Sumber daya tambahan
 
-- The [Vim lecture](/2020/editors/) from the previous iteration of this class --- we have covered Vim in more depth there
-- `vimtutor` is a tutorial that comes installed with Vim --- if Vim is installed, you should be able to run `vimtutor` from your shell
-- [Vim Adventures](https://vim-adventures.com/) is a game to learn Vim
+- [Kuliah Vim](/2020/editors/) dari iterasi sebelumnya kelas ini --- kita telah membahas Vim lebih mendalam di sana
+- `vimtutor` adalah tutorial yang sudah terpasang bersama Vim --- jika Vim sudah terinstal, Anda seharusnya bisa menjalankan `vimtutor` dari shell
+- [Vim Adventures](https://vim-adventures.com/) adalah permainan untuk belajar Vim
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2019/) has various Vim tips
-- [VimGolf](https://www.vimgolf.com/) is [code golf](https://en.wikipedia.org/wiki/Code_golf), but where the programming language is Vim's UI
+- [Vim Advent Calendar](https://vimways.org/2019/) memiliki berbagai tips Vim
+- [VimGolf](https://www.vimgolf.com/) adalah [code golf](https://en.wikipedia.org/wiki/Code_golf), tetapi di mana bahasa pemrogramannya adalah UI Vim
 - [Vi/Vim Stack Exchange](https://vi.stackexchange.com/)
 - [Vim Screencasts](http://vimcasts.org/)
-- [Practical Vim](https://pragprog.com/titles/dnvim2/) (book)
+- [Practical Vim](https://pragprog.com/titles/dnvim2/) (buku)
 
 [Vim]: https://www.vim.org/
 
-# Code intelligence and language servers
+# Kecerdasan kode dan language server
 
-IDEs generally offer language-specific support that requires semantic understanding of the code through IDE extensions that connect to _language servers_ that implement [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). For example, the [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) relies on [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), and the [Go extension for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) relies on the first-party [gopls](https://go.dev/gopls/). By installing the extension and language server for the languages you work with, you can enable many language-specific features in your IDE, such as:
+IDE umumnya menawarkan dukungan khusus bahasa yang memerlukan pemahaman semantik dari kode melalui ekstensi IDE yang terhubung ke _language server_ yang mengimplementasikan [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Sebagai contoh, [ekstensi Python untuk VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) bergantung pada [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), dan [ekstensi Go untuk VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) bergantung pada [gopls](https://go.dev/gopls/) buatan pengembang pertama. Dengan memasang ekstensi dan language server untuk bahasa yang Anda gunakan, Anda dapat mengaktifkan banyak fitur khusus bahasa di IDE Anda, seperti:
 
-- **Code completion.** Better autocomplete and autosuggest, such as being able to see an object's fields and methods after typing `object.`.
-- **Inline documentation.** Seeing documentation on hover and autosuggest.
-- **Jump-to-definition.** Jumping from a use site to the definition, such as being able to go from a field reference `object.field` to the definition of the field.
-- **Find references.** The inverse of the above, find all sites where a particular item such as a field or type is referenced.
-- **Help with imports.** Organizing imports, removing unused imports, flagging missing imports.
-- **Code quality.** These tools can be used standalone, but this functionality is often provided by language servers as well. Code formatting auto-indents and auto-formats code, and type checkers and linters find errors in your code, as you type. We will cover this class of functionality in greater depth in the [lecture on code quality](/2026/code-quality/).
+- **Pelengkapan kode.** Autocomplete dan autosuggest yang lebih baik, seperti kemampuan melihat field dan method sebuah objek setelah mengetik `object.`.
+- **Dokumentasi inline.** Melihat dokumentasi saat hover dan autosuggest.
+- **Lompat ke definisi.** Melompat dari tempat penggunaan ke definisi, seperti dapat pergi dari referensi field `object.field` ke definisi field tersebut.
+- **Cari referensi.** Kebalikan dari di atas, cari semua tempat di mana item tertentu seperti field atau tipe direferensikan.
+- **Bantuan impor.** Mengorganisir impor, menghapus impor yang tidak digunakan, menandai impor yang hilang.
+- **Kualitas kode.** Alat-alat ini dapat digunakan secara mandiri, tetapi fungsionalitas ini sering juga disediakan oleh language server. Pemformatan kode melakukan indentasi otomatis dan pemformatan otomatis kode, dan pemeriksa tipe serta linter menemukan kesalahan dalam kode Anda, saat Anda mengetik. Kita akan membahas kelas fungsionalitas ini lebih mendalam di [kuliah tentang kualitas kode](/2026/code-quality/).
 
-## Configuring language servers
+## Mengonfigurasi language server
 
-For some languages, all you need to do is install the extension and language server, and you'll be all set. For others, to get the maximum benefit from the language server, you need to tell the IDE about your environment. For example, pointing VS Code to your [Python environment](https://code.visualstudio.com/docs/python/environments) will enable the language server to see your installed packages. Environments are covered in more depth in our [lecture on packaging and shipping code](/2026/shipping-code/).
+Untuk beberapa bahasa, yang perlu Anda lakukan hanyalah memasang ekstensi dan language server, dan Anda siap menggunakannya. Untuk bahasa lain, untuk mendapatkan manfaat maksimal dari language server, Anda perlu memberi tahu IDE tentang environment Anda. Sebagai contoh, menunjuk VS Code ke [environment Python](https://code.visualstudio.com/docs/python/environments) Anda akan memungkinkan language server melihat paket-paket yang telah Anda instal. Environment dibahas lebih mendalam di [kuliah tentang pengemasan dan pendistribusian kode](/2026/shipping-code/).
 
-Depending on the language, there might be some settings you can configure for your language server. For example, using the Python support in VS Code, you can disable static type checking for projects that don't make use of Python's optional type annotations.
+Tergantung pada bahasanya, mungkin ada beberapa pengaturan yang dapat Anda konfigurasikan untuk language server. Sebagai contoh, menggunakan dukungan Python di VS Code, Anda dapat menonaktifkan pemeriksaan tipe statis untuk proyek yang tidak menggunakan anotasi tipe opsional Python.
 
-# AI-powered development
+# Pengembangan berbasis AI
 
-Since the introduction of [GitHub Copilot][github-copilot] using OpenAI's [Codex model](https://openai.com/index/openai-codex/) in mid 2021, [LLMs](https://en.wikipedia.org/wiki/Large_language_model) have become widely adopted in software engineering. There are three main form factors in use right now: autocomplete, inline chat, and coding agents.
+Sejak diperkenalkannya [GitHub Copilot][github-copilot] menggunakan [model Codex](https://openai.com/index/openai-codex/) dari OpenAI pada pertengahan 2021, [LLM](https://en.wikipedia.org/wiki/Large_language_model) telah banyak diadopsi dalam rekayasa perangkat lunak. Ada tiga bentuk utama yang digunakan saat ini: autocomplete, chat inline, dan agen coding.
 
 [github-copilot]: https://github.com/features/copilot/ai-code-editor
 
 ## Autocomplete
 
-AI-powered autocomplete has the same form factor as traditional autocomplete in your IDE, suggesting completions at your cursor position as you type. Sometimes, it's used as a passive feature that "just works". Beyond that, AI autocomplete is generally [prompted](https://en.wikipedia.org/wiki/Prompt_engineering) using code comments.
+Autocomplete berbasis AI memiliki bentuk yang sama dengan autocomplete tradisional di IDE Anda, mengusulkan pelengkapan di posisi kursor saat Anda mengetik. Terkadang, ia digunakan sebagai fitur pasif yang "langsung berfungsi". Selain itu, autocomplete AI umumnya diberi [prompt](https://en.wikipedia.org/wiki/Prompt_engineering) menggunakan komentar kode.
 
-For example, let's write a script to download the contents of these lecture notes and extract all the links. We can start with:
+Sebagai contoh, mari tulis skrip untuk mengunduh isi catatan kuliah ini dan mengekstrak semua tautan. Kita bisa mulai dengan:
 
 ```python
 import requests
@@ -216,34 +216,34 @@ import requests
 def download_contents(url: str) -> str:
 ```
 
-The model will autocomplete the body of the function:
+Model akan melengkapi isi fungsi tersebut:
 
 ```python
     response = requests.get(url)
     return response.text
 ```
 
-We can further guide completions using comments. For example, if we start writing a function to extract all Markdown links, but it doesn't have a particularly descriptive name:
+Kita dapat lebih mengarahkan pelengkapan menggunakan komentar. Sebagai contoh, jika kita mulai menulis fungsi untuk mengekstrak semua tautan Markdown, tetapi namanya tidak terlalu deskriptif:
 
 ```python
 def extract(contents: str) -> list[str]:
 ```
 
-The model will autocomplete something like this:
+Model akan melengkapi sesuatu seperti ini:
 
 ```python
     lines = contents.splitlines()
     return [line for line in lines if line.strip()]
 ```
 
-We can guide the completion through code comments:
+Kita dapat mengarahkan pelengkapan melalui komentar kode:
 
 ```python
 def extract(content: str) -> list[str]:
     # extract all Markdown links from the content
 ```
 
-This time, the model gives a better completion:
+Kali ini, model memberikan pelengkapan yang lebih baik:
 
 ```python
     import re
@@ -251,27 +251,27 @@ This time, the model gives a better completion:
     return re.findall(pattern, content)
 ```
 
-Here, we see one downside of this AI coding tool: it can only provide completions at the cursor. In this case, it would be better practice to put the `import re` at the module level, rather than inside the function.
+Di sini, kita melihat salah satu kekurangan alat coding AI ini: ia hanya dapat memberikan pelengkapan di kursor. Dalam kasus ini, akan lebih baik menempatkan `import re` di level modul, bukan di dalam fungsi.
 
-The example above used a poorly-named function to demonstrate how code completion can be steered using comments; in practice, you'd want to write code with functions named more descriptively, like `extract_links`, and you'd want to write docstrings (and based on this, the model should generate a completion analogous to the one above).
+Contoh di atas menggunakan fungsi dengan nama yang kurang baik untuk mendemonstrasikan bagaimana pelengkapan kode dapat diarahkan menggunakan komentar; dalam praktik, Anda ingin menulis kode dengan fungsi yang dinamai lebih deskriptif, seperti `extract_links`, dan Anda ingin menulis docstring (dan berdasarkan ini, model seharusnya menghasilkan pelengkapan yang serupa dengan yang di atas).
 
-For demonstration purposes, we can complete the script:
+Untuk tujuan demonstrasi, kita dapat melengkapi skripnya:
 
 ```python
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
 ```
 
-## Inline chat
+## Chat inline
 
-Inline chat lets you select a line or block and then directly prompt the AI model to propose an edit. In this interaction mode, the model can make changes to existing code (which differs from autocomplete, which only completes code beyond the cursor).
+Chat inline memungkinkan Anda memilih satu baris atau blok dan kemudian langsung memberi prompt ke model AI untuk mengusulkan perubahan. Dalam mode interaksi ini, model dapat membuat perubahan pada kode yang sudah ada (berbeda dengan autocomplete yang hanya melengkapi kode setelah kursor).
 
-Continuing the example from above, suppose we decided not to use the third-party `requests` library. We could select the relevant three lines of code, invoke inline chat, and say something like:
+Melanjutkan contoh dari atas, misalkan kita memutuskan untuk tidak menggunakan library `requests` dari pihak ketiga. Kita bisa memilih tiga baris kode yang relevan, memanggil chat inline, dan mengatakan sesuatu seperti:
 
 ```
 use built-in libraries instead
 ```
 
-The model proposes:
+Model mengusulkan:
 
 ```python
 from urllib.request import urlopen
@@ -281,25 +281,25 @@ def download_contents(url: str) -> str:
         return response.read().decode('utf-8')
 ```
 
-## Coding agents
+## Agen coding
 
-Coding agents are covered in depth in the [Agentic Coding](/2026/agentic-coding/) lecture.
+Agen coding dibahas secara mendalam di kuliah [Pemrograman Agentik](/2026/agentic-coding/).
 
-## Recommended software
+## Perangkat lunak yang direkomendasikan
 
-Some popular AI IDEs are [VS Code][vs-code] with the [GitHub Copilot][github-copilot] extension and [Cursor](https://cursor.com/). GitHub Copilot is currently available [for free for students](https://github.com/education/students), teachers, and maintainers of popular open source projects. This is a rapidly evolving space. Many of the leading products have roughly equivalent functionality.
+Beberapa IDE AI yang populer adalah [VS Code][vs-code] dengan ekstensi [GitHub Copilot][github-copilot] dan [Cursor](https://cursor.com/). GitHub Copilot saat ini tersedia [gratis untuk pelajar](https://github.com/education/students), pengajar, dan pengelola proyek open source populer. Ini adalah ruang yang berkembang pesat. Banyak produk terkemuka memiliki fungsionalitas yang kurang lebih setara.
 
-# Extensions and other IDE functionality
+# Ekstensi dan fungsionalitas IDE lainnya
 
-IDEs are powerful tools, made even more powerful by _extensions_. We can't cover all of these features in a single lecture, but here we provide some pointers to a couple popular extensions. We encourage you to explore this space on your own; there are many lists of popular IDE extensions available online, such as [Vim Awesome](https://vimawesome.com/) for Vim plugins and [VS Code extensions sorted by popularity](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
+IDE adalah alat yang powerful, dan menjadi lebih powerful lagi dengan _ekstensi_. Kita tidak dapat membahas semua fitur ini dalam satu kuliah, tetapi di sini kami memberikan beberapa petunjuk ke beberapa ekstensi populer. Kami mendorong Anda untuk menjelajahi ruang ini sendiri; ada banyak daftar ekstensi IDE populer yang tersedia secara online, seperti [Vim Awesome](https://vimawesome.com/) untuk plugin Vim dan [ekstensi VS Code diurutkan berdasarkan popularitas](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
 
-- [Development containers](https://containers.dev/): supported by popular IDEs (e.g., [supported by VS Code](https://code.visualstudio.com/docs/devcontainers/containers)), dev containers let you use a container to run development tools. This can be helpful for portability or isolation. The [lecture on packaging and shipping code](/2026/shipping-code/) covers containers in more depth.
-- Remote development: do development on a remote machine using SSH (e.g., with the [Remote SSH plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). This can be handy, for example, if you want to develop and run code on a beefy GPU machine in the cloud.
-- Collaborative editing: edit the same file, Google Docs style (e.g., with the [Live Share plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
+- [Development containers](https://containers.dev/): didukung oleh IDE populer (misalnya, [didukung oleh VS Code](https://code.visualstudio.com/docs/devcontainers/containers)), dev container memungkinkan Anda menggunakan container untuk menjalankan alat pengembangan. Ini bisa membantu untuk portabilitas atau isolasi. [Kuliah tentang pengemasan dan pendistribusian kode](/2026/shipping-code/) membahas container lebih mendalam.
+- Pengembangan jarak jauh: lakukan pengembangan di mesin jarak jauh menggunakan SSH (misalnya, dengan [plugin Remote SSH untuk VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). Ini bisa berguna, misalnya, jika Anda ingin mengembangkan dan menjalankan kode di mesin GPU yang kuat di cloud.
+- Penyuntingan kolaboratif: sunting file yang sama, seperti Google Docs (misalnya, dengan [plugin Live Share untuk VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
 
-# Exercises
+# Latihan
 
-1. Enable Vim mode in all the software you use that supports it, such as your editor and your shell, and use Vim mode for all your text editing for the next month. Whenever something seems inefficient, or when you think "there must be a better way", try Googling it, there probably is a better way.
-1. Complete a challenge from [VimGolf](https://www.vimgolf.com/).
-1. Configure an IDE extension and language server for a project that you're working on. Ensure that all the expected functionality, such as jump-to-definition for library dependencies, works as expected. If you don't have code that you can use for this exercise, you can use some open-source project from GitHub (such as [this one](https://github.com/spf13/cobra)).
-1. Browse a list of IDE extensions and install one that seems useful to you.
+1. Aktifkan mode Vim di semua perangkat lunak yang Anda gunakan yang mendukungnya, seperti penyunting dan shell Anda, dan gunakan mode Vim untuk semua penyuntingan teks Anda selama sebulan ke depan. Setiap kali ada yang terasa tidak efisien, atau ketika Anda berpikir "pasti ada cara yang lebih baik", coba cari di Google, kemungkinan besar ada cara yang lebih baik.
+1. Selesaikan sebuah tantangan dari [VimGolf](https://www.vimgolf.com/).
+1. Konfigurasikan ekstensi IDE dan language server untuk proyek yang sedang Anda kerjakan. Pastikan semua fungsionalitas yang diharapkan, seperti lompat ke definisi untuk dependensi library, berfungsi sebagaimana mestinya. Jika Anda tidak memiliki kode yang bisa digunakan untuk latihan ini, Anda bisa menggunakan beberapa proyek open-source dari GitHub (seperti [yang ini](https://github.com/spf13/cobra)).
+1. Jelajahi daftar ekstensi IDE dan pasang satu yang tampaknya berguna bagi Anda.

--- a/_2026/development-environment.md
+++ b/_2026/development-environment.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Development Environment and Tools"
+title: "Environment dan Tools Pengembangan"
 description: >
   Pelajari tentang IDE, Vim, language server, dan tools pengembangan berbasis AI.
 thumbnail: /static/assets/thumbnails/2026/lec3.png
@@ -11,121 +11,121 @@ video:
   id: QnM1nVzrkx8
 ---
 
-A _development environment_ is a set of tools for developing software. At the heart of a development environment is text editing functionality, along with accompanying features such as syntax highlighting, type checking, code formatting, and autocomplete. _Integrated development environments_ (IDEs) such as [VS Code][vs-code] bring together all of this functionality into a single application. Terminal-based development workflows combine tools such as [tmux](https://github.com/tmux/tmux) (a terminal multiplexer), [Vim](https://www.vim.org/) (a text editor), [Zsh](https://www.zsh.org/) (a shell), and language-specific command-line tools, such as [Ruff](https://docs.astral.sh/ruff/) (a Python linter and code formatter) and [Mypy](https://mypy-lang.org/) (a Python type checker).
+_Environment pengembangan_ (_development environment_) adalah sekumpulan tools untuk mengembangkan perangkat lunak. Di inti dari environment pengembangan terdapat fungsionalitas editing teks, beserta fitur-fitur pendukung seperti syntax highlighting, type checking, code formatting, dan autocomplete. _Integrated development environment_ (IDE) seperti [VS Code][vs-code] menggabungkan semua fungsionalitas ini ke dalam satu aplikasi. Workflow pengembangan berbasis terminal menggabungkan tools-tools seperti [tmux](https://github.com/tmux/tmux) (terminal multiplexer), [Vim](https://www.vim.org/) (text editor), [Zsh](https://www.zsh.org/) (shell), dan tools command-line spesifik bahasa pemrograman, seperti [Ruff](https://docs.astral.sh/ruff/) (linter dan code formatter Python) dan [Mypy](https://mypy-lang.org/) (type checker Python).
 
-IDEs and terminal-based workflows each have their strengths and weaknesses. For example, graphical IDEs can be easier to learn, and today's IDEs generally have better out-of-the-box AI integrations like AI autocomplete; on the other hand, terminal-based workflows are lightweight, and they may be your only option in environments where you don't have a GUI or can't install software. We recommend you develop basic familiarity with both and develop mastery of at least one. If you don't already have a preferred IDE, we recommend starting with [VS Code][vs-code].
+IDE dan workflow berbasis terminal masing-masing memiliki kelebihan dan kekurangan. Sebagai contoh, IDE grafis mungkin lebih mudah dipelajari, dan IDE saat ini umumnya memiliki integrasi AI bawaan yang lebih baik seperti AI autocomplete; di sisi lain, workflow berbasis terminal bersifat ringan, dan mungkin menjadi satu-satunya pilihan Anda di environment di mana Anda tidak memiliki GUI atau tidak bisa menginstal perangkat lunak. Kami merekomendasikan Anda untuk mengembangkan keterampilan dasar di keduanya dan menguasai setidaknya salah satunya. Jika Anda belum memiliki IDE pilihan, kami merekomendasikan untuk memulai dengan [VS Code][vs-code].
 
-In this lecture, we'll cover:
+Dalam kuliah ini, kita akan membahas:
 
-- [Text editing and Vim](#text-editing-and-vim)
-- [Code intelligence and language servers](#code-intelligence-and-language-servers)
-- [AI-powered development](#ai-powered-development)
-- [Extensions and other IDE functionality](#extensions-and-other-ide-functionality)
+- [Editing teks dan Vim](#text-editing-and-vim)
+- [Code intelligence dan language server](#code-intelligence-and-language-servers)
+- [Pengembangan berbasis AI](#ai-powered-development)
+- [Ekstensi dan fungsionalitas IDE lainnya](#extensions-and-other-ide-functionality)
 
 [vs-code]: https://code.visualstudio.com/
 
 # Text editing and Vim
 
-When programming, you spend most of your time navigating through code, reading snippets of code, and making edits to code, rather than writing long streams or reading files top-to-bottom. [Vim] is a text editor that is optimized for this distribution of tasks.
+Saat pemrograman, Anda menghabiskan sebagian besar waktu untuk menavigasi kode, membaca potongan kode, dan melakukan edit pada kode, daripada menulis aliran kode yang panjang atau membaca file dari awal sampai akhir. [Vim] adalah text editor yang dioptimalkan untuk distribusi tugas ini.
 
-**The philosophy of Vim.** Vim has a beautiful idea as its foundation: its interface is itself a programming language, designed for navigating and editing text. Keystrokes (with mnemonic names) are commands, and these commands are composable. Vim avoids the use of the mouse, because it's too slow; Vim even avoids use of the arrow keys because it requires too much movement. The result: an editor that feels like a brain-computer interface and matches the speed at which you think.
+**Filosofi Vim.** Vim memiliki gagasan indah sebagai fondasinya: antarmukanya itu sendiri adalah sebuah bahasa pemrograman, yang dirancang untuk menavigasi dan mengedit teks. Penekanan tombol (dengan nama mnemonik) adalah perintah-perintah, dan perintah-perintah ini dapat dikomposisikan. Vim menghindari penggunaan mouse, karena terlalu lambat; Vim bahkan menghindari penggunaan tombol panah karena membutuhkan terlalu banyak pergerakan. Hasilnya: sebuah editor yang terasa seperti antarmuka otak-komputer dan mengikuti kecepatan berpikir Anda.
 
-**Vim support in other software.** You don't have to use [Vim] itself to benefit from the ideas at its core. Many programs that involve any kind of text editing support "Vim mode", either as built-in functionality or as a plugin. For example, VS Code has the [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) plugin, Zsh has [built-in support](https://zsh.sourceforge.io/Guide/zshguide04.html) for Vim emulation, and even Claude Code has [built-in support](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) for Vim editor mode. Chances are that any tool you use that involves text editing supports Vim mode in one way or another.
+**Dukungan Vim di perangkat lunak lain.** Anda tidak harus menggunakan [Vim] itu sendiri untuk mendapatkan manfaat dari gagasan-gagasan intinya. Banyak program yang melibatkan editing teks mendukung "mode Vim", baik sebagai fungsionalitas bawaan maupun sebagai plugin. Sebagai contoh, VS Code memiliki plugin [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim), Zsh memiliki [dukungan bawaan](https://zsh.sourceforge.io/Guide/zshguide04.html) untuk emulasi Vim, dan bahkan Claude Code memiliki [dukungan bawaan](https://code.claude.com/docs/en/interactive-mode#vim-editor-mode) untuk mode editor Vim. Kemungkinan besar, tool apa pun yang Anda gunakan yang melibatkan editing teks mendukung mode Vim dengan satu cara atau lainnya.
 
 ## Modal editing
 
-Vim is a _modal editor_: it has different operating modes for different classes of tasks.
+Vim adalah _editor modal_: ia memiliki mode operasi yang berbeda untuk kelas tugas yang berbeda.
 
-- **Normal**: for moving around a file and making edits
-- **Insert**: for inserting text
-- **Replace**: for replacing text
-- **Visual** (plain, line, or block): for selecting blocks of text
-- **Command-line**: for running a command
+- **Normal**: untuk berpindah-pindah dalam file dan melakukan edit
+- **Insert**: untuk menyisipkan teks
+- **Replace**: untuk mengganti teks
+- **Visual** (plain, line, atau block): untuk memblok teks
+- **Command-line**: untuk menjalankan perintah
 
-Keystrokes have different meanings in different operating modes. For example, the letter `x` in Insert mode will just insert a literal character "x", but in Normal mode, it will delete the character under the cursor, and in Visual mode, it will delete the selection.
+Penekanan tombol memiliki arti yang berbeda di mode operasi yang berbeda. Sebagai contoh, huruf `x` di mode Insert hanya akan menyisipkan karakter literal "x", tetapi di mode Normal, ia akan menghapus karakter di bawah kursor, dan di mode Visual, ia akan menghapus seleksi.
 
-In its default configuration, Vim shows the current mode in the bottom left. The initial/default mode is Normal mode. You'll generally spend most of your time between Normal mode and Insert mode.
+Pada konfigurasi default, Vim menampilkan mode saat ini di pojok kiri bawah. Mode awal/default adalah mode Normal. Anda umumnya akan menghabiskan sebagian besar waktu antara mode Normal dan mode Insert.
 
-You change modes by pressing `<ESC>` (the escape key) to switch from any mode back to Normal mode. From Normal mode, enter Insert mode with `i`, Replace mode with `R`, Visual mode with `v`, Visual Line mode with `V`, Visual Block mode with `<C-v>` (Ctrl-V, sometimes also written `^V`), and Command-line mode with `:`.
+Anda berpindah mode dengan menekan `<ESC>` (tombol escape) untuk beralih dari mode apa pun kembali ke mode Normal. Dari mode Normal, masuk ke mode Insert dengan `i`, mode Replace dengan `R`, mode Visual dengan `v`, mode Visual Line dengan `V`, mode Visual Block dengan `<C-v>` (Ctrl-V, terkadang juga ditulis `^V`), dan mode Command-line dengan `:`.
 
-You use the `<ESC>` key a lot when using Vim: consider remapping Caps Lock to Escape ([macOS instructions](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)) or create an [alternative mapping](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) for `<ESC>` with a simple key sequence.
+Anda banyak menggunakan tombol `<ESC>` saat menggunakan Vim: pertimbangkan untuk memetakan ulang Caps Lock ke Escape ([instruksi macOS](https://vim.fandom.com/wiki/Map_caps_lock_to_escape_in_macOS)) atau buat [pemetaan alternatif](https://vim.fandom.com/wiki/Avoid_the_escape_key#Mappings) untuk `<ESC>` dengan urutan tombol sederhana.
 
 ## Basics: inserting text
 
-From Normal mode, press `i` to enter Insert mode. Now, Vim behaves like any other text editor, until you press `<ESC>` to return to Normal mode. This, along with the basics explained above, are all you need to start editing files using Vim (though not particularly efficiently, if you're spending all your time editing from Insert mode).
+Dari mode Normal, tekan `i` untuk masuk ke mode Insert. Sekarang, Vim berperilaku seperti text editor lainnya, sampai Anda menekan `<ESC>` untuk kembali ke mode Normal. Ini, beserta dasar-dasar yang dijelaskan di atas, adalah semua yang Anda butuhkan untuk mulai mengedit file menggunakan Vim (meskipun tidak terlalu efisien, jika Anda menghabiskan seluruh waktu mengedit dari mode Insert).
 
-## Vim's interface is a programming language
+## Antarmuka Vim adalah bahasa pemrograman
 
-Vim's interface is a programming language. Keystrokes (with mnemonic names) are commands, and these commands _compose_. This enables efficient movement and edits, especially once the commands become muscle memory, just like typing becomes super efficient once you've learned your keyboard layout.
+Antarmuka Vim adalah bahasa pemrograman. Penekanan tombol (dengan nama mnemonik) adalah perintah-perintah, dan perintah-perintah ini dapat _dikomposisikan_. Ini memungkinkan pergerakan dan edit yang efisien, terutama setelah perintah-perintah tersebut menjadi memori otot, sama seperti mengetik menjadi sangat efisien setelah Anda menguasai layout keyboard Anda.
 
 ### Movement
 
-You should spend most of your time in Normal mode, using movement commands to navigate the file. Movements in Vim are also called "nouns", because they refer to chunks of text.
+Anda seharusnya menghabiskan sebagian besar waktu di mode Normal, menggunakan perintah pergerakan untuk menavigasi file. Pergerakan di Vim juga disebut "kata benda" (_nouns_), karena merujuk pada potongan teks.
 
-- Basic movement: `hjkl` (left, down, up, right)
-- Words: `w` (next word), `b` (beginning of word), `e` (end of word)
-- Lines: `0` (beginning of line), `^` (first non-blank character), `$` (end of line)
-- Screen: `H` (top of screen), `M` (middle of screen), `L` (bottom of screen)
-- Scroll: `Ctrl-u` (up), `Ctrl-d` (down)
-- File: `gg` (beginning of file), `G` (end of file)
-- Line numbers: `:{number}<CR>` or `{number}G` (line {number})
-    - `<CR>` refers to the carriage return / enter key
-- Misc: `%` (matching item, like parenthesis or brace)
-- Find: `f{character}`, `t{character}`, `F{character}`, `T{character}`
-    - find/to forward/backward {character} on the current line
-    - `,` / `;` for navigating matches
-- Search: `/{regex}`, `n` / `N` for navigating matches
+- Pergerakan dasar: `hjkl` (kiri, bawah, atas, kanan)
+- Kata: `w` (kata berikutnya), `b` (awal kata), `e` (akhir kata)
+- Baris: `0` (awal baris), `^` (karakter non-kosong pertama), `$` (akhir baris)
+- Layar: `H` (atas layar), `M` (tengah layar), `L` (bawah layar)
+- Scroll: `Ctrl-u` (atas), `Ctrl-d` (bawah)
+- File: `gg` (awal file), `G` (akhir file)
+- Nomor baris: `:{number}<CR>` atau `{number}G` (baris ke-{number})
+    - `<CR>` merujuk pada carriage return / tombol enter
+- Lainnya: `%` (item yang cocok, seperti tanda kurung atau kurung kurawal)
+- Cari: `f{character}`, `t{character}`, `F{character}`, `T{character}`
+    - cari/menuju maju/mundur {character} pada baris saat ini
+    - `,` / `;` untuk menavigasi hasil pencarian
+- Pencarian: `/{regex}`, `n` / `N` untuk menavigasi hasil pencarian
 
 ### Selection
 
-Visual modes:
+Mode Visual:
 
 - Visual: `v`
 - Visual Line: `V`
 - Visual Block: `Ctrl-v`
 
-Can use movement keys to make selection.
+Dapat menggunakan tombol pergerakan untuk membuat seleksi.
 
 ### Edits
 
-Everything that you used to do with the mouse, you now do with the keyboard using editing commands that compose with movement commands. Here's where Vim's interface starts to look like a programming language. Vim's editing commands are also called "verbs", because verbs act on nouns.
+Semua yang biasa Anda lakukan dengan mouse, sekarang Anda lakukan dengan keyboard menggunakan perintah editing yang dikomposisikan dengan perintah pergerakan. Di sinilah antarmuka Vim mulai terlihat seperti bahasa pemrograman. Perintah editing Vim juga disebut "kata kerja" (_verbs_), karena kata kerja bekerja pada kata benda.
 
-- `i` enter Insert mode
-    - but for manipulating/deleting text, want to use something more than backspace
-- `o` / `O` insert line below / above
-- `d{motion}` delete {motion}
-    - e.g. `dw` is delete word, `d$` is delete to end of line, `d0` is delete to beginning of line
-- `c{motion}` change {motion}
-    - e.g. `cw` is change word
-    - like `d{motion}` followed by `i`
-- `x` delete character (equivalent to `dl`)
-- `s` substitute character (equivalent to `cl`)
-- Visual mode + manipulation
-    - select text, `d` to delete it or `c` to change it
-- `u` to undo, `<C-r>` to redo
-- `y` to copy / "yank" (some other commands like `d` also copy)
-- `p` to paste
-- Lots more to learn: for example, `~` flips the case of a character, and `J` joins together lines
+- `i` masuk mode Insert
+    - tetapi untuk memanipulasi/menghapus teks, Anda ingin menggunakan sesuatu yang lebih dari sekadar backspace
+- `o` / `O` sisipkan baris di bawah / di atas
+- `d{motion}` hapus {motion}
+    - contoh: `dw` adalah hapus kata, `d$` adalah hapus sampai akhir baris, `d0` adalah hapus sampai awal baris
+- `c{motion}` ubah {motion}
+    - contoh: `cw` adalah ubah kata
+    - seperti `d{motion}` diikuti oleh `i`
+- `x` hapus karakter (setara dengan `dl`)
+- `s` substitusi karakter (setara dengan `cl`)
+- Mode Visual + manipulasi
+    - seleksi teks, `d` untuk menghapusnya atau `c` untuk mengubahnya
+- `u` untuk undo, `<C-r>` untuk redo
+- `y` untuk copy / "yank" (beberapa perintah lain seperti `d` juga menyalin)
+- `p` untuk paste
+- Masih banyak yang bisa dipelajari: sebagai contoh, `~` membalikkan huruf besar/kecil sebuah karakter, dan `J` menggabungkan baris-baris
 
 ### Counts
 
-You can combine nouns and verbs with a count, which will perform a given action a number of times.
+Anda dapat menggabungkan kata benda dan kata kerja dengan jumlah (_count_), yang akan melakukan tindakan tertentu sebanyak beberapa kali.
 
-- `3w` move 3 words forward
-- `5j` move 5 lines down
-- `7dw` delete 7 words
+- `3w` pindah 3 kata ke depan
+- `5j` pindah 5 baris ke bawah
+- `7dw` hapus 7 kata
 
 ### Modifiers
 
-You can use modifiers to change the meaning of a noun. Some modifiers are `i`, which means "inner" or "inside", and `a`, which means "around".
+Anda dapat menggunakan modifier untuk mengubah arti dari kata benda. Beberapa modifier adalah `i`, yang berarti "inner" atau "inside", dan `a`, yang berarti "around".
 
-- `ci(` change the contents inside the current pair of parentheses
-- `ci[` change the contents inside the current pair of square brackets
-- `da'` delete a single-quoted string, including the surrounding single quotes
+- `ci(` ubah konten di dalam tanda kurung saat ini
+- `ci[` ubah konten di dalam tanda kurung siku saat ini
+- `da'` hapus string bertanda kutip tunggal, termasuk tanda kutip tunggal di sekitarnya
 
 ## Putting it all together
 
-Here is a broken [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) implementation:
+Berikut adalah implementasi [fizz buzz](https://en.wikipedia.org/wiki/Fizz_buzz) yang salah:
 
 ```python
 def fizz_buzz(limit):
@@ -142,73 +142,73 @@ def main():
     fizz_buzz(20)
 ```
 
-We use the following sequence of commands to fix the issues, beginning in Normal mode:
+Kita menggunakan urutan perintah berikut untuk memperbaiki masalah-masalah tersebut, dimulai dari mode Normal:
 
-- Main is never called
-    - `G` to jump to the end of the file
-    - `o` to **o**pen a new line below
-    - Type in `if __name__ == "__main__": main()`
-        - If your editor has Python language support, it might do some auto-indentation for you in Insert mode
-    - `<ESC>` to go back to Normal mode
-- Starts at 0 instead of 1
-    - `/` followed by `range` and `<CR>` to search for "range"
-    - `ww` to move forward two **w**ords (you could also use `2w`, but in practice, for small counts it's common to repeat the key instead of using the count functionality)
-    - `i` to switch to **i**nsert mode, and add `1,`
-    - `<ESC>` to go back to Normal mode
-    - `e` to jump to the **e**nd of the next word
-    - `a` to start **a**ppending text, and add `+ 1`
-    - `<ESC>` to go back to Normal mode
-- Prints "fizz" for multiples of 5
-    - `:6<CR>` to go to line 6
-    - `ci"` to **c**hange **i**nside the '**"**', change to `"buzz"`
-    - `<ESC>` to go back to Normal mode
+- Main tidak pernah dipanggil
+    - `G` untuk melompat ke akhir file
+    - `o` untuk memb**o**ka baris baru di bawah
+    - Ketik `if __name__ == "__main__": main()`
+        - Jika editor Anda memiliki dukungan bahasa Python, mungkin akan melakukan auto-indentation untuk Anda di mode Insert
+    - `<ESC>` untuk kembali ke mode Normal
+- Dimulai dari 0, bukan 1
+    - `/` diikuti oleh `range` dan `<CR>` untuk mencari "range"
+    - `ww` untuk maju dua **w**ord (Anda juga bisa menggunakan `2w`, tetapi dalam praktiknya, untuk jumlah kecil, umum untuk mengulang tombol daripada menggunakan fungsionalitas count)
+    - `i` untuk beralih ke mode **i**nsert, dan tambahkan `1,`
+    - `<ESC>` untuk kembali ke mode Normal
+    - `e` untuk melompat ke **e**nd (akhir) kata berikutnya
+    - `a` untuk mulai **a**ppending teks, dan tambahkan `+ 1`
+    - `<ESC>` untuk kembali ke mode Normal
+- Mencetak "fizz" untuk kelipatan 5
+    - `:6<CR>` untuk pergi ke baris 6
+    - `ci"` untuk **c**hange **i**nside '**"**', ubah menjadi `"buzz"`
+    - `<ESC>` untuk kembali ke mode Normal
 
 ## Learning Vim
 
-The best way to learn Vim is to learn the fundamentals (what we've covered so far) and then just enable Vim mode in all your software and start using it in practice. Avoid the temptation to use the mouse or the arrow keys; in some editors, you can unbind the arrow keys to force yourself to build good habits.
+Cara terbaik untuk belajar Vim adalah mempelajari dasar-dasarnya (yang telah kita bahas sejauh ini) dan kemudian mengaktifkan mode Vim di semua perangkat lunak Anda dan mulai menggunakannya dalam praktik. Hindari godaan untuk menggunakan mouse atau tombol panah; di beberapa editor, Anda dapat melepas pemetaan tombol panah untuk memaksa diri Anda membangun kebiasaan yang baik.
 
 ### Additional resources
 
-- The [Vim lecture](/2020/editors/) from the previous iteration of this class --- we have covered Vim in more depth there
-- `vimtutor` is a tutorial that comes installed with Vim --- if Vim is installed, you should be able to run `vimtutor` from your shell
-- [Vim Adventures](https://vim-adventures.com/) is a game to learn Vim
+- [Kuliah Vim](/2020/editors/) dari iterasi sebelumnya kelas ini --- kita telah membahas Vim lebih mendalam di sana
+- `vimtutor` adalah tutorial yang terinstal bersama Vim --- jika Vim terinstal, Anda seharusnya bisa menjalankan `vimtutor` dari shell Anda
+- [Vim Adventures](https://vim-adventures.com/) adalah permainan untuk belajar Vim
 - [Vim Tips Wiki](https://vim.fandom.com/wiki/Vim_Tips_Wiki)
-- [Vim Advent Calendar](https://vimways.org/2019/) has various Vim tips
-- [VimGolf](https://www.vimgolf.com/) is [code golf](https://en.wikipedia.org/wiki/Code_golf), but where the programming language is Vim's UI
+- [Vim Advent Calendar](https://vimways.org/2019/) memiliki berbagai tips Vim
+- [VimGolf](https://www.vimgolf.com/) adalah [code golf](https://en.wikipedia.org/wiki/Code_golf), tetapi di mana bahasa pemrogramannya adalah UI Vim
 - [Vi/Vim Stack Exchange](https://vi.stackexchange.com/)
 - [Vim Screencasts](http://vimcasts.org/)
-- [Practical Vim](https://pragprog.com/titles/dnvim2/) (book)
+- [Practical Vim](https://pragprog.com/titles/dnvim2/) (buku)
 
 [Vim]: https://www.vim.org/
 
-# Code intelligence and language servers
+# Code intelligence dan language server
 
-IDEs generally offer language-specific support that requires semantic understanding of the code through IDE extensions that connect to _language servers_ that implement [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). For example, the [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) relies on [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), and the [Go extension for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) relies on the first-party [gopls](https://go.dev/gopls/). By installing the extension and language server for the languages you work with, you can enable many language-specific features in your IDE, such as:
+IDE umumnya menawarkan dukungan spesifik bahasa yang membutuhkan pemahaman semantik dari kode melalui ekstensi IDE yang terhubung ke _language server_ yang mengimplementasikan [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Sebagai contoh, [ekstensi Python untuk VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) bergantung pada [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), dan [ekstensi Go untuk VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) bergantung pada [gopls](https://go.dev/gopls/) dari pihak pertama. Dengan menginstal ekstensi dan language server untuk bahasa yang Anda gunakan, Anda dapat mengaktifkan banyak fitur spesifik bahasa di IDE Anda, seperti:
 
-- **Code completion.** Better autocomplete and autosuggest, such as being able to see an object's fields and methods after typing `object.`.
-- **Inline documentation.** Seeing documentation on hover and autosuggest.
-- **Jump-to-definition.** Jumping from a use site to the definition, such as being able to go from a field reference `object.field` to the definition of the field.
-- **Find references.** The inverse of the above, find all sites where a particular item such as a field or type is referenced.
-- **Help with imports.** Organizing imports, removing unused imports, flagging missing imports.
-- **Code quality.** These tools can be used standalone, but this functionality is often provided by language servers as well. Code formatting auto-indents and auto-formats code, and type checkers and linters find errors in your code, as you type. We will cover this class of functionality in greater depth in the [lecture on code quality](/2026/code-quality/).
+- **Code completion.** Autocomplete dan autosuggest yang lebih baik, seperti kemampuan untuk melihat field dan method sebuah objek setelah mengetik `object.`.
+- **Inline documentation.** Melihat dokumentasi saat hover dan autosuggest.
+- **Jump-to-definition.** Melompat dari tempat penggunaan ke definisi, seperti bisa pergi dari referensi field `object.field` ke definisi field tersebut.
+- **Find references.** Kebalikan dari di atas, menemukan semua tempat di mana item tertentu seperti field atau tipe direferensikan.
+- **Bantuan dengan import.** Mengorganisir import, menghapus import yang tidak terpakai, menandai import yang hilang.
+- **Code quality.** Tool-tool ini dapat digunakan secara mandiri, tetapi fungsionalitas ini sering juga disediakan oleh language server. Code formatting melakukan auto-indent dan auto-format kode, dan type checker serta linter menemukan kesalahan dalam kode Anda, saat Anda mengetik. Kita akan membahas kelas fungsionalitas ini lebih mendalam di [kuliah tentang code quality](/2026/code-quality/).
 
-## Configuring language servers
+## Mengonfigurasi language server
 
-For some languages, all you need to do is install the extension and language server, and you'll be all set. For others, to get the maximum benefit from the language server, you need to tell the IDE about your environment. For example, pointing VS Code to your [Python environment](https://code.visualstudio.com/docs/python/environments) will enable the language server to see your installed packages. Environments are covered in more depth in our [lecture on packaging and shipping code](/2026/shipping-code/).
+Untuk beberapa bahasa, yang perlu Anda lakukan hanyalah menginstal ekstensi dan language server, dan Anda siap menggunakannya. Untuk bahasa lain, untuk mendapatkan manfaat maksimal dari language server, Anda perlu memberi tahu IDE tentang environment Anda. Sebagai contoh, menunjuk VS Code ke [environment Python](https://code.visualstudio.com/docs/python/environments) Anda akan memungkinkan language server untuk melihat package yang telah Anda instal. Environment dibahas lebih mendalam di [kuliah tentang packaging dan shipping kode](/2026/shipping-code/).
 
-Depending on the language, there might be some settings you can configure for your language server. For example, using the Python support in VS Code, you can disable static type checking for projects that don't make use of Python's optional type annotations.
+Tergantung pada bahasanya, mungkin ada beberapa pengaturan yang dapat Anda konfigurasikan untuk language server Anda. Sebagai contoh, menggunakan dukungan Python di VS Code, Anda dapat menonaktifkan static type checking untuk proyek yang tidak menggunakan type annotation opsional Python.
 
-# AI-powered development
+# Pengembangan berbasis AI
 
-Since the introduction of [GitHub Copilot][github-copilot] using OpenAI's [Codex model](https://openai.com/index/openai-codex/) in mid 2021, [LLMs](https://en.wikipedia.org/wiki/Large_language_model) have become widely adopted in software engineering. There are three main form factors in use right now: autocomplete, inline chat, and coding agents.
+Sejak diperkenalkannya [GitHub Copilot][github-copilot] menggunakan [model Codex](https://openai.com/index/openai-codex/) dari OpenAI pada pertengahan 2021, [LLM](https://en.wikipedia.org/wiki/Large_language_model) telah menjadi banyak digunakan dalam rekayasa perangkat lunak. Ada tiga bentuk utama yang digunakan saat ini: autocomplete, inline chat, dan coding agent.
 
 [github-copilot]: https://github.com/features/copilot/ai-code-editor
 
 ## Autocomplete
 
-AI-powered autocomplete has the same form factor as traditional autocomplete in your IDE, suggesting completions at your cursor position as you type. Sometimes, it's used as a passive feature that "just works". Beyond that, AI autocomplete is generally [prompted](https://en.wikipedia.org/wiki/Prompt_engineering) using code comments.
+Autocomplete berbasis AI memiliki bentuk yang sama dengan autocomplete tradisional di IDE Anda, menyarankan pelengkapan di posisi kursor Anda saat Anda mengetik. Terkadang, ini digunakan sebagai fitur pasif yang "berjalan dengan sendirinya". Selain itu, autocomplete AI umumnya di-[prompt](https://en.wikipedia.org/wiki/Prompt_engineering) menggunakan komentar kode.
 
-For example, let's write a script to download the contents of these lecture notes and extract all the links. We can start with:
+Sebagai contoh, mari tulis script untuk mengunduh isi catatan kuliah ini dan mengekstrak semua link. Kita bisa mulai dengan:
 
 ```python
 import requests
@@ -216,34 +216,34 @@ import requests
 def download_contents(url: str) -> str:
 ```
 
-The model will autocomplete the body of the function:
+Model akan melengkapi body fungsi:
 
 ```python
     response = requests.get(url)
     return response.text
 ```
 
-We can further guide completions using comments. For example, if we start writing a function to extract all Markdown links, but it doesn't have a particularly descriptive name:
+Kita dapat lebih lanjut mengarahkan pelengkapan menggunakan komentar. Sebagai contoh, jika kita mulai menulis fungsi untuk mengekstrak semua link Markdown, tetapi namanya tidak terlalu deskriptif:
 
 ```python
 def extract(contents: str) -> list[str]:
 ```
 
-The model will autocomplete something like this:
+Model akan melengkapi sesuatu seperti ini:
 
 ```python
     lines = contents.splitlines()
     return [line for line in lines if line.strip()]
 ```
 
-We can guide the completion through code comments:
+Kita dapat mengarahkan pelengkapan melalui komentar kode:
 
 ```python
 def extract(content: str) -> list[str]:
     # extract all Markdown links from the content
 ```
 
-This time, the model gives a better completion:
+Kali ini, model memberikan pelengkapan yang lebih baik:
 
 ```python
     import re
@@ -251,11 +251,11 @@ This time, the model gives a better completion:
     return re.findall(pattern, content)
 ```
 
-Here, we see one downside of this AI coding tool: it can only provide completions at the cursor. In this case, it would be better practice to put the `import re` at the module level, rather than inside the function.
+Di sini, kita melihat salah satu kekurangan dari tool coding AI ini: ia hanya dapat memberikan pelengkapan di kursor. Dalam kasus ini, akan lebih baik jika meletakkan `import re` di level modul, daripada di dalam fungsi.
 
-The example above used a poorly-named function to demonstrate how code completion can be steered using comments; in practice, you'd want to write code with functions named more descriptively, like `extract_links`, and you'd want to write docstrings (and based on this, the model should generate a completion analogous to the one above).
+Contoh di atas menggunakan fungsi dengan nama yang buruk untuk mendemonstrasikan bagaimana code completion dapat diarahkan menggunakan komentar; dalam praktik, Anda ingin menulis kode dengan fungsi yang dinamai lebih deskriptif, seperti `extract_links`, dan Anda ingin menulis docstring (dan berdasarkan ini, model seharusnya menghasilkan pelengkapan yang analog dengan yang di atas).
 
-For demonstration purposes, we can complete the script:
+Untuk tujuan demonstrasi, kita dapat melengkapi script:
 
 ```python
 print(extract(download_contents("https://raw.githubusercontent.com/missing-semester/missing-semester/refs/heads/master/_2026/development-environment.md")))
@@ -263,15 +263,15 @@ print(extract(download_contents("https://raw.githubusercontent.com/missing-semes
 
 ## Inline chat
 
-Inline chat lets you select a line or block and then directly prompt the AI model to propose an edit. In this interaction mode, the model can make changes to existing code (which differs from autocomplete, which only completes code beyond the cursor).
+Inline chat memungkinkan Anda memilih satu baris atau blok dan kemudian langsung memberikan prompt ke model AI untuk mengusulkan edit. Dalam mode interaksi ini, model dapat membuat perubahan pada kode yang sudah ada (berbeda dengan autocomplete, yang hanya melengkapi kode di luar kursor).
 
-Continuing the example from above, suppose we decided not to use the third-party `requests` library. We could select the relevant three lines of code, invoke inline chat, and say something like:
+Melanjutkan contoh dari atas, misalkan kita memutuskan untuk tidak menggunakan library `requests` dari pihak ketiga. Kita bisa memilih tiga baris kode yang relevan, memanggil inline chat, dan mengatakan sesuatu seperti:
 
 ```
 use built-in libraries instead
 ```
 
-The model proposes:
+Model mengusulkan:
 
 ```python
 from urllib.request import urlopen
@@ -281,25 +281,25 @@ def download_contents(url: str) -> str:
         return response.read().decode('utf-8')
 ```
 
-## Coding agents
+## Coding agent
 
-Coding agents are covered in depth in the [Agentic Coding](/2026/agentic-coding/) lecture.
+Coding agent dibahas secara mendalam di kuliah [Agentic Coding](/2026/agentic-coding/).
 
-## Recommended software
+## Perangkat lunak yang direkomendasikan
 
-Some popular AI IDEs are [VS Code][vs-code] with the [GitHub Copilot][github-copilot] extension and [Cursor](https://cursor.com/). GitHub Copilot is currently available [for free for students](https://github.com/education/students), teachers, and maintainers of popular open source projects. This is a rapidly evolving space. Many of the leading products have roughly equivalent functionality.
+Beberapa IDE AI yang populer adalah [VS Code][vs-code] dengan ekstensi [GitHub Copilot][github-copilot] dan [Cursor](https://cursor.com/). GitHub Copilot saat ini tersedia [gratis untuk mahasiswa](https://github.com/education/students), pengajar, dan maintainer proyek open source populer. Ini adalah ruang yang berkembang pesat. Banyak produk terkemuka memiliki fungsionalitas yang kurang lebih setara.
 
 # Extensions and other IDE functionality
 
-IDEs are powerful tools, made even more powerful by _extensions_. We can't cover all of these features in a single lecture, but here we provide some pointers to a couple popular extensions. We encourage you to explore this space on your own; there are many lists of popular IDE extensions available online, such as [Vim Awesome](https://vimawesome.com/) for Vim plugins and [VS Code extensions sorted by popularity](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
+IDE adalah tool yang powerful, yang menjadi bahkan lebih powerful dengan _ekstensi_. Kita tidak bisa membahas semua fitur ini dalam satu kuliah, tetapi di sini kami memberikan beberapa petunjuk ke beberapa ekstensi populer. Kami mendorong Anda untuk menjelajahi ruang ini sendiri; ada banyak daftar ekstensi IDE populer yang tersedia online, seperti [Vim Awesome](https://vimawesome.com/) untuk plugin Vim dan [ekstensi VS Code diurutkan berdasarkan popularitas](https://marketplace.visualstudio.com/search?target=VSCode&category=All%20categories&sortBy=Installs).
 
-- [Development containers](https://containers.dev/): supported by popular IDEs (e.g., [supported by VS Code](https://code.visualstudio.com/docs/devcontainers/containers)), dev containers let you use a container to run development tools. This can be helpful for portability or isolation. The [lecture on packaging and shipping code](/2026/shipping-code/) covers containers in more depth.
-- Remote development: do development on a remote machine using SSH (e.g., with the [Remote SSH plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). This can be handy, for example, if you want to develop and run code on a beefy GPU machine in the cloud.
-- Collaborative editing: edit the same file, Google Docs style (e.g., with the [Live Share plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
+- [Development containers](https://containers.dev/): didukung oleh IDE populer (misalnya, [didukung oleh VS Code](https://code.visualstudio.com/docs/devcontainers/containers)), dev container memungkinkan Anda menggunakan container untuk menjalankan tools pengembangan. Ini bisa berguna untuk portabilitas atau isolasi. [Kuliah tentang packaging dan shipping kode](/2026/shipping-code/) membahas container lebih mendalam.
+- Remote development: melakukan pengembangan di mesin remote menggunakan SSH (misalnya, dengan [plugin Remote SSH untuk VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)). Ini bisa berguna, misalnya, jika Anda ingin mengembangkan dan menjalankan kode di mesin GPU yang kuat di cloud.
+- Collaborative editing: mengedit file yang sama, seperti Google Docs (misalnya, dengan [plugin Live Share untuk VS Code](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)).
 
-# Exercises
+# Latihan
 
-1. Enable Vim mode in all the software you use that supports it, such as your editor and your shell, and use Vim mode for all your text editing for the next month. Whenever something seems inefficient, or when you think "there must be a better way", try Googling it, there probably is a better way.
-1. Complete a challenge from [VimGolf](https://www.vimgolf.com/).
-1. Configure an IDE extension and language server for a project that you're working on. Ensure that all the expected functionality, such as jump-to-definition for library dependencies, works as expected. If you don't have code that you can use for this exercise, you can use some open-source project from GitHub (such as [this one](https://github.com/spf13/cobra)).
-1. Browse a list of IDE extensions and install one that seems useful to you.
+1. Aktifkan mode Vim di semua perangkat lunak yang Anda gunakan yang mendukungnya, seperti editor dan shell Anda, dan gunakan mode Vim untuk semua editing teks Anda selama sebulan ke depan. Setiap kali sesuatu terasa tidak efisien, atau ketika Anda berpikir "pasti ada cara yang lebih baik", cobalah mencari di Google, kemungkinan besar ada cara yang lebih baik.
+1. Selesaikan satu tantangan dari [VimGolf](https://www.vimgolf.com/).
+1. Konfigurasikan ekstensi IDE dan language server untuk proyek yang sedang Anda kerjakan. Pastikan semua fungsionalitas yang diharapkan, seperti jump-to-definition untuk dependensi library, berjalan sesuai harapan. Jika Anda tidak memiliki kode yang bisa digunakan untuk latihan ini, Anda bisa menggunakan beberapa proyek open-source dari GitHub (seperti [yang ini](https://github.com/spf13/cobra)).
+1. Jelajahi daftar ekstensi IDE dan instal satu yang tampaknya berguna bagi Anda.

--- a/_2026/index.md
+++ b/_2026/index.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: "2026 Lectures"
+title: "Kuliah 2026"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2026.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2026.
 permalink: /2026/
 phony: true
 ---
@@ -29,11 +29,11 @@ phony: true
   {% endfor %}
 </ul>
 
-Video recordings of the lectures are available [on YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L).
+Rekaman video kuliah tersedia [di YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L).
 
-# Beyond MIT
+# Di Luar MIT
 
-We've also shared this class beyond MIT in the hopes that others may benefit from these resources. You can find posts and discussion on
+Kami juga membagikan kelas ini di luar MIT dengan harapan orang lain dapat memanfaatkan sumber daya ini. Anda dapat menemukan postingan dan diskusi di
 
 - [Hacker News](https://news.ycombinator.com/item?id=47124171)
 - [Lobsters](https://lobste.rs/s/q4ykw7/missing_semester_your_cs_education_2026)
@@ -44,6 +44,6 @@ We've also shared this class beyond MIT in the hopes that others may benefit fro
 - [LinkedIn](https://www.linkedin.com/posts/anishathalye_i-returned-to-mit-during-iap-january-term-activity-7430285026933522433-Ehr9)
 - [YouTube](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L)
 
-# Acknowledgments
+# Ucapan Terima Kasih
 
-We thank Elaine Mello and [MIT Open Learning](https://openlearning.mit.edu/) for making it possible for us to record lecture videos. We thank Luis Turino / [SIPB](https://sipb.mit.edu/) for supporting this class as part of [SIPB IAP 2026](https://sipb.mit.edu/iap/).
+Kami mengucapkan terima kasih kepada Elaine Mello dan [MIT Open Learning](https://openlearning.mit.edu/) yang telah memungkinkan kami untuk merekam video kuliah. Kami mengucapkan terima kasih kepada Luis Turino / [SIPB](https://sipb.mit.edu/) yang telah mendukung kelas ini sebagai bagian dari [SIPB IAP 2026](https://sipb.mit.edu/iap/).

--- a/_2026/index.md
+++ b/_2026/index.md
@@ -2,7 +2,7 @@
 layout: page
 title: "2026 Lectures"
 description: >
-  Lecture notes and videos for Missing Semester, MIT IAP 2026.
+  Catatan kuliah dan video untuk Missing Semester, MIT IAP 2026.
 permalink: /2026/
 phony: true
 ---

--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Packaging and Shipping Code"
+title: "Pengemasan dan Distribusi Kode"
 description: >
-  Learn about project packaging, environments, versioning, and deploying libraries, applications, and services.
+  Pelajari tentang pengemasan proyek, environment, versioning, dan deployment pustaka, aplikasi, serta layanan.
 thumbnail: /static/assets/thumbnails/2026/lec6.png
 date: 2026-01-20
 ready: true
@@ -11,14 +11,14 @@ video:
   id: KBMiB-8P4Ns
 ---
 
-Getting code to work as intended is hard; getting that same code to run on a machine different from your own is often harder.
+Membuat kode berjalan sesuai harapan itu sulit; membuat kode yang sama berjalan di mesin yang berbeda dari mesin Anda seringkali lebih sulit lagi.
 
-Shipping code means taking the code you wrote and converting it into a usable form that someone else can run without your computer's exact setup.
-Shipping code takes many forms and depends on the choices of programming language, system libraries, and operating system, among many other factors.
-It also depends on what you are building: a software library, a command line tool, and a web service all have different requirements and deployment steps.
-Regardless, there is a common pattern between all these scenarios: we need to define what the deliverable is --- a.k.a. the _artifact_ --- and what assumptions it makes about the environment around it.
+Distribusi kode berarti mengambil kode yang Anda tulis dan mengubahnya menjadi bentuk yang dapat digunakan oleh orang lain tanpa memerlukan setup komputer yang sama persis dengan komputer Anda.
+Distribusi kode memiliki banyak bentuk dan bergantung pada pilihan bahasa pemrograman, pustaka sistem, dan sistem operasi, serta banyak faktor lainnya.
+Bentuk distribusi juga bergantung pada apa yang Anda bangun: pustaka perangkat lunak, alat baris perintah, dan layanan web semuanya memiliki kebutuhan dan langkah deployment yang berbeda.
+Meskipun demikian, terdapat pola umum di semua skenario ini: kita perlu mendefinisikan apa deliverable-nya --- alias _artifact_ --- dan asumsi apa yang dibuatnya tentang lingkungan di sekitarnya.
 
-In this lecture, we'll cover:
+Dalam kuliah ini, kita akan membahas:
 
 - [Dependencies & Environments](#dependencies--environments)
 - [Artifacts & Packaging](#artifacts--packaging)
@@ -29,14 +29,14 @@ In this lecture, we'll cover:
 - [Services & Orchestration](#services--orchestration)
 - [Publishing](#publishing)
 
-We'll explain these concepts through examples from the Python ecosystem, as concrete examples are helpful for understanding. While the tools are different for other programming language ecosystems, the concepts will largely be the same.
+Kita akan menjelaskan konsep-konsep ini melalui contoh dari ekosistem Python, karena contoh konkret sangat membantu untuk memahami. Meskipun alat yang digunakan berbeda untuk ekosistem bahasa pemrograman lain, konsepnya sebagian besar sama.
 
 # Dependencies & Environments
 
-In modern software development, layers of abstraction are ubiquitous.
-Programs naturally offload logic to other libraries or services.
-However, this introduces a _dependency_ relationship between your program and the libraries it requires to function.
-For instance, in Python, to fetch the content of a website we often do:
+Dalam pengembangan perangkat lunak modern, lapisan abstraksi ada di mana-mana.
+Program secara alami membebankan logika ke pustaka atau layanan lain.
+Namun, ini memperkenalkan hubungan _dependency_ antara program Anda dan pustaka yang dibutuhkannya untuk berfungsi.
+Sebagai contoh, di Python, untuk mengambil konten sebuah website kita sering melakukan:
 
 ```python
 import requests
@@ -44,7 +44,7 @@ import requests
 response = requests.get("https://missing.csail.mit.edu")
 ```
 
-Yet the `requests` library does not come bundled with the Python runtime, so if we try to run this code without having `requests` installed, Python will raise an error:
+Namun pustaka `requests` tidak disertakan bersama runtime Python, jadi jika kita mencoba menjalankan kode ini tanpa menginstal `requests`, Python akan memunculkan error:
 
 ```console
 $ python fetch.py
@@ -54,14 +54,14 @@ Traceback (most recent call last):
 ModuleNotFoundError: No module named 'requests'
 ```
 
-To make this library available we need to first run `pip install requests` to install it.
-`pip` is the command line tool that the Python programming language provides for installing packages.
-Executing `pip install requests` produces the following sequence of actions:
+Untuk membuat pustaka ini tersedia, kita perlu menjalankan `pip install requests` terlebih dahulu untuk menginstalnya.
+`pip` adalah alat baris perintah yang disediakan bahasa pemrograman Python untuk menginstal paket.
+Menjalankan `pip install requests` menghasilkan urutan tindakan berikut:
 
-1. Search for requests in the Python Package Index ([PyPI](https://pypi.org/))
-1. Search for the appropriate artifact for the platform we are running under
-1. Resolve dependencies --- the `requests` library itself depends on other packages, so the installer must find compatible versions of all transitive dependencies and install them beforehand
-1. Download the artifacts, then unpack and copy the files into the right places in our filesystem
+1. Mencari requests di Python Package Index ([PyPI](https://pypi.org/))
+1. Mencari artifact yang sesuai untuk platform yang sedang dijalankan
+1. Menyelesaikan dependency --- pustaka `requests` sendiri bergantung pada paket lain, sehingga installer harus menemukan versi yang kompatibel dari semua dependency transitif dan menginstalnya terlebih dahulu
+1. Mengunduh artifact, lalu mengekstrak dan menyalin file ke lokasi yang tepat di filesystem kita
 
 ```console
 $ pip install requests
@@ -79,8 +79,8 @@ Installing collected packages: urllib3, idna, charset-normalizer, certifi, reque
 Successfully installed certifi-2024.8.30 charset-normalizer-3.4.0 idna-3.10 requests-2.32.3 urllib3-2.2.3
 ```
 
-Here we can see that `requests` has its own dependencies such as `certifi` or `charset-normalizer` and that they have to be installed before `requests` can be installed.
-Once installed, the Python runtime can find this library when importing it.
+Di sini kita dapat melihat bahwa `requests` memiliki dependency-nya sendiri seperti `certifi` atau `charset-normalizer` dan bahwa mereka harus diinstal sebelum `requests` dapat diinstal.
+Setelah terinstal, runtime Python dapat menemukan pustaka ini saat mengimpornya.
 
 ```console
 $ python -c 'import requests; print(requests.__path__)'
@@ -90,19 +90,19 @@ $ pip list | grep requests
 requests        2.32.3
 ```
 
-Programming languages have different tools, conventions and practices for installing and publishing libraries.
-In some languages like Rust, the toolchain is unified --- `cargo` handles building, testing, dependency management, and publishing.
-In others like Python, the unification happens at a specification level --- rather than a single tool, there are standardized specifications that define how packaging works, allowing multiple competing tools for each task (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
-And in some ecosystems like LaTeX, distributions like TeX Live or MacTeX come bundled with thousands of packages pre-installed.
+Bahasa pemrograman memiliki alat, konvensi, dan praktik yang berbeda untuk menginstal dan mempublikasikan pustaka.
+Di beberapa bahasa seperti Rust, toolchain-nya terpadu --- `cargo` menangani building, testing, manajemen dependency, dan publishing.
+Di bahasa lain seperti Python, pemaduan terjadi di tingkat spesifikasi --- alih-alih satu alat tunggal, terdapat spesifikasi standar yang mendefinisikan cara kerja pengemasan, yang memungkinkan beberapa alat yang bersaing untuk setiap tugas (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
+Dan di beberapa ekosistem seperti LaTeX, distribusi seperti TeX Live atau MacTeX disertakan bersama ribuan paket yang sudah terinstal.
 
-Introducing dependencies also introduces dependency conflicts.
-Conflicts happen when programs require incompatible versions of the same dependency.
-For example, if `tensorflow==2.3.0` requires `numpy>=1.16.0,<1.19.0` and `pandas==1.2.0`  requires `numpy>=1.16.5`, then any version satisfying `numpy>=1.16.5,<1.19.0` will be valid.
-But if another package in your project requires `numpy>=1.19`, you have a conflict with no valid version that satisfies all constraints.
+Memasukkan dependency juga memperkenalkan konflik dependency.
+Konflik terjadi ketika program membutuhkan versi yang tidak kompatibel dari dependency yang sama.
+Sebagai contoh, jika `tensorflow==2.3.0` membutuhkan `numpy>=1.16.0,<1.19.0` dan `pandas==1.2.0` membutuhkan `numpy>=1.16.5`, maka setiap versi yang memenuhi `numpy>=1.16.5,<1.19.0` akan valid.
+Tetapi jika paket lain di proyek Anda membutuhkan `numpy>=1.19`, Anda memiliki konflik tanpa versi valid yang memenuhi semua batasan.
 
-This situation --- where multiple packages require mutually incompatible versions of shared dependencies --- is commonly referred to as _dependency hell_.
-One way to deal with conflicts is to isolate the dependencies of each program into their own _environment_.
-In Python we create a virtual environment by running:
+Situasi ini --- di mana beberapa paket membutuhkan versi yang saling tidak kompatibel dari dependency bersama --- sering disebut sebagai _dependency hell_.
+Salah satu cara menangani konflik adalah dengan mengisolasi dependency setiap program ke dalam _environment_-nya sendiri.
+Di Python kita membuat virtual environment dengan menjalankan:
 
 ```console
 $ which python
@@ -124,17 +124,17 @@ Package Version
 pip     24.0
 ```
 
-You can think of an environment as an entire standalone version of the language runtime with its own set of installed packages.
-This virtual environment or venv isolates the installed dependencies from the global Python installation.
-It is a good practice to have a virtual environment for each project, containing the dependencies it requires.
+Anda dapat membayangkan environment sebagai versi runtime bahasa yang sepenuhnya berdiri sendiri dengan kumpulan paket terinstal-nya sendiri.
+Virtual environment atau venv ini mengisolasi dependency yang terinstal dari instalasi Python global.
+Merupakan praktik yang baik untuk memiliki virtual environment untuk setiap proyek, yang berisi dependency yang dibutuhkannya.
 
-> While many modern operating systems ship with installations of programming language runtimes like Python, it is unwise to modify these installations since the OS might rely on them for its own functionality. Prefer using separate environments instead.
+> Meskipun banyak sistem operasi modern disertakan dengan instalasi runtime bahasa pemrograman seperti Python, tidak bijaksana untuk memodifikasi instalasi tersebut karena OS mungkin mengandalkannya untuk fungsionalitasnya sendiri. Lebih baik gunakan environment terpisah.
 
-In some languages, the installation protocol is not defined by a tool but as a specification.
-In Python [PEP 517](https://peps.python.org/pep-0517/) defines the build system interface and [PEP 621](https://peps.python.org/pep-0621/) specifies how project metadata is stored in `pyproject.toml`.
-This has enabled developers to improve upon `pip` and produce more optimized tools like `uv`. To install `uv` it suffices to do `pip install uv`.
+Di beberapa bahasa, protokol instalasi tidak didefinisikan oleh sebuah alat tetapi sebagai spesifikasi.
+Di Python, [PEP 517](https://peps.python.org/pep-0517/) mendefinisikan antarmuka build system dan [PEP 621](https://peps.python.org/pep-0621/) menentukan bagaimana metadata proyek disimpan di `pyproject.toml`.
+Hal ini memungkinkan pengembang untuk meningkatkan `pip` dan menghasilkan alat yang lebih teroptimasi seperti `uv`. Untuk menginstal `uv` cukup dengan melakukan `pip install uv`.
 
-Using `uv` instead of `pip` follows the same interface but is significantly faster:
+Menggunakan `uv` alih-alih `pip` mengikuti antarmuka yang sama tetapi secara signifikan lebih cepat:
 
 ```console
 $ uv pip install requests
@@ -148,9 +148,9 @@ Installed 5 packages in 8ms
  + urllib3==2.2.3
 ```
 
-> We strongly recommend using `uv pip` instead of `pip` whenever possible as it dramatically reduces the installation time.
+> Kami sangat menyarankan menggunakan `uv pip` alih-alih `pip` kapan pun memungkinkan karena secara dramatis mengurangi waktu instalasi.
 
-Beyond dependency isolation, environments also allow you to have different versions of your programming language runtime.
+Selain isolasi dependency, environment juga memungkinkan Anda memiliki berbagai versi runtime bahasa pemrograman.
 
 ```console
 $ uv venv --python 3.12 venv312
@@ -168,15 +168,15 @@ $ source venv311/bin/activate && python --version
 Python 3.11.10
 ```
 
-This helps when you need to test your code across multiple Python versions or when a project requires a specific version.
+Ini membantu ketika Anda perlu menguji kode Anda di berbagai versi Python atau ketika sebuah proyek membutuhkan versi tertentu.
 
-> In some programming languages, each project automatically gets its own environment for its dependencies rather than you creating it manually, but the principle is the same. Most languages these days also have a mechanism for managing multiple versions of the language on a single system, and then specifying which version to use for individual projects.
+> Di beberapa bahasa pemrograman, setiap proyek secara otomatis mendapatkan environment-nya sendiri untuk dependency-nya alih-alih Anda membuatnya secara manual, tetapi prinsipnya sama. Sebagian besar bahasa saat ini juga memiliki mekanisme untuk mengelola beberapa versi bahasa pada satu sistem, dan kemudian menentukan versi mana yang digunakan untuk masing-masing proyek.
 
 # Artifacts & Packaging
 
-In software development we differentiate between source code and artifacts. Developers write and read source code, while artifacts are the packaged, distributable outputs produced from that source code --- ready to be installed or deployed.
-An artifact can be as simple as a file of code that we run, and as complex as an entire Virtual Machine that contains all the necessary bits and bobs of an application.
-Consider this example where we have a Python file `greet.py` in our current directory:
+Dalam pengembangan perangkat lunak, kita membedakan antara source code dan artifact. Pengembang menulis dan membaca source code, sedangkan artifact adalah output yang dikemas dan dapat didistribusikan yang dihasilkan dari source code tersebut --- siap untuk diinstal atau di-deploy.
+Sebuah artifact bisa sesederhana file kode yang kita jalankan, dan serumit sebuah Virtual Machine yang berisi semua komponen yang diperlukan dari sebuah aplikasi.
+Perhatikan contoh ini di mana kita memiliki file Python `greet.py` di direktori saat ini:
 
 ```console
 $ cat greet.py
@@ -191,15 +191,15 @@ $ python -c "from greet import greet; print(greet('World'))"
 ModuleNotFoundError: No module named 'greet'
 ```
 
-The import fails once we move to a different directory because Python only searches for modules in specific locations (the current directory, installed packages, and paths in `PYTHONPATH`). Packaging solves this by installing the code into a known location.
+Import gagal setelah kita pindah ke direktori lain karena Python hanya mencari modul di lokasi tertentu (direktori saat ini, paket yang terinstal, dan path di `PYTHONPATH`). Pengemasan menyelesaikan masalah ini dengan menginstal kode ke lokasi yang diketahui.
 
-In Python, packaging a library involves producing an artifact that package installers like `pip` or `uv` can use to install the relevant files.
-Python artifacts are called _wheels_ and contain all the necessary information to install a package: the code files, metadata about the package (name, version, dependencies), and instructions for where to place files in the environment.
-Building an artifact requires that we write a project file (also often known as manifest) detailing the specifics of the project, the required dependencies, the version of the package, and other information. In Python, we use `pyproject.toml` for this purpose.
+Di Python, mengemas sebuah pustaka melibatkan pembuatan artifact yang dapat digunakan oleh installer paket seperti `pip` atau `uv` untuk menginstal file-file yang relevan.
+Artifact Python disebut _wheel_ dan berisi semua informasi yang diperlukan untuk menginstal sebuah paket: file kode, metadata tentang paket (nama, versi, dependency), dan instruksi untuk menempatkan file di environment.
+Membangun sebuah artifact memerlukan kita untuk menulis file proyek (sering juga dikenal sebagai manifest) yang merinci spesifikasi proyek, dependency yang diperlukan, versi paket, dan informasi lainnya. Di Python, kita menggunakan `pyproject.toml` untuk tujuan ini.
 
-> `pyproject.toml` is the modern and recommended way. While earlier packaging methods like `requirements.txt` or `setup.py` are still supported, you should prefer `pyproject.toml` whenever possible.
+> `pyproject.toml` adalah cara modern dan yang direkomendasikan. Meskipun metode pengemasan sebelumnya seperti `requirements.txt` atau `setup.py` masih didukung, Anda harus lebih memilih `pyproject.toml` kapan pun memungkinkan.
 
-Here's a minimal `pyproject.toml` for a library that also provides a command-line tool:
+Berikut adalah `pyproject.toml` minimal untuk sebuah pustaka yang juga menyediakan alat baris perintah:
 
 ```toml
 [project]
@@ -216,9 +216,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 ```
 
-The `typer` library is a popular Python package for creating command-line interfaces with minimal boilerplate.
+Pustaka `typer` adalah paket Python populer untuk membuat antarmuka baris perintah dengan boilerplate minimal.
 
-And the corresponding `greeting.py`:
+Dan file `greeting.py` yang sesuai:
 
 ```python
 import typer
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     cli()
 ```
 
-With this file, we can now build the wheel:
+Dengan file ini, kita sekarang dapat membangun wheel:
 
 ```console
 $ uv build
@@ -250,9 +250,9 @@ greeting-0.1.0-py3-none-any.whl
 greeting-0.1.0.tar.gz
 ```
 
-The `.whl` file is the wheel (a zip archive with a specific structure), and the `.tar.gz` is a source distribution for systems that need to build from source.
+File `.whl` adalah wheel (arsip zip dengan struktur tertentu), dan `.tar.gz` adalah source distribution untuk sistem yang perlu membangun dari source.
 
-You can inspect the contents of a wheel to see what gets packaged:
+Anda dapat memeriksa isi sebuah wheel untuk melihat apa yang dikemas:
 
 ```console
 $ unzip -l dist/greeting-0.1.0-py3-none-any.whl
@@ -268,7 +268,7 @@ Archive:  dist/greeting-0.1.0-py3-none-any.whl
       998                     5 files
 ```
 
-Now if we were to give this wheel to someone else, they could install it by running:
+Sekarang jika kita memberikan wheel ini kepada orang lain, mereka dapat menginstalnya dengan menjalankan:
 
 ```console
 $ uv pip install ./greeting-0.1.0-py3-none-any.whl
@@ -276,72 +276,72 @@ $ greet Alice
 Hello, Alice!
 ```
 
-This would install the library we built earlier into their environment, including the `greet` cli tool.
+Ini akan menginstal pustaka yang kita bangun sebelumnya ke environment mereka, termasuk alat cli `greet`.
 
-There are limitations to this approach. In particular if our library depends on platform-specific libraries, e.g. CUDA for GPU acceleration, then our artifact only works on systems with those specific libraries installed, and we may need to build separate wheels for different platforms (Linux, macOS, Windows) and architectures (x86, ARM).
+Ada batasan pada pendekatan ini. Khususnya jika pustaka kita bergantung pada pustaka yang spesifik terhadap platform, misalnya CUDA untuk akselerasi GPU, maka artifact kita hanya berfungsi di sistem dengan pustaka spesifik tersebut yang terinstal, dan kita mungkin perlu membangun wheel terpisah untuk platform yang berbeda (Linux, macOS, Windows) dan arsitektur yang berbeda (x86, ARM).
 
 
-When installing software, there's an important distinction between installing from source and installing a prebuilt binary. Installing from source means downloading the original code and compiling it on your machine --- this requires having a compiler and build tools installed, and can take significant time for large projects.
+Saat menginstal perangkat lunak, terdapat perbedaan penting antara menginstal dari source dan menginstal binary yang sudah dibangun. Menginstal dari source berarti mengunduh kode asli dan mengompilasinya di mesin Anda --- ini memerlukan compiler dan build tools yang terinstal, dan bisa memakan waktu yang signifikan untuk proyek besar.
 
-Installing a prebuilt binary means downloading an artifact that was already compiled by someone else --- faster and simpler, but the binary must match your platform and architecture.
-For example, [ripgrep's releases page](https://github.com/BurntSushi/ripgrep/releases) shows prebuilt binaries for Linux (x86_64, ARM), macOS (Intel, Apple Silicon), and Windows.
+Menginstal binary yang sudah dibangun berarti mengunduh artifact yang sudah dikompilasi oleh orang lain --- lebih cepat dan lebih sederhana, tetapi binary harus cocok dengan platform dan arsitektur Anda.
+Sebagai contoh, [halaman rilis ripgrep](https://github.com/BurntSushi/ripgrep/releases) menampilkan binary yang sudah dibangun untuk Linux (x86_64, ARM), macOS (Intel, Apple Silicon), dan Windows.
 
 
 # Releases & Versioning
 
-Code is built in a continuous process but is released on a discrete basis.
-In software development there is a clear distinction between development and production environments.
-Code needs to be proven to work in a dev environment before getting _shipped_ to prod.
-The release process involves many steps, including testing, dependency management, versioning, configuration, deployment and publishing.
+Kode dibangun dalam proses yang berkelanjutan tetapi dirilis secara diskrit.
+Dalam pengembangan perangkat lunak terdapat perbedaan yang jelas antara environment development dan production.
+Kode perlu terbukti berfungsi di environment dev sebelum _dikirim_ ke prod.
+Proses rilis melibatkan banyak langkah, termasuk testing, manajemen dependency, versioning, konfigurasi, deployment, dan publishing.
 
 
-Software libraries are not static and evolve over time getting fixes and new features.
-We track this evolution by discrete version identifiers that correspond to the state of the library at a certain point in time.
-Changes in the behavior of a library can range from patches that fix noncritical functionality, new features that extend its functionality, to changes breaking backwards compatibility.
-Changelogs document what changes a version introduces --- these are documents that software developers use to communicate the changes associated with a new release.
+Pustaka perangkat lunak tidak statis dan berkembang seiring waktu dengan perbaikan dan fitur baru.
+Kita melacak evolusi ini dengan pengenal versi diskrit yang sesuai dengan keadaan pustaka pada titik waktu tertentu.
+Perubahan perilaku pustaka dapat berkisar dari patch yang memperbaiki fungsionalitas yang tidak kritis, fitur baru yang memperluas fungsionalitasnya, hingga perubahan yang memecah kompatibilitas ke belakang (breaking changes).
+Changelog mendokumentasikan perubahan apa yang diperkenalkan oleh sebuah versi --- ini adalah dokumen yang digunakan pengembang perangkat lunak untuk mengkomunikasikan perubahan yang terkait dengan rilis baru.
 
-However, keeping track of the ongoing changes in each and every dependency is impractical, even more so when we consider the transitive dependencies --- i.e. the dependencies of our dependencies.
+Namun, melacak perubahan yang sedang berlangsung di setiap dependency tidak praktis, terlebih lagi ketika kita mempertimbangkan dependency transitif --- yaitu dependency dari dependency kita.
 
-> You can visualize the entire dependency tree of your project with `uv tree`, which shows all packages and their transitive dependencies in a tree format.
+> Anda dapat memvisualisasikan seluruh dependency tree proyek Anda dengan `uv tree`, yang menampilkan semua paket dan dependency transitifnya dalam format tree.
 
-To simplify this problem there are conventions on how to version software, and one of the most prevalent is [Semantic Versioning](https://semver.org/) or SemVer.
-Under Semantic Versioning a version has an identifier of the form MAJOR.MINOR.PATCH where each one of the values takes an integer value. The short version is that upgrading:
+Untuk menyederhanakan masalah ini, terdapat konvensi tentang cara memberi versi pada perangkat lunak, dan salah satu yang paling umum adalah [Semantic Versioning](https://semver.org/) atau SemVer.
+Dalam Semantic Versioning, sebuah versi memiliki pengenal dalam bentuk MAJOR.MINOR.PATCH di mana masing-masing nilai mengambil nilai integer. Versi singkatnya adalah, upgrade:
 
-- PATCH (e.g., 1.2.3 → 1.2.4) should only contain bug fixes and be fully backwards compatible
-- MINOR (e.g., 1.2.3 → 1.3.0) adds new functionality in a backwards-compatible way
-- MAJOR (e.g., 1.2.3 → 2.0.0) indicates breaking changes that may require code modifications
+- PATCH (misalnya, 1.2.3 → 1.2.4) seharusnya hanya berisi perbaikan bug dan sepenuhnya kompatibel ke belakang
+- MINOR (misalnya, 1.2.3 → 1.3.0) menambahkan fungsionalitas baru dengan cara yang kompatibel ke belakang
+- MAJOR (misalnya, 1.2.3 → 2.0.0) menunjukkan perubahan yang memecah kompatibilitas (breaking changes) yang mungkin memerlukan modifikasi kode
 
-> This is a simplification and we encourage reading the full SemVer specification to understand for instance why going from 0.1.3 to 0.2.0 might cause breaking changes or what 1.0.0-rc.1 means.
-Python packaging supports semantic versioning natively, so when we specify the versions of our dependencies we can use various specifiers:
+> Ini adalah penyederhanaan dan kami mendorong Anda untuk membaca spesifikasi SemVer lengkap untuk memahami misalnya mengapa berpindah dari 0.1.3 ke 0.2.0 dapat menyebabkan breaking changes atau apa arti 1.0.0-rc.1.
+Pengemasan Python mendukung semantic versioning secara native, jadi ketika kita menentukan versi dependency kita, kita dapat menggunakan berbagai specifier:
 
-In the `pyproject.toml` we have different ways of constraining the ranges of compatible versions of our dependencies:
+Di `pyproject.toml` kita memiliki berbagai cara untuk membatasi rentang versi yang kompatibel dari dependency kita:
 
 ```toml
 [project]
 dependencies = [
-    "requests==2.32.3",  # Exact version - only this specific version
+    "requests==2.32.3",  # Exact Version - only this specific version
     "click>=8.0",        # Minimum version - 8.0 or newer
     "numpy>=1.24,<2.0",  # Range - at least 1.24 but less than 2.0
     "pandas~=2.1.0",     # Compatible release - >=2.1.0 and <2.2.0
 ]
 ```
 
-Version specifiers exist across many package managers (npm, cargo, etc.) with varying exact semantics. The `~=` operator is Python's "compatible release" operator --- `~=2.1.0` means "any version that is compatible with 2.1.0", which translates to `>=2.1.0` and `<2.2.0`. This is roughly equivalent to the caret (`^`) operator in npm and cargo, which follows SemVer's notion of compatibility.
+Version specifier ada di banyak package manager (npm, cargo, dll.) dengan semantik yang bervariasi. Operator `~=` adalah operator "compatible release" Python --- `~=2.1.0` berarti "versi apa pun yang kompatibel dengan 2.1.0", yang diterjemahkan menjadi `>=2.1.0` dan `<2.2.0`. Ini kurang lebih setara dengan operator caret (`^`) di npm dan cargo, yang mengikuti notions kompatibilitas SemVer.
 
-Not all software uses semantic versioning. A common alternative is Calendar Versioning (CalVer), where versions are based on release dates rather than semantic meaning. For example, Ubuntu uses versions like `24.04` (April 2024) and `24.10` (October 2024). CalVer makes it easy to see how old a release is, though it doesn't communicate anything about compatibility.  Lastly, semantic versioning is not infallible, and sometimes maintainers inadvertently introduce breaking changes in minor or patch releases.
+Tidak semua perangkat lunak menggunakan semantic versioning. Alternatif yang umum adalah Calendar Versioning (CalVer), di mana versi didasarkan pada tanggal rilis alih-alih makna semantik. Sebagai contoh, Ubuntu menggunakan versi seperti `24.04` (April 2024) dan `24.10` (Oktober 2024). CalVer memudahkan untuk melihat seberapa lama sebuah rilis, meskipun tidak mengkomunikasikan apa pun tentang kompatibilitas. Terakhir, semantic versioning tidak sempurna, dan terkadang maintainer tanpa sengaja memperkenalkan breaking changes di rilis minor atau patch.
 
 
 # Reproducibility
 
-In modern software development the code you write sits atop a significant number of layers of abstraction.
-This includes things like your programming language runtime, third party libraries, the operating system, or even the hardware itself.
-Any difference across any of these layers might change the behavior of your code or even prevent it from working as intended.
-Furthermore, even differences in the underlying hardware impact your ability to ship software.
+Dalam pengembangan perangkat lunak modern, kode yang Anda tulis berada di atas sejumlah lapisan abstraksi yang signifikan.
+Ini mencakup hal-hal seperti runtime bahasa pemrograman Anda, pustaka pihak ketiga, sistem operasi, atau bahkan hardware itu sendiri.
+Perbedaan apa pun di salah satu lapisan ini dapat mengubah perilaku kode Anda atau bahkan mencegahnya berfungsi sebagaimana mestinya.
+Selain itu, perbedaan dalam hardware yang mendasari juga memengaruhi kemampuan Anda untuk mendistribusikan perangkat lunak.
 
-Pinning a library refers to specifying an exact version rather than a range, e.g. `requests==2.32.3` instead of `requests>=2.0`.
+Pinning sebuah pustaka berarti menentukan versi yang tepat alih-alih rentang, misalnya `requests==2.32.3` alih-alih `requests>=2.0`.
 
-Part of the job of a package manager is to consider all the constraints provided by the dependencies --- and transitive dependencies --- and then produce a valid list of versions that will satisfy all the constraints.
-The specific list of versions can then be saved to a file for reproducibility purposes; these files are referred to as _lock files_.
+Bagian dari tugas package manager adalah mempertimbangkan semua batasan yang diberikan oleh dependency --- dan dependency transitif --- dan kemudian menghasilkan daftar versi yang valid yang akan memenuhi semua batasan.
+Daftar versi spesifik kemudian dapat disimpan ke file untuk keperluan reproducibility; file-file ini disebut sebagai _lock file_.
 
 ```console
 $ uv lock
@@ -362,37 +362,37 @@ wheels = [
 ...
 ```
 
-One critical distinction when dealing with dependency versioning and reproducibility is the difference between libraries and applications/services.
-A library is intended to be imported and used by other code which might have its own dependencies, so specifying overly strict version constraints can cause conflicts with the user's other dependencies.
-In contrast, applications or services are final consumers of the software and typically expose their functionality through a user interface or an API, not through a programming interface.
-For libraries, it is good practice to specify version ranges to maximize compatibility with the wider package ecosystem. For applications, pinning exact versions ensures reproducibility --- everyone running the application uses the exact same dependencies.
+Satu perbedaan penting saat menangani versioning dependency dan reproducibility adalah perbedaan antara pustaka dan aplikasi/layanan.
+Sebuah pustaka dimaksudkan untuk diimpor dan digunakan oleh kode lain yang mungkin memiliki dependency-nya sendiri, sehingga menentukan batasan versi yang terlalu ketat dapat menyebabkan konflik dengan dependency lain milik pengguna.
+Sebaliknya, aplikasi atau layanan adalah konsumen akhir perangkat lunak dan biasanya mengekspos fungsionalitasnya melalui antarmuka pengguna atau API, bukan melalui antarmuka pemrograman.
+Untuk pustaka, praktik yang baik adalah menentukan rentang versi untuk memaksimalkan kompatibilitas dengan ekosistem paket yang lebih luas. Untuk aplikasi, pinning versi yang tepat memastikan reproducibility --- semua orang yang menjalankan aplikasi menggunakan dependency yang sama persis.
 
 
-For projects requiring maximum reproducibility, tools like [Nix](https://nixos.org/) and [Bazel](https://bazel.build/) provide _hermetic_ builds --- where every input including compilers, system libraries, and even the build environment itself is pinned and content-addressed. This guarantees bit-for-bit identical outputs regardless of when or where the build runs.
+Untuk proyek yang membutuhkan reproducibility maksimal, alat seperti [Nix](https://nixos.org/) dan [Bazel](https://bazel.build/) menyediakan build _hermetic_ --- di mana setiap input termasuk compiler, pustaka sistem, dan bahkan environment build itu sendiri dipin dan di-address berdasarkan konten. Ini menjamin output yang identik bit demi bit terlepas dari kapan atau di mana build dijalankan.
 
-> You can even use NixOS to manage your entire computer install so that you can trivially spin up new copies of your computer setup and manage their complete configuration through version-controlled configuration files.
+> Anda bahkan dapat menggunakan NixOS untuk mengelola seluruh instalasi komputer Anda sehingga Anda dapat dengan mudah membuat salinan baru dari setup komputer Anda dan mengelola konfigurasi lengkapnya melalui file konfigurasi yang terkontrol versi.
 
-A neverending tension in software development is that new software versions introduce breakage either intentionally or unintentionally, while on the other hand, old software versions become compromised with security vulnerabilities over time.
-We can address this by using continuous integration pipelines (we'll see more in the [Code Quality and CI](/2026/code-quality/) lecture) that test our application against new software versions and having automation in place for detecting when new versions of our dependencies are released, such as [Dependabot](https://github.com/dependabot).
+Ketegangan yang tidak pernah berakhir dalam pengembangan perangkat lunak adalah bahwa versi perangkat lunak baru memperkenalkan kerusakan baik secara sengaja maupun tidak sengaja, sementara di sisi lain, versi perangkat lunak lama menjadi rentan terhadap kerentanan keamanan seiring berjalannya waktu.
+Kita dapat mengatasi ini dengan menggunakan pipeline continuous integration (kita akan melihat lebih lanjut di kuliah [Code Quality and CI](/2026/code-quality/)) yang menguji aplikasi kita terhadap versi perangkat lunak baru dan memiliki otomatisasi untuk mendeteksi ketika versi baru dari dependency kita dirilis, seperti [Dependabot](https://github.com/dependabot).
 
-Even with CI testing in place, issues still occur when upgrading software versions, often because of the inevitable mismatch between dev and prod environments.
-In those circumstances the best course of action is to have a _rollback_ plan, where the version upgrade is reverted and a known good version is redeployed instead.
+Bahkan dengan pengujian CI yang ada, masalah masih terjadi saat mengupgrade versi perangkat lunak, sering kali karena ketidakcocokan yang tak terelakkan antara environment dev dan prod.
+Dalam keadaan tersebut, tindakan terbaik adalah memiliki rencana _rollback_, di mana upgrade versi dibatalkan dan versi yang diketahui baik di-deploy ulang.
 
 # VMs & Containers
 
-As you start relying on more complex dependencies, it is likely that the dependencies of your code will span beyond the boundaries of what the package manager can handle.
-One common reason is having to interface with specific system libraries or hardware drivers.
-For example, in scientific computing and AI, programs often need specialized libraries and drivers to utilize GPU hardware.
-Many system-level dependencies (GPU drivers, specific compiler versions, shared libraries like OpenSSL) still require system-wide installation.
+Saat Anda mulai mengandalkan dependency yang lebih kompleks, kemungkinan dependency kode Anda akan melampaui batas-batas yang dapat ditangani oleh package manager.
+Salah satu alasan umum adalah harus berinteraksi dengan pustaka sistem atau driver hardware tertentu.
+Sebagai contoh, dalam komputasi ilmiah dan AI, program sering membutuhkan pustaka dan driver khusus untuk memanfaatkan hardware GPU.
+Banyak dependency tingkat sistem (driver GPU, versi compiler tertentu, pustaka bersama seperti OpenSSL) masih memerlukan instalasi di seluruh sistem.
 
-Traditionally this wider dependency problem was solved with Virtual Machines (VMs).
-VMs abstract the entire computer and provide a completely isolated environment with its own dedicated operating system.
-A more modern approach is containers, which package an application along with its dependencies, libraries, and filesystem, but share the host's operating system kernel rather than virtualizing an entire computer.
-Containers are lighter weight than VMs because they share the kernel, making them faster to start and more efficient to run.
+Secara tradisional, masalah dependency yang lebih luas ini diselesaikan dengan Virtual Machine (VM).
+VM mengabstraksi seluruh komputer dan menyediakan environment yang sepenuhnya terisolasi dengan sistem operasi khusus-nya sendiri.
+Pendekatan yang lebih modern adalah container, yang mengemas sebuah aplikasi beserta dependency, pustaka, dan filesystem-nya, tetapi berbagi kernel sistem operasi host alih-alih memvirtualisasi seluruh komputer.
+Container lebih ringan daripada VM karena mereka berbagi kernel, sehingga lebih cepat untuk dimulai dan lebih efisien untuk dijalankan.
 
-The most popular container platform is [Docker](https://www.docker.com/). Docker introduced a standardized way to build, distribute, and run containers. Under the hood, Docker uses containerd as its container runtime --- an industry standard that other tools like Kubernetes also use.
+Platform container yang paling populer adalah [Docker](https://www.docker.com/). Docker memperkenalkan cara standar untuk membangun, mendistribusikan, dan menjalankan container. Di balik layar, Docker menggunakan containerd sebagai container runtime-nya --- standar industri yang juga digunakan oleh alat lain seperti Kubernetes.
 
-Running a container is straightforward. For example, to run a Python interpreter inside a container we use `docker run` (The `-it` flags make the container interactive with a terminal. When you exit, the container stops.).
+Menjalankan container cukup mudah. Sebagai contoh, untuk menjalankan interpreter Python di dalam container kita menggunakan `docker run` (Flag `-it` membuat container bersifat interaktif dengan terminal. Ketika Anda keluar, container berhenti.).
 
 ```console
 $ docker run -it python:3.12 python
@@ -401,9 +401,9 @@ Python 3.12.7 (main, Nov  5 2024, 02:53:25) [GCC 12.2.0] on linux
 Hello from inside a container!
 ```
 
-In practice your program might depend on the entire filesystem.
-To overcome this, we can use container images that ship the entire filesystem of the application as the artifact.
-The container images are created programmatically. With docker we specify exactly the dependencies, system libraries, and configuration of the image using a Dockerfile syntax:
+Dalam praktiknya, program Anda mungkin bergantung pada keseluruhan filesystem.
+Untuk mengatasinya, kita dapat menggunakan container image yang mengangkut seluruh filesystem aplikasi sebagai artifact.
+Container image dibuat secara terprogram. Dengan docker kita menentukan secara tepat dependency, pustaka sistem, dan konfigurasi image menggunakan sintaks Dockerfile:
 
 ```dockerfile
 FROM python:3.12
@@ -417,11 +417,11 @@ WORKDIR /app
 RUN pip install .
 ```
 
-An important distinction: a Docker **image** is the packaged artifact (like a template), while a **container** is a running instance of that image. You can run multiple containers from the same image. Images are built in layers, where each instruction (`FROM`, `RUN`, `COPY`, etc) in a Dockerfile creates a new layer. Docker caches these layers, so if you change a line in your Dockerfile, only that layer and subsequent layers need to be rebuilt.
+Perbedaan penting: Docker **image** adalah artifact yang dikemas (seperti template), sedangkan **container** adalah instance yang sedang berjalan dari image tersebut. Anda dapat menjalankan beberapa container dari image yang sama. Image dibangun dalam lapisan, di mana setiap instruksi (`FROM`, `RUN`, `COPY`, dll) di Dockerfile membuat lapisan baru. Docker melakukan cache pada lapisan-lapisan ini, jadi jika Anda mengubah sebuah baris di Dockerfile Anda, hanya lapisan tersebut dan lapisan setelahnya yang perlu dibangun ulang.
 
-The previous Dockerfile has several issues: it uses the full Python image instead of a slim variant, runs separate `RUN` commands creating unnecessary layers, versions are not pinned, and it doesn't clean up package manager caches, shipping unnecessary files. Other frequent mistakes include insecurely running containers as root and accidentally embedding secrets in layers.
+Dockerfile sebelumnya memiliki beberapa masalah: menggunakan image Python penuh alih-alih varian slim, menjalankan perintah `RUN` terpisah yang membuat lapisan yang tidak perlu, versi tidak dipin, dan tidak membersihkan cache package manager, sehingga mengangkut file yang tidak perlu. Kesalahan umum lainnya termasuk menjalankan container secara tidak aman sebagai root dan secara tidak sengaja menyematkan secrets di lapisan.
 
-Here's an improved version
+Berikut adalah versi yang lebih baik
 
 ```dockerfile
 FROM python:3.12-slim
@@ -434,19 +434,19 @@ RUN uv pip install --system -r uv.lock
 COPY . /app
 ```
 
-In the previous example we see that instead of installing `uv` from source, we are copying the prebuilt binary from the `ghcr.io/astral-sh/uv:latest` image. This is known as the _builder_ pattern. With this pattern we do not need to ship all the tools needed to compile our code, just the final binary that is needed to run the application (`uv` in this case).
+Pada contoh sebelumnya kita melihat bahwa alih-alih menginstal `uv` dari source, kita menyalin binary yang sudah dibangun dari image `ghcr.io/astral-sh/uv:latest`. Ini dikenal sebagai pola _builder_. Dengan pola ini kita tidak perlu mengangkut semua alat yang dibutuhkan untuk mengompilasi kode kita, hanya binary akhir yang diperlukan untuk menjalankan aplikasi (`uv` dalam kasus ini).
 
-Docker has important limitations to be aware of. First, container images are often platform-specific --- an image built for `linux/amd64` won't run natively on `linux/arm64` (Apple Silicon Macs) without emulation, which is slow. Second, Docker containers require a Linux kernel, so on macOS and Windows, Docker actually runs a lightweight Linux VM under the hood, adding overhead. Third, Docker's isolation is weaker than VMs --- containers share the host kernel, which is a security concern in multi-tenant environments.
+Docker memiliki batasan-batasan penting yang perlu diperhatikan. Pertama, container image seringkali spesifik terhadap platform --- image yang dibangun untuk `linux/amd64` tidak akan berjalan secara native di `linux/arm64` (Mac Apple Silicon) tanpa emulasi, yang lambat. Kedua, container Docker memerlukan kernel Linux, jadi di macOS dan Windows, Docker sebenarnya menjalankan VM Linux ringan di balik layar, yang menambah overhead. Ketiga, isolasi Docker lebih lemah daripada VM --- container berbagi kernel host, yang menjadi masalah keamanan di environment multi-tenant.
 
-> These days, more projects are also making use of nix to manage even "system-wide" libraries and applications per project through [nix flakes](https://serokell.io/blog/practical-nix-flakes).
+> Saat ini, semakin banyak proyek yang juga menggunakan nix untuk mengelola bahkan pustaka "tingkat sistem" dan aplikasi per proyek melalui [nix flakes](https://serokell.io/blog/practical-nix-flakes).
 
 # Configuration
 
-Software is inherently configurable. In the [command line environment](/2026/command-line-environment/) lecture we saw programs receiving options via flags, environment variables or even configuration files a.k.a. dotfiles. This holds true even for more complex applications, and there are established patterns for managing configuration at scale.
-Software configuration should not be embedded in the code but be provided at runtime.
-A couple of common ones being environment variables and config files.
+Perangkat lunak pada dasarnya dapat dikonfigurasi. Dalam kuliah [command line environment](/2026/command-line-environment/) kita melihat program menerima opsi melalui flag, environment variable, atau bahkan file konfigurasi alias dotfiles. Hal ini berlaku bahkan untuk aplikasi yang lebih kompleks, dan terdapat pola yang sudah mapan untuk mengelola konfigurasi dalam skala besar.
+Konfigurasi perangkat lunak tidak boleh disematkan di dalam kode tetapi harus disediakan saat runtime.
+Beberapa yang umum adalah environment variable dan file konfigurasi.
 
-Here's an example of an application that is configured via environment variables:
+Berikut adalah contoh sebuah aplikasi yang dikonfigurasi melalui environment variable:
 
 ```python
 import os
@@ -456,7 +456,7 @@ DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
 API_KEY = os.environ["API_KEY"]  # Required - will raise if not set
 ```
 
-An application could also be configured via a configuration file (e.g., a Python program that loads a config via `yaml.load`), `config.yaml`:
+Sebuah aplikasi juga dapat dikonfigurasi melalui file konfigurasi (misalnya, program Python yang memuat konfigurasi melalui `yaml.load`), `config.yaml`:
 
 ```yaml
 database:
@@ -468,22 +468,22 @@ server:
   debug: false
 ```
 
-A good right-hand rule for thinking about configuration is that the same codebase should be deployable to different environments (development, staging, production) with only configuration changes, never code changes.
+Aturan praktis yang baik untuk memikirkan konfigurasi adalah bahwa codebase yang sama harus dapat di-deploy ke environment yang berbeda (development, staging, production) hanya dengan perubahan konfigurasi, bukan perubahan kode.
 
-Among the many configuration options there is often sensitive data such as API keys.
-Secrets need to be handled with care to avoid exposing them accidentally, and must not be included in version control.
+Di antara banyak opsi konfigurasi, sering kali terdapat data sensitif seperti API key.
+Secrets perlu ditangani dengan hati-hati untuk menghindari paparan yang tidak disengaja, dan tidak boleh disertakan dalam version control.
 
 
 # Services & Orchestration
 
-Modern applications rarely exist in isolation. A typical web application might need a database for persistent storage, a cache for performance, a message queue for background tasks, and various other supporting services. Rather than bundling everything into a single monolithic application, modern architectures often decompose functionality into separate services that can be developed, deployed, and scaled independently.
+Aplikasi modern jarang ada dalam isolasi. Sebuah aplikasi web tipikal mungkin membutuhkan database untuk penyimpanan persisten, cache untuk performa, message queue untuk tugas latar belakang, dan berbagai layanan pendukung lainnya. Daripada menggabungkan semuanya menjadi satu aplikasi monolitik, arsitektur modern sering menguraikan fungsionalitas menjadi layanan terpisah yang dapat dikembangkan, di-deploy, dan di-scale secara independen.
 
-As an example, if we determine our application might benefit from using a cache, instead of rolling our own we can leverage existing battle tested solutions like [Redis](https://redis.io/) or [Memcached](https://memcached.org/).
-We could embed Redis in our application dependencies by building it as part of the container, but that means harmonizing all the dependencies between Redis and our application which could be challenging or even unfeasible.
-Instead what we can do is deploy each application separately in its own container.
-This is commonly referred to as a microservice architecture where each component runs as an independent service that communicates over the network, typically via HTTP APIs.
+Sebagai contoh, jika kita menentukan bahwa aplikasi kita mungkin mendapat manfaat dari penggunaan cache, alih-alih membuatnya sendiri kita dapat memanfaatkan solusi yang sudah teruji seperti [Redis](https://redis.io/) atau [Memcached](https://memcached.org/).
+Kita bisa menyematkan Redis di dependency aplikasi kita dengan membangunnya sebagai bagian dari container, tetapi itu berarti menyelaraskan semua dependency antara Redis dan aplikasi kita yang bisa menantang atau bahkan tidak layak.
+Sebaliknya, yang dapat kita lakukan adalah men-deploy setiap aplikasi secara terpisah di container-nya sendiri.
+Ini sering disebut sebagai arsitektur microservice di mana setiap komponen berjalan sebagai layanan independen yang berkomunikasi melalui jaringan, biasanya melalui API HTTP.
 
-[Docker Compose](https://docs.docker.com/compose/) is a tool for defining and running multi-container applications. Rather than managing containers individually, you declare all services in a single YAML file and orchestrate them together. Now our full application encompasses more than one container:
+[Docker Compose](https://docs.docker.com/compose/) adalah alat untuk mendefinisikan dan menjalankan aplikasi multi-container. Alih-alih mengelola container secara individual, Anda mendeklarasikan semua layanan dalam satu file YAML dan mengorkestrasikannya bersama. Sekarang aplikasi lengkap kita mencakup lebih dari satu container:
 
 ```yaml
 # docker-compose.yml
@@ -506,10 +506,10 @@ volumes:
   redis_data:
 ```
 
-With `docker compose up`, both services start together, and the web application can connect to Redis using the hostname `cache` (Docker's internal DNS resolves service names automatically).
-Docker Compose lets us declare how we want to deploy one or more services, and handles the orchestration of starting them together, setting up networking between them, and managing shared volumes for data persistence.
+Dengan `docker compose up`, kedua layanan dimulai bersama, dan aplikasi web dapat terhubung ke Redis menggunakan hostname `cache` (DNS internal Docker menyelesaikan nama layanan secara otomatis).
+Docker Compose memungkinkan kita mendeklarasikan bagaimana kita ingin men-deploy satu atau lebih layanan, dan menangani orkestrasi untuk memulai mereka bersama, mengatur jaringan di antara mereka, dan mengelola volume bersama untuk persistensi data.
 
-For production deployments, you often want your docker compose services to start automatically on boot and restart on failure. A common approach is to use systemd to manage the docker compose deployment:
+Untuk deployment production, Anda sering ingin layanan docker compose Anda dimulai secara otomatis saat boot dan dimulai ulang saat terjadi kegagalan. Pendekatan yang umum adalah menggunakan systemd untuk mengelola deployment docker compose:
 
 ```ini
 # /etc/systemd/system/myapp.service
@@ -529,11 +529,11 @@ ExecStop=/usr/bin/docker compose down
 WantedBy=multi-user.target
 ```
 
-This systemd unit file ensures your application starts when the system boots (after Docker is ready), and provides standard controls like `systemctl start myapp`, `systemctl stop myapp`, and `systemctl status myapp`.
+File unit systemd ini memastikan aplikasi Anda dimulai ketika sistem boot (setelah Docker siap), dan menyediakan kontrol standar seperti `systemctl start myapp`, `systemctl stop myapp`, dan `systemctl status myapp`.
 
-As deployment requirements grow more complex --- needing scalability across multiple machines, fault tolerance when services crash, and high availability guarantees --- organizations turn to sophisticated container orchestration platforms like Kubernetes (k8s), which can manage thousands of containers across clusters of machines. That said, Kubernetes has a steep learning curve and significant operational overhead, so it's often overkill for smaller projects.
+Seiring kebutuhan deployment yang semakin kompleks --- membutuhkan skalabilitas di beberapa mesin, toleransi kesalahan saat layanan crash, dan jaminan ketersediaan tinggi --- organisasi beralih ke platform orkestrasi container yang canggih seperti Kubernetes (k8s), yang dapat mengelola ribuan container di seluruh cluster mesin. Meskipun demikian, Kubernetes memiliki kurva pembelajaran yang curam dan overhead operasional yang signifikan, sehingga sering berlebihan untuk proyek yang lebih kecil.
 
-This multi-container setup is partly feasible because modern services communicate with each other via standardized APIs, with HTTP REST APIs. For example, whenever a program interacts with an LLM provider like OpenAI or Anthropic, under the hood it is sending an HTTP request to their servers and parsing the response:
+Setup multi-container ini sebagian memungkinkan karena layanan modern berkomunikasi satu sama lain melalui API yang terstandarisasi, dengan HTTP REST API. Sebagai contoh, setiap kali sebuah program berinteraksi dengan penyedia LLM seperti OpenAI atau Anthropic, di balik layar ia mengirim permintaan HTTP ke server mereka dan mengurai responsnya:
 
 ```console
 $ curl https://api.anthropic.com/v1/messages \
@@ -546,17 +546,17 @@ $ curl https://api.anthropic.com/v1/messages \
 
 # Publishing
 
-Once you have shown your code to work, you might be interested in distributing it for others to download and install.
-Distribution takes many forms and is intrinsically tied to the programming language and environments that you operate with.
+Setelah Anda menunjukkan bahwa kode Anda berfungsi, Anda mungkin tertarik untuk mendistribusikannya agar orang lain dapat mengunduh dan menginstalnya.
+Distribusi memiliki banyak bentuk dan terkait erat dengan bahasa pemrograman dan environment yang Anda gunakan.
 
-The simplest form of distribution is uploading artifacts for people to download and install locally.
-This is still common and you can find it in places like [Ubuntu's package archive](http://archive.ubuntu.com/ubuntu/pool/main/), which is essentially an HTTP directory listing of `.deb` files.
+Bentuk distribusi paling sederhana adalah mengunggah artifact untuk orang lain unduh dan instal secara lokal.
+Ini masih umum dan Anda dapat menemukannya di tempat-tempat seperti [arsip paket Ubuntu](http://archive.ubuntu.com/ubuntu/pool/main/), yang pada dasarnya adalah daftar direktori HTTP dari file `.deb`.
 
-These days, GitHub has become the de facto platform for publishing source code and artifacts.
-While the source code is often publicly available, GitHub Releases allow maintainers to attach prebuilt binaries and other artifacts to tagged versions.
+Saat ini, GitHub telah menjadi platform de facto untuk mempublikasikan source code dan artifact.
+Meskipun source code sering tersedia secara publik, GitHub Releases memungkinkan maintainer untuk melampirkan binary yang sudah dibangun dan artifact lainnya ke versi yang di-tag.
 
 
-Package managers sometimes support installing directly from GitHub, either from source or from a pre-built wheel:
+Package manager terkadang mendukung menginstal langsung dari GitHub, baik dari source maupun dari wheel yang sudah dibangun:
 
 ```console
 # Install from source (will clone and build)
@@ -569,8 +569,8 @@ $ pip install git+https://github.com/psf/requests.git@v2.32.3
 $ pip install https://github.com/user/repo/releases/download/v1.0/package-1.0-py3-none-any.whl
 ```
 
-In fact, some languages like Go use a decentralized distribution model --- rather than a central package repository, Go modules are distributed directly from their source code repositories.
-Module paths like `github.com/gorilla/mux` indicate where the code lives, and `go get` fetches directly from there. However, most package managers like `pip`, `cargo`, or `brew` have central indexes of pre-packaged projects for ease of distribution and installation. If we run
+Faktanya, beberapa bahasa seperti Go menggunakan model distribusi terdesentralisasi --- alih-alih repositori paket terpusat, modul Go didistribusikan langsung dari repositori source code mereka.
+Path modul seperti `github.com/gorilla/mux` menunjukkan di mana kode berada, dan `go get` mengambil langsung dari sana. Namun, sebagian besar package manager seperti `pip`, `cargo`, atau `brew` memiliki indeks terpusat dari proyek yang sudah dikemas untuk kemudahan distribusi dan instalasi. Jika kita menjalankan
 
 ```console
 $ uv pip install requests --verbose --no-cache 2>&1 | grep -F '.whl'
@@ -579,18 +579,18 @@ DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3ea
 DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
 ```
 
-we see where we are fetching the `requests` wheel from. Notice the `py3-none-any` in the filename --- this means the wheel works with any Python 3 version, on any OS, on any architecture. For packages with compiled code, the wheel is platform-specific:
+kita melihat dari mana kita mengambil wheel `requests`. Perhatikan `py3-none-any` di nama file --- ini berarti wheel berfungsi dengan versi Python 3 apa pun, di OS apa pun, di arsitektur apa pun. Untuk paket dengan kode yang dikompilasi, wheel-nya spesifik terhadap platform:
 
 ```console
 $ uv pip install numpy --verbose --no-cache 2>&1 | grep -F '.whl'
 DEBUG Selecting: numpy==2.2.1 [compatible] (numpy-2.2.1-cp312-cp312-macosx_14_0_arm64.whl)
 ```
 
-Here `cp312-cp312-macosx_14_0_arm64` indicates this wheel is specifically for CPython 3.12 on macOS 14+ for ARM64 (Apple Silicon). If you're on a different platform, `pip` will download a different wheel or build from source.
+Di sini `cp312-cp312-macosx_14_0_arm64` menunjukkan bahwa wheel ini khusus untuk CPython 3.12 di macOS 14+ untuk ARM64 (Apple Silicon). Jika Anda berada di platform yang berbeda, `pip` akan mengunduh wheel yang berbeda atau membangun dari source.
 
-Conversely, for people to be able to find a package we've created, we need to publish it to one of these registries.
-In Python, the main registry is the [Python Package Index (PyPI)](https://pypi.org).
-Like with installing, there are multiple ways of publishing packages. The `uv publish` command provides a modern interface for uploading packages to PyPI:
+Sebaliknya, agar orang lain dapat menemukan paket yang telah kita buat, kita perlu mempublikasikannya ke salah satu registri ini.
+Di Python, registri utama adalah [Python Package Index (PyPI)](https://pypi.org).
+Seperti halnya menginstal, ada beberapa cara untuk mempublikasikan paket. Perintah `uv publish` menyediakan antarmuka modern untuk mengunggah paket ke PyPI:
 
 ```console
 $ uv publish --publish-url https://test.pypi.org/legacy/
@@ -598,33 +598,33 @@ Publishing greeting-0.1.0.tar.gz
 Publishing greeting-0.1.0-py3-none-any.whl
 ```
 
-Here we are using [TestPyPI](https://test.pypi.org) --- a separate package registry intended for testing your publishing workflow without polluting the real PyPI. Once uploaded, you can install from TestPyPI:
+Di sini kita menggunakan [TestPyPI](https://test.pypi.org) --- registri paket terpisah yang ditujukan untuk menguji alur kerja publishing Anda tanpa mengotori PyPI yang sebenarnya. Setelah diunggah, Anda dapat menginstal dari TestPyPI:
 
 ```console
 $ uv pip install --index-url https://test.pypi.org/simple/ greeting
 ```
 
-A key consideration when publishing software is trust. How do users verify that the package they download actually comes from you and hasn't been tampered with? Package registries use checksums to verify integrity, and some ecosystems support package signing to provide cryptographic proof of authorship.
+Pertimbangan penting saat mempublikasikan perangkat lunak adalah kepercayaan. Bagaimana pengguna memverifikasi bahwa paket yang mereka unduh benar-benar berasal dari Anda dan belum diubah? Registri paket menggunakan checksum untuk memverifikasi integritas, dan beberapa ekosistem mendukung penandatanganan paket untuk memberikan bukti kriptografis kepengarangan.
 
-Different languages have their own package registries: [crates.io](https://crates.io) for Rust, [npm](https://www.npmjs.com) for JavaScript, [RubyGems](https://rubygems.org) for Ruby, and [Docker Hub](https://hub.docker.com) for container images. Meanwhile, for private or internal packages, organizations often deploy their own package repositories (such as a private PyPI server or a private Docker registry) or use managed solutions from cloud providers.
+Bahasa yang berbeda memiliki registri paket mereka sendiri: [crates.io](https://crates.io) untuk Rust, [npm](https://www.npmjs.com) untuk JavaScript, [RubyGems](https://rubygems.org) untuk Ruby, dan [Docker Hub](https://hub.docker.com) untuk container image. Sementara itu, untuk paket pribadi atau internal, organisasi sering men-deploy repositori paket mereka sendiri (seperti server PyPI pribadi atau registri Docker pribadi) atau menggunakan solusi terkelola dari penyedia cloud.
 
-Deploying a web service to the internet involves additional infrastructure: domain name registration, DNS configuration to point your domain to your server, and often a reverse proxy like nginx to handle HTTPS and route traffic. For simpler use cases like documentation or static sites, [GitHub Pages](https://pages.github.com/) provides free hosting directly from a repository.
+Men-deploy layanan web ke internet melibatkan infrastruktur tambahan: pendaftaran nama domain, konfigurasi DNS untuk mengarahkan domain Anda ke server Anda, dan sering kali reverse proxy seperti nginx untuk menangani HTTPS dan merutekan traffic. Untuk kasus penggunaan yang lebih sederhana seperti dokumentasi atau situs statis, [GitHub Pages](https://pages.github.com/) menyediakan hosting gratis langsung dari repositori.
 
 <!--
 ## Documentation
 
-So far we have emphasized the deliverable _artifact_ as the main output of packaging and shipping code.
-In addition to the artifact, we need to document for users the code's functionality, installation instructions, and usage examples.
+Sejauh ini kita telah menekankan _artifact_ deliverable sebagai output utama dari pengemasan dan distribusi kode.
+Selain artifact, kita perlu mendokumentasikan untuk pengguna tentang fungsionalitas kode, instruksi instalasi, dan contoh penggunaan.
 
-Tools like [Sphinx](https://www.sphinx-doc.org/) (Python) and [MkDocs](https://www.mkdocs.org/) can automatically generate browsable documentation from docstrings and markdown files, often hosted on services like [Read the Docs](https://readthedocs.org/).
-For HTTP-based APIs, the [OpenAPI specification](https://www.openapis.org/) (formerly Swagger) provides a standard format for describing API endpoints, which tools can use to generate interactive documentation and client libraries automatically. -->
+Alat seperti [Sphinx](https://www.sphinx-doc.org/) (Python) dan [MkDocs](https://www.mkdocs.org/) dapat secara otomatis menghasilkan dokumentasi yang dapat ditelusuri dari docstring dan file markdown, sering di-host di layanan seperti [Read the Docs](https://readthedocs.org/).
+Untuk API berbasis HTTP, [spesifikasi OpenAPI](https://www.openapis.org/) (sebelumnya Swagger) menyediakan format standar untuk mendeskripsikan endpoint API, yang dapat digunakan oleh alat untuk menghasilkan dokumentasi interaktif dan pustaka klien secara otomatis. -->
 
 
 # Exercises
 
-1. Save your environment with `printenv` to a file, create a venv, activate it, `printenv` to another file and `diff before.txt after.txt`. What changed in the environment? Why does the shell prefer the venv? (Hint: look at `$PATH` before and after activation.) Run `which deactivate` and reason about what the deactivate bash function is doing.
-1. Create a Python package with a `pyproject.toml` and install it in a virtual environment. Create a lockfile and inspect it.
-1. Install Docker and use it to build the Missing Semester class website locally using docker compose.
-1. Write a Dockerfile for a simple Python application. Then write a `docker-compose.yml` that runs your application alongside a Redis cache.
-1. Publish a Python package to TestPyPI (don't publish to the real PyPI unless it's worth sharing!). Then build a Docker image with said package and push it to `ghcr.io`.
-1. Make a website using [GitHub Pages](https://docs.github.com/en/pages/quickstart). Extra (non-)credit: configure it with a custom domain.
+1. Simpan environment Anda dengan `printenv` ke sebuah file, buat sebuah venv, aktifkan, `printenv` ke file lain dan `diff before.txt after.txt`. Apa yang berubah di environment? Mengapa shell lebih memilih venv? (Petunjuk: lihat `$PATH` sebelum dan setelah aktivasi.) Jalankan `which deactivate` dan pikirkan tentang apa yang dilakukan fungsi bash deactivate.
+1. Buat sebuah paket Python dengan `pyproject.toml` dan instal di virtual environment. Buat lockfile dan periksa isinya.
+1. Instal Docker dan gunakan untuk membangun website kelas Missing Semester secara lokal menggunakan docker compose.
+1. Tulis sebuah Dockerfile untuk aplikasi Python sederhana. Kemudian tulis `docker-compose.yml` yang menjalankan aplikasi Anda bersama dengan cache Redis.
+1. Publikasikan sebuah paket Python ke TestPyPI (jangan publikasikan ke PyPI yang sebenarnya kecuali memang layak untuk dibagikan!). Kemudian bangun sebuah Docker image dengan paket tersebut dan push ke `ghcr.io`.
+1. Buat sebuah website menggunakan [GitHub Pages](https://docs.github.com/en/pages/quickstart). Nilai tambah (non-)kredit: konfigurasikan dengan domain kustom.

--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Packaging and Shipping Code"
 description: >
-  Learn about project packaging, environments, versioning, and deploying libraries, applications, and services.
+  Pelajari tentang packaging proyek, environment, versioning, dan deployment library, aplikasi, dan layanan.
 thumbnail: /static/assets/thumbnails/2026/lec6.png
 date: 2026-01-20
 ready: true

--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -1,6 +1,6 @@
 ---
 layout: lecture
-title: "Packaging and Shipping Code"
+title: "Mengemas dan Mendistribusikan Kode"
 description: >
   Pelajari tentang packaging proyek, environment, versioning, dan deployment library, aplikasi, dan layanan.
 thumbnail: /static/assets/thumbnails/2026/lec6.png
@@ -11,14 +11,14 @@ video:
   id: KBMiB-8P4Ns
 ---
 
-Getting code to work as intended is hard; getting that same code to run on a machine different from your own is often harder.
+Membuat kode bekerja sesuai yang diharapkan itu sulit; membuat kode yang sama berjalan di mesin yang berbeda dari mesin Anda seringkali lebih sulit.
 
-Shipping code means taking the code you wrote and converting it into a usable form that someone else can run without your computer's exact setup.
-Shipping code takes many forms and depends on the choices of programming language, system libraries, and operating system, among many other factors.
-It also depends on what you are building: a software library, a command line tool, and a web service all have different requirements and deployment steps.
-Regardless, there is a common pattern between all these scenarios: we need to define what the deliverable is --- a.k.a. the _artifact_ --- and what assumptions it makes about the environment around it.
+Mendistribusikan kode berarti mengambil kode yang Anda tulis dan mengubahnya menjadi bentuk yang dapat digunakan oleh orang lain tanpa memerlukan setup komputer Anda.
+Mendistribusikan kode memiliki banyak bentuk dan bergantung pada pilihan bahasa pemrograman, library sistem, dan sistem operasi, di antara banyak faktor lainnya.
+Hal ini juga bergantung pada apa yang Anda bangun: sebuah library perangkat lunak, alat baris perintah, dan layanan web semuanya memiliki kebutuhan dan langkah deployment yang berbeda.
+Meskipun demikian, terdapat pola umum di antara semua skenario ini: kita perlu mendefinisikan apa deliverable tersebut --- alias _artifact_ --- dan asumsi apa yang dibuatnya tentang lingkungan di sekitarnya.
 
-In this lecture, we'll cover:
+Dalam kuliah ini, kita akan membahas:
 
 - [Dependencies & Environments](#dependencies--environments)
 - [Artifacts & Packaging](#artifacts--packaging)
@@ -29,14 +29,14 @@ In this lecture, we'll cover:
 - [Services & Orchestration](#services--orchestration)
 - [Publishing](#publishing)
 
-We'll explain these concepts through examples from the Python ecosystem, as concrete examples are helpful for understanding. While the tools are different for other programming language ecosystems, the concepts will largely be the same.
+Kita akan menjelaskan konsep-konsep ini melalui contoh dari ekosistem Python, karena contoh konkret sangat membantu untuk pemahaman. Meskipun tool-nya berbeda untuk ekosistem bahasa pemrograman lain, konsepnya sebagian besar akan sama.
 
 # Dependencies & Environments
 
-In modern software development, layers of abstraction are ubiquitous.
-Programs naturally offload logic to other libraries or services.
-However, this introduces a _dependency_ relationship between your program and the libraries it requires to function.
-For instance, in Python, to fetch the content of a website we often do:
+Dalam pengembangan perangkat lunak modern, lapisan abstraksi ada di mana-mana.
+Program secara alami membebankan logika ke library atau layanan lain.
+Namun, ini memperkenalkan hubungan _dependency_ antara program Anda dan library yang dibutuhkannya untuk berfungsi.
+Sebagai contoh, di Python, untuk mengambil konten sebuah website kita sering melakukan:
 
 ```python
 import requests
@@ -44,7 +44,7 @@ import requests
 response = requests.get("https://missing.csail.mit.edu")
 ```
 
-Yet the `requests` library does not come bundled with the Python runtime, so if we try to run this code without having `requests` installed, Python will raise an error:
+Namun library `requests` tidak disertakan bersama runtime Python, jadi jika kita mencoba menjalankan kode ini tanpa menginstal `requests`, Python akan memunculkan error:
 
 ```console
 $ python fetch.py
@@ -54,14 +54,14 @@ Traceback (most recent call last):
 ModuleNotFoundError: No module named 'requests'
 ```
 
-To make this library available we need to first run `pip install requests` to install it.
-`pip` is the command line tool that the Python programming language provides for installing packages.
-Executing `pip install requests` produces the following sequence of actions:
+Untuk membuat library ini tersedia, kita perlu menjalankan `pip install requests` terlebih dahulu untuk menginstalnya.
+`pip` adalah alat baris perintah yang disediakan oleh bahasa pemrograman Python untuk menginstal package.
+Menjalankan `pip install requests` menghasilkan urutan tindakan berikut:
 
-1. Search for requests in the Python Package Index ([PyPI](https://pypi.org/))
-1. Search for the appropriate artifact for the platform we are running under
-1. Resolve dependencies --- the `requests` library itself depends on other packages, so the installer must find compatible versions of all transitive dependencies and install them beforehand
-1. Download the artifacts, then unpack and copy the files into the right places in our filesystem
+1. Mencari requests di Python Package Index ([PyPI](https://pypi.org/))
+1. Mencari artifact yang sesuai untuk platform yang kita gunakan
+1. Menyelesaikan dependency --- library `requests` sendiri bergantung pada package lain, sehingga installer harus menemukan versi yang kompatibel dari semua dependency transitif dan menginstalnya terlebih dahulu
+1. Mengunduh artifact, lalu mengekstrak dan menyalin file ke lokasi yang tepat di filesystem kita
 
 ```console
 $ pip install requests
@@ -79,8 +79,8 @@ Installing collected packages: urllib3, idna, charset-normalizer, certifi, reque
 Successfully installed certifi-2024.8.30 charset-normalizer-3.4.0 idna-3.10 requests-2.32.3 urllib3-2.2.3
 ```
 
-Here we can see that `requests` has its own dependencies such as `certifi` or `charset-normalizer` and that they have to be installed before `requests` can be installed.
-Once installed, the Python runtime can find this library when importing it.
+Di sini kita dapat melihat bahwa `requests` memiliki dependency-nya sendiri seperti `certifi` atau `charset-normalizer` dan bahwa mereka harus diinstal sebelum `requests` dapat diinstal.
+Setelah diinstal, runtime Python dapat menemukan library ini saat mengimpornya.
 
 ```console
 $ python -c 'import requests; print(requests.__path__)'
@@ -90,19 +90,19 @@ $ pip list | grep requests
 requests        2.32.3
 ```
 
-Programming languages have different tools, conventions and practices for installing and publishing libraries.
-In some languages like Rust, the toolchain is unified --- `cargo` handles building, testing, dependency management, and publishing.
-In others like Python, the unification happens at a specification level --- rather than a single tool, there are standardized specifications that define how packaging works, allowing multiple competing tools for each task (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
-And in some ecosystems like LaTeX, distributions like TeX Live or MacTeX come bundled with thousands of packages pre-installed.
+Bahasa pemrograman memiliki tool, konvensi, dan praktik yang berbeda untuk menginstal dan mempublikasikan library.
+Dalam beberapa bahasa seperti Rust, toolchain-nya terpadu --- `cargo` menangani building, testing, dependency management, dan publishing.
+Dalam bahasa lain seperti Python, penyatuan terjadi pada tingkat spesifikasi --- daripada satu tool tunggal, terdapat spesifikasi standar yang mendefinisikan cara kerja packaging, memungkinkan beberapa tool yang bersaing untuk setiap tugas (`pip` vs [`uv`](https://docs.astral.sh/uv/), `setuptools` vs [`hatch`](https://hatch.pypa.io/) vs [`poetry`](https://python-poetry.org/)).
+Dan dalam beberapa ekosistem seperti LaTeX, distribusi seperti TeX Live atau MacTeX disertakan dengan ribuan package yang telah terinstal.
 
-Introducing dependencies also introduces dependency conflicts.
-Conflicts happen when programs require incompatible versions of the same dependency.
-For example, if `tensorflow==2.3.0` requires `numpy>=1.16.0,<1.19.0` and `pandas==1.2.0`  requires `numpy>=1.16.5`, then any version satisfying `numpy>=1.16.5,<1.19.0` will be valid.
-But if another package in your project requires `numpy>=1.19`, you have a conflict with no valid version that satisfies all constraints.
+Memperkenalkan dependency juga memperkenalkan konflik dependency.
+Konflik terjadi ketika program membutuhkan versi yang tidak kompatibel dari dependency yang sama.
+Sebagai contoh, jika `tensorflow==2.3.0` membutuhkan `numpy>=1.16.0,<1.19.0` dan `pandas==1.2.0` membutuhkan `numpy>=1.16.5`, maka versi apa pun yang memenuhi `numpy>=1.16.5,<1.19.0` akan valid.
+Tetapi jika package lain dalam proyek Anda membutuhkan `numpy>=1.19`, Anda memiliki konflik tanpa versi valid yang memenuhi semua batasan.
 
-This situation --- where multiple packages require mutually incompatible versions of shared dependencies --- is commonly referred to as _dependency hell_.
-One way to deal with conflicts is to isolate the dependencies of each program into their own _environment_.
-In Python we create a virtual environment by running:
+Situasi ini --- di mana beberapa package membutuhkan versi yang saling tidak kompatibel dari dependency bersama --- sering disebut sebagai _dependency hell_.
+Salah satu cara untuk mengatasi konflik adalah dengan mengisolasi dependency setiap program ke dalam _environment_-nya sendiri.
+Di Python kita membuat virtual environment dengan menjalankan:
 
 ```console
 $ which python
@@ -124,17 +124,17 @@ Package Version
 pip     24.0
 ```
 
-You can think of an environment as an entire standalone version of the language runtime with its own set of installed packages.
-This virtual environment or venv isolates the installed dependencies from the global Python installation.
-It is a good practice to have a virtual environment for each project, containing the dependencies it requires.
+Anda dapat menganggap environment sebagai versi runtime bahasa yang berdiri sendiri dengan kumpulan package terinstal-nya sendiri.
+Virtual environment atau venv ini mengisolasi dependency yang terinstal dari instalasi Python global.
+Merupakan praktik yang baik untuk memiliki virtual environment untuk setiap proyek, yang berisi dependency yang dibutuhkannya.
 
-> While many modern operating systems ship with installations of programming language runtimes like Python, it is unwise to modify these installations since the OS might rely on them for its own functionality. Prefer using separate environments instead.
+> Meskipun banyak sistem operasi modern dilengkapi dengan instalasi runtime bahasa pemrograman seperti Python, tidak bijaksana untuk memodifikasi instalasi ini karena OS mungkin mengandalkannya untuk fungsionalitasnya sendiri. Lebih baik gunakan environment terpisah.
 
-In some languages, the installation protocol is not defined by a tool but as a specification.
-In Python [PEP 517](https://peps.python.org/pep-0517/) defines the build system interface and [PEP 621](https://peps.python.org/pep-0621/) specifies how project metadata is stored in `pyproject.toml`.
-This has enabled developers to improve upon `pip` and produce more optimized tools like `uv`. To install `uv` it suffices to do `pip install uv`.
+Dalam beberapa bahasa, protokol instalasi tidak didefinisikan oleh sebuah tool tetapi sebagai spesifikasi.
+Di Python [PEP 517](https://peps.python.org/pep-0517/) mendefinisikan antarmuka build system dan [PEP 621](https://peps.python.org/pep-0621/) menentukan bagaimana metadata proyek disimpan di `pyproject.toml`.
+Hal ini telah memungkinkan pengembang untuk meningkatkan `pip` dan menghasilkan tool yang lebih optimal seperti `uv`. Untuk menginstal `uv` cukup dengan melakukan `pip install uv`.
 
-Using `uv` instead of `pip` follows the same interface but is significantly faster:
+Menggunakan `uv` alih-alih `pip` mengikuti antarmuka yang sama tetapi secara signifikan lebih cepat:
 
 ```console
 $ uv pip install requests
@@ -148,9 +148,9 @@ Installed 5 packages in 8ms
  + urllib3==2.2.3
 ```
 
-> We strongly recommend using `uv pip` instead of `pip` whenever possible as it dramatically reduces the installation time.
+> Kami sangat menyarankan menggunakan `uv pip` alih-alih `pip` kapan pun memungkinkan karena ini secara dramatis mengurangi waktu instalasi.
 
-Beyond dependency isolation, environments also allow you to have different versions of your programming language runtime.
+Selain isolasi dependency, environment juga memungkinkan Anda memiliki berbagai versi runtime bahasa pemrograman.
 
 ```console
 $ uv venv --python 3.12 venv312
@@ -168,15 +168,15 @@ $ source venv311/bin/activate && python --version
 Python 3.11.10
 ```
 
-This helps when you need to test your code across multiple Python versions or when a project requires a specific version.
+Ini membantu ketika Anda perlu menguji kode Anda di berbagai versi Python atau ketika sebuah proyek membutuhkan versi tertentu.
 
-> In some programming languages, each project automatically gets its own environment for its dependencies rather than you creating it manually, but the principle is the same. Most languages these days also have a mechanism for managing multiple versions of the language on a single system, and then specifying which version to use for individual projects.
+> Dalam beberapa bahasa pemrograman, setiap proyek secara otomatis mendapatkan environment-nya sendiri untuk dependency-nya daripada Anda membuatnya secara manual, tetapi prinsipnya sama. Sebagian besar bahasa saat ini juga memiliki mekanisme untuk mengelola beberapa versi bahasa pada satu sistem, dan kemudian menentukan versi mana yang akan digunakan untuk proyek individual.
 
 # Artifacts & Packaging
 
-In software development we differentiate between source code and artifacts. Developers write and read source code, while artifacts are the packaged, distributable outputs produced from that source code --- ready to be installed or deployed.
-An artifact can be as simple as a file of code that we run, and as complex as an entire Virtual Machine that contains all the necessary bits and bobs of an application.
-Consider this example where we have a Python file `greet.py` in our current directory:
+Dalam pengembangan perangkat lunak, kita membedakan antara source code dan artifact. Pengembang menulis dan membaca source code, sementara artifact adalah output yang dikemas dan dapat didistribusikan yang dihasilkan dari source code tersebut --- siap untuk diinstal atau di-deploy.
+Sebuah artifact bisa sesederhana file kode yang kita jalankan, dan serumit seluruh Virtual Machine yang berisi semua bagian yang diperlukan dari sebuah aplikasi.
+Perhatikan contoh ini di mana kita memiliki file Python `greet.py` di direktori saat ini:
 
 ```console
 $ cat greet.py
@@ -191,15 +191,15 @@ $ python -c "from greet import greet; print(greet('World'))"
 ModuleNotFoundError: No module named 'greet'
 ```
 
-The import fails once we move to a different directory because Python only searches for modules in specific locations (the current directory, installed packages, and paths in `PYTHONPATH`). Packaging solves this by installing the code into a known location.
+Import gagal setelah kita berpindah ke direktori lain karena Python hanya mencari modul di lokasi tertentu (direktori saat ini, package yang terinstal, dan path di `PYTHONPATH`). Packaging menyelesaikan masalah ini dengan menginstal kode ke lokasi yang diketahui.
 
-In Python, packaging a library involves producing an artifact that package installers like `pip` or `uv` can use to install the relevant files.
-Python artifacts are called _wheels_ and contain all the necessary information to install a package: the code files, metadata about the package (name, version, dependencies), and instructions for where to place files in the environment.
-Building an artifact requires that we write a project file (also often known as manifest) detailing the specifics of the project, the required dependencies, the version of the package, and other information. In Python, we use `pyproject.toml` for this purpose.
+Di Python, memaketkan sebuah library melibatkan pembuatan artifact yang dapat digunakan oleh installer package seperti `pip` atau `uv` untuk menginstal file yang relevan.
+Artifact Python disebut _wheel_ dan berisi semua informasi yang diperlukan untuk menginstal sebuah package: file kode, metadata tentang package (nama, versi, dependency), dan instruksi untuk menempatkan file di environment.
+Membangun sebuah artifact mengharuskan kita menulis file proyek (juga sering dikenal sebagai manifest) yang merinci spesifikasi proyek, dependency yang diperlukan, versi package, dan informasi lainnya. Di Python, kita menggunakan `pyproject.toml` untuk tujuan ini.
 
-> `pyproject.toml` is the modern and recommended way. While earlier packaging methods like `requirements.txt` or `setup.py` are still supported, you should prefer `pyproject.toml` whenever possible.
+> `pyproject.toml` adalah cara modern dan yang direkomendasikan. Meskipun metode packaging sebelumnya seperti `requirements.txt` atau `setup.py` masih didukung, Anda sebaiknya lebih memilih `pyproject.toml` kapan pun memungkinkan.
 
-Here's a minimal `pyproject.toml` for a library that also provides a command-line tool:
+Berikut adalah `pyproject.toml` minimal untuk sebuah library yang juga menyediakan alat baris perintah:
 
 ```toml
 [project]
@@ -216,9 +216,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 ```
 
-The `typer` library is a popular Python package for creating command-line interfaces with minimal boilerplate.
+Library `typer` adalah package Python populer untuk membuat antarmuka baris perintah dengan boilerplate minimal.
 
-And the corresponding `greeting.py`:
+Dan `greeting.py` yang sesuai:
 
 ```python
 import typer
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     cli()
 ```
 
-With this file, we can now build the wheel:
+Dengan file ini, kita sekarang dapat membangun wheel:
 
 ```console
 $ uv build
@@ -250,9 +250,9 @@ greeting-0.1.0-py3-none-any.whl
 greeting-0.1.0.tar.gz
 ```
 
-The `.whl` file is the wheel (a zip archive with a specific structure), and the `.tar.gz` is a source distribution for systems that need to build from source.
+File `.whl` adalah wheel (arsip zip dengan struktur tertentu), dan `.tar.gz` adalah source distribution untuk sistem yang perlu membangun dari source.
 
-You can inspect the contents of a wheel to see what gets packaged:
+Anda dapat memeriksa isi sebuah wheel untuk melihat apa yang dikemas:
 
 ```console
 $ unzip -l dist/greeting-0.1.0-py3-none-any.whl
@@ -268,7 +268,7 @@ Archive:  dist/greeting-0.1.0-py3-none-any.whl
       998                     5 files
 ```
 
-Now if we were to give this wheel to someone else, they could install it by running:
+Sekarang jika kita memberikan wheel ini kepada orang lain, mereka dapat menginstalnya dengan menjalankan:
 
 ```console
 $ uv pip install ./greeting-0.1.0-py3-none-any.whl
@@ -276,72 +276,72 @@ $ greet Alice
 Hello, Alice!
 ```
 
-This would install the library we built earlier into their environment, including the `greet` cli tool.
+Ini akan menginstal library yang kita bangun sebelumnya ke environment mereka, termasuk tool cli `greet`.
 
-There are limitations to this approach. In particular if our library depends on platform-specific libraries, e.g. CUDA for GPU acceleration, then our artifact only works on systems with those specific libraries installed, and we may need to build separate wheels for different platforms (Linux, macOS, Windows) and architectures (x86, ARM).
+Ada batasan pada pendekatan ini. Khususnya jika library kita bergantung pada library spesifik platform, misalnya CUDA untuk akselerasi GPU, maka artifact kita hanya berfungsi di sistem dengan library spesifik tersebut yang terinstal, dan kita mungkin perlu membangun wheel terpisah untuk platform yang berbeda (Linux, macOS, Windows) dan arsitektur yang berbeda (x86, ARM).
 
 
-When installing software, there's an important distinction between installing from source and installing a prebuilt binary. Installing from source means downloading the original code and compiling it on your machine --- this requires having a compiler and build tools installed, and can take significant time for large projects.
+Saat menginstal perangkat lunak, terdapat perbedaan penting antara menginstal dari source dan menginstal biner yang sudah dibangun. Menginstal dari source berarti mengunduh kode asli dan mengompilasinya di mesin Anda --- ini memerlukan compiler dan tool build yang terinstal, dan bisa memakan waktu yang signifikan untuk proyek-proyek besar.
 
-Installing a prebuilt binary means downloading an artifact that was already compiled by someone else --- faster and simpler, but the binary must match your platform and architecture.
-For example, [ripgrep's releases page](https://github.com/BurntSushi/ripgrep/releases) shows prebuilt binaries for Linux (x86_64, ARM), macOS (Intel, Apple Silicon), and Windows.
+Menginstal biner yang sudah dibangun berarti mengunduh artifact yang sudah dikompilasi oleh orang lain --- lebih cepat dan lebih sederhana, tetapi biner tersebut harus cocok dengan platform dan arsitektur Anda.
+Sebagai contoh, [halaman rilis ripgrep](https://github.com/BurntSushi/ripgrep/releases) menampilkan biner yang sudah dibangun untuk Linux (x86_64, ARM), macOS (Intel, Apple Silicon), dan Windows.
 
 
 # Releases & Versioning
 
-Code is built in a continuous process but is released on a discrete basis.
-In software development there is a clear distinction between development and production environments.
-Code needs to be proven to work in a dev environment before getting _shipped_ to prod.
-The release process involves many steps, including testing, dependency management, versioning, configuration, deployment and publishing.
+Kode dibangun dalam proses yang berkelanjutan tetapi dirilis secara diskrit.
+Dalam pengembangan perangkat lunak terdapat perbedaan yang jelas antara environment development dan production.
+Kode perlu terbukti berfungsi di environment dev sebelum _didistribusikan_ ke prod.
+Proses rilis melibatkan banyak langkah, termasuk testing, dependency management, versioning, configuration, deployment, dan publishing.
 
 
-Software libraries are not static and evolve over time getting fixes and new features.
-We track this evolution by discrete version identifiers that correspond to the state of the library at a certain point in time.
-Changes in the behavior of a library can range from patches that fix noncritical functionality, new features that extend its functionality, to changes breaking backwards compatibility.
-Changelogs document what changes a version introduces --- these are documents that software developers use to communicate the changes associated with a new release.
+Library perangkat lunak tidak statis dan berkembang seiring waktu dengan perbaikan dan fitur baru.
+Kita melacak evolusi ini dengan pengenal versi diskrit yang sesuai dengan keadaan library pada titik waktu tertentu.
+Perubahan perilaku library dapat berkisar dari patch yang memperbaiki fungsionalitas tidak kritis, fitur baru yang memperluas fungsionalitasnya, hingga perubahan yang memecah kompatibilitas ke belakang.
+Changelog mendokumentasikan perubahan apa yang diperkenalkan oleh sebuah versi --- ini adalah dokumen yang digunakan pengembang perangkat lunak untuk mengkomunikasikan perubahan yang terkait dengan rilis baru.
 
-However, keeping track of the ongoing changes in each and every dependency is impractical, even more so when we consider the transitive dependencies --- i.e. the dependencies of our dependencies.
+Namun, melacak perubahan yang sedang berlangsung di setiap dependency tidak praktis, terlebih lagi ketika kita mempertimbangkan dependency transitif --- yaitu dependency dari dependency kita.
 
-> You can visualize the entire dependency tree of your project with `uv tree`, which shows all packages and their transitive dependencies in a tree format.
+> Anda dapat memvisualisasikan seluruh dependency tree proyek Anda dengan `uv tree`, yang menampilkan semua package dan dependency transitifnya dalam format tree.
 
-To simplify this problem there are conventions on how to version software, and one of the most prevalent is [Semantic Versioning](https://semver.org/) or SemVer.
-Under Semantic Versioning a version has an identifier of the form MAJOR.MINOR.PATCH where each one of the values takes an integer value. The short version is that upgrading:
+Untuk menyederhanakan masalah ini, terdapat konvensi tentang cara memberi versi pada perangkat lunak, dan salah satu yang paling umum adalah [Semantic Versioning](https://semver.org/) atau SemVer.
+Dalam Semantic Versioning, sebuah versi memiliki pengenal dalam bentuk MAJOR.MINOR.PATCH di mana masing-masing nilai mengambil nilai integer. Versi singkatnya adalah, melakukan upgrade:
 
-- PATCH (e.g., 1.2.3 → 1.2.4) should only contain bug fixes and be fully backwards compatible
-- MINOR (e.g., 1.2.3 → 1.3.0) adds new functionality in a backwards-compatible way
-- MAJOR (e.g., 1.2.3 → 2.0.0) indicates breaking changes that may require code modifications
+- PATCH (misalnya, 1.2.3 → 1.2.4) hanya boleh berisi perbaikan bug dan sepenuhnya kompatibel ke belakang
+- MINOR (misalnya, 1.2.3 → 1.3.0) menambahkan fungsionalitas baru dengan cara yang kompatibel ke belakang
+- MAJOR (misalnya, 1.2.3 → 2.0.0) menunjukkan perubahan yang memecah kompatibilitas yang mungkin memerlukan modifikasi kode
 
-> This is a simplification and we encourage reading the full SemVer specification to understand for instance why going from 0.1.3 to 0.2.0 might cause breaking changes or what 1.0.0-rc.1 means.
-Python packaging supports semantic versioning natively, so when we specify the versions of our dependencies we can use various specifiers:
+> Ini adalah penyederhanaan dan kami mendorong Anda untuk membaca spesifikasi SemVer lengkap untuk memahami misalnya mengapa berpindah dari 0.1.3 ke 0.2.0 dapat menyebabkan perubahan yang memecah kompatibilitas atau apa arti 1.0.0-rc.1.
+Python packaging mendukung semantic versioning secara native, jadi ketika kita menentukan versi dependency kita, kita dapat menggunakan berbagai specifier:
 
-In the `pyproject.toml` we have different ways of constraining the ranges of compatible versions of our dependencies:
+Di `pyproject.toml` kita memiliki berbagai cara untuk membatasi rentang versi yang kompatibel dari dependency kita:
 
 ```toml
 [project]
 dependencies = [
-    "requests==2.32.3",  # Exact version - only this specific version
+    "requests==2.32.3",  # Exact Version - only this specific version
     "click>=8.0",        # Minimum version - 8.0 or newer
     "numpy>=1.24,<2.0",  # Range - at least 1.24 but less than 2.0
     "pandas~=2.1.0",     # Compatible release - >=2.1.0 and <2.2.0
 ]
 ```
 
-Version specifiers exist across many package managers (npm, cargo, etc.) with varying exact semantics. The `~=` operator is Python's "compatible release" operator --- `~=2.1.0` means "any version that is compatible with 2.1.0", which translates to `>=2.1.0` and `<2.2.0`. This is roughly equivalent to the caret (`^`) operator in npm and cargo, which follows SemVer's notion of compatibility.
+Version specifier ada di banyak package manager (npm, cargo, dll.) dengan semantik yang bervariasi. Operator `~=` adalah operator "compatible release" Python --- `~=2.1.0` berarti "versi apa pun yang kompatibel dengan 2.1.0", yang diterjemahkan menjadi `>=2.1.0` dan `<2.2.0`. Ini kira-kira setara dengan operator caret (`^`) di npm dan cargo, yang mengikuti konsep kompatibilitas SemVer.
 
-Not all software uses semantic versioning. A common alternative is Calendar Versioning (CalVer), where versions are based on release dates rather than semantic meaning. For example, Ubuntu uses versions like `24.04` (April 2024) and `24.10` (October 2024). CalVer makes it easy to see how old a release is, though it doesn't communicate anything about compatibility.  Lastly, semantic versioning is not infallible, and sometimes maintainers inadvertently introduce breaking changes in minor or patch releases.
+Tidak semua perangkat lunak menggunakan semantic versioning. Alternatif yang umum adalah Calendar Versioning (CalVer), di mana versi didasarkan pada tanggal rilis daripada makna semantik. Sebagai contoh, Ubuntu menggunakan versi seperti `24.04` (April 2024) dan `24.10` (Oktober 2024). CalVer memudahkan untuk melihat seberapa lama sebuah rilis, meskipun tidak mengkomunikasikan apa pun tentang kompatibilitas. Terakhir, semantic versioning tidak sempurna, dan terkadang maintainer secara tidak sengaja memperkenalkan perubahan yang memecah kompatibilitas di rilis minor atau patch.
 
 
 # Reproducibility
 
-In modern software development the code you write sits atop a significant number of layers of abstraction.
-This includes things like your programming language runtime, third party libraries, the operating system, or even the hardware itself.
-Any difference across any of these layers might change the behavior of your code or even prevent it from working as intended.
-Furthermore, even differences in the underlying hardware impact your ability to ship software.
+Dalam pengembangan perangkat lunak modern, kode yang Anda tulis berada di atas sejumlah lapisan abstraksi yang signifikan.
+Ini mencakup hal-hal seperti runtime bahasa pemrograman Anda, library pihak ketiga, sistem operasi, atau bahkan hardware itu sendiri.
+Perbedaan apa pun di salah satu lapisan ini dapat mengubah perilaku kode Anda atau bahkan mencegahnya berfungsi sebagaimana mestinya.
+Selain itu, bahkan perbedaan pada hardware yang mendasarinya memengaruhi kemampuan Anda untuk mendistribusikan perangkat lunak.
 
-Pinning a library refers to specifying an exact version rather than a range, e.g. `requests==2.32.3` instead of `requests>=2.0`.
+Pinning sebuah library merujuk pada menentukan versi yang tepat daripada sebuah rentang, misalnya `requests==2.32.3` alih-alih `requests>=2.0`.
 
-Part of the job of a package manager is to consider all the constraints provided by the dependencies --- and transitive dependencies --- and then produce a valid list of versions that will satisfy all the constraints.
-The specific list of versions can then be saved to a file for reproducibility purposes; these files are referred to as _lock files_.
+Sebagian dari tugas package manager adalah mempertimbangkan semua batasan yang diberikan oleh dependency --- dan dependency transitif --- dan kemudian menghasilkan daftar versi yang valid yang akan memenuhi semua batasan.
+Daftar versi spesifik kemudian dapat disimpan ke file untuk tujuan reproducibility; file-file ini disebut sebagai _lock file_.
 
 ```console
 $ uv lock
@@ -362,37 +362,37 @@ wheels = [
 ...
 ```
 
-One critical distinction when dealing with dependency versioning and reproducibility is the difference between libraries and applications/services.
-A library is intended to be imported and used by other code which might have its own dependencies, so specifying overly strict version constraints can cause conflicts with the user's other dependencies.
-In contrast, applications or services are final consumers of the software and typically expose their functionality through a user interface or an API, not through a programming interface.
-For libraries, it is good practice to specify version ranges to maximize compatibility with the wider package ecosystem. For applications, pinning exact versions ensures reproducibility --- everyone running the application uses the exact same dependencies.
+Perbedaan penting saat menangani versioning dependency dan reproducibility adalah perbedaan antara library dan aplikasi/layanan.
+Sebuah library dimaksudkan untuk diimpor dan digunakan oleh kode lain yang mungkin memiliki dependency-nya sendiri, jadi menentukan batasan versi yang terlalu ketat dapat menyebabkan konflik dengan dependency lain milik pengguna.
+Sebaliknya, aplikasi atau layanan adalah konsumen akhir perangkat lunak dan biasanya mengekspos fungsionalitasnya melalui antarmuka pengguna atau API, bukan melalui antarmuka pemrograman.
+Untuk library, merupakan praktik yang baik untuk menentukan rentang versi guna memaksimalkan kompatibilitas dengan ekosistem package yang lebih luas. Untuk aplikasi, pinning versi yang tepat memastikan reproducibility --- semua orang yang menjalankan aplikasi menggunakan dependency yang persis sama.
 
 
-For projects requiring maximum reproducibility, tools like [Nix](https://nixos.org/) and [Bazel](https://bazel.build/) provide _hermetic_ builds --- where every input including compilers, system libraries, and even the build environment itself is pinned and content-addressed. This guarantees bit-for-bit identical outputs regardless of when or where the build runs.
+Untuk proyek yang membutuhkan reproducibility maksimal, tool seperti [Nix](https://nixos.org/) dan [Bazel](https://bazel.build/) menyediakan build _hermetic_ --- di mana setiap input termasuk compiler, library sistem, dan bahkan environment build itu sendiri di-pin dan di-address berdasarkan konten. Ini menjamin output yang identik bit-demi-bit terlepas dari kapan atau di mana build dijalankan.
 
-> You can even use NixOS to manage your entire computer install so that you can trivially spin up new copies of your computer setup and manage their complete configuration through version-controlled configuration files.
+> Anda bahkan dapat menggunakan NixOS untuk mengelola seluruh instalasi komputer Anda sehingga Anda dapat dengan mudah membuat salinan baru dari setup komputer Anda dan mengelola konfigurasi lengkapnya melalui file konfigurasi yang terkontrol versi.
 
-A neverending tension in software development is that new software versions introduce breakage either intentionally or unintentionally, while on the other hand, old software versions become compromised with security vulnerabilities over time.
-We can address this by using continuous integration pipelines (we'll see more in the [Code Quality and CI](/2026/code-quality/) lecture) that test our application against new software versions and having automation in place for detecting when new versions of our dependencies are released, such as [Dependabot](https://github.com/dependabot).
+Ketegangan yang tidak pernah berakhir dalam pengembangan perangkat lunak adalah bahwa versi perangkat lunak baru memperkenalkan kerusakan baik secara sengaja maupun tidak sengaja, sementara di sisi lain, versi perangkat lunak lama menjadi rentan terhadap kerentanan keamanan seiring berjalannya waktu.
+Kita dapat mengatasi hal ini dengan menggunakan pipeline continuous integration (kita akan melihat lebih lanjut di kuliah [Code Quality and CI](/2026/code-quality/)) yang menguji aplikasi kita terhadap versi perangkat lunak baru dan memiliki otomatisasi untuk mendeteksi ketika versi baru dari dependency kita dirilis, seperti [Dependabot](https://github.com/dependabot).
 
-Even with CI testing in place, issues still occur when upgrading software versions, often because of the inevitable mismatch between dev and prod environments.
-In those circumstances the best course of action is to have a _rollback_ plan, where the version upgrade is reverted and a known good version is redeployed instead.
+Meskipun dengan pengujian CI, masalah masih terjadi saat mengupgrade versi perangkat lunak, sering kali karena ketidakcocokan yang tak terelakkan antara environment dev dan prod.
+Dalam situasi tersebut, langkah terbaik adalah memiliki rencana _rollback_, di mana upgrade versi dibatalkan dan versi yang sudah terbukti baik di-deploy ulang.
 
 # VMs & Containers
 
-As you start relying on more complex dependencies, it is likely that the dependencies of your code will span beyond the boundaries of what the package manager can handle.
-One common reason is having to interface with specific system libraries or hardware drivers.
-For example, in scientific computing and AI, programs often need specialized libraries and drivers to utilize GPU hardware.
-Many system-level dependencies (GPU drivers, specific compiler versions, shared libraries like OpenSSL) still require system-wide installation.
+Saat Anda mulai bergantung pada dependency yang lebih kompleks, kemungkinan dependency kode Anda akan melampaui batas apa yang dapat ditangani oleh package manager.
+Salah satu alasan umum adalah harus berinteraksi dengan library sistem tertentu atau driver hardware.
+Sebagai contoh, dalam komputasi ilmiah dan AI, program sering membutuhkan library dan driver khusus untuk memanfaatkan hardware GPU.
+Banyak dependency tingkat sistem (driver GPU, versi compiler tertentu, shared library seperti OpenSSL) masih memerlukan instalasi di seluruh sistem.
 
-Traditionally this wider dependency problem was solved with Virtual Machines (VMs).
-VMs abstract the entire computer and provide a completely isolated environment with its own dedicated operating system.
-A more modern approach is containers, which package an application along with its dependencies, libraries, and filesystem, but share the host's operating system kernel rather than virtualizing an entire computer.
-Containers are lighter weight than VMs because they share the kernel, making them faster to start and more efficient to run.
+Secara tradisional, masalah dependency yang lebih luas ini diselesaikan dengan Virtual Machine (VM).
+VM mengabstraksikan seluruh komputer dan menyediakan environment yang sepenuhnya terisolasi dengan sistem operasi tersendiri.
+Pendekatan yang lebih modern adalah container, yang mengemas sebuah aplikasi beserta dependency, library, dan filesystem-nya, tetapi berbagi kernel sistem operasi host daripada memvirtualisasi seluruh komputer.
+Container lebih ringan daripada VM karena mereka berbagi kernel, sehingga lebih cepat untuk dijalankan dan lebih efisien.
 
-The most popular container platform is [Docker](https://www.docker.com/). Docker introduced a standardized way to build, distribute, and run containers. Under the hood, Docker uses containerd as its container runtime --- an industry standard that other tools like Kubernetes also use.
+Platform container yang paling populer adalah [Docker](https://www.docker.com/). Docker memperkenalkan cara standar untuk membangun, mendistribusikan, dan menjalankan container. Di balik layar, Docker menggunakan containerd sebagai container runtime-nya --- standar industri yang juga digunakan oleh tool lain seperti Kubernetes.
 
-Running a container is straightforward. For example, to run a Python interpreter inside a container we use `docker run` (The `-it` flags make the container interactive with a terminal. When you exit, the container stops.).
+Menjalankan container cukup mudah. Sebagai contoh, untuk menjalankan interpreter Python di dalam container kita menggunakan `docker run` (Flag `-it` membuat container interaktif dengan terminal. Ketika Anda keluar, container berhenti.).
 
 ```console
 $ docker run -it python:3.12 python
@@ -401,9 +401,9 @@ Python 3.12.7 (main, Nov  5 2024, 02:53:25) [GCC 12.2.0] on linux
 Hello from inside a container!
 ```
 
-In practice your program might depend on the entire filesystem.
-To overcome this, we can use container images that ship the entire filesystem of the application as the artifact.
-The container images are created programmatically. With docker we specify exactly the dependencies, system libraries, and configuration of the image using a Dockerfile syntax:
+Dalam praktiknya, program Anda mungkin bergantung pada keseluruhan filesystem.
+Untuk mengatasinya, kita dapat menggunakan container image yang mengemas seluruh filesystem aplikasi sebagai artifact.
+Container image dibuat secara terprogram. Dengan docker kita menentukan secara tepat dependency, library sistem, dan konfigurasi image menggunakan sintaks Dockerfile:
 
 ```dockerfile
 FROM python:3.12
@@ -417,11 +417,11 @@ WORKDIR /app
 RUN pip install .
 ```
 
-An important distinction: a Docker **image** is the packaged artifact (like a template), while a **container** is a running instance of that image. You can run multiple containers from the same image. Images are built in layers, where each instruction (`FROM`, `RUN`, `COPY`, etc) in a Dockerfile creates a new layer. Docker caches these layers, so if you change a line in your Dockerfile, only that layer and subsequent layers need to be rebuilt.
+Perbedaan penting: Docker **image** adalah artifact yang dikemas (seperti template), sementara **container** adalah instance yang berjalan dari image tersebut. Anda dapat menjalankan beberapa container dari image yang sama. Image dibangun dalam lapisan, di mana setiap instruksi (`FROM`, `RUN`, `COPY`, dll.) di Dockerfile membuat lapisan baru. Docker melakukan cache pada lapisan-lapisan ini, jadi jika Anda mengubah satu baris di Dockerfile, hanya lapisan tersebut dan lapisan setelahnya yang perlu dibangun ulang.
 
-The previous Dockerfile has several issues: it uses the full Python image instead of a slim variant, runs separate `RUN` commands creating unnecessary layers, versions are not pinned, and it doesn't clean up package manager caches, shipping unnecessary files. Other frequent mistakes include insecurely running containers as root and accidentally embedding secrets in layers.
+Dockerfile sebelumnya memiliki beberapa masalah: menggunakan image Python penuh alih-alih varian slim, menjalankan perintah `RUN` terpisah yang membuat lapisan yang tidak perlu, versi tidak di-pin, dan tidak membersihkan cache package manager, sehingga mengemas file yang tidak perlu. Kesalahan umum lainnya termasuk menjalankan container secara tidak aman sebagai root dan secara tidak sengaja menyematkan secret di lapisan.
 
-Here's an improved version
+Berikut adalah versi yang lebih baik
 
 ```dockerfile
 FROM python:3.12-slim
@@ -434,19 +434,19 @@ RUN uv pip install --system -r uv.lock
 COPY . /app
 ```
 
-In the previous example we see that instead of installing `uv` from source, we are copying the prebuilt binary from the `ghcr.io/astral-sh/uv:latest` image. This is known as the _builder_ pattern. With this pattern we do not need to ship all the tools needed to compile our code, just the final binary that is needed to run the application (`uv` in this case).
+Pada contoh sebelumnya kita melihat bahwa alih-alih menginstal `uv` dari source, kita menyalin biner yang sudah dibangun dari image `ghcr.io/astral-sh/uv:latest`. Ini dikenal sebagai pola _builder_. Dengan pola ini kita tidak perlu mengirimkan semua tool yang diperlukan untuk mengompilasi kode kita, hanya biner akhir yang diperlukan untuk menjalankan aplikasi (`uv` dalam kasus ini).
 
-Docker has important limitations to be aware of. First, container images are often platform-specific --- an image built for `linux/amd64` won't run natively on `linux/arm64` (Apple Silicon Macs) without emulation, which is slow. Second, Docker containers require a Linux kernel, so on macOS and Windows, Docker actually runs a lightweight Linux VM under the hood, adding overhead. Third, Docker's isolation is weaker than VMs --- containers share the host kernel, which is a security concern in multi-tenant environments.
+Docker memiliki batasan penting yang perlu diperhatikan. Pertama, container image seringkali spesifik platform --- image yang dibangun untuk `linux/amd64` tidak akan berjalan secara native di `linux/arm64` (Mac Apple Silicon) tanpa emulasi, yang lambat. Kedua, container Docker memerlukan kernel Linux, jadi di macOS dan Windows, Docker sebenarnya menjalankan VM Linux ringan di balik layar, yang menambah overhead. Ketiga, isolasi Docker lebih lemah daripada VM --- container berbagi kernel host, yang menjadi masalah keamanan di environment multi-tenant.
 
-> These days, more projects are also making use of nix to manage even "system-wide" libraries and applications per project through [nix flakes](https://serokell.io/blog/practical-nix-flakes).
+> Saat ini, lebih banyak proyek juga menggunakan nix untuk mengelola bahkan library "seluruh sistem" dan aplikasi per proyek melalui [nix flakes](https://serokell.io/blog/practical-nix-flakes).
 
 # Configuration
 
-Software is inherently configurable. In the [command line environment](/2026/command-line-environment/) lecture we saw programs receiving options via flags, environment variables or even configuration files a.k.a. dotfiles. This holds true even for more complex applications, and there are established patterns for managing configuration at scale.
-Software configuration should not be embedded in the code but be provided at runtime.
-A couple of common ones being environment variables and config files.
+Perangkat lunak pada dasarnya dapat dikonfigurasi. Dalam kuliah [command line environment](/2026/command-line-environment/) kita melihat program yang menerima opsi melalui flag, environment variable, atau bahkan file konfigurasi alias dotfiles. Hal ini berlaku bahkan untuk aplikasi yang lebih kompleks, dan terdapat pola yang sudah mapan untuk mengelola konfigurasi dalam skala besar.
+Konfigurasi perangkat lunak tidak boleh disematkan dalam kode tetapi disediakan saat runtime.
+Beberapa yang umum adalah environment variable dan file konfigurasi.
 
-Here's an example of an application that is configured via environment variables:
+Berikut adalah contoh aplikasi yang dikonfigurasi melalui environment variable:
 
 ```python
 import os
@@ -456,7 +456,7 @@ DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
 API_KEY = os.environ["API_KEY"]  # Required - will raise if not set
 ```
 
-An application could also be configured via a configuration file (e.g., a Python program that loads a config via `yaml.load`), `config.yaml`:
+Sebuah aplikasi juga dapat dikonfigurasi melalui file konfigurasi (misalnya, program Python yang memuat konfigurasi melalui `yaml.load`), `config.yaml`:
 
 ```yaml
 database:
@@ -468,22 +468,22 @@ server:
   debug: false
 ```
 
-A good right-hand rule for thinking about configuration is that the same codebase should be deployable to different environments (development, staging, production) with only configuration changes, never code changes.
+Aturan praktis yang baik untuk memikirkan konfigurasi adalah bahwa codebase yang sama harus dapat di-deploy ke environment yang berbeda (development, staging, production) hanya dengan perubahan konfigurasi, bukan perubahan kode.
 
-Among the many configuration options there is often sensitive data such as API keys.
-Secrets need to be handled with care to avoid exposing them accidentally, and must not be included in version control.
+Di antara banyak opsi konfigurasi sering terdapat data sensitif seperti API key.
+Secret perlu ditangani dengan hati-hati untuk menghindari eksposur yang tidak disengaja, dan tidak boleh disertakan dalam version control.
 
 
 # Services & Orchestration
 
-Modern applications rarely exist in isolation. A typical web application might need a database for persistent storage, a cache for performance, a message queue for background tasks, and various other supporting services. Rather than bundling everything into a single monolithic application, modern architectures often decompose functionality into separate services that can be developed, deployed, and scaled independently.
+Aplikasi modern jarang ada dalam isolasi. Sebuah aplikasi web tipikal mungkin membutuhkan database untuk penyimpanan persisten, cache untuk performa, message queue untuk tugas latar belakang, dan berbagai layanan pendukung lainnya. Daripada menggabungkan semuanya menjadi satu aplikasi monolitik, arsitektur modern sering menguraikan fungsionalitas menjadi layanan terpisah yang dapat dikembangkan, di-deploy, dan diskalakan secara independen.
 
-As an example, if we determine our application might benefit from using a cache, instead of rolling our own we can leverage existing battle tested solutions like [Redis](https://redis.io/) or [Memcached](https://memcached.org/).
-We could embed Redis in our application dependencies by building it as part of the container, but that means harmonizing all the dependencies between Redis and our application which could be challenging or even unfeasible.
-Instead what we can do is deploy each application separately in its own container.
-This is commonly referred to as a microservice architecture where each component runs as an independent service that communicates over the network, typically via HTTP APIs.
+Sebagai contoh, jika kita menentukan aplikasi kita mungkin mendapat manfaat dari penggunaan cache, alih-alih membuatnya sendiri kita dapat memanfaatkan solusi yang sudah teruji seperti [Redis](https://redis.io/) atau [Memcached](https://memcached.org/).
+Kita bisa menyematkan Redis di dependency aplikasi kita dengan membangunnya sebagai bagian dari container, tetapi itu berarti menyelaraskan semua dependency antara Redis dan aplikasi kita yang bisa menantang atau bahkan tidak layak.
+Sebaliknya, yang dapat kita lakukan adalah men-deploy setiap aplikasi secara terpisah di container-nya sendiri.
+Ini sering disebut sebagai arsitektur microservice di mana setiap komponen berjalan sebagai layanan independen yang berkomunikasi melalui jaringan, biasanya melalui API HTTP.
 
-[Docker Compose](https://docs.docker.com/compose/) is a tool for defining and running multi-container applications. Rather than managing containers individually, you declare all services in a single YAML file and orchestrate them together. Now our full application encompasses more than one container:
+[Docker Compose](https://docs.docker.com/compose/) adalah tool untuk mendefinisikan dan menjalankan aplikasi multi-container. Daripada mengelola container secara individual, Anda mendeklarasikan semua layanan dalam satu file YAML dan mengorkestrasinya bersama. Sekarang aplikasi lengkap kita mencakup lebih dari satu container:
 
 ```yaml
 # docker-compose.yml
@@ -506,10 +506,10 @@ volumes:
   redis_data:
 ```
 
-With `docker compose up`, both services start together, and the web application can connect to Redis using the hostname `cache` (Docker's internal DNS resolves service names automatically).
-Docker Compose lets us declare how we want to deploy one or more services, and handles the orchestration of starting them together, setting up networking between them, and managing shared volumes for data persistence.
+Dengan `docker compose up`, kedua layanan dimulai bersama, dan aplikasi web dapat terhubung ke Redis menggunakan hostname `cache` (DNS internal Docker menyelesaikan nama layanan secara otomatis).
+Docker Compose memungkinkan kita mendeklarasikan bagaimana kita ingin men-deploy satu atau lebih layanan, dan menangani orkestrasi untuk memulai mereka bersama, menyiapkan jaringan di antara mereka, dan mengelola volume bersama untuk persistensi data.
 
-For production deployments, you often want your docker compose services to start automatically on boot and restart on failure. A common approach is to use systemd to manage the docker compose deployment:
+Untuk deployment production, Anda sering ingin layanan docker compose Anda dimulai secara otomatis saat boot dan dimulai ulang saat gagal. Pendekatan umum adalah menggunakan systemd untuk mengelola deployment docker compose:
 
 ```ini
 # /etc/systemd/system/myapp.service
@@ -529,11 +529,11 @@ ExecStop=/usr/bin/docker compose down
 WantedBy=multi-user.target
 ```
 
-This systemd unit file ensures your application starts when the system boots (after Docker is ready), and provides standard controls like `systemctl start myapp`, `systemctl stop myapp`, and `systemctl status myapp`.
+File unit systemd ini memastikan aplikasi Anda dimulai ketika sistem boot (setelah Docker siap), dan menyediakan kontrol standar seperti `systemctl start myapp`, `systemctl stop myapp`, dan `systemctl status myapp`.
 
-As deployment requirements grow more complex --- needing scalability across multiple machines, fault tolerance when services crash, and high availability guarantees --- organizations turn to sophisticated container orchestration platforms like Kubernetes (k8s), which can manage thousands of containers across clusters of machines. That said, Kubernetes has a steep learning curve and significant operational overhead, so it's often overkill for smaller projects.
+Seiring kebutuhan deployment yang semakin kompleks --- membutuhkan skalabilitas di beberapa mesin, toleransi kesalahan saat layanan crash, dan jaminan ketersediaan tinggi --- organisasi beralih ke platform orkestrasi container yang canggih seperti Kubernetes (k8s), yang dapat mengelola ribuan container di seluruh kluster mesin. Meskipun demikian, Kubernetes memiliki kurva pembelajaran yang curam dan overhead operasional yang signifikan, sehingga sering berlebihan untuk proyek yang lebih kecil.
 
-This multi-container setup is partly feasible because modern services communicate with each other via standardized APIs, with HTTP REST APIs. For example, whenever a program interacts with an LLM provider like OpenAI or Anthropic, under the hood it is sending an HTTP request to their servers and parsing the response:
+Setup multi-container ini sebagian memungkinkan karena layanan modern berkomunikasi satu sama lain melalui API standar, dengan API HTTP REST. Sebagai contoh, setiap kali sebuah program berinteraksi dengan penyedia LLM seperti OpenAI atau Anthropic, di balik layar ia mengirim permintaan HTTP ke server mereka dan mengurai responsnya:
 
 ```console
 $ curl https://api.anthropic.com/v1/messages \
@@ -546,17 +546,17 @@ $ curl https://api.anthropic.com/v1/messages \
 
 # Publishing
 
-Once you have shown your code to work, you might be interested in distributing it for others to download and install.
-Distribution takes many forms and is intrinsically tied to the programming language and environments that you operate with.
+Setelah Anda menunjukkan kode Anda berfungsi, Anda mungkin tertarik untuk mendistribusikannya agar orang lain dapat mengunduh dan menginstalnya.
+Distribusi memiliki banyak bentuk dan secara intrinsik terkait dengan bahasa pemrograman dan environment yang Anda gunakan.
 
-The simplest form of distribution is uploading artifacts for people to download and install locally.
-This is still common and you can find it in places like [Ubuntu's package archive](http://archive.ubuntu.com/ubuntu/pool/main/), which is essentially an HTTP directory listing of `.deb` files.
+Bentuk distribusi paling sederhana adalah mengunggah artifact untuk orang unduh dan instal secara lokal.
+Ini masih umum dan Anda dapat menemukannya di tempat-tempat seperti [arsip package Ubuntu](http://archive.ubuntu.com/ubuntu/pool/main/), yang pada dasarnya adalah daftar direktori HTTP dari file `.deb`.
 
-These days, GitHub has become the de facto platform for publishing source code and artifacts.
-While the source code is often publicly available, GitHub Releases allow maintainers to attach prebuilt binaries and other artifacts to tagged versions.
+Saat ini, GitHub telah menjadi platform de facto untuk mempublikasikan source code dan artifact.
+Meskipun source code sering tersedia secara publik, GitHub Releases memungkinkan maintainer untuk melampirkan biner yang sudah dibangun dan artifact lainnya ke versi yang di-tag.
 
 
-Package managers sometimes support installing directly from GitHub, either from source or from a pre-built wheel:
+Package manager terkadang mendukung penginstalan langsung dari GitHub, baik dari source maupun dari wheel yang sudah dibangun:
 
 ```console
 # Install from source (will clone and build)
@@ -569,8 +569,8 @@ $ pip install git+https://github.com/psf/requests.git@v2.32.3
 $ pip install https://github.com/user/repo/releases/download/v1.0/package-1.0-py3-none-any.whl
 ```
 
-In fact, some languages like Go use a decentralized distribution model --- rather than a central package repository, Go modules are distributed directly from their source code repositories.
-Module paths like `github.com/gorilla/mux` indicate where the code lives, and `go get` fetches directly from there. However, most package managers like `pip`, `cargo`, or `brew` have central indexes of pre-packaged projects for ease of distribution and installation. If we run
+Faktanya, beberapa bahasa seperti Go menggunakan model distribusi terdesentralisasi --- alih-alih repositori package terpusat, modul Go didistribusikan langsung dari repositori source code mereka.
+Path modul seperti `github.com/gorilla/mux` menunjukkan di mana kode berada, dan `go get` mengambil langsung dari sana. Namun, sebagian besar package manager seperti `pip`, `cargo`, atau `brew` memiliki indeks terpusat dari proyek yang sudah dikemas untuk kemudahan distribusi dan instalasi. Jika kita menjalankan
 
 ```console
 $ uv pip install requests --verbose --no-cache 2>&1 | grep -F '.whl'
@@ -579,18 +579,18 @@ DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3ea
 DEBUG No cache entry for: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
 ```
 
-we see where we are fetching the `requests` wheel from. Notice the `py3-none-any` in the filename --- this means the wheel works with any Python 3 version, on any OS, on any architecture. For packages with compiled code, the wheel is platform-specific:
+kita melihat dari mana kita mengambil wheel `requests`. Perhatikan `py3-none-any` di nama file --- ini berarti wheel berfungsi dengan versi Python 3 apa pun, di OS apa pun, di arsitektur apa pun. Untuk package dengan kode yang dikompilasi, wheel-nya spesifik platform:
 
 ```console
 $ uv pip install numpy --verbose --no-cache 2>&1 | grep -F '.whl'
 DEBUG Selecting: numpy==2.2.1 [compatible] (numpy-2.2.1-cp312-cp312-macosx_14_0_arm64.whl)
 ```
 
-Here `cp312-cp312-macosx_14_0_arm64` indicates this wheel is specifically for CPython 3.12 on macOS 14+ for ARM64 (Apple Silicon). If you're on a different platform, `pip` will download a different wheel or build from source.
+Di sini `cp312-cp312-macosx_14_0_arm64` menunjukkan bahwa wheel ini khusus untuk CPython 3.12 di macOS 14+ untuk ARM64 (Apple Silicon). Jika Anda berada di platform yang berbeda, `pip` akan mengunduh wheel yang berbeda atau membangun dari source.
 
-Conversely, for people to be able to find a package we've created, we need to publish it to one of these registries.
-In Python, the main registry is the [Python Package Index (PyPI)](https://pypi.org).
-Like with installing, there are multiple ways of publishing packages. The `uv publish` command provides a modern interface for uploading packages to PyPI:
+Sebaliknya, agar orang dapat menemukan package yang telah kita buat, kita perlu mempublikasikannya ke salah satu registri ini.
+Di Python, registri utamanya adalah [Python Package Index (PyPI)](https://pypi.org).
+Seperti halnya menginstal, terdapat beberapa cara untuk mempublikasikan package. Perintah `uv publish` menyediakan antarmuka modern untuk mengunggah package ke PyPI:
 
 ```console
 $ uv publish --publish-url https://test.pypi.org/legacy/
@@ -598,33 +598,33 @@ Publishing greeting-0.1.0.tar.gz
 Publishing greeting-0.1.0-py3-none-any.whl
 ```
 
-Here we are using [TestPyPI](https://test.pypi.org) --- a separate package registry intended for testing your publishing workflow without polluting the real PyPI. Once uploaded, you can install from TestPyPI:
+Di sini kita menggunakan [TestPyPI](https://test.pypi.org) --- registri package terpisah yang ditujukan untuk menguji workflow publishing Anda tanpa mengotori PyPI yang sebenarnya. Setelah diunggah, Anda dapat menginstal dari TestPyPI:
 
 ```console
 $ uv pip install --index-url https://test.pypi.org/simple/ greeting
 ```
 
-A key consideration when publishing software is trust. How do users verify that the package they download actually comes from you and hasn't been tampered with? Package registries use checksums to verify integrity, and some ecosystems support package signing to provide cryptographic proof of authorship.
+Pertimbangan penting saat mempublikasikan perangkat lunak adalah kepercayaan. Bagaimana pengguna memverifikasi bahwa package yang mereka unduh benar-benar berasal dari Anda dan belum diubah? Registri package menggunakan checksum untuk memverifikasi integritas, dan beberapa ekosistem mendukung penandatanganan package untuk memberikan bukti kriptografis kepengarangan.
 
-Different languages have their own package registries: [crates.io](https://crates.io) for Rust, [npm](https://www.npmjs.com) for JavaScript, [RubyGems](https://rubygems.org) for Ruby, and [Docker Hub](https://hub.docker.com) for container images. Meanwhile, for private or internal packages, organizations often deploy their own package repositories (such as a private PyPI server or a private Docker registry) or use managed solutions from cloud providers.
+Bahasa yang berbeda memiliki registri package mereka sendiri: [crates.io](https://crates.io) untuk Rust, [npm](https://www.npmjs.com) untuk JavaScript, [RubyGems](https://rubygems.org) untuk Ruby, dan [Docker Hub](https://hub.docker.com) untuk container image. Sementara itu, untuk package privat atau internal, organisasi sering men-deploy repositori package mereka sendiri (seperti server PyPI privat atau registri Docker privat) atau menggunakan solusi terkelola dari penyedia cloud.
 
-Deploying a web service to the internet involves additional infrastructure: domain name registration, DNS configuration to point your domain to your server, and often a reverse proxy like nginx to handle HTTPS and route traffic. For simpler use cases like documentation or static sites, [GitHub Pages](https://pages.github.com/) provides free hosting directly from a repository.
+Men-deploy layanan web ke internet melibatkan infrastruktur tambahan: pendaftaran nama domain, konfigurasi DNS untuk mengarahkan domain Anda ke server Anda, dan seringkali reverse proxy seperti nginx untuk menangani HTTPS dan merutekan traffic. Untuk kasus penggunaan yang lebih sederhana seperti dokumentasi atau situs statis, [GitHub Pages](https://pages.github.com/) menyediakan hosting gratis langsung dari repositori.
 
 <!--
 ## Documentation
 
-So far we have emphasized the deliverable _artifact_ as the main output of packaging and shipping code.
-In addition to the artifact, we need to document for users the code's functionality, installation instructions, and usage examples.
+Sejauh ini kita telah menekankan _artifact_ deliverable sebagai output utama dari packaging dan distribusi kode.
+Selain artifact, kita perlu mendokumentasikan untuk pengguna fungsionalitas kode, instruksi instalasi, dan contoh penggunaan.
 
-Tools like [Sphinx](https://www.sphinx-doc.org/) (Python) and [MkDocs](https://www.mkdocs.org/) can automatically generate browsable documentation from docstrings and markdown files, often hosted on services like [Read the Docs](https://readthedocs.org/).
-For HTTP-based APIs, the [OpenAPI specification](https://www.openapis.org/) (formerly Swagger) provides a standard format for describing API endpoints, which tools can use to generate interactive documentation and client libraries automatically. -->
+Tool seperti [Sphinx](https://www.sphinx-doc.org/) (Python) dan [MkDocs](https://www.mkdocs.org/) dapat secara otomatis menghasilkan dokumentasi yang dapat ditelusuri dari docstring dan file markdown, sering di-host di layanan seperti [Read the Docs](https://readthedocs.org/).
+Untuk API berbasis HTTP, [spesifikasi OpenAPI](https://www.openapis.org/) (sebelumnya Swagger) menyediakan format standar untuk mendeskripsikan endpoint API, yang dapat digunakan tool untuk menghasilkan dokumentasi interaktif dan library klien secara otomatis. -->
 
 
-# Exercises
+# Latihan
 
-1. Save your environment with `printenv` to a file, create a venv, activate it, `printenv` to another file and `diff before.txt after.txt`. What changed in the environment? Why does the shell prefer the venv? (Hint: look at `$PATH` before and after activation.) Run `which deactivate` and reason about what the deactivate bash function is doing.
-1. Create a Python package with a `pyproject.toml` and install it in a virtual environment. Create a lockfile and inspect it.
-1. Install Docker and use it to build the Missing Semester class website locally using docker compose.
-1. Write a Dockerfile for a simple Python application. Then write a `docker-compose.yml` that runs your application alongside a Redis cache.
-1. Publish a Python package to TestPyPI (don't publish to the real PyPI unless it's worth sharing!). Then build a Docker image with said package and push it to `ghcr.io`.
-1. Make a website using [GitHub Pages](https://docs.github.com/en/pages/quickstart). Extra (non-)credit: configure it with a custom domain.
+1. Simpan environment Anda dengan `printenv` ke sebuah file, buat venv, aktifkan, `printenv` ke file lain dan `diff before.txt after.txt`. Apa yang berubah di environment? Mengapa shell lebih memilih venv? (Petunjuk: lihat `$PATH` sebelum dan setelah aktivasi.) Jalankan `which deactivate` dan pikirkan apa yang dilakukan fungsi bash deactivate.
+1. Buat sebuah package Python dengan `pyproject.toml` dan instal di virtual environment. Buat lockfile dan periksa isinya.
+1. Instal Docker dan gunakan untuk membangun website kelas Missing Semester secara lokal menggunakan docker compose.
+1. Tulis Dockerfile untuk aplikasi Python sederhana. Kemudian tulis `docker-compose.yml` yang menjalankan aplikasi Anda bersama dengan cache Redis.
+1. Publikasikan package Python ke TestPyPI (jangan mempublikasikan ke PyPI yang sebenarnya kecuali memang layak untuk dibagikan!). Kemudian bangun Docker image dengan package tersebut dan push ke `ghcr.io`.
+1. Buat website menggunakan [GitHub Pages](https://docs.github.com/en/pages/quickstart). Nilai tambahan (non-): konfigurasikan dengan domain kustom.

--- a/_2026/version-control.md
+++ b/_2026/version-control.md
@@ -2,7 +2,7 @@
 layout: lecture
 title: "Version Control and Git"
 description: >
-  Learn Git's data model and how to use Git for version control and collaboration.
+  Pelajari model data Git dan cara menggunakan Git untuk version control dan kolaborasi.
 thumbnail: /static/assets/thumbnails/2026/lec5.png
 date: 2026-01-16
 ready: true

--- a/_2026/version-control.md
+++ b/_2026/version-control.md
@@ -1,8 +1,8 @@
 ---
 layout: lecture
-title: "Version Control and Git"
+title: "Version Control dan Git"
 description: >
-  Learn Git's data model and how to use Git for version control and collaboration.
+  Pelajari model data Git dan cara menggunakan Git untuk version control dan kolaborasi.
 thumbnail: /static/assets/thumbnails/2026/lec5.png
 date: 2026-01-16
 ready: true
@@ -11,61 +11,60 @@ video:
   id: 9K8lB61dl3Y
 ---
 
-Version control systems (VCSs) are tools used to track changes to source code
-(or other collections of files and folders). As the name implies, these tools
-help maintain a history of changes; furthermore, they facilitate collaboration.
-Logically, VCSs track changes to a folder and its contents in a series of
-_snapshots_, where each snapshot encapsulates the entire state of files/folders
-within a top-level directory. VCSs also maintain metadata like who created each
-snapshot, messages associated with each snapshot, and so on.
+Sistem version control (VCS) adalah alat yang digunakan untuk melacak perubahan pada source code
+(atau koleksi file dan folder lainnya). Sesuai namanya, alat ini
+membantu mempertahankan riwayat perubahan; selain itu, alat ini juga memfasilitasi kolaborasi.
+Secara logika, VCS melacak perubahan pada sebuah folder dan isinya dalam serangkaian
+_snapshot_, di mana setiap snapshot mencakup keseluruhan state file/folder
+dalam direktori tingkat atas. VCS juga menyimpan metadata seperti siapa yang membuat setiap
+snapshot, pesan yang terkait dengan setiap snapshot, dan sebagainya.
 
-Why is version control useful? Even when you're working by yourself, it can let
-you look at old snapshots of a project, keep a log of why certain changes were
-made, work on parallel branches of development, and much more. When working
-with others, it's an invaluable tool for seeing what other people have changed,
-as well as resolving conflicts in concurrent development.
+Mengapa version control berguna? Bahkan ketika Anda bekerja sendiri, version control memungkinkan Anda
+melihat snapshot lama dari sebuah proyek, menyimpan log alasan mengapa perubahan tertentu
+dibuat, bekerja pada branch pengembangan secara paralel, dan masih banyak lagi. Ketika bekerja
+dengan orang lain, ini adalah alat yang sangat berharga untuk melihat apa yang telah diubah oleh orang lain,
+serta menyelesaikan konflik dalam pengembangan secara bersamaan.
 
-Modern VCSs also let you easily (and often automatically) answer questions
-like:
+VCS modern juga memungkinkan Anda untuk dengan mudah (dan sering kali secara otomatis) menjawab pertanyaan
+seperti:
 
-- Who wrote this module?
-- When was this particular line of this particular file edited? By whom? Why
-  was it edited?
-- Over the last 1000 revisions, when/why did a particular unit test stop
-working?
+- Siapa yang menulis modul ini?
+- Kapan baris tertentu dari file tertentu ini diedit? Oleh siapa? Mengapa
+  baris ini diedit?
+- Dalam 1000 revisi terakhir, kapan/mengapa unit test tertentu berhenti
+bekerja?
 
-While other VCSs exist, **Git** is the de facto standard for version control.
-This [XKCD comic](https://xkcd.com/1597/) captures Git's reputation:
+Meskipun ada VCS lain, **Git** adalah standar de facto untuk version control.
+[Komik XKCD](https://xkcd.com/1597/) ini menggambarkan reputasi Git:
 
 ![xkcd 1597](https://imgs.xkcd.com/comics/git.png)
 
-Because Git's interface is a leaky abstraction, learning Git top-down (starting
-with its interface / command-line interface) can lead to a lot of confusion.
-It's possible to memorize a handful of commands and think of them as magic
-incantations, and follow the approach in the comic above whenever anything goes
-wrong.
+Karena antarmuka Git merupakan abstraksi yang bocor, mempelajari Git dari atas ke bawah
+(dimulai dari antarmuka / command-line interface) dapat menyebabkan banyak kebingungan.
+Anda mungkin bisa menghafal beberapa perintah dan menganggapnya sebagai mantra ajaib,
+serta mengikuti pendekatan dalam komik di atas setiap kali ada yang salah.
 
-While Git admittedly has an ugly interface, its underlying design and ideas are
-beautiful. While an ugly interface has to be _memorized_, a beautiful design
-can be _understood_. For this reason, we give a bottom-up explanation of Git,
-starting with its data model and later covering the command-line interface.
-Once the data model is understood, the commands can be better understood in
-terms of how they manipulate the underlying data model.
+Meskipun Git memang memiliki antarmuka yang kurang menarik, desain dan ide di baliknya
+sangat indah. Meskipun antarmuka yang kurang menarik harus _dihafal_, desain yang indah
+dapat _dipahami_. Oleh karena itu, kami memberikan penjelasan Git dari bawah ke atas,
+dimulai dari model datanya dan kemudian membahas command-line interface.
+Setelah model data dipahami, perintah-perintah dapat lebih dipahami dalam
+hal bagaimana mereka memanipulasi model data yang mendasarinya.
 
-# Git's data model
+# Model data Git
 
-Git's ingenuity is in its well-thought-out data model that enables all the nice
-features of version control, like maintaining history, supporting branches, and
-enabling collaboration.
+Kejeniusan Git terletak pada model datanya yang dirancang dengan baik yang memungkinkan semua fitur
+bagus dari version control, seperti mempertahankan riwayat history, mendukung branch, dan
+memungkinkan kolaborasi.
 
-## Snapshots
+## Snapshot
 
-Git models the history of a collection of files and folders within some
-top-level directory as a series of snapshots. In Git terminology, a file is
-called a "blob", and it's just a bunch of bytes. A directory is called a
-"tree", and it maps names to blobs or trees (so directories can contain other
-directories). A snapshot is the top-level tree that is being tracked. For
-example, we might have a tree as follows:
+Git memodelkan riwayat koleksi file dan folder dalam suatu
+direktori tingkat atas sebagai serangkaian snapshot. Dalam terminologi Git, sebuah file disebut
+"blob", dan isinya hanyalah sekumpulan byte. Sebuah direktori disebut
+"tree", dan ia memetakan nama ke blob atau tree (sehingga direktori dapat berisi direktori
+lain). Sebuah snapshot adalah tree tingkat atas yang sedang dilacak. Sebagai
+contoh, kita mungkin memiliki tree sebagai berikut:
 
 ```
 <root> (tree)
@@ -77,24 +76,24 @@ example, we might have a tree as follows:
 +- baz.txt (blob, contents = "git is wonderful")
 ```
 
-The top-level tree contains two elements, a tree "foo" (that itself contains
-one element, a blob "bar.txt"), and a blob "baz.txt".
+Tree tingkat atas berisi dua elemen, sebuah tree "foo" (yang berisi
+satu elemen, sebuah blob "bar.txt"), dan sebuah blob "baz.txt".
 
-## Modeling history: relating snapshots
+## Memodelkan riwayat: menghubungkan snapshot
 
-How should a version control system relate snapshots? One simple model would be
-to have a linear history. A history would be a list of snapshots in time-order.
-For many reasons, Git doesn't use a simple model like this.
+Bagaimana seharusnya sistem version control menghubungkan snapshot? Satu model sederhana adalah
+memiliki riwayat linear. Sebuah riwayat akan menjadi daftar snapshot dalam urutan waktu.
+Karena banyak alasan, Git tidak menggunakan model sederhana seperti ini.
 
-In Git, a history is a directed acyclic graph (DAG) of snapshots. That may
-sound like a fancy math word, but don't be intimidated. All this means is that
-each snapshot in Git refers to a set of "parents", the snapshots that preceded
-it. It's a set of parents rather than a single parent (as would be the case in
-a linear history) because a snapshot might descend from multiple parents, for
-example, due to combining (merging) two parallel branches of development.
+Dalam Git, sebuah riwayat adalah directed acyclic graph (DAG) dari snapshot. Itu mungkin
+terdengar seperti istilah matematika yang rumit, tetapi jangan terintimidasi. Artinya adalah
+setiap snapshot di Git merujuk pada sekumpulan "parent", yaitu snapshot-snapshot yang mendahuluinya.
+Ini adalah sekumpulan parent, bukan satu parent (seperti yang terjadi pada
+riwayat linear), karena sebuah snapshot bisa berasal dari beberapa parent, misalnya
+karena penggabungan (merge) dua branch pengembangan yang paralel.
 
-Git calls these snapshots "commit"s. Visualizing a commit history might look
-something like this:
+Git menyebut snapshot-snapshot ini sebagai "commit". Memvisualisasikan riwayat commit mungkin terlihat
+seperti ini:
 
 ```
 o <-- o <-- o <-- o
@@ -103,14 +102,14 @@ o <-- o <-- o <-- o
               --- o <-- o
 ```
 
-In the ASCII art above, the `o`s correspond to individual commits (snapshots).
-The arrows point to the parent of each commit (it's a "comes before" relation,
-not "comes after"). After the third commit, the history branches into two
-separate branches. This might correspond to, for example, two separate features
-being developed in parallel, independently from each other. In the future,
-these branches may be merged to create a new snapshot that incorporates both of
-the features, producing a new history that looks like this, with the newly
-created merge commit shown in bold:
+Dalam ASCII art di atas, `o` mewakili commit individual (snapshot).
+Panah menunjuk ke parent dari setiap commit (ini adalah relasi "datang sebelum",
+bukan "datang setelah"). Setelah commit ketiga, riwayat bercabang menjadi dua
+branch terpisah. Ini mungkin sesuai dengan, misalnya, dua fitur terpisah
+yang dikembangkan secara paralel, secara independen satu sama lain. Di masa depan,
+branch-branch ini mungkin digabungkan untuk membuat snapshot baru yang mencakup kedua
+fitur tersebut, menghasilkan riwayat baru yang terlihat seperti ini, dengan commit merge
+yang baru dibuat ditunjukkan dalam huruf tebal:
 
 <pre class="highlight">
 <code>
@@ -121,14 +120,14 @@ o <-- o <-- o <-- o <---- <strong>o</strong>
 </code>
 </pre>
 
-Commits in Git are immutable. This doesn't mean that mistakes can't be
-corrected, however; it's just that "edits" to the commit history are actually
-creating entirely new commits, and references (see below) are updated to point
-to the new ones.
+Commit di Git bersifat immutable. Ini bukan berarti kesalahan tidak bisa
+diperbaiki; hanya saja "suntingan" pada riwayat commit sebenarnya
+membuat commit yang sama sekali baru, dan referensi (lihat di bawah) diperbarui untuk menunjuk
+ke yang baru.
 
-## Data model, as pseudocode
+## Model data, dalam pseudocode
 
-It may be instructive to see Git's data model written down in pseudocode:
+Mungkin bermanfaat untuk melihat model data Git dituliskan dalam pseudocode:
 
 ```
 // a file is a bunch of bytes
@@ -146,18 +145,18 @@ type commit = struct {
 }
 ```
 
-It's a clean, simple model of history.
+Ini adalah model riwayat yang bersih dan sederhana.
 
-## Objects and content-addressing
+## Object dan content-addressing
 
-An "object" is a blob, tree, or commit:
+Sebuah "object" adalah blob, tree, atau commit:
 
 ```
 type object = blob | tree | commit
 ```
 
-In Git's data store, all objects are content-addressed by their [SHA-1
-hash](https://en.wikipedia.org/wiki/SHA-1).
+Dalam penyimpanan data Git, semua object di-address berdasarkan [hash
+SHA-1](https://en.wikipedia.org/wiki/SHA-1) mereka.
 
 ```
 objects = map<string, object>
@@ -170,38 +169,37 @@ def load(id):
     return objects[id]
 ```
 
-Blobs, trees, and commits are unified in this way: they are all objects. When
-they reference other objects, they don't actually _contain_ them in their
-on-disk representation, but have a reference to them by their hash.
+Blob, tree, dan commit disatukan dengan cara ini: mereka semua adalah object. Ketika
+mereka mereferensikan object lain, mereka sebenarnya tidak _berisi_ object tersebut dalam
+representasi on-disk mereka, tetapi memiliki referensi ke object tersebut melalui hash-nya.
 
-For example, the tree for the example directory structure [above](#snapshots)
-(visualized using `git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d`),
-looks like this:
+Sebagai contoh, tree untuk struktur direktori contoh [di atas](#snapshots)
+(divisualisasikan menggunakan `git cat-file -p 698281bc680d1995c5f4caaf3359721a5a58d48d`),
+terlihat seperti ini:
 
 ```
 100644 blob 4448adbf7ecd394f42ae135bbeed9676e894af85    baz.txt
 040000 tree c68d233a33c5c06e0340e4c224f0afca87c8ce87    foo
 ```
 
-The tree itself contains pointers to its contents, `baz.txt` (a blob) and `foo`
-(a tree). If we look at the contents addressed by the hash corresponding to
-baz.txt with `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85`, we get
-the following:
+Tree itu sendiri berisi pointer ke isinya, `baz.txt` (sebuah blob) dan `foo`
+(sebuah tree). Jika kita melihat isi yang di-address oleh hash yang sesuai dengan
+baz.txt menggunakan `git cat-file -p 4448adbf7ecd394f42ae135bbeed9676e894af85`, kita mendapatkan:
 
 ```
 git is wonderful
 ```
 
-## References
+## Reference
 
-Now, all snapshots can be identified by their SHA-1 hashes. That's inconvenient,
-because humans aren't good at remembering strings of 40 hexadecimal characters.
+Sekarang, semua snapshot dapat diidentifikasi oleh hash SHA-1 mereka. Itu tidak praktis,
+karena manusia tidak pandai mengingat string yang terdiri dari 40 karakter heksadesimal.
 
-Git's solution to this problem is human-readable names for SHA-1 hashes, called
-"references". References are pointers to commits. Unlike objects, which are
-immutable, references are mutable (can be updated to point to a new commit).
-For example, the `master` reference usually points to the latest commit in the
-main branch of development.
+Solusi Git untuk masalah ini adalah nama yang mudah dibaca manusia untuk hash SHA-1, yang disebut
+"reference". Reference adalah pointer ke commit. Berbeda dengan object yang bersifat
+immutable, reference bersifat mutable (dapat diperbarui untuk menunjuk ke commit yang baru).
+Sebagai contoh, reference `master` biasanya menunjuk ke commit terbaru di
+branch utama pengembangan.
 
 ```
 references = map<string, string>
@@ -219,214 +217,214 @@ def load_reference(name_or_id):
         return load(name_or_id)
 ```
 
-With this, Git can use human-readable names like "master" to refer to a
-particular snapshot in the history, instead of a long hexadecimal string.
+Dengan ini, Git dapat menggunakan nama yang mudah dibaca manusia seperti "master" untuk merujuk ke
+snapshot tertentu dalam riwayat, alih-alih string heksadesimal yang panjang.
 
-One detail is that we often want a notion of "where we currently are" in the
-history, so that when we take a new snapshot, we know what it is relative to
-(how we set the `parents` field of the commit). In Git, that "where we
-currently are" is a special reference called "HEAD".
+Satu detail adalah kita sering kali membutuhkan konsep "di mana kita saat ini" dalam
+riwayat, sehingga ketika kita mengambil snapshot baru, kita tahu snapshot itu relatif terhadap apa
+(bagaimana kita mengatur field `parents` dari commit). Di Git, "di mana kita
+saat ini" adalah reference khusus yang disebut "HEAD".
 
-## Repositories
+## Repository
 
-Finally, we can define what (roughly) is a Git _repository_: it is the data
-`objects` and `references`.
+Terakhir, kita dapat mendefinisikan apa yang (kira-kira) merupakan _repository_ Git: yaitu data
+`objects` dan `references`.
 
-On disk, all Git stores are objects and references: that's all there is to Git's
-data model. All `git` commands map to some manipulation of the commit DAG by
-adding objects and adding/updating references.
+Di disk, semua penyimpanan Git adalah object dan reference: hanya itu model data Git.
+Semua perintah `git` memetakan ke beberapa manipulasi pada DAG commit dengan
+menambahkan object dan menambahkan/memperbarui reference.
 
-Whenever you're typing in any command, think about what manipulation the
-command is making to the underlying graph data structure. Conversely, if you're
-trying to make a particular kind of change to the commit DAG, e.g. "discard
-uncommitted changes and make the 'master' ref point to commit `5d83f9e`", there's
-probably a command to do it (e.g. in this case, `git checkout master; git reset
+Setiap kali Anda mengetik perintah apa pun, pikirkanlah manipulasi apa yang
+dibuat perintah tersebut pada struktur data graph yang mendasarinya. Sebaliknya, jika Anda
+mencoba membuat perubahan tertentu pada DAG commit, misalnya "buang perubahan yang belum
+di-commit dan buat ref 'master' menunjuk ke commit `5d83f9e`", kemungkinan ada
+perintah untuk melakukannya (misalnya dalam kasus ini, `git checkout master; git reset
 --hard 5d83f9e`).
 
 # Staging area
 
-This is another concept that's orthogonal to the data model, but it's a part of
-the interface to create commits.
+Ini adalah konsep lain yang ortogonal terhadap model data, tetapi merupakan bagian dari
+antarmuka untuk membuat commit.
 
-One way you might imagine implementing snapshotting as described above is to have
-a "create snapshot" command that creates a new snapshot based on the _current
-state_ of the working directory. Some version control tools work like this, but
-not Git. We want clean snapshots, and it might not always be ideal to make a
-snapshot from the current state. For example, imagine a scenario where you've
-implemented two separate features, and you want to create two separate commits,
-where the first introduces the first feature, and the next introduces the
-second feature. Or imagine a scenario where you have debugging print statements
-added all over your code, along with a bugfix; you want to commit the bugfix
-while discarding all the print statements.
+Salah satu cara yang mungkin Anda bayangkan untuk mengimplementasikan snapshot seperti yang dijelaskan di atas adalah
+dengan memiliki perintah "create snapshot" yang membuat snapshot baru berdasarkan _state
+saat ini_ dari working directory. Beberapa alat version control bekerja seperti ini, tetapi
+bukan Git. Kita menginginkan snapshot yang bersih, dan mungkin tidak selalu ideal untuk membuat
+snapshot dari state saat ini. Sebagai contoh, bayangkan skenario di mana Anda telah
+mengimplementasikan dua fitur terpisah, dan Anda ingin membuat dua commit terpisah,
+di mana yang pertama memperkenalkan fitur pertama, dan yang berikutnya memperkenalkan
+fitur kedua. Atau bayangkan skenario di mana Anda memiliki print statement untuk debugging
+yang ditambahkan di seluruh kode Anda, bersama dengan sebuah bugfix; Anda ingin meng-commit bugfix
+tersebut sambil membuang semua print statement.
 
-Git accommodates such scenarios by allowing you to specify which modifications
-should be included in the next snapshot through a mechanism called the "staging
+Git mengakomodasi skenario seperti ini dengan memungkinkan Anda menentukan modifikasi mana
+yang harus disertakan dalam snapshot berikutnya melalui mekanisme yang disebut "staging
 area".
 
-# Git command-line interface
+# Command-line interface Git
 
-To avoid duplicating information, we're not going to explain the commands below
-in detail in these lecture notes. See the highly recommended [Pro
-Git](https://git-scm.com/book/en/v2) for more information, or watch the lecture
-video.
+Untuk menghindari duplikasi informasi, kami tidak akan menjelaskan perintah-perintah di bawah ini
+secara detail dalam catatan kuliah ini. Lihat [Pro
+Git](https://git-scm.com/book/en/v2) yang sangat direkomendasikan untuk informasi lebih lanjut, atau tonton video
+kuliah.
 
-## Basics
+## Dasar-dasar
 
-- `git help <command>`: get help for a git command
-- `git init`: creates a new git repo, with data stored in the `.git` directory
-- `git status`: tells you what's going on
-- `git add <filename>`: adds files to staging area
-- `git commit`: creates a new commit
-    - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)!
-    - Even more reasons to write [good commit messages](https://chris.beams.io/posts/git-commit/)!
-- `git log`: shows a flattened log of history
-- `git log --all --graph --decorate`: visualizes history as a DAG
-- `git diff <filename>`: show changes you made relative to the staging area
-- `git diff <revision> <filename>`: shows differences in a file between snapshots
-- `git checkout <revision>`: updates HEAD (and current branch if checking out a branch)
+- `git help <command>`: mendapatkan bantuan untuk perintah git
+- `git init`: membuat repo git baru, dengan data disimpan di direktori `.git`
+- `git status`: memberi tahu Anda apa yang sedang terjadi
+- `git add <filename>`: menambahkan file ke staging area
+- `git commit`: membuat commit baru
+    - Tulis [pesan commit yang baik](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)!
+    - Alasan tambahan untuk menulis [pesan commit yang baik](https://chris.beams.io/posts/git-commit/)!
+- `git log`: menampilkan log riwayat yang diratakan
+- `git log --all --graph --decorate`: memvisualisasikan riwayat sebagai DAG
+- `git diff <filename>`: menampilkan perubahan yang Anda buat relatif terhadap staging area
+- `git diff <revision> <filename>`: menampilkan perbedaan dalam file antar snapshot
+- `git checkout <revision>`: memperbarui HEAD (dan branch saat ini jika melakukan checkout sebuah branch)
 
-## Branching and merging
+## Branching dan merging
 
-- `git branch`: shows branches
-- `git branch <name>`: creates a branch
-- `git switch <name>`: switches to a branch
-- `git checkout -b <name>`: creates a branch and switches to it
-    - same as `git branch <name>; git switch <name>`
-- `git merge <revision>`: merges into current branch
-- `git mergetool`: use a fancy tool to help resolve merge conflicts
-- `git rebase`: rebase set of patches onto a new base
+- `git branch`: menampilkan branch
+- `git branch <name>`: membuat branch
+- `git switch <name>`: berpindah ke branch
+- `git checkout -b <name>`: membuat branch dan berpindah ke branch tersebut
+    - sama dengan `git branch <name>; git switch <name>`
+- `git merge <revision>`: menggabungkan ke branch saat ini
+- `git mergetool`: menggunakan alat bantu untuk membantu menyelesaikan konflik merge
+- `git rebase`: rebase sekumpulan patch ke base yang baru
 
-## Remotes
+## Remote
 
-- `git remote`: list remotes
-- `git remote add <name> <url>`: add a remote
-- `git push <remote> <local branch>:<remote branch>`: send objects to remote, and update remote reference
-- `git branch --set-upstream-to=<remote>/<remote branch>`: set up correspondence between local and remote branch
-- `git fetch`: retrieve objects/references from a remote
-- `git pull`: same as `git fetch; git merge`
-- `git clone`: download repository from remote
+- `git remote`: daftar remote
+- `git remote add <name> <url>`: menambahkan remote
+- `git push <remote> <local branch>:<remote branch>`: mengirim object ke remote, dan memperbarui reference remote
+- `git branch --set-upstream-to=<remote>/<remote branch>`: mengatur korespondensi antara branch lokal dan remote
+- `git fetch`: mengambil object/reference dari remote
+- `git pull`: sama dengan `git fetch; git merge`
+- `git clone`: mengunduh repository dari remote
 
 ## Undo
 
-- `git commit --amend`: edit a commit's contents/message
-- `git reset <file>`: unstage a file
-- `git restore`: discard changes
+- `git commit --amend`: mengedit isi/pesan commit
+- `git reset <file>`: menghapus file dari staging area
+- `git restore`: membuang perubahan
 
-# Advanced Git
+# Git Lanjutan
 
-- `git config`: Git is [highly customizable](https://git-scm.com/docs/git-config)
-- `git clone --depth=1`: shallow clone, without entire version history
-- `git add -p`: interactive staging
-- `git rebase -i`: interactive rebasing
-- `git blame`: show who last edited which line
-- `git stash`: temporarily remove modifications to working directory
-- `git bisect`: binary search history (e.g. for regressions)
-- `git revert`: create a new commit that reverses the effect of an earlier commit
-- `git worktree`: check out multiple branches at the same time
-- `.gitignore`: [specify](https://git-scm.com/docs/gitignore) intentionally untracked files to ignore
+- `git config`: Git [sangat dapat dikustomisasi](https://git-scm.com/docs/git-config)
+- `git clone --depth=1`: shallow clone, tanpa seluruh riwayat versi
+- `git add -p`: staging interaktif
+- `git rebase -i`: rebasing interaktif
+- `git blame`: menampilkan siapa yang terakhir mengedit baris tertentu
+- `git stash`: menghapus sementara modifikasi pada working directory
+- `git bisect`: pencarian biner pada riwayat (misalnya untuk regresi)
+- `git revert`: membuat commit baru yang membalik efek dari commit sebelumnya
+- `git worktree`: checkout beberapa branch secara bersamaan
+- `.gitignore`: [menentukan](https://git-scm.com/docs/gitignore) file yang sengaja tidak dilacak untuk diabaikan
 
-# Miscellaneous
+# Lain-lain
 
-- **GUIs**: there are many [GUI clients](https://git-scm.com/downloads/guis)
-out there for Git. We personally don't use them and use the command-line
-interface instead.
-- **Shell integration**: it's super handy to have a Git status as part of your
-shell prompt ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
-[bash](https://github.com/magicmonty/bash-git-prompt)). Often included in
-frameworks like [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
-- **Editor integration**: similarly to the above, handy integrations with many
-features. [fugitive.vim](https://github.com/tpope/vim-fugitive) is the standard
-one for Vim.
-- **Workflows**: we taught you the data model, plus some basic commands; we
-didn't tell you what practices to follow when working on big projects (and
-there are [many](https://nvie.com/posts/a-successful-git-branching-model/)
-[different](https://www.endoflineblog.com/gitflow-considered-harmful)
-[approaches](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)).
-- **GitHub**: Git is not GitHub. GitHub has a specific way of contributing code
-to other projects, called [pull
-requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
-- **Other Git providers**: GitHub is not special: there are many Git repository
-hosts, like [GitLab](https://about.gitlab.com/) and
+- **GUI**: ada banyak [klien GUI](https://git-scm.com/downloads/guis)
+untuk Git. Kami pribadi tidak menggunakannya dan lebih memilih menggunakan
+command-line interface.
+- **Integrasi shell**: sangat berguna untuk memiliki status Git sebagai bagian dari
+prompt shell Anda ([zsh](https://github.com/olivierverdier/zsh-git-prompt),
+[bash](https://github.com/magicmonty/bash-git-prompt)). Seringkali sudah termasuk dalam
+framework seperti [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
+- **Integrasi editor**: serupa dengan di atas, integrasi yang berguna dengan banyak
+fitur. [fugitive.vim](https://github.com/tpope/vim-fugitive) adalah standar
+untuk Vim.
+- **Workflow**: kami mengajarkan Anda model data, ditambah beberapa perintah dasar; kami
+tidak memberitahu Anda praktik apa yang harus diikuti ketika mengerjakan proyek besar (dan
+ada [banyak](https://nvie.com/posts/a-successful-git-branching-model/)
+[berbeda](https://www.endoflineblog.com/gitflow-considered-harmful)
+[pendekatan](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)).
+- **GitHub**: Git bukan GitHub. GitHub memiliki cara khusus untuk berkontribusi kode
+ke proyek lain, yang disebut [pull
+request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+- **Penyedia Git lainnya**: GitHub bukanlah yang istimewa: ada banyak penyedia
+repository Git, seperti [GitLab](https://about.gitlab.com/) dan
 [BitBucket](https://bitbucket.org/).
 
-# Resources
+# Sumber Daya
 
-- [Pro Git](https://git-scm.com/book/en/v2) is **highly recommended reading**.
-Going through Chapters 1--5 should teach you most of what you need to use Git
-proficiently, now that you understand the data model. The later chapters have
-some interesting, advanced material.
-- [Oh Shit, Git!?!](https://ohshitgit.com/) is a short guide on how to recover
-from some common Git mistakes.
+- [Pro Git](https://git-scm.com/book/en/v2) adalah **bacaan yang sangat direkomendasikan**.
+Membaca Bab 1--5 seharusnya mengajarkan Anda sebagian besar yang perlu Anda ketahui untuk menggunakan Git
+dengan mahir, sekarang Anda sudah memahami model datanya. Bab-bab selanjutnya memiliki
+beberapa materi menarik dan lanjutan.
+- [Oh Shit, Git!?!](https://ohshitgit.com/) adalah panduan singkat tentang cara memulihkan
+dari beberapa kesalahan umum Git.
 - [Git for Computer
-Scientists](https://eagain.net/articles/git-for-computer-scientists/) is a
-short explanation of Git's data model, with less pseudocode and more fancy
-diagrams than these lecture notes.
+Scientists](https://eagain.net/articles/git-for-computer-scientists/) adalah
+penjelasan singkat tentang model data Git, dengan lebih sedikit pseudocode dan lebih banyak diagram
+yang bagus daripada catatan kuliah ini.
 - [Git from the Bottom Up](https://jwiegley.github.io/git-from-the-bottom-up/)
-is a detailed explanation of Git's implementation details beyond just the data
-model, for the curious.
+adalah penjelasan detail tentang detail implementasi Git di luar hanya model
+data, bagi yang penasaran.
 - [How to explain git in simple
 words](https://smusamashah.github.io/blog/2017/10/14/explain-git-in-simple-words)
-- [Learn Git Branching](https://learngitbranching.js.org/) is a browser-based
-game that teaches you Git.
+- [Learn Git Branching](https://learngitbranching.js.org/) adalah game
+berbasis browser yang mengajari Anda Git.
 
-# Exercises
+# Latihan
 
-1. If you don't have any past experience with Git, either try reading the first
-   couple chapters of [Pro Git](https://git-scm.com/book/en/v2) or go through a
-   tutorial like [Learn Git Branching](https://learngitbranching.js.org/). As
-   you're working through it, relate Git commands to the data model.
-1. Clone the [repository for the
-class website](https://github.com/missing-semester/missing-semester).
-    1. Explore the version history by visualizing it as a graph.
-    1. Who was the last person to modify `README.md`? (Hint: use `git log` with
-       an argument).
-    1. What was the commit message associated with the last modification to the
-       `collections:` line of `_config.yml`? (Hint: use `git blame` and `git
+1. Jika Anda belum memiliki pengalaman dengan Git, cobalah membaca beberapa
+   bab pertama [Pro Git](https://git-scm.com/book/en/v2) atau ikuti
+   tutorial seperti [Learn Git Branching](https://learngitbranching.js.org/). Saat
+   Anda mengerjakannya, hubungkan perintah-perintah Git dengan model data.
+1. Clone [repository untuk
+   website kelas](https://github.com/missing-semester/missing-semester).
+    1. Jelajahi riwayat versi dengan memvisualisasikannya sebagai graph.
+    1. Siapa orang terakhir yang memodifikasi `README.md`? (Petunjuk: gunakan `git log` dengan
+       sebuah argumen).
+    1. Apa pesan commit yang terkait dengan modifikasi terakhir pada
+       baris `collections:` di `_config.yml`? (Petunjuk: gunakan `git blame` dan `git
        show`).
-1. One common mistake when learning Git is to commit large files that should
-   not be managed by Git or adding sensitive information. Try adding a file to
-   a repository, making some commits and then deleting that file from _history_
-   (not just the latest commit). You may want to look at
-   [this](https://help.github.com/articles/removing-sensitive-data-from-a-repository/).
-1. Clone some repository from GitHub, and modify one of its existing files.
-   What happens when you do `git stash`? What do you see when running `git log
-   --all --oneline`? Run `git stash pop` to undo what you did with `git stash`.
-   In what scenario might this be useful?
-1. Like many command line tools, Git provides a configuration file (or dotfile)
-   called `~/.gitconfig`. Create an alias in `~/.gitconfig` so that when you
-   run `git graph`, you get the output of `git log --all --graph --decorate
-   --oneline`. You can do this by directly
-   [editing](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias)
-   the `~/.gitconfig` file, or you can use the `git config` command to add the
-   alias. Information about git aliases can be found
-   [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
-1. You can define global ignore patterns in `~/.gitignore_global` after running
-   `git config --global core.excludesfile ~/.gitignore_global`. This sets the
-   location of the global ignore file that Git will use, but you still need to
-   manually create the file at that path. Set up your global gitignore file to
-   ignore OS-specific or editor-specific temporary files, like `.DS_Store`.
-1. Fork the [repository for the class
-   website](https://github.com/missing-semester/missing-semester), find a typo
-   or some other improvement you can make, and submit a pull request on GitHub
-   (you may want to look at [this](https://github.com/firstcontributions/first-contributions)).
-   Please only submit PRs that are useful (don't spam us, please!). If you
-   can't find an improvement to make, you can skip this exercise.
-1. Practice resolving merge conflicts by simulating a collaborative scenario:
-    1. Create a new repository with `git init` and create a file called
-       `recipe.txt` with a few lines (e.g., a simple recipe).
-    1. Commit it, then create two branches: `git branch salty` and `git branch
+1. Kesalahan umum saat belajar Git adalah meng-commit file besar yang seharusnya
+   tidak dikelola oleh Git atau menambahkan informasi sensitif. Cobalah menambahkan file ke
+   repository, membuat beberapa commit, kemudian menghapus file tersebut dari _riwayat_
+   (bukan hanya dari commit terbaru). Anda mungkin ingin melihat
+   [ini](https://help.github.com/articles/removing-sensitive-data-from-a-repository/).
+1. Clone beberapa repository dari GitHub, dan modifikasi salah satu file yang ada.
+   Apa yang terjadi ketika Anda melakukan `git stash`? Apa yang Anda lihat ketika menjalankan `git log
+   --all --oneline`? Jalankan `git stash pop` untuk membatalkan apa yang Anda lakukan dengan `git stash`.
+   Dalam skenario apa ini mungkin berguna?
+1. Seperti banyak alat command line, Git menyediakan file konfigurasi (atau dotfile)
+   yang disebut `~/.gitconfig`. Buat sebuah alias di `~/.gitconfig` sehingga ketika Anda
+   menjalankan `git graph`, Anda mendapatkan output dari `git log --all --graph --decorate
+   --oneline`. Anda dapat melakukannya dengan langsung
+   [mengedit](https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias)
+   file `~/.gitconfig`, atau Anda dapat menggunakan perintah `git config` untuk menambahkan
+   alias. Informasi tentang alias git dapat ditemukan
+   [di sini](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases).
+1. Anda dapat mendefinisikan pola ignore global di `~/.gitignore_global` setelah menjalankan
+   `git config --global core.excludesfile ~/.gitignore_global`. Ini mengatur
+   lokasi file ignore global yang akan digunakan Git, tetapi Anda masih perlu
+   membuat file tersebut secara manual di path itu. Siapkan file gitignore global Anda untuk
+   mengabaikan file sementara khusus OS atau editor, seperti `.DS_Store`.
+1. Fork [repository untuk
+   website kelas](https://github.com/missing-semester/missing-semester), temukan typo
+   atau perbaikan lain yang dapat Anda buat, dan ajukan pull request di GitHub
+   (Anda mungkin ingin melihat [ini](https://github.com/firstcontributions/first-contributions)).
+   Harap hanya ajukan PR yang berguna (jangan spam kami!). Jika Anda
+   tidak dapat menemukan perbaikan untuk dibuat, Anda dapat melewati latihan ini.
+1. Latih menyelesaikan konflik merge dengan mensimulasikan skenario kolaboratif:
+    1. Buat repository baru dengan `git init` dan buat file bernama
+       `recipe.txt` dengan beberapa baris (misalnya, resep sederhana).
+    1. Commit, lalu buat dua branch: `git branch salty` dan `git branch
        sweet`.
-    1. In the `salty` branch, modify a line (e.g., change "1 cup sugar" to "1
-       cup salt") and commit.
-    1. In the `sweet` branch, modify the same line differently (e.g., change "1
-       cup sugar" to "2 cups sugar") and commit.
-    1. Now switch to `master` and try `git merge salty`, then `git merge
-       sweet`. What happens? Look at the contents of `recipe.txt` - what do the
-       `<<<<<<<`, `=======`, and `>>>>>>>` markers mean?
-    1. Resolve the conflict by editing the file to keep the content you want,
-       removing the conflict markers, and completing the merge with `git add`
-       and `git commit` (or `git merge --continue`). Alternatively, try using
-       `git mergetool` to resolve the conflict with a graphical or
-       terminal-based merge tool.
-    1. Use `git log --graph --oneline` to visualize the merge history you just
-       created.
+    1. Di branch `salty`, modifikasi sebuah baris (misalnya, ubah "1 cup sugar" menjadi "1
+       cup salt") dan commit.
+    1. Di branch `sweet`, modifikasi baris yang sama secara berbeda (misalnya, ubah "1
+       cup sugar" menjadi "2 cups sugar") dan commit.
+    1. Sekarang pindah ke `master` dan coba `git merge salty`, lalu `git merge
+       sweet`. Apa yang terjadi? Lihat isi dari `recipe.txt` - apa arti
+       marker `<<<<<<<`, `=======`, dan `>>>>>>>`?
+    1. Selesaikan konflik dengan mengedit file untuk menyimpan konten yang Anda inginkan,
+       menghapus marker konflik, dan menyelesaikan merge dengan `git add`
+       dan `git commit` (atau `git merge --continue`). Atau, coba gunakan
+       `git mergetool` untuk menyelesaikan konflik dengan alat merge grafis atau
+       berbasis terminal.
+    1. Gunakan `git log --graph --oneline` untuk memvisualisasikan riwayat merge yang baru
+       saja Anda buat.

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Setup
 title: 'Missing Semester'
-url: https://missing.csail.mit.edu
+description: 'Kuliah Missing Semester dari MIT — versi Bahasa Indonesia'
+url: https://missing-semester-idn.github.io
 thumbnail: "/static/assets/thumbnails/default.png"
 
 # Settings

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,9 +5,9 @@
     <label class="menu-label" for="menu-icon"></label>
     <div class="trigger">
       <div class="trigger-child">
-        <span class="nav-link"><a href="/2026/">lectures</a></span>
-        <span class="nav-link"><a href="/past/">past</a></span>
-        <span class="nav-link"><a href="/about/">about</a></span>
+        <span class="nav-link"><a href="/2026/">kuliah</a></span>
+        <span class="nav-link"><a href="/past/">sebelumnya</a></span>
+        <span class="nav-link"><a href="/about/">tentang</a></span>
       </div>
     </div>
   </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="id">
 
   {% include head.html %}
 

--- a/_layouts/lecture.html
+++ b/_layouts/lecture.html
@@ -10,13 +10,13 @@ layout: default
     <iframe src="https://www.youtube.com/embed/{{ page.video.id }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 {% elsif page.panopto %}
-  <p class="center padded bordered"><strong><a href="{{ page.panopto }}">Click here to view the raw lecture video on Panopto (MIT Kerberos login required).</a></strong><br>
-  An edited version of this video will be posted after the course is over. Edited lecture videos will be posted to YouTube shortly after the conclusion of the course.</p>
+  <p class="center padded bordered"><strong><a href="{{ page.panopto }}">Klik di sini untuk melihat video kuliah mentah di Panopto (diperlukan login Kerberos MIT).</a></strong><br>
+  Versi suntingan dari video ini akan diposting setelah kursus selesai. Video kuliah yang telah disunting akan diposting ke YouTube segera setelah kursus berakhir.</p>
 {% elsif page.last_year %}
-  <p class="center padded bordered"><strong><a href="{{ page.last_year }}">Click here to view last year's lecture video.</a></strong><br>
-  This year's lecture video is coming soon.</p>
+  <p class="center padded bordered"><strong><a href="{{ page.last_year }}">Klik di sini untuk melihat video kuliah tahun lalu.</a></strong><br>
+  Video kuliah tahun ini akan segera tersedia.</p>
 {% elsif page.video %}
-  <p class="center padded bordered"><strong>Lecture video coming soon!</strong></p>
+  <p class="center padded bordered"><strong>Video kuliah akan segera tersedia!</strong></p>
 {% endif %}
 
 {{ content }}
@@ -24,6 +24,6 @@ layout: default
 <hr>
 
 <div class="small center">
-<p><a href="https://github.com/missing-semester/missing-semester/blob/master/{{ page.path }}">Edit this page</a>.</p>
-<p>Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0">CC BY-NC-SA</a>.</p>
+<p><a href="https://github.com/missing-semester/missing-semester/blob/master/{{ page.path }}">Sunting halaman ini</a>.</p>
+<p>Dilisensikan di bawah <a href="https://creativecommons.org/licenses/by-nc-sa/4.0">CC BY-NC-SA</a>.</p>
 </div>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -14,6 +14,6 @@ layout: null
     <script>
       window.location = '{{ page.redirect }}';
     </script>
-    <p>Redirecting you to <a href="{{ page.redirect }}">{{ page.redirect }}</a></p>
+    <p>Mengalihkan Anda ke <a href="{{ page.redirect }}">{{ page.redirect }}</a></p>
   </body>
 </html>

--- a/about.md
+++ b/about.md
@@ -1,53 +1,52 @@
 ---
 layout: lecture
-title: "Why we are teaching this class"
+title: "Mengapa kami mengajarkan kelas ini"
 ---
 
-During a traditional Computer Science education, chances are you will take
-plenty of classes that teach you advanced topics within CS, everything from
-Operating Systems to Programming Languages to Machine Learning. But at many
-institutions there is one essential topic that is rarely covered and is instead
-left for students to pick up on their own: computing ecosystem literacy.
+Dalam pendidikan Ilmu Komputer tradisional, kemungkinan besar Anda akan mengambil
+banyak kelas yang mengajarkan topik-topik lanjutan dalam ilmu komputer, mulai dari
+Sistem Operasi hingga Bahasa Pemrograman hingga Machine Learning. Namun di banyak
+institusi, ada satu topik penting yang jarang dibahas dan justru
+dibiarkan untuk dipelajari sendiri oleh para mahasiswa: literasi ekosistem komputasi.
 
-Over the years, we have helped teach several classes at MIT, and over and over
-we have seen that many students have limited knowledge of the tools available
-to them. Computers were built to automate manual tasks, yet students often
-perform repetitive tasks by hand or fail to take full advantage of powerful
-tools such as version control and text editors. In the best case, this results
-in inefficiencies and wasted time; in the worst case, it results in issues like
-data loss or inability to complete certain tasks.
+Selama bertahun-tahun, kami telah membantu mengajar beberapa kelas di MIT, dan berulang kali
+kami melihat bahwa banyak mahasiswa memiliki pengetahuan terbatas tentang alat-alat yang tersedia
+untuk mereka. Komputer diciptakan untuk mengotomatisasi tugas-tugas manual, namun mahasiswa sering
+melakukan tugas-tugas berulang secara manual atau gagal memanfaatkan sepenuhnya alat-alat canggih
+seperti version control dan text editor. Dalam kasus terbaik, ini mengakibatkan
+inefisiensi dan waktu yang terbuang; dalam kasus terburuk, ini mengakibatkan masalah seperti
+kehilangan data atau ketidakmampuan menyelesaikan tugas tertentu.
 
-These topics are not taught as part of the university curriculum: students are
-never shown how to use these tools, or at least not how to use them
-efficiently, and thus waste time and effort on tasks that _should_ be simple.
-The standard CS curriculum is missing critical topics about the computing
-ecosystem that could make students' lives significantly easier.
+Topik-topik ini tidak diajarkan sebagai bagian dari kurikulum universitas: mahasiswa
+tidak pernah ditunjukkan cara menggunakan alat-alat ini, atau setidaknya tidak cara menggunakannya
+secara efisien, sehingga membuang waktu dan usaha untuk tugas-tugas yang _seharusnya_ sederhana.
+Kurikulum ilmu komputer standar tidak mencakup topik-topik penting tentang ekosistem komputasi
+yang dapat membuat kehidupan mahasiswa jauh lebih mudah.
 
-# The missing semester of your CS education
+# Semester yang hilang dari pendidikan ilmu komputer Anda
 
-To help remedy this, we created a class that covers all the topics we
-consider crucial to be an effective computer scientist and programmer. The
-class is pragmatic and practical, and it provides hands-on introduction to
-tools and techniques that you can immediately apply in a wide variety of
-situations you will encounter. The latest iteration of this class, with
-substantially revised material, is being run during MIT's "Independent
-Activities Period" in January 2026 — a one-month semester that features shorter
-student-run classes. While the lectures themselves are only available to the MIT
-community, we will provide all lecture materials along with video recordings of
-lectures to the public.
+Untuk membantu mengatasi hal ini, kami membuat kelas yang mencakup semua topik yang kami
+anggap penting untuk menjadi ilmuwan komputer dan programmer yang efektif. Kelas ini
+bersifat pragmatis dan praktis, dan memberikan pengenalan langsung terhadap
+alat-alat dan teknik yang dapat langsung Anda terapkan dalam berbagai situasi
+yang akan Anda hadapi. Iterasi terbaru kelas ini, dengan
+materi yang telah direvisi secara substansial, diadakan selama "Independent
+Activities Period" MIT pada Januari 2026 — semester satu bulan yang menampilkan kelas-kelas
+lebih pendek yang dijalankan oleh mahasiswa. Meskipun kuliah itu sendiri hanya tersedia untuk komunitas MIT,
+kami akan menyediakan semua materi kuliah beserta rekaman video
+kuliah untuk publik.
 
-If this sounds like it might be for you, here are some concrete
-examples of what the class will teach:
+Jika ini terdengar menarik untuk Anda, berikut adalah beberapa contoh konkret
+tentang apa yang akan diajarkan di kelas ini:
 
 ## Command shell
 
-How to automate common and repetitive tasks with aliases, scripts,
-and build systems. No more copy-pasting commands from a text
-document. No more "run these 15 commands one after the other". No
-more "you forgot to run this thing" or "you forgot to pass this
-argument".
+Cara mengotomatisasi tugas-tugas umum dan berulang dengan alias, script,
+dan build system. Tidak perlu lagi copy-paste perintah dari dokumen
+teks. Tidak perlu lagi "jalankan 15 perintah ini satu per satu". Tidak
+perlu lagi "Anda lupa menjalankan ini" atau "Anda lupa memasukkan argumen ini".
 
-For example, searching through your history quickly can be a huge time saver. In the example below we show several tricks related to navigating your shell history for `convert` commands.
+Sebagai contoh, mencari melalui history Anda dengan cepat dapat menghemat banyak waktu. Dalam contoh di bawah kami menunjukkan beberapa trik terkait navigasi history shell Anda untuk perintah `convert`.
 
 <video autoplay="autoplay" loop="loop" controls muted playsinline  oncontextmenu="return false;"  preload="auto"  class="demo">
   <source src="/static/media/demos/history.mp4" type="video/mp4">
@@ -55,52 +54,52 @@ For example, searching through your history quickly can be a huge time saver. In
 
 ## Version control
 
-How to use version control _properly_, and take advantage of it to
-save you from disaster, collaborate with others, and quickly find and
-isolate problematic changes. No more `rm -rf; git clone`. No more
-merge conflicts (well, fewer of them at least). No more huge blocks
-of commented-out code. No more fretting over how to find what broke
-your code. No more "oh no, did we delete the working code?!". We'll
-even teach you how to contribute to other people's projects with pull
-requests!
+Cara menggunakan version control _dengan benar_, dan memanfaatkannya untuk
+menyelamatkan Anda dari bencana, berkolaborasi dengan orang lain, dan dengan cepat menemukan serta
+mengisolasi perubahan yang bermasalah. Tidak perlu lagi `rm -rf; git clone`. Tidak perlu lagi
+merge conflict (setidaknya lebih sedikit). Tidak perlu lagi blok kode besar
+yang dikomentari. Tidak perlu lagi pusing mencari apa yang merusak
+kode Anda. Tidak perlu lagi "oh tidak, apakah kita menghapus kode yang berfungsi?!". Kami bahkan
+akan mengajarkan Anda cara berkontribusi pada proyek orang lain dengan pull
+request!
 
-In the example below we use `git bisect` to find which commit broke a unit test and then we fix it with `git revert`.
+Dalam contoh di bawah kami menggunakan `git bisect` untuk menemukan commit mana yang merusak unit test dan kemudian kami memperbaikinya dengan `git revert`.
 <video autoplay="autoplay" loop="loop" controls muted playsinline  oncontextmenu="return false;"  preload="auto"  class="demo">
   <source src="/static/media/demos/git.mp4" type="video/mp4">
 </video>
 
 ## Text editing
 
-How to efficiently edit files from the command-line, both locally and
-remotely, and take advantage of advanced editor features. No more
-copying files back and forth. No more repetitive file editing.
+Cara mengedit file secara efisien dari command-line, baik secara lokal maupun
+remote, dan memanfaatkan fitur-fitur editor yang canggih. Tidak perlu lagi
+menyalin file bolak-balik. Tidak perlu lagi mengedit file secara berulang.
 
-Vim macros are one of its best features, in the example below we quickly convert an html table to csv format using a nested vim macro.
+Vim macros adalah salah satu fitur terbaiknya, dalam contoh di bawah kami dengan cepat mengkonversi tabel html ke format csv menggunakan nested vim macro.
 <video autoplay="autoplay" loop="loop" controls muted playsinline  oncontextmenu="return false;"  preload="auto"  class="demo">
   <source src="/static/media/demos/vim.mp4" type="video/mp4">
 </video>
 
 ## Remote machines
 
-How to stay sane when working with remote machines using SSH keys and
-terminal multiplexing. No more keeping many terminals open just to
-run two commands at once. No more typing your password every time you
-connect. No more losing everything just because your Internet
-disconnected or you had to reboot your laptop.
+Cara tetap waras ketika bekerja dengan mesin remote menggunakan SSH keys dan
+terminal multiplexing. Tidak perlu lagi membuka banyak terminal hanya untuk
+menjalankan dua perintah sekaligus. Tidak perlu lagi mengetik password setiap kali Anda
+terhubung. Tidak perlu lagi kehilangan semuanya hanya karena Internet
+Anda terputus atau Anda harus me-reboot laptop Anda.
 
-In the example below we use `tmux` to keep sessions alive in remote servers and `mosh` to support network roaming and disconnection.
+Dalam contoh di bawah kami menggunakan `tmux` untuk menjaga sesi tetap hidup di server remote dan `mosh` untuk mendukung roaming jaringan dan diskoneksi.
 
 <video autoplay="autoplay" loop="loop" controls muted playsinline  oncontextmenu="return false;"  preload="auto"  class="demo">
   <source src="/static/media/demos/ssh.mp4" type="video/mp4">
 </video>
 
-## Finding files
+## Mencari file
 
-How to quickly find files that you are looking for. No
-more clicking through files in your project until you find the one
-that has the code you want.
+Cara dengan cepat menemukan file yang Anda cari. Tidak
+perlu lagi mengklik melalui file-file di proyek Anda sampai Anda menemukan yang
+memiliki kode yang Anda inginkan.
 
-In the example below we quickly look for files with `fd` and for code snippets with `rg`. We also quickly `cd` and `vim` recent/frequent files/folder using `fasd`.
+Dalam contoh di bawah kami dengan cepat mencari file dengan `fd` dan mencari cuplikan kode dengan `rg`. Kami juga dengan cepat `cd` dan `vim` file/folder terbaru/sering digunakan menggunakan `fasd`.
 
 <video autoplay="autoplay" loop="loop" controls muted playsinline  oncontextmenu="return false;"  preload="auto"  class="demo">
   <source src="/static/media/demos/find.mp4" type="video/mp4">
@@ -108,33 +107,31 @@ In the example below we quickly look for files with `fd` and for code snippets w
 
 ## Data wrangling
 
-How to quickly and easily modify, view, parse, plot, and compute over
-data and files directly from the command-line. No more copy pasting
-from log files. No more manually computing statistics over data. No
-more spreadsheet plotting.
+Cara dengan cepat dan mudah memodifikasi, melihat, parse, memplot, dan menghitung
+data dan file langsung dari command-line. Tidak perlu lagi copy paste
+dari file log. Tidak perlu lagi menghitung statistik data secara manual. Tidak
+perlu lagi plotting spreadsheet.
 
-## Code quality and continuous integration
+## Kualitas kode dan continuous integration
 
-How to use autoformatting, linting, testing, and code coverage tools to improve
-code quality. No more ugly code. No more regressions. No more code that works
-on your computer but crashes on everyone else's.
+Cara menggunakan autoformatting, linting, testing, dan code coverage tools untuk meningkatkan
+kualitas kode. Tidak perlu lagi kode yang berantakan. Tidak perlu lagi regresi. Tidak perlu lagi kode yang berfungsi
+di komputer Anda tetapi crash di komputer orang lain.
 
-## Beyond the code
+## Di luar kode
 
-How to write great documentation, communicate clearly with open-source
-maintainers, submit actionable issues, and contribute pull requests that get
-merged. No more confused users who can't get started using your software. No
-more ghosting from maintainers.
+Cara menulis dokumentasi yang hebat, berkomunikasi dengan jelas dengan
+maintainer open-source, mengirimkan issue yang dapat ditindaklanjuti, dan berkontribusi pull request yang di-merge. Tidak perlu lagi pengguna yang bingung yang tidak bisa memulai menggunakan software Anda. Tidak
+perlu lagi maintainer yang menghilang.
 
-# Conclusion
+# Kesimpulan
 
-This, and more, will be covered across the 9 class lectures, each including
-exercises for you to get more familiar with the tools on your own. If you can't
-wait until January 2026, you can also take a look at the lectures from the
-[previous offering of the course](/2020/), which covers many of the same
-topics.
+Ini, dan lebih banyak lagi, akan dibahas dalam 9 kuliah, masing-masing termasuk
+latihan untuk Anda agar lebih familiar dengan alat-alat secara mandiri. Jika Anda tidak
+sabar menunggu hingga Januari 2026, Anda juga dapat melihat kuliah dari
+[penawaran kursus sebelumnya](/2020/), yang mencakup banyak topik yang sama.
 
-We hope to see you in January, whether virtually or in person!
+Kami berharap dapat melihat Anda pada bulan Januari, baik secara virtual maupun langsung!
 
 Happy hacking,<br>
-[Anish](https://anish.io/), [Jon](https://thesquareplanet.com/), and [Jose](https://josejg.com/)
+[Anish](https://anish.io/), [Jon](https://thesquareplanet.com/), dan [Jose](https://josejg.com/)

--- a/index.md
+++ b/index.md
@@ -2,35 +2,36 @@
 layout: page
 title: The Missing Semester of Your CS Education
 description: >
-  Master powerful tools that will make you a more productive computer scientist and programmer.
+  Kuasai alat-alat canggih yang akan membuat Anda menjadi ilmuwan komputer dan programmer yang lebih produktif.
 # subtitle: IAP 2026
 subtitle: "2026"
 nositetitle: true
 ---
 
-Classes teach you all about advanced topics within CS, from operating systems
-to machine learning, but there's one critical subject that's rarely covered,
-and is instead left to students to figure out on their own: proficiency with
-their tools. We'll teach you how to master the command-line, use a powerful
-text editor, use fancy features of version control systems, and much more!
+Kuliah mengajarkan Anda semua tentang topik-topik lanjutan dalam ilmu komputer, dari sistem operasi
+hingga machine learning, tetapi ada satu subjek penting yang jarang dibahas,
+dan dibiarkan untuk dipelajari sendiri oleh para mahasiswa: kemahiran menggunakan
+alat-alat mereka. Kami akan mengajarkan Anda cara menguasai command-line, menggunakan
+text editor yang canggih, menggunakan fitur-fitur menarik dari sistem version control,
+dan masih banyak lagi!
 
-Students spend hundreds of hours using these tools over the course of their
-education (and thousands over their career), so it makes sense to make the
-experience as fluid and frictionless as possible. Mastering these tools not
-only enables you to spend less time on figuring out how to bend your tools to
-your will, but it also lets you solve problems that would previously seem
-impossibly complex.
+Mahasiswa menghabiskan ratusan jam menggunakan alat-alat ini selama
+pendidikan mereka (dan ribuan jam selama karier mereka), jadi masuk akal untuk membuat
+pengalaman tersebut selancar dan seefisien mungkin. Menguasai alat-alat ini tidak
+hanya memungkinkan Anda menghabiskan lebih sedikit waktu untuk mencari cara menggunakan alat sesuai
+keinginan Anda, tetapi juga memungkinkan Anda menyelesaikan masalah yang sebelumnya tampak
+sangat kompleks.
 
-These days, many aspects of software engineering are also in flux
-through the introduction of AI-enabled and AI-enhanced tools and
-workflows. When used appropriately and with awareness of their
-shortcomings, these can often provide significant benefits to
-CS practitioners and are thus worth developing working knowledge of.
-Since AI is a cross-functional enabling technology, there is not a
-standalone AI lecture; we've instead folded the use of the latest
-applicable AI tools and techniques into each lecture directly.
+Saat ini, banyak aspek software engineering juga mengalami perubahan
+dengan diperkenalkannya alat dan workflow berbasis AI.
+Ketika digunakan dengan tepat dan dengan kesadaran akan
+keterbatasannya, alat-alat ini sering kali dapat memberikan manfaat signifikan bagi
+praktisi ilmu komputer dan karenanya layak untuk dipelajari.
+Karena AI adalah teknologi yang bersifat lintas fungsi, tidak ada
+kuliah khusus AI; sebaliknya, kami telah mengintegrasikan penggunaan
+alat dan teknik AI terkini ke dalam setiap kuliah secara langsung.
 
-Read about the [motivation behind this class](/about/).
+Baca tentang [motivasi di balik kelas ini](/about/).
 
 {% comment %}
 # Registration
@@ -38,7 +39,7 @@ Read about the [motivation behind this class](/about/).
 Sign up for the IAP 2026 class by filling out this [registration form](https://forms.gle/j2wMzi7qeiZmzEWy9).
 {% endcomment %}
 
-# Syllabus
+# Silabus
 
 {% comment %}
 **Lecture**: [35-225](https://whereis.mit.edu/?go=35), 1:30--2:30pm (_exception_: 3--4pm on Friday 1/16)<br>
@@ -61,9 +62,9 @@ Sign up for the IAP 2026 class by filling out this [registration form](https://f
 {% endfor %}
 </ul>
 
-## Special topics from previous years
+## Topik khusus dari tahun-tahun sebelumnya
 
-The topics we cover vary from year to year. For students who are interested in the complete set of topics we have covered over the years, we highlight topics covered in previous years that we did not cover in 2026.
+Topik yang kami bahas bervariasi dari tahun ke tahun. Untuk mahasiswa yang tertarik pada kumpulan topik lengkap yang telah kami bahas selama bertahun-tahun, kami menyoroti topik-topik yang dibahas pada tahun-tahun sebelumnya yang tidak kami bahas di tahun 2026.
 
 {% comment %} pop to remove default "posts" collection {% endcomment %}
 {% assign sorted_collections = site.collections | sort: 'label' | pop | reverse %}
@@ -92,16 +93,16 @@ from the [previous offering of the course](/2020/), which covers many of the
 same topics.
 {% endcomment %}
 
-# General information
+# Informasi Umum
 
-**Staff**: This class is co-taught by [Anish](https://anish.io/), [Jon](https://thesquareplanet.com/), and [Jose](https://josejg.com/).<br>
-**Questions**: Email us at [missing-semester@mit.edu](mailto:missing-semester@mit.edu).<br>
-**Discussion**: [OSSU Discord](https://ossu.dev/#community) (use `#missing-semester-forum` like you would use Piazza, and `#missing-semester` to chat with the class/instructors).
+**Pengajar**: Kelas ini diajarkan bersama oleh [Anish](https://anish.io/), [Jon](https://thesquareplanet.com/), dan [Jose](https://josejg.com/).<br>
+**Pertanyaan**: Email kami di [missing-semester@mit.edu](mailto:missing-semester@mit.edu).<br>
+**Diskusi**: [OSSU Discord](https://ossu.dev/#community) (gunakan `#missing-semester-forum` seperti Anda menggunakan Piazza, dan `#missing-semester` untuk mengobrol dengan kelas/pengajar).
 
-# Beyond MIT
+# Di Luar MIT
 
-We've also shared this class beyond MIT in the hopes that others may
-benefit from these resources. You can find posts and discussion on
+Kami juga telah membagikan kelas ini di luar MIT dengan harapan orang lain dapat
+memanfaat dari sumber daya ini. Anda dapat menemukan posting dan diskusi di
 
  - Hacker News ([2026](https://news.ycombinator.com/item?id=47124171), [2020](https://news.ycombinator.com/item?id=22226380), [2019](https://news.ycombinator.com/item?id=19078281))
  - Lobsters ([2026](https://lobste.rs/s/q4ykw7/missing_semester_your_cs_education_2026), [2020](https://lobste.rs/s/ti1k98/missing_semester_your_cs_education_mit), [2019](https://lobste.rs/s/h6157x/mit_hacker_tools_lecture_series_on))
@@ -113,49 +114,49 @@ benefit from these resources. You can find posts and discussion on
  - LinkedIn ([2026](https://www.linkedin.com/posts/anishathalye_i-returned-to-mit-during-iap-january-term-activity-7430285026933522433-Ehr9))
  - YouTube ([2026](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L), [2020](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J), [2019](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuiujH1lpn8cA9dsyulbYRv))
 
-# Translations
+# Terjemahan
 
 {% comment %} keep these in alphabetical order {% endcomment %}
 
-- [Arabic](https://missing-semester-ar.github.io/)
+- [Arab](https://missing-semester-ar.github.io/)
 - [Bengali](https://missing-semester-bn.github.io/)
-- [Chinese (Simplified)](https://missing-semester-cn.github.io/)
-- [Chinese (Traditional, Taiwan)](https://missing-semester-tw.github.io/)
-- [German](https://missing-semester-de.github.io/)
-- [Italian](https://missing-semester-it.github.io/)
-- [Japanese](https://missing-semester-jp.github.io/)
+- [Cina (Sederhana)](https://missing-semester-cn.github.io/)
+- [Cina (Tradisional, Taiwan)](https://missing-semester-tw.github.io/)
+- [Jerman](https://missing-semester-de.github.io/)
+- [Italia](https://missing-semester-it.github.io/)
+- [Jepang](https://missing-semester-jp.github.io/)
 - [Kannada](https://missing-semester-kn.github.io/)
-- [Korean](https://missing-semester-kr.github.io/)
-- [Mongolian](https://missing-semester-mn.github.io)
-- [Persian](https://missing-semester-fa.github.io/)
-- [Portuguese](https://missing-semester-pt.github.io/)
-- [Russian](https://missing-semester-rus.github.io/)
-- [Serbian](https://netboxify.com/missing-semester/)
-- [Spanish](https://missing-semester-esp.github.io/)
-- [Swedish](https://den-saknade-terminen.l10n.se/)
-- [Thai](https://missing-semester-th.github.io/)
-- [Turkish](https://missing-semester-tr.github.io/)
-- [Vietnamese](https://missing-semester-vn.github.io/)
+- [Korea](https://missing-semester-kr.github.io/)
+- [Mongolia](https://missing-semester-mn.github.io)
+- [Persia](https://missing-semester-fa.github.io/)
+- [Portugis](https://missing-semester-pt.github.io/)
+- [Rusia](https://missing-semester-rus.github.io/)
+- [Serbia](https://netboxify.com/missing-semester/)
+- [Spanyol](https://missing-semester-esp.github.io/)
+- [Swedia](https://den-saknade-terminen.l10n.se/)
+- [Thailand](https://missing-semester-th.github.io/)
+- [Turki](https://missing-semester-tr.github.io/)
+- [Vietnam](https://missing-semester-vn.github.io/)
 
-Note: these are external links to community translations. We have not vetted
-them.
+Catatan: ini adalah tautan eksternal ke terjemahan komunitas. Kami belum memverifikasi
+isinya.
 
-Have you created a translation of the course notes from this class? Submit a
-[pull request](https://github.com/missing-semester/missing-semester/pulls) so
-we can add it to the list!
+Apakah Anda telah membuat terjemahan catatan kuliah dari kelas ini? Kirimkan
+[pull request](https://github.com/missing-semester/missing-semester/pulls) agar
+kami dapat menambahkannya ke daftar!
 
-## Acknowledgments
+## Ucapan Terima Kasih
 
 {% comment %}
 2026 acks; previous years' acks are on their respective pages
 {% endcomment %}
 
-We thank Elaine Mello and [MIT Open Learning](https://openlearning.mit.edu/) for making it possible for us to record lecture videos. We thank Luis Turino / [SIPB](https://sipb.mit.edu/) for supporting this class as part of [SIPB IAP 2026](https://sipb.mit.edu/iap/).
+Kami mengucapkan terima kasih kepada Elaine Mello dan [MIT Open Learning](https://openlearning.mit.edu/) yang telah memungkinkan kami merekam video kuliah. Kami juga berterima kasih kepada Luis Turino / [SIPB](https://sipb.mit.edu/) yang telah mendukung kelas ini sebagai bagian dari [SIPB IAP 2026](https://sipb.mit.edu/iap/).
 
 ---
 
 <div class="small center">
-<p><a href="https://github.com/missing-semester/missing-semester">Source code</a>.</p>
-<p>Licensed under CC BY-NC-SA.</p>
-<p>See <a href="/license/">here</a> for contribution &amp; translation guidelines.</p>
+<p><a href="https://github.com/missing-semester/missing-semester">Kode sumber</a>.</p>
+<p>Dilisensikan di bawah CC BY-NC-SA.</p>
+<p>Lihat <a href="/license/">di sini</a> untuk panduan kontribusi &amp; terjemahan.</p>
 </div>

--- a/license.md
+++ b/license.md
@@ -1,33 +1,33 @@
 ---
 layout: default
-title: "License"
+title: "Lisensi"
 permalink: /license/
 ---
 
-# License
+# Lisensi
 
-All the content in this course, including the website source code, lecture notes, exercises, and lecture videos is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+Semua konten dalam kursus ini, termasuk kode sumber website, catatan kuliah, latihan, dan video kuliah dilisensikan di bawah [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-This means that you are free to:
-- **Share** — copy and redistribute the material in any medium or format
-- **Adapt** — remix, transform, and build upon the material
+Ini berarti Anda bebas untuk:
+- **Berbagi** — menyalin dan mendistribusikan kembali materi dalam media atau format apa pun
+- **Mengadaptasi** — menggubah, mengubah, dan membangun dari materi tersebut
 
-Under the following terms:
+Dengan ketentuan berikut:
 
-- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
-- **NonCommercial** — You may not use the material for commercial purposes.
-- **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+- **Atribusi** — Anda harus memberikan kredit yang sesuai, menyertakan tautan ke lisensi, dan menunjukkan apakah ada perubahan yang dibuat. Anda dapat melakukannya dengan cara yang wajar, tetapi tidak dengan cara yang menunjukkan bahwa pemberi lisensi mendukung Anda atau penggunaan Anda.
+- **NonKomersial** — Anda tidak boleh menggunakan materi tersebut untuk tujuan komersial.
+- **BerbagiSerupa** — Jika Anda menggubah, mengubah, atau membangun dari materi tersebut, Anda harus mendistribusikan kontribusi Anda di bawah lisensi yang sama dengan aslinya.
 
-This is a human-readable summary of (and not a substitute for) the [license](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
+Ini adalah ringkasan yang dapat dibaca manusia (dan bukan pengganti) dari [lisensi](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 
-## Contribution guidelines
+## Panduan kontribusi
 
-You can submit corrections and suggestions to the course material by submitting issues and pull requests on our GitHub [repo](https://github.com/missing-semester/missing-semester). This includes the captions for the video lectures which are also in the repo (see [here](https://github.com/missing-semester/missing-semester/tree/master/static/files/subtitles/2020)).
+Anda dapat mengirimkan koreksi dan saran untuk materi kursus dengan mengirimkan issue dan pull request di [repo](https://github.com/missing-semester/missing-semester) GitHub kami. Ini termasuk subtitle untuk video kuliah yang juga ada di repo (lihat [di sini](https://github.com/missing-semester/missing-semester/tree/master/static/files/subtitles/2020)).
 
-## Translation guidelines
+## Panduan terjemahan
 
-You are free to translate the lecture notes and exercises as long as you follow the license terms.
-If your translation mirrors the course structure, please contact us so we can link your translated version from our page.
+Anda bebas menerjemahkan catatan kuliah dan latihan selama Anda mengikuti ketentuan lisensi.
+Jika terjemahan Anda mengikuti struktur kursus, silakan hubungi kami sehingga kami dapat menautkan versi terjemahan Anda dari halaman kami.
 
-For translating the video captions, please submit your translations as community contributions in YouTube.
+Untuk menerjemahkan subtitle video, silakan kirimkan terjemahan Anda sebagai kontribusi komunitas di YouTube.
 

--- a/past.md
+++ b/past.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: Past Offerings
+title: Penawaran Sebelumnya
 description: >
-  Find all past offerings of Missing Semester.
+  Temukan semua penawaran sebelumnya dari Missing Semester.
 ---
 
 {% comment %} pop to remove default "posts" collection {% endcomment %}
@@ -13,4 +13,4 @@ description: >
 {% endfor %}
 </ul>
 
-Each year's lectures are fully self-contained. We recommend starting with the most recent version of the material. There is variation in the topics covered year to year, so we continue to host notes and videos for earlier versions of this course.
+Kuliah setiap tahun sepenuhnya mandiri. Kami merekomendasikan untuk memulai dengan versi materi terbaru. Ada variasi dalam topik yang dibahas dari tahun ke tahun, jadi kami terus menyediakan catatan dan video untuk versi kursus sebelumnya.

--- a/static/files/subtitles/2020/command-line.sbv
+++ b/static/files/subtitles/2020/command-line.sbv
@@ -1,2846 +1,2841 @@
 0:00:00.480,0:00:02.480
-Okay, can everyone hear me okay?
+Oke, bisa semua dengar saya dengan baik?
 
 0:00:03.720,0:00:06.160
-Okay, so welcome back.
+Oke, jadi selamat datang kembali.
 
 0:00:06.160,0:00:10.320
-I'm gonna address a couple of items
-in kind of the administratrivia.
+Saya akan membahas beberapa hal
+sekitar administrasi.
 
 0:00:10.640,0:00:13.080
-With the end of the first week,
+Dengan berakhirnya minggu pertama,
 
 0:00:13.179,0:00:16.349
-we sent an email, noticing you that
+kami mengirim email, memberi tahu bahwa
 
 0:00:16.600,0:00:20.219
-we have uploaded the videos for the first
-week, so you can now find them online.
+kami telah mengunggah video untuk minggu pertama,
+jadi kalian bisa menemukannya secara online.
 
 0:00:20.470,0:00:26.670
-They have all the screen recordings for the things
-that we were doing, so you can go back to them.
+Semua rekaman layar untuk hal-hal
+yang kita lakukan sudah tersedia, jadi kalian bisa kembali melihatnya.
 
 0:00:26.830,0:00:31.439
-Look if you're were confused about if
-we did something quick and, again,
+Lihat jika kalian bingung tentang sesuatu
+yang kita lakukan terlalu cepat, dan sekali lagi,
 
 0:00:31.440,0:00:37.560
-feel free to ask us any questions if anything in the
-lecture notes is not clear. We also sent you a
+jangan ragu untuk bertanya jika ada yang tidak jelas
+dari catatan kuliah. Kami juga mengirim
 
 0:00:37.880,0:00:42.360
-survey so you can give us feedback
-about what was not clear,
+survei agar kalian bisa memberi masukan
+tentang apa yang belum jelas,
 
 0:00:42.360,0:00:46.280
-what items you would want a
-more thorough explanation or
+hal apa yang kalian ingin penjelasan
+lebih mendalam, atau
 
 0:00:47.110,0:00:51.749
-just any other item, if you're finding
-the exercises too hard, too easy,
+hal lainnya, jika kalian merasa
+latihannya terlalu sulit, terlalu mudah,
 
 0:00:52.239,0:00:55.288
-go into that URL and we'll really
+masuk ke URL tersebut dan kami sangat
 
 0:00:55.960,0:01:00.040
-appreciate getting that feedback, because
-that will make the course better
+menghargai masukan tersebut, karena
+itu akan membuat kuliah ini lebih baik
 
 0:01:00.480,0:01:03.800
-for the remaining lectures and for
-future iterations of the course.
+untuk kuliah-kuliah berikutnya dan untuk
+iterasi kuliah di masa depan.
 
 0:01:05.080,0:01:07.080
-With that out of the way
+Dengan itu selesai
 
 0:01:07.080,0:01:10.840
-Oh, and we're gonna try to upload the
-videos in a more timely manner.
+Oh, dan kami akan mencoba mengunggah video
+dengan lebih tepat waktu.
 
 0:01:11.200,0:01:16.040
-We don't want to kind of wait until the end of
-the week for that. So keep tuned for that.
+Kami tidak ingin menunggu sampai akhir
+minggu untuk itu. Jadi pantau terus.
 
 0:01:18.760,0:01:19.840
-That out of the way,
+Dengan itu selesai,
 
 0:01:19.920,0:01:20.800
-now I'm gonna
+sekarang saya akan
 
 0:01:21.120,0:01:24.960
-This lecture's called command-line
-environment and we're
+Kuliah ini berjudul command-line
+environment dan kita akan
 
 0:01:25.160,0:01:28.440
-going to cover a few different topics. So the
+membahas beberapa topik berbeda. Jadi
 
 0:01:28.990,0:01:30.990
-main topics we're gonna
+topik utama yang akan kita
 
 0:01:32.040,0:01:34.520
-cover, so you can keep track,
+bahas, supaya kalian bisa mengikuti,
 
 0:01:34.680,0:01:36.400
-it's probably better here,
+lebih baik di sini,
 
 0:01:36.400,0:01:37.720
-keep track of what I'm talking.
+ikuti apa yang saya bicarakan.
 
 0:01:37.920,0:01:41.560
-The first is gonna be job control.
+Yang pertama adalah job control.
 
 0:01:42.040,0:01:44.280
-The second one is going to be
+Yang kedua adalah
 
 0:01:44.600,0:01:46.600
-terminal multiplexers.
+terminal multiplexer.
 
 0:01:51.720,0:01:57.360
-Then I'm going to explain what dotfiles
-are and how to configure your shell.
+Kemudian saya akan menjelaskan apa itu dotfiles
+dan cara mengonfigurasi shell kalian.
 
 0:01:57.360,0:02:03.240
-And lastly, how to efficiently work with
-remote machines. So if things are not
+Dan terakhir, cara bekerja secara efisien dengan
+mesin remote. Jadi jika ada yang belum
 
 0:02:05.110,0:02:07.589
-fully clear, kind of keep the structure.
+sepenuhnya jelas, ikuti strukturnya.
 
 0:02:08.200,0:02:12.320
-They all kind of interact in some
-way, of how you use your terminal,
+Semuanya saling berinteraksi dalam beberapa
+cara, tentang bagaimana kalian menggunakan terminal,
 
 0:02:12.880,0:02:17.280
-but they are somewhat separate
-topics, so keep that in mind.
+tapi mereka adalah topik yang agak terpisah,
+jadi ingat itu.
 
 0:02:17.600,0:02:23.800
-So let's go with job control. So far we have
-been using the shell in a very, kind of
+Jadi mari kita mulai dengan job control. Sejauh ini kita
+telah menggunakan shell dengan cara yang sangat
 
 0:02:24.800,0:02:27.720
-mono-command way. Like, you
-execute a command and then
+satu perintah. Seperti, kalian
+menjalankan perintah lalu
 
 0:02:27.840,0:02:31.800
-the command executes, then you get some output,
-and that's all about what you can do.
+perintah itu berjalan, kalian mendapat output,
+dan itu semua yang bisa kalian lakukan.
 
 0:02:32.200,0:02:36.520
-And if you want to run several
-things, it's not clear
+Dan jika kalian ingin menjalankan beberapa
+hal, tidak jelas
 
 0:02:36.540,0:02:41.099
-how you will do it. Or if you want to stop
-the execution of a program, it's again,
+bagaimana kalian akan melakukannya. Atau jika kalian ingin menghentikan
+eksekusi program, sekali lagi,
 
 0:02:41.099,0:02:43.768
-like how do I know how to stop a program?
+bagaimana saya tahu cara menghentikan program?
 
 0:02:44.650,0:02:47.940
-Let's showcase this with a command called sleep.
+Mari kita tunjukkan dengan perintah bernama sleep.
 
 0:02:48.160,0:02:50.320
-Sleep is a command that takes an argument,
+Sleep adalah perintah yang menerima argumen,
 
 0:02:50.320,0:02:54.360
-and that argument is going to be an
-integer number, and it will sleep.
+dan argumen itu adalah bilangan
+bulat, dan ia akan tidur.
 
 0:02:54.360,0:02:58.440
-It will just kind of be there, on the
-background, for that many seconds.
+Ia hanya akan diam di
+latar belakang, selama detik yang ditentukan.
 
 0:02:58.440,0:03:03.539
-So if we do something like sleep 20, this process
-is gonna be sleeping for 20 seconds.
+Jadi jika kita melakukan sleep 20, proses ini
+akan tidur selama 20 detik.
 
 0:03:03.539,0:03:07.720
-But we don't want to wait 20 seconds
-for the command to complete.
+Tapi kita tidak ingin menunggu 20 detik
+agar perintah selesai.
 
 0:03:08.040,0:03:10.800
-So what we can do is type "Ctrl+C".
+Jadi yang bisa kita lakukan adalah menekan "Ctrl+C".
 
 0:03:10.840,0:03:12.580
-By typing "Ctrl+C"
+Dengan menekan "Ctrl+C"
 
 0:03:12.580,0:03:17.840
-We can see that, here, the terminal let us know,
+Kita bisa melihat bahwa, di sini, terminal memberi tahu kita,
 
 0:03:18.880,0:03:22.840
-and it's part of the syntax that we covered
-in the editors / Vim lecture,
+dan itu bagian dari sintaks yang kita bahas
+di kuliah editor / Vim,
 
 0:03:23.000,0:03:27.200
-that we typed "Ctrl+C" and it stopped
-the execution of the process.
+bahwa kita menekan "Ctrl+C" dan itu menghentikan
+eksekusi proses.
 
 0:03:27.640,0:03:29.640
-What is actually going on here
+Yang sebenarnya terjadi di sini
 
 0:03:29.880,0:03:34.840
-is that this is using a UNIX communication
-mechanism called signals.
+adalah ini menggunakan mekanisme komunikasi UNIX
+yang disebut signals.
 
 0:03:35.120,0:03:37.360
-When we type "Ctrl+C",
+Ketika kita menekan "Ctrl+C",
 
 0:03:37.800,0:03:42.080
-what the terminal did for us,
-or the shell did for us,
+yang dilakukan terminal untuk kita,
+atau shell untuk kita,
 
 0:03:42.160,0:03:45.960
-is send a signal called SIGINT,
+adalah mengirim signal bernama SIGINT,
 
 0:03:45.960,0:03:51.320
-that stands for SIGnal INTerrupt, that
-tells the program to stop itself.
+singkatan dari SIGnal INTerrupt, yang
+memberitahu program untuk menghentikan dirinya.
 
 0:03:51.680,0:03:57.520
-And there are many, many, many signals
-of this kind. If you do man signal,
+Dan ada banyak, banyak signal
+seperti ini. Jika kalian melakukan man signal,
 
 0:03:58.880,0:04:05.060
-and just go down a little bit,
-here you have a list of them.
+dan turun sedikit,
+di sini kalian punya daftar mereka.
 
 0:04:05.060,0:04:07.040
-They all have number identifiers,
+Mereka semua punya pengenal nomor,
 
 0:04:07.520,0:04:10.640
-they have kind of a short name
-and you can find a description.
+mereka punya nama singkat
+dan kalian bisa menemukan deskripsinya.
 
 0:04:10.960,0:04:16.400
-So for example, the one I have just
-described is here, number 2, SIGINT.
+Jadi misalnya, yang baru saya
+jelaskan ada di sini, nomor 2, SIGINT.
 
 0:04:16.520,0:04:22.200
-This is the signal that a terminal will send to a
-program when it wants to interrupt its execution.
+Ini adalah signal yang akan dikirim terminal ke
+program ketika ingin menghentikan eksekusinya.
 
 0:04:22.520,0:04:25.840
-A few more to be familiar with
+Beberapa lagi yang perlu dikenal
 
 0:04:26.460,0:04:28.530
-is SIGQUIT, this is
+adalah SIGQUIT, ini
 
 0:04:29.229,0:04:34.409
-again, if you work from a terminal and you
-want to quit the execution of a program.
+sekali lagi, jika kalian bekerja dari terminal dan
+ingin keluar dari eksekusi program.
 
 0:04:34.409,0:04:37.720
-For most programs it will do the same thing,
+Untuk sebagian besar program akan melakukan hal yang sama,
 
 0:04:37.720,0:04:41.120
-but we're gonna showcase now a program
-which will be different,
+tapi kita akan tunjukkan sekarang sebuah program
+yang akan berbeda,
 
 0:04:41.440,0:04:43.760
-and this is the signal that will be sent.
+dan ini adalah signal yang akan dikirim.
 
 0:04:44.680,0:04:49.229
-It can be confusing sometimes. Looking at
-these signals, for example, the SIGTERM is
+Terkadang bisa membingungkan. Melihat
+signal-signal ini, misalnya SIGTERM adalah
 
 0:04:50.080,0:04:54.100
-for most cases equivalent to SIGINT and SIGQUIT
+untuk sebagian besar kasus setara dengan SIGINT dan SIGQUIT
 
 0:04:54.480,0:04:58.380
-but it's just when it's not
-sent through a terminal.
+tapi hanya ketika tidak
+dikirim melalui terminal.
 
 0:04:59.680,0:05:01.680
-A few more that we're gonna
+Beberapa lagi yang akan kita
 
 0:05:01.900,0:05:06.209
-cover is SIGHUP, it's when there's
-like a hang-up in the terminal.
+bahas adalah SIGHUP, ini ketika ada
+hang-up di terminal.
 
 0:05:06.210,0:05:10.199
-So for example, when you are in your
-terminal, if you close your terminal
+Jadi misalnya, ketika kalian di
+terminal, jika kalian menutup terminal
 
 0:05:10.199,0:05:13.348
-and there are still things
-running in the terminal,
+dan masih ada yang
+berjalan di terminal,
 
 0:05:13.480,0:05:17.000
-that's the signal that the program is gonna send
+itu adalah signal yang akan dikirim program
 
 0:05:17.000,0:05:19.960
-to all the processes to tell
-that they should close,
+ke semua proses untuk memberi tahu
+bahwa mereka harus menutup,
 
 0:05:19.960,0:05:25.080
-like there was a hang-up in the
-command line communication
+seperti ada hang-up dalam
+komunikasi command line
 
 0:05:25.080,0:05:26.800
-and they should close now.
+dan mereka harus menutup sekarang.
 
 0:05:28.400,0:05:34.260
-Signals can do more things than just stopping, interrupting
-programs and asking them to finish.
+Signal bisa melakukan lebih dari sekadar menghentikan, menginterupsi
+program dan meminta mereka selesai.
 
 0:05:34.260,0:05:36.840
-You can for example use the
+Kalian bisa misalnya menggunakan
 
 0:05:37.520,0:05:43.840
-SIGSTOP to pause the execution of the
-program, and then you can use the
+SIGSTOP untuk menjeda eksekusi
+program, dan kemudian kalian bisa menggunakan
 
 0:05:44.480,0:05:50.160
-SIGCONT command for continuing, to continue the execution
-of the program at a point later in time.
+perintah SIGCONT untuk melanjutkan, melanjutkan eksekusi
+program di waktu kemudian.
 
 0:05:51.160,0:05:55.440
-Since all of this might be slightly too
-abstract, let's see a few examples.
+Karena semua ini mungkin agak terlalu
+abstrak, mari lihat beberapa contoh.
 
 0:05:58.040,0:06:00.560
-First, let's showcase a
+Pertama, mari tunjukkan
 
 0:06:01.960,0:06:06.240
-Python program. I'm going to very
-quickly go through the program.
+program Python. Saya akan dengan cepat
+melewati programnya.
 
 0:06:06.440,0:06:08.360
-This is a Python program,
+Ini adalah program Python,
 
 0:06:08.720,0:06:10.760
-that like most python programs,
+yang seperti kebanyakan program python,
 
 0:06:11.520,0:06:13.960
-is importing this signal library and
+mengimpor library signal ini dan
 
 0:06:14.960,0:06:20.400
-is defining this handler here.
-And this handler is writing,
+mendefinisikan handler ini di sini.
+Dan handler ini menulis,
 
 0:06:20.440,0:06:23.040
-"Oh, I got a SIGINT, but
-I'm not gonna stop here".
+"Oh, saya dapat SIGINT, tapi
+saya tidak akan berhenti di sini".
 
 0:06:23.480,0:06:24.960
-And after that,
+Dan setelah itu,
 
 0:06:24.960,0:06:30.720
-we tell Python that we want this program,
-when it gets a SIGINT, to stop.
+kita beri tahu Python bahwa kita ingin program ini,
+ketika mendapat SIGINT, untuk berhenti.
 
 0:06:31.120,0:06:34.880
-The rest of the program is a very silly program
-that is just going to be printing numbers.
+Sisa programnya adalah program sangat sederhana
+yang hanya akan mencetak angka.
 
 0:06:35.060,0:06:37.540
-So let's see this in action.
+Jadi mari lihat ini beraksi.
 
 0:06:37.560,0:06:39.560
-We do Python SIGINT.
+Kita lakukan Python SIGINT.
 
 0:06:39.880,0:06:44.970
-And it's counting. We try doing
-"Ctrl+C", this sends a SIGINT,
+Dan ia menghitung. Kita coba melakukan
+"Ctrl+C", ini mengirim SIGINT,
 
 0:06:44.970,0:06:50.000
-but the program didn't actually stop. This
-is because we have a way in the program of
+tapi programnya tidak benar-benar berhenti. Ini
+karena kita punya cara dalam program untuk
 
 0:06:50.400,0:06:54.600
-dealing with this exception,
-and we didn't want to exit.
+menangani exception ini,
+dan kita tidak ingin keluar.
 
 0:06:54.760,0:06:57.600
-If we send a SIGQUIT, which is done through
+Jika kita mengirim SIGQUIT, yang dilakukan melalui
 
 0:06:57.800,0:07:03.680
-"Ctrl+\", here, we can see that since the program
-doesn't have a way of dealing with SIGQUIT,
+"Ctrl+\", di sini, kita bisa melihat bahwa karena program
+tidak punya cara menangani SIGQUIT,
 
 0:07:03.730,0:07:06.269
-it does the default operation, which is
+ia melakukan operasi default, yaitu
 
 0:07:06.820,0:07:08.800
-terminate the program.
+menghentikan program.
 
 0:07:09.080,0:07:11.460
-And you could use this, for example,
+Dan kalian bisa menggunakan ini, misalnya,
 
 0:07:11.880,0:07:15.880
-if someone Ctrl+C's your program, and your
-program is supposed to do something,
+jika seseorang melakukan Ctrl+C pada program kalian, dan program
+kalian seharusnya melakukan sesuatu,
 
 0:07:16.040,0:07:19.320
-like you maybe want to save the intermediate
-state of your program
+mungkin kalian ingin menyimpan state
+program kalian
 
 0:07:19.320,0:07:21.520
-to a file, so you can recover it for later.
+ke file, supaya bisa memulihkannya nanti.
 
 0:07:21.600,0:07:25.640
-This is how you could write a handler like this.
+Begini cara kalian bisa menulis handler seperti ini.
 
 0:07:29.520,0:07:30.720
-Can you repeat the question?
+Bisa ulangi pertanyaannya?
 
 0:07:30.880,0:07:32.280
-What did you type right now, when it stopped?
+Apa yang baru saja kamu ketik, saat berhenti?
 
 0:07:32.480,0:07:34.480
-So I...
+Jadi saya...
 
 0:07:34.630,0:07:38.880
-So what I typed is, I type
-"Ctrl+C" to try to stop it
+Jadi yang saya ketik adalah, saya mengetik
+"Ctrl+C" untuk mencoba menghentikannya
 
 0:07:38.880,0:07:42.869
-but it didn't, because SIGINT is captured
-by the program. Then I type
+tapi tidak berhasil, karena SIGINT ditangkap
+oleh program. Kemudian saya ketik
 
 0:07:43.120,0:07:48.040
-"Ctrl+\", which sends a SIGQUIT,
-which is a different signal,
+"Ctrl+\", yang mengirim SIGQUIT,
+yang merupakan signal berbeda,
 
 0:07:49.000,0:07:51.720
-and this signal is not captured by the program.
+dan signal ini tidak ditangkap oleh program.
 
 0:07:52.090,0:07:54.869
-It's also worth mentioning
-that there is a couple of
+Penting juga disebutkan
+bahwa ada beberapa
 
 0:07:54.970,0:07:59.970
-signals that cannot be captured by software.
-There is a couple of signals
+signal yang tidak bisa ditangkap oleh software.
+Ada beberapa signal
 
 0:08:00.820,0:08:02.820
-like SIGKILL
+seperti SIGKILL
 
 0:08:03.940,0:08:06.600
-that cannot be captured. Like that, it will
+yang tidak bisa ditangkap. Seperti itu, ia akan
 
 0:08:06.660,0:08:09.300
-terminate the execution of the
-process, no matter what.
+menghentikan eksekusi
+proses, tidak peduli apa pun.
 
 0:08:09.300,0:08:12.000
-And it can be sometimes harmful.
-You do not want to be using it by
+Dan terkadang bisa berbahaya.
+Kalian tidak ingin menggunakannya secara
 
 0:08:12.000,0:08:16.460
-default, because this can leave for example an
-orphan child, orphaned children processes.
+default, karena ini bisa meninggalkan misalnya
+proses anak yang yatim.
 
 0:08:16.470,0:08:20.940
-Like if a process has other small children
-processes that it started, and you
+Seperti jika sebuah proses punya proses anak kecil
+yang dimulainya, dan kalian
 
 0:08:21.400,0:08:25.470
-SIGKILL it, all of those will
-keep running in there,
+melakukan SIGKILL padanya, semua itu akan
+terus berjalan di sana,
 
 0:08:25.760,0:08:30.800
-but they won't have a parent, and you can maybe
-have a really weird behavior going on.
+tapi mereka tidak punya induk, dan kalian mungkin
+mengalami perilaku yang sangat aneh.
 
 0:08:32.040,0:08:35.680
-What signal is given to the
-program if we log off?
+Signal apa yang diberikan ke
+program jika kita log out?
 
 0:08:35.800,0:08:37.440
-If you log off?
+Jika kalian log out?
 
 0:08:37.920,0:08:41.920
-That would be... so for example, if you're in an
-SSH connection and you close the connection,
+Itu akan menjadi... jadi misalnya, jika kalian dalam
+koneksi SSH dan menutup koneksi,
 
 0:08:41.920,0:08:45.600
-that is the hang-up signal,
+itu adalah signal hang-up,
 
 0:08:45.600,0:08:51.200
-SIGHUP, which I'm gonna cover in an example.
-So this is what would be sent up.
+SIGHUP, yang akan saya bahas dalam contoh.
+Jadi ini yang akan dikirim.
 
 0:08:51.560,0:08:56.360
-And you could write for example, if you want
-the process to keep working even if you close
+Dan kalian bisa menulis misalnya, jika ingin
+proses tetap bekerja bahkan jika kalian menutup
 
 0:08:56.960,0:09:02.560
-that, you can write a wrapper around
-that to ignore that signal.
+itu, kalian bisa menulis wrapper di sekitarnya
+untuk mengabaikan signal itu.
 
 0:09:04.720,0:09:09.760
-Let's display what we could do
-with the stop and continue.
+Mari tunjukkan apa yang bisa kita lakukan
+dengan stop dan continue.
 
 0:09:09.980,0:09:16.389
-So, for example, we can start a really long process.
-Let's sleep a thousand, we're gonna take forever.
+Jadi, misalnya, kita bisa memulai proses yang sangat panjang.
+Mari sleep seribu, ini akan lama sekali.
 
 0:09:16.960,0:09:18.920
-We can control-c,
+Kita bisa control-c,
 
 0:09:18.920,0:09:20.360
-"Ctrl+Z", sorry,
+"Ctrl+Z", maaf,
 
 0:09:20.360,0:09:25.280
-and if we do "Ctrl+Z" we can see that the
-terminal is saying "it's suspended".
+dan jika kita melakukan "Ctrl+Z" kita bisa melihat bahwa
+terminal mengatakan "it's suspended".
 
 0:09:25.400,0:09:31.520
-What this actually meant is that this process
-was sent a SIGSTOP signal and now is
+Yang sebenarnya dimaksud adalah proses ini
+dikirim signal SIGSTOP dan sekarang
 
 0:09:31.900,0:09:36.900
-still there, you could continue its execution, but right
-now it's completely stopped and in the background
+masih ada, kalian bisa melanjutkan eksekusinya, tapi saat
+ini benar-benar berhenti dan di latar belakang
 
 0:09:38.580,0:09:41.720
-and we can launch a different program.
+dan kita bisa meluncurkan program berbeda.
 
 0:09:41.720,0:09:43.680
-When we try to run this program,
+Ketika kita mencoba menjalankan program ini,
 
 0:09:43.680,0:09:46.620
-please notice that I have included
-an "&" at the end.
+tolong perhatikan bahwa saya telah menyertakan
+"&" di akhir.
 
 0:09:46.820,0:09:52.380
-This tells bash that I want this program
-to start running in the background.
+Ini memberi tahu bash bahwa saya ingin program ini
+mulai berjalan di latar belakang.
 
 0:09:52.560,0:09:55.660
-This is kind of related to all these
+Ini agak terkait dengan semua konsep
 
 0:09:55.660,0:09:59.720
-concepts of running programs in
-the shell, but backgrounded.
+menjalankan program di
+shell, tapi di latar belakang.
 
 0:10:00.350,0:10:04.359
-And what is gonna happen is
-the program is gonna start
+Dan yang akan terjadi adalah
+program akan mulai
 
 0:10:04.720,0:10:07.580
-but it's not gonna take over my prompt.
+tapi tidak akan mengambil alih prompt saya.
 
 0:10:07.580,0:10:11.540
-If I just ran this command without
-this, I could not do anything.
+Jika saya hanya menjalankan perintah ini tanpa
+ini, saya tidak bisa melakukan apa-apa.
 
 0:10:11.540,0:10:15.820
-I would have no access to the prompt
-until the command either finished
+Saya tidak punya akses ke prompt
+sampai perintah selesai
 
 0:10:16.060,0:10:19.380
-or I ended it abruptly. But if I do this,
+atau saya menghentikannya secara paksa. Tapi jika saya lakukan ini,
 
 0:10:19.520,0:10:23.080
-it's saying "there's a new
-process which is this".
+ia mengatakan "ada proses baru
+yaitu ini".
 
 0:10:23.080,0:10:25.180
-This is the process identifying number,
+Ini adalah nomor identifikasi proses,
 
 0:10:25.180,0:10:26.940
-we can ignore this for now.
+kita bisa abaikan ini untuk sekarang.
 
 0:10:27.800,0:10:32.919
-If I type the command "jobs", I get the
-output that I have a suspended job
+Jika saya ketik perintah "jobs", saya mendapat
+output bahwa saya punya job yang ditangguhkan
 
 0:10:32.920,0:10:35.800
-that is the "sleep 1000" job.
+yaitu job "sleep 1000".
 
 0:10:36.040,0:10:38.100
-And then I have another running job,
+Dan kemudian saya punya job lain yang berjalan,
 
 0:10:38.120,0:10:42.200
-which is this "NOHUP sleep 2000".
+yaitu "NOHUP sleep 2000" ini.
 
 0:10:42.640,0:10:45.660
-Say I want to continue the first job.
+Katakan saya ingin melanjutkan job pertama.
 
 0:10:45.660,0:10:48.520
-The first job is suspended,
-it's not executing anymore.
+Job pertama ditangguhkan,
+tidak berjalan lagi.
 
 0:10:48.640,0:10:52.600
-I can continue that doing "BG %1"
+Saya bisa melanjutkannya dengan melakukan "BG %1"
 
 0:10:53.870,0:10:58.359
-That "%" is referring to the fact that
-I want to refer to this specific
+"%" itu mengacu pada fakta bahwa
+saya ingin merujuk ke proses
 
 0:11:00.280,0:11:04.280
-process. And now, if I do that
-and I look at the jobs,
+spesifik ini. Dan sekarang, jika saya lakukan itu
+dan melihat jobs,
 
 0:11:04.300,0:11:06.460
-now this job is running again. Now
+sekarang job ini berjalan lagi. Sekarang
 
 0:11:06.460,0:11:08.940
-both of them are running.
+keduanya berjalan.
 
 0:11:09.300,0:11:13.820
-If I wanted to stop these all,
-I can use the kill command.
+Jika saya ingin menghentikan semuanya,
+saya bisa menggunakan perintah kill.
 
 0:11:14.040,0:11:16.060
-The kill command
+Perintah kill
 
 0:11:16.220,0:11:18.620
-is for killing jobs,
+adalah untuk membunuh jobs,
 
 0:11:19.180,0:11:22.080
-which is just stopping them, intuitively,
+yang hanya menghentikannya, secara intuitif,
 
 0:11:22.120,0:11:23.760
-but actually it's really useful.
+tapi sebenarnya sangat berguna.
 
 0:11:23.860,0:11:28.200
-The kill command just allows you
-to send any sort of Unix signal.
+Perintah kill hanya mengizinkan kalian
+mengirim semua jenis signal Unix.
 
 0:11:28.360,0:11:32.220
-So here for example, instead
-of killing it completely,
+Jadi di sini misalnya, alih-alih
+membunuhnya sepenuhnya,
 
 0:11:32.220,0:11:34.640
-we just send a stop signal.
+kita hanya mengirim signal stop.
 
 0:11:34.640,0:11:39.160
-Here I'm gonna send a stop signal, which
-is gonna pause the process again.
+Di sini saya akan mengirim signal stop, yang
+akan menjeda proses lagi.
 
 0:11:39.160,0:11:41.280
-I still have to include the identifier,
+Saya masih harus menyertakan pengenal,
 
 0:11:41.600,0:11:46.480
-because without the identifier the shell wouldn't know
-whether to stop the first one or the second one.
+karena tanpa pengenal shell tidak akan tahu
+apakah menghentikan yang pertama atau yang kedua.
 
 0:11:47.480,0:11:52.480
-Now it's said this has been suspended,
-because there was a signal sent.
+Sekarang dikatakan ini telah ditangguhkan,
+karena ada signal yang dikirim.
 
 0:11:52.620,0:11:57.360
-If I do "jobs", again, we can see
-that the second one is running
+Jika saya lakukan "jobs", lagi, kita bisa melihat
+bahwa yang kedua berjalan
 
 0:11:57.460,0:12:00.740
-and the first one has been stopped.
+dan yang pertama telah dihentikan.
 
 0:12:01.420,0:12:04.300
-Going back to one of the questions,
+Kembali ke salah satu pertanyaan,
 
 0:12:04.300,0:12:06.980
-what happens when you close
-the cell, for example,
+apa yang terjadi ketika kalian menutup
+shell, misalnya,
 
 0:12:06.980,0:12:12.860
-and why sometimes people will say that
-you should use this NOHUP command
+dan mengapa terkadang orang mengatakan bahwa
+kalian harus menggunakan perintah NOHUP ini
 
 0:12:12.860,0:12:15.960
-before your run jobs in a remote session.
+sebelum menjalankan jobs di sesi remote.
 
 0:12:16.220,0:12:23.120
-This is because if we try to send
-a hung up command to the first job
+Ini karena jika kita mencoba mengirim
+perintah hung up ke job pertama
 
 0:12:23.560,0:12:27.820
-it's gonna, in a similar fashion
-as the other signals,
+ia akan, dengan cara yang mirip
+seperti signal lainnya,
 
 0:12:27.820,0:12:32.280
-it's gonna hang it up and that's
-gonna terminate the job.
+ia akan meng-hang-up dan itu
+akan menghentikan job.
 
 0:12:32.800,0:12:35.960
-And the first job isn't there anymore
+Dan job pertama tidak ada lagi
 
 0:12:36.320,0:12:39.140
-whereas we have still the second job running.
+sedangkan kita masih punya job kedua yang berjalan.
 
 0:12:39.400,0:12:42.920
-However, if we try to send the
-signal to the second job
+Namun, jika kita mencoba mengirim
+signal ke job kedua
 
 0:12:42.920,0:12:46.060
-what will happen if we close
-our terminal right now
+yang akan terjadi jika kita menutup
+terminal kita sekarang
 
 0:12:47.040,0:12:48.660
-is it's still running.
+adalah ia masih berjalan.
 
 0:12:48.660,0:12:52.480
-Like NOHUP, what it's doing
-is kind of encapsulating
+Seperti NOHUP, yang dilakukannya
+adalah semacam mengenkapsulasi
 
 0:12:52.480,0:12:54.480
-whatever command you're executing and
+perintah apa pun yang kalian jalankan dan
 
 0:12:54.740,0:12:58.720
-ignoring wherever you get a hang up signal,
+mengabaikan di mana pun kalian mendapat signal hang up,
 
 0:12:58.900,0:13:03.680
-and just ignoring that so it can keep running.
+dan mengabaikannya sehingga bisa terus berjalan.
 
 0:13:05.060,0:13:08.500
-And if we send the "kill"
-signal to the second job,
+Dan jika kita mengirim signal "kill"
+ke job kedua,
 
 0:13:08.500,0:13:12.820
-that one can't be ignored and that
-will kill the job, no matter what.
+itu tidak bisa diabaikan dan itu
+akan membunuh job, tidak peduli apa pun.
 
 0:13:13.280,0:13:15.780
-And we don't have any jobs anymore.
+Dan kita tidak punya job lagi.
 
 0:13:17.000,0:13:22.540
-That kind of completes the
-section on job control.
+Itu cukup menyelesaikan
+bagian tentang job control.
 
 0:13:22.740,0:13:27.100
-Any questions so far? Anything
-that wasn't fully clear?
+Ada pertanyaan sejauh ini? Ada yang
+belum sepenuhnya jelas?
 
 0:13:29.040,0:13:30.400
-What does BG do?
+Apa yang dilakukan BG?
 
 0:13:30.960,0:13:31.800
-So BG...
+Jadi BG...
 
 0:13:31.800,0:13:36.860
-There are like two commands. Whenever you
-have a command that has been backgrounded
+Ada seperti dua perintah. Setiap kali kalian
+punya perintah yang telah dilatarbelakangkan
 
 0:13:37.200,0:13:41.820
-and is stopped you can use
-BG (short for background)
+dan dihentikan kalian bisa menggunakan
+BG (singkatan dari background)
 
 0:13:41.820,0:13:44.180
-to continue that process running
-on the background.
+untuk melanjutkan proses itu berjalan
+di latar belakang.
 
 0:13:44.440,0:13:47.400
-That's equivalent of just kind of sending it
+Itu setara dengan hanya mengirimnya
 
 0:13:47.680,0:13:50.820
-a continue signal, so it keeps running.
+signal continue, sehingga terus berjalan.
 
 0:13:50.820,0:13:54.820
-And then there's another one which
-is called FG, if you want to
+Dan kemudian ada lagi yang
+disebut FG, jika kalian ingin
 
 0:13:54.860,0:13:59.580
-recover it to the foreground and you want
-to reattach your standard output.
+mengembalikannya ke foreground dan kalian ingin
+menempelkan kembali standard output kalian.
 
 0:14:04.760,0:14:06.760
-Okay, good.
+Oke, bagus.
 
 0:14:07.120,0:14:11.420
-Jobs are useful and in general, I
-think knowing about signals can be
+Jobs berguna dan secara umum, saya
+berpikir mengetahui tentang signal bisa
 
 0:14:11.420,0:14:14.360
-really beneficial when dealing
-with some part of Unix
+sangat bermanfaat saat berurusan
+dengan beberapa bagian Unix
 
 0:14:14.360,0:14:19.420
-but most of the time what you actually want
-to do is something along the lines of
+tapi sebagian besar waktu yang sebenarnya ingin
+kalian lakukan adalah sesuatu seperti
 
 0:14:19.670,0:14:24.099
-having your editor in one side and then
-the program in another, and maybe
+memiliki editor kalian di satu sisi dan kemudian
+program di sisi lain, dan mungkin
 
 0:14:24.720,0:14:28.280
-monitoring what the resource
-consumption is in our tab.
+memantau konsumsi
+sumber daya di tab lain.
 
 0:14:28.680,0:14:33.640
-We could achieve this using probably
-what you have seen a lot of the time,
+Kita bisa mencapai ini mungkin menggunakan
+apa yang sudah sering kalian lihat,
 
 0:14:33.640,0:14:35.200
-which is just opening more windows.
+yaitu hanya membuka lebih banyak jendela.
 
 0:14:35.200,0:14:37.200
-We can keep opening terminal windows.
+Kita bisa terus membuka jendela terminal.
 
 0:14:37.320,0:14:41.280
-But the fact is there are kind of more
-convenient solutions to this and
+Tapi faktanya ada solusi yang lebih
+nyaman untuk ini dan
 
 0:14:41.280,0:14:43.800
-this is what a terminal multiplexer does.
+inilah yang dilakukan terminal multiplexer.
 
 0:14:44.080,0:14:48.520
-A terminal multiplexer like tmux
+Terminal multiplexer seperti tmux
 
 0:14:48.840,0:14:52.160
-will let you create different workspaces
-that you can work in,
+akan membiarkan kalian membuat workspace berbeda
+yang bisa kalian gunakan,
 
 0:14:52.640,0:14:54.280
-and quickly kind of,
+dan dengan cepat,
 
 0:14:54.280,0:14:56.960
-this has a huge variety of functionality,
+ini punya banyak variasi fungsionalitas,
 
 0:14:57.320,0:15:02.760
-It will let you rearrange the environment and
-it will let you have different sessions.
+Ini akan membiarkan kalian menata ulang lingkungan dan
+memiliki sesi berbeda.
 
 0:15:03.400,0:15:05.400
-There's another more...
+Ada lagi yang lebih...
 
 0:15:05.600,0:15:07.640
-older command, which is called "screen",
+perintah lama, yang disebut "screen",
 
 0:15:07.640,0:15:09.360
-that might be more readily available.
+yang mungkin lebih readily tersedia.
 
 0:15:09.360,0:15:12.200
-But I think the concept kind
-of extrapolates to both.
+Tapi saya pikir konsepnya
+berlaku untuk keduanya.
 
 0:15:12.600,0:15:15.400
-We recommend tmux, that you go and learn it.
+Kami merekomendasikan tmux, supaya kalian mempelajarinya.
 
 0:15:15.400,0:15:17.480
-And in fact, we have exercises on it.
+Dan faktanya, kami punya latihan tentang itu.
 
 0:15:17.480,0:15:20.240
-I'm gonna showcase a different
-scenario right now.
+Saya akan menunjukkan skenario berbeda
+sekarang.
 
 0:15:20.320,0:15:22.000
-So whenever I talked...
+Jadi setiap kali saya bicara...
 
 0:15:22.320,0:15:24.880
-Oh, let me make a quick note.
+Oh, biarkan saya membuat catatan cepat.
 
 0:15:25.200,0:15:28.800
-There are kind of three core concepts
-in tmux, that I'm gonna go through and
+Ada tiga konsep inti
+di tmux, yang akan saya bahas dan
 
 0:15:30.110,0:15:33.130
-the main idea is that there are what is called
+ide utamanya adalah ada yang disebut
 
 0:15:35.180,0:15:37.180
 "sessions".
 
 0:15:37.760,0:15:40.510
-Sessions have "windows" and
+Sessions punya "windows" dan
 
 0:15:42.019,0:15:44.019
-windows have "panes".
+windows punya "panes".
 
 0:15:45.709,0:15:49.539
-It's gonna be kind of useful to
-keep this hierarchy in mind.
+Ini akan berguna untuk
+mengingat hierarki ini.
 
 0:15:50.760,0:15:57.280
-You can pretty much equate "windows" to what
-"tabs" are in other editors and others,
+Kalian bisa hampir menyamakan "windows" dengan apa
+yang "tabs" di editor lain dan lainnya,
 
 0:15:57.280,0:16:00.720
-like for example your web browser.
+seperti misalnya web browser kalian.
 
 0:16:01.280,0:16:06.440
-I'm gonna go through the features, mainly
-what you can do at the different levels.
+Saya akan melalui fitur-fiturnya, terutama
+apa yang bisa kalian lakukan di level berbeda.
 
 0:16:07.000,0:16:10.480
-So first, when we do tmux, that starts a session.
+Jadi pertama, ketika kita melakukan tmux, itu memulai sesi.
 
 0:16:11.360,0:16:14.960
-And here right now it seems like nothing changed
+Dan di sini sekarang sepertinya tidak ada yang berubah
 
 0:16:14.960,0:16:20.360
-but what's happening right now is we're within a shell
-that is different from the one we started before.
+tapi yang terjadi sekarang adalah kita berada dalam shell
+yang berbeda dari yang kita mulai sebelumnya.
 
 0:16:20.640,0:16:24.840
-So in our shell we started
-a process, that is tmux
+Jadi di shell kita kita memulai
+proses, yaitu tmux
 
 0:16:24.840,0:16:28.840
-and that tmux started a different process,
-which is the shell we're currently in.
+dan tmux itu memulai proses berbeda,
+yaitu shell yang sedang kita gunakan sekarang.
 
 0:16:28.980,0:16:30.400
-And the nice thing about this is that
+Dan hal baiknya tentang ini adalah
 
 0:16:30.580,0:16:34.740
-that tmux process is separate from
-the original shell process.
+proses tmux itu terpisah dari
+proses shell asli.
 
 0:16:34.860,0:16:36.860
-So
+Jadi
 
 0:16:40.580,0:16:44.460
-here, we can do things.
+di sini, kita bisa melakukan sesuatu.
 
 0:16:44.480,0:16:48.600
-We can do "ls -la", for example, to
-tell us what is going on in here.
+Kita bisa melakukan "ls -la", misalnya, untuk
+memberi tahu apa yang terjadi di sini.
 
 0:16:48.920,0:16:53.960
-And then we can start running our program,
-and it will start running in there
+Dan kemudian kita bisa mulai menjalankan program kita,
+dan ia akan mulai berjalan di sana
 
 0:16:54.160,0:16:57.880
-and we can do "Ctrl+A d", for example, to detach
+dan kita bisa melakukan "Ctrl+A d", misalnya, untuk detach
 
 0:17:12.760,0:17:15.960
-to detach from the session.
+untuk detach dari sesi.
 
 0:17:16.140,0:17:19.120
-And if we do "tmux a"
+Dan jika kita melakukan "tmux a"
 
 0:17:19.160,0:17:21.560
-that's gonna reattach us to the session.
+itu akan mengaitkan kembali kita ke sesi.
 
 0:17:21.560,0:17:22.300
-So the process,
+Jadi prosesnya,
 
 0:17:22.300,0:17:25.180
-we abandon the process counting numbers.
+kita tinggalkan proses penghitungan angka.
 
 0:17:25.180,0:17:28.300
-This really silly Python program
-that was just counting numbers,
+Program Python yang sangat sederhana
+yang hanya menghitung angka,
 
 0:17:28.340,0:17:30.160
-we left it running there.
+kita tinggalkan berjalan di sana.
 
 0:17:30.200,0:17:31.720
-And if we tmux...
+Dan jika kita tmux...
 
 0:17:31.720,0:17:33.760
-Hey, the process is still running there.
+Hei, prosesnya masih berjalan di sana.
 
 0:17:33.780,0:17:37.820
-And we could close this entire
-terminal and open a new one and
+Dan kita bisa menutup seluruh
+terminal ini dan membuka yang baru dan
 
 0:17:37.880,0:17:41.860
-we could still reattach because this
-tmux session is still running.
+kita masih bisa mengaitkan kembali karena sesi tmux
+ini masih berjalan.
 
 0:17:43.340,0:17:45.340
-Again, we can...
+Sekali lagi, kita bisa...
 
 0:17:46.640,0:17:48.640
-Before I go any further.
+Sebelum saya melangkah lebih jauh.
 
 0:17:48.920,0:17:53.740
-Pretty much... Unlike Vim, where
-you have this notion of modes,
+Hampir... Berbeda dengan Vim, di mana
+kalian punya notions modes,
 
 0:17:53.960,0:17:58.180
-tmux will work in a more emacsy way, which is
+tmux akan bekerja dengan cara yang lebih emacsy, yaitu
 
 0:17:58.180,0:18:04.140
-every command, pretty much every command in tmux,
+setiap perintah, hampir setiap perintah di tmux,
 
 0:18:04.220,0:18:06.020
-you could enter it through the...
+kalian bisa memasukkannya melalui...
 
 0:18:06.020,0:18:08.160
-it has a command line, that we could use.
+ia punya command line, yang bisa kita gunakan.
 
 0:18:08.240,0:18:11.320
-But I recommend you to get familiar
-with the key bindings.
+Tapi saya merekomendasikan kalian untuk familiar
+dengan key bindings.
 
 0:18:11.880,0:18:15.080
-It can be somehow non intuitive at first,
+Ini bisa agak tidak intuitif pada awalnya,
 
 0:18:15.300,0:18:17.880
-but once you get used to them...
+tapi setelah kalian terbiasa...
 
 0:18:22.140,0:18:23.020
-"Ctrl+C", yeah
+"Ctrl+C", ya
 
 0:18:24.440,0:18:30.760
-When you get familiar with them, you will be much faster
-just using the key bindings than using the commands.
+Ketika kalian familiar dengan mereka, kalian akan jauh lebih cepat
+hanya menggunakan key bindings daripada menggunakan perintah.
 
 0:18:31.280,0:18:35.980
-One note about the key bindings: all the
-key bindings have a form that is like
+Satu catatan tentang key bindings: semua
+key bindings punya bentuk seperti
 
 0:18:36.140,0:18:39.840
-you type a prefix and then some key.
+kalian mengetik prefix dan kemudian beberapa key.
 
 0:18:40.060,0:18:44.000
-So for example, to detach we
-do "Ctrl+A" and then "D".
+Jadi misalnya, untuk detach kita
+lakukan "Ctrl+A" lalu "D".
 
 0:18:44.160,0:18:50.140
-This means you press "Ctrl+A" first, you release
-that, and then press "D" to detach.
+Ini berarti kalian tekan "Ctrl+A" dulu, lepaskan
+itu, lalu tekan "D" untuk detach.
 
 0:18:50.380,0:18:54.200
-On default tmux, the prefix is "Ctrl+B",
+Di tmux default, prefixnya adalah "Ctrl+B",
 
 0:18:54.200,0:18:58.780
-but you will find that most people
-will have this remapped to "Ctrl+A"
+tapi kalian akan menemukan bahwa kebanyakan orang
+akan memetakan ulang ini ke "Ctrl+A"
 
 0:18:58.780,0:19:02.680
-because it's a much more ergonomic
-type on the keyboard.
+karena itu jauh lebih ergonomis
+di keyboard.
 
 0:19:02.700,0:19:06.420
-You can find more about how to do these
-things in one of the exercises,
+Kalian bisa menemukan lebih banyak tentang cara melakukan ini
+di salah satu latihan,
 
 0:19:06.960,0:19:12.780
-where we link you to the basics and how to do some
-kind of quality of life modifications to tmux.
+di mana kami menautkan kalian ke dasar-dasar dan cara melakukan beberapa
+modifikasi quality of life ke tmux.
 
 0:19:13.380,0:19:16.720
-Going back to the concept of sessions,
+Kembali ke konsep sessions,
 
 0:19:16.960,0:19:22.120
-we can create a new session just
-doing something like tmux new
+kita bisa membuat sesi baru hanya
+dengan melakukan sesuatu seperti tmux new
 
 0:19:22.320,0:19:24.540
-and we can give sessions names.
+dan kita bisa memberi nama pada sesi.
 
 0:19:24.760,0:19:27.220
-So we can do like "tmux new -t foobar"
+Jadi kita bisa melakukan seperti "tmux new -t foobar"
 
 0:19:27.220,0:19:30.900
-and this is a completely different
-session, that we have started.
+dan ini adalah sesi yang benar-benar berbeda,
+yang telah kita mulai.
 
 0:19:32.240,0:19:36.360
-We can work here, we can detach from it.
+Kita bisa bekerja di sini, kita bisa detach darinya.
 
 0:19:36.360,0:19:40.000
-"tmux ls" will tell us that we
-have two different sessions:
+"tmux ls" akan memberi tahu bahwa kita
+punya dua sesi berbeda:
 
 0:19:40.000,0:19:43.460
-the first one is named "0", because
-I didn't give it a name,
+yang pertama bernama "0", karena
+saya tidak memberinya nama,
 
 0:19:43.500,0:19:45.820
-and the second one is called "foobar".
+dan yang kedua disebut "foobar".
 
 0:19:46.580,0:19:51.020
-I can attach the foobar session
+Saya bisa mengaitkan sesi foobar
 
 0:19:51.020,0:19:53.700
-and I can end it.
+dan saya bisa mengakhirinya.
 
 0:19:54.680,0:19:56.340
-And it's really nice because
+Dan ini sangat bagus karena
 
 0:19:56.340,0:20:00.139
-having this you can kind of work
-in completely different projects.
+dengan ini kalian bisa bekerja
+di proyek yang benar-benar berbeda.
 
 0:20:00.140,0:20:04.340
-For example, having two different
-tmux sessions and different
+Misalnya, memiliki dua sesi tmux berbeda dan
 
 0:20:04.480,0:20:08.440
-editor sessions, different processes running...
+sesi editor berbeda, proses berbeda yang berjalan...
 
 0:20:10.160,0:20:15.100
-When you are within a session, we
-start with the concept of windows.
+Ketika kalian berada dalam sesi, kita
+mulai dengan konsep windows.
 
 0:20:15.100,0:20:21.160
-Here we have a single window, but we
-can use "Ctrl+A c" (for "create")
+Di sini kita punya satu window, tapi kita
+bisa menggunakan "Ctrl+A c" (untuk "create")
 
 0:20:21.160,0:20:23.720
-to open a new window.
+untuk membuka window baru.
 
 0:20:24.000,0:20:26.340
-And here nothing is executing.
+Dan di sini tidak ada yang berjalan.
 
 0:20:26.380,0:20:29.420
-What it's doing is, tmux has
-opened a new shell for us
+Yang dilakukannya adalah, tmux telah
+membuka shell baru untuk kita
 
 0:20:30.360,0:20:34.840
-and we can start running another
-one of these programs here.
+dan kita bisa mulai menjalankan
+program lain di sini.
 
 0:20:35.460,0:20:42.460
-And to quickly jump between the tabs,
-we can do "Ctrl+A" and "previous",
+Dan untuk berpindah dengan cepat antar tab,
+kita bisa lakukan "Ctrl+A" dan "previous",
 
 0:20:42.460,0:20:44.520
-"p" for "previous",
+"p" untuk "previous",
 
 0:20:45.220,0:20:48.020
-and that will go up to the previous window.
+dan itu akan kembali ke window sebelumnya.
 
 0:20:48.020,0:20:50.920
-"Ctrl+A" "next", to go to the next window.
+"Ctrl+A" "next", untuk pergi ke window berikutnya.
 
 0:20:51.260,0:20:56.060
-You can also use the numbers. So if we
-start opening a lot of these tabs,
+Kalian juga bisa menggunakan angka. Jadi jika kita
+mulai membuka banyak tab ini,
 
 0:20:56.200,0:21:00.160
-we could use "Ctrl+A 1", to
-specifically jump to the
+kita bisa menggunakan "Ctrl+A 1", untuk
+khususnya melompat ke
 
 0:21:00.240,0:21:04.400
-to the window that is number "1".
+window yang bernomor "1".
 
 0:21:04.780,0:21:08.620
-And, lastly, it's also pretty
-useful to know sometimes
+Dan, terakhir, juga cukup
+berguna untuk diketahui terkadang
 
 0:21:08.660,0:21:10.400
-that you can rename them.
+bahwa kalian bisa mengubah namanya.
 
 0:21:10.400,0:21:13.380
-For example here I'm executing
-this Python process,
+Misalnya di sini saya menjalankan
+proses Python ini,
 
 0:21:13.580,0:21:16.800
-but that might not be really
-informative and I want...
+tapi itu mungkin tidak terlalu
+informatif dan saya ingin...
 
 0:21:16.880,0:21:21.160
-I maybe want to have something like
-execution or something like that and
+saya mungkin ingin memiliki sesuatu seperti
+execution atau semacam itu dan
 
 0:21:21.740,0:21:26.840
-that will rename the name of that window so
-you can have this really neatly organized.
+itu akan mengubah nama window itu sehingga
+kalian bisa menatanya dengan sangat rapi.
 
 0:21:27.080,0:21:33.500
-This still doesn't solve the need when you want to
-have two things at the same time in your terminal,
+Ini masih belum menyelesaikan kebutuhan ketika kalian ingin
+memiliki dua hal sekaligus di terminal kalian,
 
 0:21:33.680,0:21:35.740
-like in the same display.
+seperti di tampilan yang sama.
 
 0:21:35.740,0:21:38.320
-This is what panes are for. Right now, here
+Inilah fungsi panes. Sekarang, di sini
 
 0:21:38.420,0:21:40.420
-we have a window with a single pane
+kita punya window dengan satu pane
 
 0:21:40.420,0:21:43.540
-(all the windows that we have opened
-so far have a single pane).
+(semua window yang telah kita buka
+sejauh ini punya satu pane).
 
 0:21:43.640,0:21:50.800
-But if we do 'Ctrl+A "'
+Tapi jika kita lakukan 'Ctrl+A "'
 
 0:21:51.040,0:21:56.540
-this will split the current display
-into two different panes.
+ini akan membagi tampilan saat ini
+menjadi dua pane berbeda.
 
 0:21:56.540,0:22:01.400
-So, you see, the one we open below is a different
-shell from the one we have above,
+Jadi, kalian lihat, yang kita buka di bawah adalah shell berbeda
+dari yang kita punya di atas,
 
 0:22:01.640,0:22:05.440
-and we can run any process that we want here.
+dan kita bisa menjalankan proses apa pun yang kita inginkan di sini.
 
 0:22:05.620,0:22:09.900
-We can keep splitting this, if we do "Ctrl+A %"
+Kita bisa terus membagi ini, jika kita lakukan "Ctrl+A %"
 
 0:22:10.080,0:22:15.000
-that will split vertically. And you can kind of
+itu akan membagi secara vertikal. Dan kalian bisa
 
 0:22:15.000,0:22:18.220
-rearrange these tabs using a
-lot of different commands.
+menata ulang ini menggunakan
+banyak perintah berbeda.
 
 0:22:18.220,0:22:22.620
-One that I find very useful, when you are
-starting and it's kind of frustrating,
+Satu yang saya temukan sangat berguna, ketika kalian
+memulai dan agak frustrasi,
 
 0:22:23.540,0:22:26.000
-rearranging them.
+menata ulang mereka.
 
 0:22:26.160,0:22:30.160
-Before I explain that, to move
-through these panes, which is
+Sebelum saya menjelaskan itu, untuk berpindah
+antar pane ini, yang merupakan
 
 0:22:30.300,0:22:32.280
-something you want to be doing all the time
+sesuatu yang akan sering kalian lakukan
 
 0:22:32.460,0:22:37.060
-You just do "Ctrl+A" and the arrow
-keys, and that will let you quickly
+Kalian hanya lakukan "Ctrl+A" dan tombol
+panah, dan itu akan membiarkan kalian dengan cepat
 
 0:22:37.460,0:22:43.960
-navigate through the different
-windows, and execute again...
+berpindah antar
+window, dan menjalankan lagi...
 
 0:22:44.340,0:22:46.300
-I'm doing a lot of "ls -a"
+Saya melakukan banyak "ls -a"
 
 0:22:47.340,0:22:52.780
-I can do "HTOP", that we'll explain in
-the debugging and profiling lecture.
+Saya bisa lakukan "HTOP", yang akan dijelaskan di
+kuliah debugging dan profiling.
 
 0:22:53.540,0:22:55.920
-And we can just navigate through them, again
+Dan kita bisa berpindah antar mereka, lagi
 
 0:22:55.920,0:22:59.040
-like to rearrange there's
-another slew of commands,
+seperti untuk menata ulang ada
+banyak perintah lain,
 
 0:22:59.080,0:23:01.080
-you will go through some in the Exercises
+kalian akan melalui beberapa di Latihan
 
 0:23:02.400,0:23:07.160
-"Ctrl+A" space is pretty neat, because it
-will kind of equispace the current ones
+"Ctrl+A" spasi cukup rapi, karena itu
+akan membagi ruang secara merata untuk yang sekarang
 
 0:23:07.160,0:23:10.260
-and let you through different layouts.
+dan membiarkan kalian melalui tata letak berbeda.
 
 0:23:11.480,0:23:14.260
-Some of them are too small for my current
+Beberapa terlalu kecil untuk konfigurasi
 
 0:23:14.840,0:23:19.220
-terminal config, but that covers,
-I think, most of it.
+terminal saya saat ini, tapi itu mencakup,
+saya pikir, sebagian besarnya.
 
 0:23:19.440,0:23:21.440
-Oh, there's also,
+Oh, ada juga,
 
 0:23:22.660,0:23:29.200
-here, for example, this Vim execution
-that we have started,
+di sini, misalnya, eksekusi Vim ini
+yang telah kita mulai,
 
 0:23:29.200,0:23:33.380
-is too small for what the current tmux pane is.
+terlalu kecil untuk pane tmux saat ini.
 
 0:23:33.720,0:23:38.240
-So one of the things that really is
-much more convenient to do in tmux,
+Jadi salah satu hal yang benar-benar
+lebih nyaman dilakukan di tmux,
 
 0:23:39.180,0:23:42.500
-in contrast to having multiple
-terminal windows, is that
+dibandingkan memiliki beberapa
+jendela terminal, adalah bahwa
 
 0:23:42.560,0:23:48.400
-you can zoom into this, you can ask
-by doing "Ctrl+A z", for "zoom".
+kalian bisa zoom ke sini, kalian bisa meminta
+dengan melakukan "Ctrl+A z", untuk "zoom".
 
 0:23:48.400,0:23:52.960
-It will expand the pane to
-take over all the space,
+Itu akan memperluas pane untuk
+mengambil alih semua ruang,
 
 0:23:52.960,0:23:56.660
-and then "Ctrl+A z", again will go back to it.
+dan kemudian "Ctrl+A z", lagi akan kembali ke semula.
 
 0:24:02.760,0:24:08.080
-Any questions for terminal multiplexers,
-or like, tmux concretely?
+Ada pertanyaan untuk terminal multiplexer,
+atau seperti, tmux secara konkret?
 
 0:24:14.140,0:24:16.780
-Is it running all the same thing?
+Apakah semuanya menjalankan hal yang sama?
 
 0:24:18.680,0:24:22.700
-Like, is there any difference in execution
-between running it in different windows?
+Seperti, apakah ada perbedaan eksekusi
+antara menjalankannya di window berbeda?
 
 0:24:24.880,0:24:28.640
-Is it really just doing it all the
-same, so that you can see it?
+Apakah benar-benar melakukan semuanya
+sama, sehingga kalian bisa melihatnya?
 
 0:24:28.800,0:24:34.900
-Yeah, it wouldn't be any different from having
-two terminal windows open in your computer.
+Ya, itu tidak akan berbeda dari memiliki
+dua jendela terminal terbuka di komputer kalian.
 
 0:24:34.920,0:24:39.220
-Like both of them are gonna be running.
-Of course, when it gets to the CPU,
+Keduanya akan berjalan. Tentu saja, ketika sampai ke CPU,
 
 0:24:39.220,0:24:41.400
-this is gonna be multiplexed again.
+ini akan dimultiplex lagi.
 
 0:24:41.460,0:24:44.400
-Like there's like a timesharing
-mechanism going there
+Seperti ada mekanisme timesharing
+yang terjadi di sana
 
 0:24:44.480,0:24:45.920
-but there's no difference.
+tapi tidak ada perbedaan.
 
 0:24:46.040,0:24:52.260
-tmux is just making this much more convenient
-to use by giving you this visual layout
+tmux hanya membuat ini jauh lebih nyaman
+untuk digunakan dengan memberi kalian tata letak visual ini
 
 0:24:52.560,0:24:55.020
-that you can quickly manipulate through.
+yang bisa kalian manipulasi dengan cepat.
 
 0:24:55.020,0:24:59.860
-And one of the main advantages will come
-when we reach the remote machines
+Dan salah satu keuntungan utama akan datang
+ketika kita mencapai mesin remote
 
 0:24:59.860,0:25:05.300
-because you can leave one of these, we can
-detach from one of these tmux systems,
+karena kalian bisa meninggalkan salah satu ini, kita bisa
+detach dari salah satu sistem tmux ini,
 
 0:25:05.300,0:25:09.120
-close the connection and even
-if we close the connection and
+menutup koneksi dan bahkan
+jika kita menutup koneksi dan
 
 0:25:09.120,0:25:11.640
-and the terminal is gonna send a hang-up signal,
+terminal akan mengirim signal hang-up,
 
 0:25:11.680,0:25:15.420
-that's not gonna close all the
-tmux's that have been started.
+itu tidak akan menutup semua
+tmux yang telah dimulai.
 
 0:25:17.110,0:25:19.110
-Any other questions?
+Ada pertanyaan lain?
 
 0:25:23.620,0:25:27.980
-Let me disable the key-caster.
+Biarkan saya menonaktifkan key-caster.
 
 0:25:33.580,0:25:38.040
-So now we're gonna move into the topic
-of dotfiles and, in general,
+Jadi sekarang kita akan pindah ke topik
+dotfiles dan, secara umum,
 
 0:25:38.040,0:25:42.460
-how to kind of configure your shell
-to do the things you want to do
+bagaimana mengonfigurasi shell kalian
+untuk melakukan hal-hal yang ingin kalian lakukan
 
 0:25:42.460,0:25:45.580
-and mainly how to do them quicker
-and in a more convenient way.
+dan terutama cara melakukannya lebih cepat
+dan lebih nyaman.
 
 0:25:46.360,0:25:49.260
-I'm gonna motivate this using aliases first.
+Saya akan memotivasi ini menggunakan aliases terlebih dahulu.
 
 0:25:49.380,0:25:51.060
-So what an alias is,
+Jadi apa itu alias,
 
 0:25:51.060,0:25:54.260
-is that by now, you might be
-starting to do something like
+adalah bahwa sekarang, kalian mungkin
+mulai melakukan sesuatu seperti
 
 0:25:54.920,0:26:01.680
-a lot of the time, I just want to LS a directory and
-I want to display all the contents into a list format
+sering, saya hanya ingin LS direktori dan
+saya ingin menampilkan semua konten dalam format daftar
 
 0:26:02.180,0:26:05.040
-and in a human readable thing.
+dan dalam format yang mudah dibaca manusia.
 
 0:26:05.260,0:26:07.400
-And it's fine. Like it's not
-that long of a command.
+Dan itu tidak masalah. Seperti itu bukan
+perintah yang terlalu panjang.
 
 0:26:07.400,0:26:10.300
-But as you start building longer
-and longer commands,
+Tapi saat kalian mulai membangun perintah yang lebih
+dan lebih panjang,
 
 0:26:10.320,0:26:14.440
-it can become kind of bothersome having
-to retype them again and again.
+ini bisa menjadi agak merepotkan harus
+mengetik ulang mereka berulang kali.
 
 0:26:14.440,0:26:17.540
-This is one of the reasons
-why aliases are useful.
+Ini adalah salah satu alasan
+mengapa aliases berguna.
 
 0:26:17.540,0:26:21.740
-Alias is a command that will
-be a built-in in your shell,
+Alias adalah perintah yang akan
+menjadi built-in di shell kalian,
 
 0:26:21.960,0:26:23.680
-and what it will do is
+dan yang akan dilakukannya adalah
 
 0:26:23.680,0:26:27.540
-it will remap a short sequence of
-characters to a longer sequence.
+ia akan memetakan ulang urutan karakter pendek
+ke urutan yang lebih panjang.
 
 0:26:27.780,0:26:31.500
-So if I do, for example, here
+Jadi jika saya lakukan, misalnya, di sini
 
 0:26:31.500,0:26:36.840
 alias ll="ls -lah"
 
 0:26:37.440,0:26:42.520
-If I execute this command, this is gonna call
-the "alias" command with this argument
+Jika saya menjalankan perintah ini, ini akan memanggil
+perintah "alias" dengan argumen ini
 
 0:26:42.520,0:26:44.320
-and the LS is going to update
+dan LS akan memperbarui
 
 0:26:44.540,0:26:49.040
-the environment in my shell
-to be aware of this mapping.
+lingkungan di shell saya
+untuk menyadari pemetaan ini.
 
 0:26:49.320,0:26:52.920
-So if I now do LL,
+Jadi jika sekarang saya lakukan LL,
 
 0:26:52.920,0:26:57.520
-it's executing that command without me
-having to type the entire command.
+ia menjalankan perintah itu tanpa saya
+harus mengetik seluruh perintah.
 
 0:26:57.720,0:27:01.180
-It can be really handy for many, many reasons.
+Ini bisa sangat berguna karena banyak alasan.
 
 0:27:01.180,0:27:04.740
-One thing to note before I go any further is that
+Satu hal yang perlu dicatat sebelum saya melangkah lebih jauh adalah bahwa
 
 0:27:05.000,0:27:09.960
-here, alias is not anything special
-compared to other commands,
+di sini, alias bukan apa-apa yang istimewa
+dibandingkan dengan perintah lain,
 
 0:27:09.960,0:27:11.400
-it's just taking a single argument.
+ia hanya mengambil satu argumen.
 
 0:27:11.680,0:27:15.600
-And there is no space around
-this equals and that's
+Dan tidak ada spasi di sekitar
+sama dengan ini dan itu
 
 0:27:16.020,0:27:18.720
-because alias takes a single argument
+karena alias mengambil satu argumen
 
 0:27:18.720,0:27:21.640
-and if you try doing
+dan jika kalian mencoba melakukan
 
 0:27:21.960,0:27:25.120
-something like this, that's giving
-it more than one argument
+sesuatu seperti ini, itu memberinya
+lebih dari satu argumen
 
 0:27:25.120,0:27:28.360
-and that's not gonna work because
-that's not the format it expects.
+dan itu tidak akan berhasil karena
+itu bukan format yang diharapkan.
 
 0:27:29.520,0:27:33.680
-So other use cases that work for aliases,
+Jadi kasus penggunaan lain yang berfungsi untuk alias,
 
 0:27:34.720,0:27:36.549
-as I was saying,
+seperti yang saya katakan,
 
 0:27:36.549,0:27:39.920
-for some things it may be much more convenient,
+untuk beberapa hal mungkin jauh lebih nyaman,
 
 0:27:40.040,0:27:41.020
-like
+seperti
 
 0:27:41.020,0:27:43.200
-one of my favorites is git status.
+salah satu favorit saya adalah git status.
 
 0:27:43.200,0:27:47.500
-It's extremely long, and I don't like typing
-that long of a command every so often,
+Ini sangat panjang, dan saya tidak suka mengetik
+perintah sepanjang itu terlalu sering,
 
 0:27:47.560,0:27:48.960
-because you end up taking a lot of time.
+karena kalian akhirnya menghabiskan banyak waktu.
 
 0:27:49.120,0:27:53.000
-So GS will replace for doing the git status
+Jadi GS akan menggantikan melakukan git status
 
 0:27:53.820,0:27:58.620
-You can also use them to alias
-things that you mistype often,
+Kalian juga bisa menggunakannya untuk meng-alias
+hal-hal yang sering kalian salah ketik,
 
 0:27:58.620,0:28:01.160
-so you can do "sl=ls",
+jadi kalian bisa lakukan "sl=ls",
 
 0:28:01.160,0:28:02.540
-that will work.
+itu akan berhasil.
 
 0:28:05.800,0:28:10.620
-Other useful mappings are,
+Pemetaan berguna lainnya adalah,
 
 0:28:10.680,0:28:15.460
-you might want to alias a command to itself
+kalian mungkin ingin meng-alias perintah ke dirinya sendiri
 
 0:28:15.740,0:28:17.520
-but with a default flag.
+tapi dengan flag default.
 
 0:28:17.520,0:28:21.100
-So here what is going on is I'm creating an alias
+Jadi di sini yang terjadi adalah saya membuat alias
 
 0:28:21.100,0:28:23.100
-which is an alias for the move command,
+yang merupakan alias untuk perintah move,
 
 0:28:23.300,0:28:29.780
-which is MV and I'm aliasing it to the
-same command but adding the "-i" flag.
+yaitu MV dan saya meng-aliasnya ke
+perintah yang sama tapi menambahkan flag "-i".
 
 0:28:29.980,0:28:34.460
-And this "-i" flag, if you go through the man page
-and look at it, it stands for "interactive".
+Dan flag "-i" ini, jika kalian melalui man page
+dan melihatnya, singkatan dari "interactive".
 
 0:28:34.780,0:28:39.880
-And what it will do is it will prompt
-me before I do an overwrite.
+Dan yang akan dilakukannya adalah akan memberi saya prompt
+sebelum saya melakukan overwrite.
 
 0:28:39.880,0:28:44.420
-So once I have executed this,
-I can do something like
+Jadi setelah saya menjalankan ini,
+saya bisa melakukan sesuatu seperti
 
 0:28:44.700,0:28:47.360
-I want to move "aliases" into "case".
+saya ingin memindahkan "aliases" ke "case".
 
 0:28:47.700,0:28:53.140
-By default "move" won't ask, and if "case"
-already exists, it will be over.
+Secara default "move" tidak akan bertanya, dan jika "case"
+sudah ada, itu akan tertimpa.
 
 0:28:53.160,0:28:55.780
-That's fine, I'm going to overwrite
-whatever that's there.
+Tidak apa-apa, saya akan menimpa
+apa pun yang ada di sana.
 
 0:28:56.020,0:28:58.580
-But here it's now expanded,
+Tapi di sini sekarang diperluas,
 
 0:28:58.580,0:29:01.660
-"move" has been expanded into this "move -i"
+"move" telah diperluas menjadi "move -i" ini
 
 0:29:01.660,0:29:03.540
-and it's using that to ask me
+dan ia menggunakan itu untuk bertanya kepada saya
 
 0:29:03.540,0:29:07.400
-"Oh, are you sure you want to overwrite this?"
+"Oh, apakah kalian yakin ingin menimpa ini?"
 
 0:29:07.700,0:29:11.780
-And I can say no, I don't want to lose that file.
+Dan saya bisa bilang tidak, saya tidak ingin kehilangan file itu.
 
 0:29:12.180,0:29:15.820
-Lastly, you can use "alias move"
+Terakhir, kalian bisa menggunakan "alias move"
 
 0:29:15.820,0:29:18.520
-to ask for what this alias stands for.
+untuk menanyakan apa arti alias ini.
 
 0:29:19.100,0:29:22.060
-So it will tell you so you can quickly make sure
+Jadi ia akan memberi tahu kalian sehingga kalian bisa dengan cepat memastikan
 
 0:29:22.080,0:29:25.400
-what the command that you
-are executing actually is.
+apa perintah yang sebenarnya
+kalian jalankan.
 
 0:29:27.040,0:29:31.400
-One inconvenient part about, for example,
-having aliases is how will you go about
+Satu bagian yang tidak nyaman tentang, misalnya,
+memiliki alias adalah bagaimana kalian akan
 
 0:29:31.760,0:29:35.340
-persisting them into your current environment?
+mempertahankannya di lingkungan kalian saat ini?
 
 0:29:35.500,0:29:38.120
-Like, if I were to close this terminal now,
+Seperti, jika saya menutup terminal ini sekarang,
 
 0:29:38.280,0:29:40.160
-all these aliases will go away.
+semua alias ini akan hilang.
 
 0:29:40.160,0:29:43.020
-And you don't want to be kind
-of retyping these commands
+Dan kalian tidak ingin
+mengetik ulang perintah-perintah ini
 
 0:29:43.020,0:29:46.760
-and more generally, if you start configuring
-your shell more and more,
+dan lebih umum, jika kalian mulai mengonfigurasi
+shell kalian semakin banyak,
 
 0:29:46.860,0:29:50.880
-you want some way of bootstrapping
-all this configuration.
+kalian ingin beberapa cara untuk mem-bootstrap
+semua konfigurasi ini.
 
 0:29:51.380,0:29:56.780
-You will find that most shell command programs
+Kalian akan menemukan bahwa kebanyakan program perintah shell
 
 0:29:56.880,0:30:01.440
-will use some sort of text
-based configuration file.
+akan menggunakan semacam konfigurasi
+berbasis teks.
 
 0:30:01.440,0:30:06.740
-And this is what we usually call "dotfiles", because
-they start with a dot for historical reasons.
+Dan ini yang biasanya kita sebut "dotfiles", karena
+mereka dimulai dengan titik untuk alasan historis.
 
 0:30:07.060,0:30:13.160
-So for bash in our case, which is a shell,
+Jadi untuk bash dalam kasus kita, yang merupakan shell,
 
 0:30:13.160,0:30:15.560
-we can look at the bashrc.
+kita bisa melihat bashrc.
 
 0:30:16.180,0:30:19.840
-For demonstration purposes,
-here I have been using ZSH,
+Untuk tujuan demonstrasi,
+di sini saya telah menggunakan ZSH,
 
 0:30:19.900,0:30:24.460
-which is a different shell, and I'm going
-to be configuring bash, and starting bash.
+yang merupakan shell berbeda, dan saya akan
+mengonfigurasi bash, dan memulai bash.
 
 0:30:24.640,0:30:29.640
-So if I create an entry here and I say
+Jadi jika saya membuat entri di sini dan saya katakan
 
 0:30:29.940,0:30:31.960
-SL maps to LS
+SL dipetakan ke LS
 
 0:30:32.600,0:30:36.020
-And I have modified that, and now I start bash.
+Dan saya telah memodifikasi itu, dan sekarang saya memulai bash.
 
 0:30:36.540,0:30:40.660
-Bash is kind of completely unconfigured,
-but now if I do SL...
+Bash sepenuhnya tidak terkonfigurasi,
+tapi sekarang jika saya lakukan SL...
 
 0:30:41.360,0:30:44.040
-Hm, that's unexpected.
+Hm, itu tidak terduga.
 
 0:30:46.280,0:30:48.000
-Oh, good. Good getting that.
+Oh, bagus. Bagus menangkap itu.
 
 0:30:48.300,0:30:52.200
-So it matters where you config file is,
+Jadi penting di mana file config kalian berada,
 
 0:30:52.200,0:30:55.260
-your config file needs to be in your home folder.
+file config kalian harus berada di folder home kalian.
 
 0:30:55.640,0:31:00.940
-So your configuration file for
-bash will live in that "~",
+Jadi file konfigurasi kalian untuk
+bash akan tinggal di "~" itu,
 
 0:31:00.940,0:31:03.940
-which will expand to your home directory,
+yang akan diperluas ke direktori home kalian,
 
 0:31:03.940,0:31:05.560
-and then bashrc.
+lalu bashrc.
 
 0:31:06.160,0:31:08.840
-And here we can create the alias
+Dan di sini kita bisa membuat alias
 
 0:31:12.040,0:31:15.840
-and now we start a bash session and we do SL.
+dan sekarang kita memulai sesi bash dan kita lakukan SL.
 
 0:31:15.840,0:31:21.500
-Now it has been loaded, and this is
-loaded at the beginning when this
+Sekarang telah dimuat, dan ini
+dimuat di awal ketika program
 
 0:31:22.300,0:31:24.300
-bash program is started.
+bash ini dimulai.
 
 0:31:24.700,0:31:31.200
-All this configuration is loaded and you can, not only use
-aliases, they can have a lot of parts of configuration.
+Semua konfigurasi ini dimuat dan kalian bisa, tidak hanya menggunakan
+alias, mereka bisa memiliki banyak bagian konfigurasi.
 
 0:31:31.390,0:31:35.729
-So for example here, I have a prompt
-which is fairly useless.
+Jadi misalnya di sini, saya punya prompt
+yang cukup tidak berguna.
 
 0:31:35.730,0:31:38.429
-It has just given me the name
-of the shell, which is bash,
+Ini hanya memberi saya nama
+shell, yaitu bash,
 
 0:31:38.640,0:31:43.820
-and the version, which is 5.0. I don't
-want this to be displayed and
+dan versinya, yaitu 5.0. Saya tidak
+ingin ini ditampilkan dan
 
 0:31:44.360,0:31:48.540
-as with many things in your shell, this
-is just an environment variable.
+seperti banyak hal di shell kalian, ini
+hanya variabel lingkungan.
 
 0:31:48.600,0:31:53.120
-So the "PS1" is just the prompt string
+Jadi "PS1" hanyalah prompt string
 
 0:31:53.710,0:31:55.480
-for your prompt and
+untuk prompt kalian dan
 
 0:31:55.480,0:32:02.520
-we can actually modify this
-to just be a "> " symbol.
+kita sebenarnya bisa memodifikasi ini
+menjadi hanya simbol "> ".
 
 0:32:02.520,0:32:08.280
-and now that has been modified, and we have
-that. But if we exit and call bash again,
+dan sekarang itu telah dimodifikasi, dan kita punya
+itu. Tapi jika kita keluar dan memanggil bash lagi,
 
 0:32:08.620,0:32:15.059
-that was lost. However, if we add this
-entry and say, oh we want "PS1"
+itu hilang. Namun, jika kita menambahkan entri ini dan katakan, oh kita ingin "PS1"
 
 0:32:15.760,0:32:17.230
-to be
+menjadi
 
 0:32:17.230,0:32:19.179
-this and
+ini dan
 
 0:32:19.179,0:32:24.689
-we call bash again, this has been persisted.
-And we can keep modifying this configuration.
+kita memanggil bash lagi, ini telah dipertahankan. Dan kita bisa terus memodifikasi konfigurasi ini.
 
 0:32:25.090,0:32:27.209
-So maybe we want to include
+Jadi mungkin kita ingin menyertakan
 
 0:32:27.880,0:32:29.880
-where the
+di mana
 
 0:32:30.370,0:32:32.939
-working directory that we are is in, and
+direktori kerja yang kita berada, dan
 
 0:32:34.140,0:32:37.380
-that's telling us the same information
-that we had in the other shell.
+itu memberi kita informasi yang sama
+yang kita punya di shell lain.
 
 0:32:37.380,0:32:40.480
-And there are many, many options,
+Dan ada banyak, banyak opsi,
 
 0:32:40.780,0:32:45.060
-shells are highly, highly configurable, and
+shell sangat, sangat dapat dikonfigurasi, dan
 
 0:32:45.700,0:32:49.920
-it's not only cells that are configured
-through these files,
+bukan hanya shell yang dikonfigurasi
+melalui file-file ini,
 
 0:32:50.590,0:32:55.740
-there are many other programs. As we saw for
-example in the editors lecture, Vim is also
+ada banyak program lain. Seperti yang kita lihat misalnya
+di kuliah editor, Vim juga
 
 0:32:55.840,0:33:02.900
-configured this way. We gave you this vimrc
-file and told you to put it under your
+dikonfigurasi dengan cara ini. Kami memberi kalian file vimrc ini
+dan menyuruh kalian menempatkannya di
 
 0:33:03.460,0:33:06.380
 home/.vimrc
 
 0:33:06.380,0:33:11.800
-and this is the same concept, but just
-for Vim. It's just giving it a set of
+dan ini konsep yang sama, tapi hanya
+untuk Vim. Ini hanya memberi set
 
 0:33:12.160,0:33:18.340
-instructions that it should load when it's started,
-so you can keep a configuration that you want.
+instruksi yang harus dimuat saat dimulai,
+sehingga kalian bisa mempertahankan konfigurasi yang kalian inginkan.
 
 0:33:19.140,0:33:21.240
-And even non...
+Dan bahkan non...
 
 0:33:21.580,0:33:27.140
-kind of a lot of programs will support this. For instance,
-my terminal emulator, which is another concept,
+banyak program akan mendukung ini. Misalnya,
+emulator terminal saya, yang merupakan konsep lain,
 
 0:33:27.260,0:33:30.159
-which is the program that is
+yang merupakan program yang
 
 0:33:30.159,0:33:35.459
-running the shell, in a way, and displaying
-this into the screen in my computer.
+menjalankan shell, dalam beberapa cara, dan menampilkan
+ini ke layar di komputer saya.
 
 0:33:35.950,0:33:38.610
-It can also be configured this way, so
+Ini juga bisa dikonfigurasi dengan cara ini, jadi
 
 0:33:39.940,0:33:43.620
-if I modify this I can
+jika saya memodifikasi ini saya bisa
 
 0:33:46.510,0:33:53.279
-change the size of the font. Like right now, for
-example, I have increased the font size a lot
+mengubah ukuran font. Seperti sekarang, misalnya,
+saya telah meningkatkan ukuran font banyak
 
 0:33:53.279,0:33:55.768
-for demonstration purposes, but
+untuk tujuan demonstrasi, tapi
 
 0:33:56.440,0:34:00.360
-if I change this entry and make it for example
+jika saya mengubah entri ini dan membuatnya misalnya
 
 0:34:01.320,0:34:06.820
-28 and write this value, you see that
-the size of the font has changed,
+28 dan menulis nilai ini, kalian lihat bahwa
+ukuran font telah berubah,
 
 0:34:06.820,0:34:12.920
-because I edited this text file that specifies
-how my terminal emulator should work.
+karena saya mengedit file teks ini yang menentukan
+bagaimana emulator terminal saya harus bekerja.
 
 0:34:19.480,0:34:20.900
-Any questions so far?
+Ada pertanyaan sejauh ini?
 
 0:34:20.900,0:34:22.280
-With dotfiles.
+Dengan dotfiles.
 
 0:34:28.040,0:34:35.940
-Okay, it can be a bit daunting knowing that there
-is like this endless wall of configurations,
+Oke, bisa agak menakutkan mengetahui bahwa ada
+seperti dinding konfigurasi yang tak ada habisnya,
 
 0:34:35.940,0:34:40.600
-and how do you go about learning
-about what can be configured?
+dan bagaimana kalian belajar
+tentang apa yang bisa dikonfigurasi?
 
 0:34:42.020,0:34:44.300
-The good news is that
+Kabar baiknya adalah bahwa
 
 0:34:44.640,0:34:48.900
-we have linked you to really good
-resources in the lecture notes.
+kami telah menautkan kalian ke sumber daya yang sangat bagus
+di catatan kuliah.
 
 0:34:48.960,0:34:56.440
-But the main idea is that a lot of people really like
-just configuring these tools and have uploaded
+Tapi ide utamanya adalah bahwa banyak orang benar-benar suka
+mengonfigurasi alat-alat ini dan telah mengunggah
 
 0:34:56.640,0:35:01.140
-their configuration files to GitHub, another
-different kind of repositories online.
+file konfigurasi mereka ke GitHub, repositori
+berbeda lainnya secara online.
 
 0:35:01.140,0:35:03.300
-So for example, here we are on GitHub,
+Jadi misalnya, di sini kita di GitHub,
 
 0:35:03.300,0:35:06.640
-we search for dotfiles, and
-can see that there are like
+kita mencari dotfiles, dan
+bisa melihat bahwa ada seperti
 
 0:35:06.780,0:35:12.540
-thousands of repositories of people sharing
-their configuration files. We have also...
+ribuan repositori orang yang berbagi
+file konfigurasi mereka. Kami juga...
 
 0:35:12.540,0:35:15.460
-Like, the class instructors
-have linked our dotfiles.
+Seperti, instruktur kelas
+telah menautkan dotfiles kami.
 
 0:35:15.460,0:35:19.420
-So if you really want to know how
-any part of our setup is working
+Jadi jika kalian benar-benar ingin tahu bagaimana
+bagian dari setup kami bekerja
 
 0:35:19.420,0:35:22.220
-you can go through it and try to figure it out.
+kalian bisa memeriksanya dan mencoba memahaminya.
 
 0:35:22.220,0:35:24.220
-You can also feel free to ask us.
+Kalian juga bebas bertanya kepada kami.
 
 0:35:24.380,0:35:27.060
-If we go for example to this repository here
+Jika kita pergi misalnya ke repositori ini di sini
 
 0:35:27.210,0:35:30.649
-we can see that there's many, many
-files that you can configure.
+kita bisa melihat bahwa ada banyak, banyak
+file yang bisa kalian konfigurasikan.
 
 0:35:30.650,0:35:37.520
-For example, there is one for bash, the first couple of ones
-are for git, that will be probably be covered in the
+Misalnya, ada satu untuk bash, beberapa pertama
+adalah untuk git, yang mungkin akan dibahas di
 
 0:35:38.610,0:35:40.819
-version control lecture tomorrow.
+kuliah version control besok.
 
 0:35:41.400,0:35:48.500
-If we go for example to the bash profile, which is
-a different form of what we saw in the bashrc,
+Jika kita pergi misalnya ke bash profile, yang merupakan
+bentuk berbeda dari apa yang kita lihat di bashrc,
 
 0:35:49.400,0:35:52.900
-it can be really useful because
-you can learn through
+ini bisa sangat berguna karena
+kalian bisa belajar melalui
 
 0:35:53.940,0:35:58.320
-just looking at the manual page, but the
-manual pages is, a lot of the time
+hanya melihat halaman manual, tapi
+halaman manual, sering kali
 
 0:35:58.480,0:36:03.520
-just kind of like a descriptive explanation
-of all the different options
+hanya seperti penjelasan deskriptif
+dari semua opsi berbeda
 
 0:36:03.520,0:36:04.880
-and sometimes it's more helpful
+dan terkadang lebih membantu
 
 0:36:04.880,0:36:09.600
-going through examples of what people have done
-and trying to understand why they did it
+melalui contoh apa yang telah dilakukan orang
+dan mencoba memahami mengapa mereka melakukannya
 
 0:36:09.600,0:36:12.200
-and how it's helping their workflow.
+dan bagaimana itu membantu workflow mereka.
 
 0:36:12.960,0:36:17.300
-We can say here that this person has
-done case-insensitive globbing.
+Kita bisa bilang di sini bahwa orang ini telah
+melakukan globbing case-insensitive.
 
 0:36:17.320,0:36:21.220
-We covered globbing as this
-kind of filename expansion
+Kita telah membahas globbing sebagai
+ekspansi nama file semacam ini
 
 0:36:22.100,0:36:25.760
-trick in the shell scripting and tools.
+trik di shell scripting dan tools.
 
 0:36:25.900,0:36:28.800
-And here you say no, I don't want this to matter,
+Dan di sini kalian bilang tidak, saya tidak ingin ini penting,
 
 0:36:28.800,0:36:30.760
-whether using uppercase and lowercase,
+apakah menggunakan huruf besar dan kecil,
 
 0:36:30.760,0:36:32.760
-and just setting this option in the shell
-for these things to work this way
+dan hanya mengatur opsi ini di shell
+untuk hal-hal ini bekerja dengan cara ini
 
 0:36:35.360,0:36:38.140
-Similarly, there is for example aliases.
+Demikian pula, ada misalnya aliases.
 
 0:36:38.140,0:36:42.220
-Here you can see a lot of aliases that this
-person is doing. For example, "d" for
+Di sini kalian bisa melihat banyak alias yang dilakukan
+orang ini. Misalnya, "d" untuk
 
 0:36:44.200,0:36:47.400
-"d" for "Dropbox", sorry, because
-that's just much shorter.
+"d" untuk "Dropbox", maaf, karena
+itu jauh lebih pendek.
 
 0:36:47.400,0:36:49.200
-"g" for "git"...
+"g" untuk "git"...
 
 0:36:49.740,0:36:54.560
-Say we go, for example, with vimrc. It
-can be actually very, very informative,
+Katakan kita pergi, misalnya, dengan vimrc. Ini
+bisa sangat, sangat informatif,
 
 0:36:54.560,0:36:58.860
-going through this and trying
-to extract useful information.
+melalui ini dan mencoba
+mengekstrak informasi berguna.
 
 0:36:59.000,0:37:06.420
-We do not recommend just kind of getting one huge blob
-of this and copying this into your config files,
+Kami tidak merekomendasikan hanya mengambil satu blob besar
+dari ini dan menyalinnya ke file config kalian,
 
 0:37:07.110,0:37:12.439
-because maybe things are prettier, but you might
-not really understand what is going on.
+karena mungkin hal-halnya lebih cantik, tapi kalian mungkin
+tidak benar-benar memahami apa yang terjadi.
 
 0:37:15.150,0:37:19.579
-Lastly one thing I want to mention
-about dotfiles is that
+Terakhir satu hal yang ingin saya sebutkan
+tentang dotfiles adalah bahwa
 
 0:37:20.460,0:37:23.390
-people not only try to push these
+orang tidak hanya mencoba mendorong ini
 
 0:37:24.660,0:37:28.849
-files into GitHub just so other
-people can read it, that's
+file ke GitHub hanya supaya orang lain
+bisa membacanya, itu
 
 0:37:29.400,0:37:33.319
-one reason. They also make really sure they can
+salah satu alasan. Mereka juga memastikan mereka bisa
 
 0:37:34.140,0:37:39.440
-reproduce their setup. And to do that
-they use a slew of different tools.
+mereproduksi setup mereka. Dan untuk melakukannya
+mereka menggunakan banyak alat berbeda.
 
 0:37:39.440,0:37:41.280
-Oops, went a little too far.
+Ups, pergi terlalu jauh.
 
 0:37:41.280,0:37:44.840
-So GNU Stow is, for example, one of them
+Jadi GNU Stow adalah, misalnya, salah satunya
 
 0:37:45.720,0:37:49.060
-and the trick that they are doing is
+dan trik yang mereka lakukan adalah
 
 0:37:50.280,0:37:54.520
-they are kind of putting all their
-dotfiles in a folder and they are
+mereka menempatkan semua
+dotfiles mereka di folder dan mereka
 
 0:37:55.200,0:37:59.520
-faking to the system, using
-a tool called symlinks,
+memalsukan ke sistem, menggunakan
+alat yang disebut symlinks,
 
 0:37:59.520,0:38:02.440
-that they are actually what
-they're not. I'm gonna
+bahwa mereka sebenarnya bukan apa
+yang mereka. Saya akan
 
 0:38:03.150,0:38:05.150
-draw really quick what I mean by that.
+menggambar dengan cepat apa yang saya maksud.
 
 0:38:05.790,0:38:10.939
-So a common folder structure might look
-like you have your home folder and
+Jadi struktur folder umum mungkin terlihat
+seperti kalian punya folder home dan
 
 0:38:11.670,0:38:14.300
-in this home folder you might have your
+di folder home ini kalian mungkin punya
 
 0:38:16.050,0:38:21.380
-bashrc, that contains your bash configuration,
-you might have your vimrc and
+bashrc kalian, yang berisi konfigurasi bash kalian,
+kalian mungkin punya vimrc kalian dan
 
 0:38:22.500,0:38:25.760
-it would be really great if you could
-keep this under version control.
+akan sangat bagus jika kalian bisa
+menjaga ini di bawah version control.
 
 0:38:26.580,0:38:29.300
-But the thing is, you might not
-want to have a git repository,
+Tapi masalahnya, kalian mungkin tidak
+ingin memiliki repositori git,
 
 0:38:29.300,0:38:31.300
-which will be covered tomorrow,
+yang akan dibahas besok,
 
 0:38:31.300,0:38:32.300
-in your home folder.
+di folder home kalian.
 
 0:38:32.300,0:38:37.360
-So what people usually do is they
-create a dotfiles repository,
+Jadi yang biasanya dilakukan orang adalah mereka
+membuat repositori dotfiles,
 
 0:38:38.280,0:38:42.160
-and then they have entries here for their
+dan kemudian mereka punya entri di sini untuk
 
 0:38:43.050,0:38:47.239
-bashrc and their vimrc. And
-this is where actually
+bashrc dan vimrc mereka. Dan
+di sinilah sebenarnya
 
 0:38:47.820,0:38:49.820
-the files are
+file-file itu berada
 
 0:38:50.100,0:38:52.400
-and what they are doing is they're just
+dan yang mereka lakukan adalah hanya
 
 0:38:53.460,0:38:56.510
-telling the OS to forward, whenever anyone
+memberi tahu OS untuk meneruskan, setiap kali siapa pun
 
 0:38:56.760,0:39:01.849
-wants to read this file or write to this file,
-just forward this to this other file.
+ingin membaca file ini atau menulis ke file ini,
+hanya teruskan ini ke file lain ini.
 
 0:39:03.000,0:39:05.719
-This is a concept called symlinks
+Ini adalah konsep yang disebut symlinks
 
 0:39:06.690,0:39:08.630
-and it's useful in this scenario,
+dan ini berguna dalam skenario ini,
 
 0:39:08.630,0:39:12.600
-but it in general it's a really
-useful tool in UNIX
+tapi secara umum ini adalah alat yang sangat
+berguna di UNIX
 
 0:39:12.700,0:39:14.700
-that we haven't covered so far in the lectures
+yang belum kita bahas sejauh ini di kuliah
 
 0:39:14.960,0:39:16.740
-but you might be...
+tapi kalian mungkin...
 
 0:39:16.740,0:39:18.740
-that you should be familiar with.
+bahwa kalian harus familiar dengannya.
 
 0:39:19.100,0:39:22.840
-And in general, the syntax will be "ln -s"
+Dan secara umum, sintaksnya akan menjadi "ln -s"
 
 0:39:22.840,0:39:29.980
-for specifying a symbolic link and then
-you will put the path to the file
+untuk menentukan symbolic link dan kemudian
+kalian akan menaruh path ke file
 
 0:39:30.570,0:39:33.049
-that you want to create and then the
+yang ingin kalian buat dan kemudian
 
 0:39:33.780,0:39:35.780
-symlink that you want to create.
+symlink yang ingin kalian buat.
 
 0:39:39.390,0:39:41.390
-And
+Dan
 
 0:39:41.880,0:39:45.619
-All these all these kind of fancy tools
-that we're seeing here listed,
+Semua semua alat mewah ini
+yang kita lihat terdaftar di sini,
 
 0:39:45.810,0:39:52.159
-they all amount to doing some sort of this trick, so
-that you can have all your dotfiles neat and tidy
+semuanya berjumlah melakukan semacam trik ini, sehingga
+kalian bisa memiliki semua dotfiles kalian rapi dan teratur
 
 0:39:52.680,0:39:57.829
-into a folder, and then they can be
-version-controlled, and they can be
+di folder, dan kemudian mereka bisa di-
+version-control, dan mereka bisa di-
 
 0:39:58.349,0:40:02.689
-symlinked so the rest of the programs can
-find them in their default locations.
+symlink sehingga program lain bisa
+menemukan mereka di lokasi default mereka.
 
 0:40:06.720,0:40:09.020
-Any questions regarding dotfiles?
+Ada pertanyaan tentang dotfiles?
 
 0:40:13.200,0:40:20.200
-Do you need to have the dotfiles in your home folder,
-and then also dotfiles in the version control folder?
+Apakah kalian perlu memiliki dotfiles di folder home kalian,
+dan juga dotfiles di folder version control?
 
 0:40:20.780,0:40:24.640
-So what you will have is,
-pretty much every program,
+Jadi yang akan kalian miliki adalah,
+hampir setiap program,
 
 0:40:24.640,0:40:26.180
-for example bash,
+misalnya bash,
 
 0:40:26.180,0:40:29.560
-will always look for "home/.bashrc".
+akan selalu mencari "home/.bashrc".
 
 0:40:29.560,0:40:33.480
-That's where the program is going to look for.
+Di situlah program akan mencari.
 
 0:40:33.820,0:40:40.200
-What you do when you do a symlink
-is, you place your "home/.bashrc"
+Yang kalian lakukan ketika kalian melakukan symlink
+adalah, kalian menempatkan "home/.bashrc" kalian
 
 0:40:40.200,0:40:44.900
-it's just a file that is kind
-of a special file in UNIX,
+itu hanya file yang merupakan
+file khusus di UNIX,
 
 0:40:45.150,0:40:49.609
-that says oh, whenever you want to read
-this file go to this other file.
+yang mengatakan oh, setiap kali kalian ingin membaca
+file ini pergi ke file lain ini.
 
 0:40:51.500,0:40:53.440
-There's no content, like there is no...
+Tidak ada konten, seperti tidak ada...
 
 0:40:53.600,0:40:58.099
-your aliases are not part of this dotfile. That file
-is just kind of like a pointer, saying now you should
+alias kalian bukan bagian dari dotfile ini. File itu
+hanya seperti pointer, mengatakan sekarang kalian harus
 
 0:40:58.100,0:40:59.400
-go that other way.
+pergi ke arah lain itu.
 
 0:40:59.400,0:41:02.600
-And by doing that you can have your other file
+Dan dengan melakukan itu kalian bisa memiliki file lain kalian
 
 0:41:02.600,0:41:04.400
-in that other folder.
+di folder lain itu.
 
 0:41:04.560,0:41:06.360
-If version controlling is not useful, think about
+Jika version controlling tidak berguna, pikirkan tentang
 
 0:41:06.360,0:41:10.740
-what if you want to have them in your Dropbox
-folder, so they're synced to the cloud,
+bagaimana jika kalian ingin memiliki mereka di folder Dropbox
+kalian, sehingga mereka disinkronkan ke cloud,
 
 0:41:10.759,0:41:15.019
-for example. That's kind of another use case
-where like symlinks could be really useful
+misalnya. Itu semacam kasus penggunaan lain
+di mana symlinks bisa sangat berguna
 
 0:41:16.240,0:41:21.040
-So you don't need the folder dotfiles
-to be in the home directory, right?
+Jadi kalian tidak perlu folder dotfiles
+berada di direktori home, kan?
 
 0:41:21.040,0:41:23.820
-Because you can just use the symlink,
-that points somewhere else.
+Karena kalian bisa hanya menggunakan symlink,
+yang menunjuk ke tempat lain.
 
 0:41:23.960,0:41:29.760
-As long as you have a way for the default path
-to resolve wherever you have it, yeah.
+Selama kalian punya cara untuk path default
+menyelesaikan di mana pun kalian memilikinya, ya.
 
 0:41:35.100,0:41:38.000
-Last thing I want to cover in the lecture...
+Hal terakhir yang ingin saya bahas di kuliah...
 
 0:41:38.000,0:41:40.380
-Oh, sorry, any other questions about dotfiles?
+Oh, maaf, ada pertanyaan lain tentang dotfiles?
 
 0:41:49.200,0:41:52.580
-Last thing I want to cover in the lecture
-is working with remote machines,
+Hal terakhir yang ingin saya bahas di kuliah
+adalah bekerja dengan mesin remote,
 
 0:41:52.580,0:41:55.549
-which is a thing that you will run into,
+yang merupakan hal yang akan kalian temui,
 
 0:41:55.559,0:41:56.900
-sooner or later.
+cepat atau lambat.
 
 0:41:56.900,0:42:02.238
-And there are a few things that will make your life
-much easier when dealing with remote machines
+Dan ada beberapa hal yang akan membuat hidup kalian
+jauh lebih mudah saat berurusan dengan mesin remote
 
 0:42:03.180,0:42:05.180
-if you know about them.
+jika kalian tahu tentang mereka.
 
 0:42:05.220,0:42:08.380
-Right now maybe because you are
-using the Athena cluster,
+Sekarang mungkin karena kalian
+menggunakan kluster Athena,
 
 0:42:08.380,0:42:10.740
-but later on, during your programming career,
+tapi nanti, selama karir pemrograman kalian,
 
 0:42:10.740,0:42:11.960
-it's pretty sure that
+sangat pasti bahwa
 
 0:42:11.960,0:42:15.400
-there is a fairly ubiquitous
-concept of having your
+ada konsep yang cukup ada di mana-mana
+yaitu memiliki
 
 0:42:15.400,0:42:20.380
-local working environment and then having some
-production server that is actually running the
+lingkungan kerja lokal kalian dan kemudian memiliki
+server produksi yang sebenarnya menjalankan
 
 0:42:20.970,0:42:23.239
-code, so it is really good to get familiar
+kode, jadi sangat bagus untuk familiar
 
 0:42:24.480,0:42:26.749
-about how to work in/with remote machines.
+tentang cara bekerja dengan mesin remote.
 
 0:42:27.420,0:42:35.180
-So the main command for working
-with remote machines is SSH.
+Jadi perintah utama untuk bekerja
+dengan mesin remote adalah SSH.
 
 0:42:37.760,0:42:43.900
-SSH is just like a secure shell, it's
-just gonna take the responsibility for
+SSH hanyalah secure shell, ia hanya
+akan mengambil tanggung jawab untuk
 
 0:42:43.900,0:42:46.540
-reaching wherever we want or tell it to go
+mencapai di mana pun kita ingin atau menyuruhnya pergi
 
 0:42:47.560,0:42:50.700
-and trying to open a session there.
+dan mencoba membuka sesi di sana.
 
 0:42:50.700,0:42:52.400
-So here the syntax is:
+Jadi di sini sintaksnya adalah:
 
 0:42:53.130,0:42:56.660
-"JJGO" is the user that I want
-to use in the remote machine,
+"JJGO" adalah user yang ingin saya
+gunakan di mesin remote,
 
 0:42:56.660,0:42:58.430
-and this is because the user is
+dan ini karena user
 
 0:42:58.529,0:43:03.460
-different from the one I have my local machine,
-which will be the case a lot of the time,
+berbeda dari yang saya punya di mesin lokal saya,
+yang akan sering terjadi,
 
 0:43:03.460,0:43:07.400
-then the "@" is telling the
-terminal that this separates
+kemudian "@" memberi tahu
+terminal bahwa ini memisahkan
 
 0:43:07.400,0:43:12.540
-what the user is from what the address is.
+apa user dari apa address.
 
 0:43:12.540,0:43:16.540
-And here I'm using an IP address because
-what I'm actually doing is
+Dan di sini saya menggunakan alamat IP karena
+yang sebenarnya saya lakukan adalah
 
 0:43:16.540,0:43:20.500
-I have a virtual machine in my computer,
+saya punya mesin virtual di komputer saya,
 
 0:43:20.500,0:43:23.240
-that is the one that is remote right now.
+yang merupakan yang remote sekarang.
 
 0:43:23.240,0:43:26.400
-And I'm gonna be SSH'ing into it. This is the
+Dan saya akan SSH ke sana. Ini adalah
 
 0:43:26.580,0:43:27.880
-URL that I'm using,
+URL yang saya gunakan,
 
 0:43:27.880,0:43:29.860
-sorry, the IP that I'm using,
+maaf, IP yang saya gunakan,
 
 0:43:29.860,0:43:32.280
-but you might also see things like
+tapi kalian mungkin juga melihat hal-hal seperti
 
 0:43:32.360,0:43:36.820
-oh I want to SSH as "JJGO"
+oh saya ingin SSH sebagai "JJGO"
 
 0:43:36.820,0:43:39.840
-at "foobar.mit.edu"
+di "foobar.mit.edu"
 
 0:43:39.840,0:43:42.960
-That's probably something more
-common, if you are using some
+Itu mungkin sesuatu yang lebih
+umum, jika kalian menggunakan beberapa
 
 0:43:42.960,0:43:47.260
-remote server that has a DNS name.
+server remote yang punya nama DNS.
 
 0:43:48.180,0:43:51.860
-So going back to a regular command,
+Jadi kembali ke perintah biasa,
 
 0:43:53.220,0:43:56.580
-we try to SSH, it asks us for a password,
+kita coba SSH, ia meminta kita password,
 
 0:43:56.580,0:43:58.180
-really common thing.
+hal yang sangat umum.
 
 0:43:58.190,0:43:59.480
-And now we're there. We have...
+Dan sekarang kita di sana. Kita punya...
 
 0:43:59.480,0:44:02.629
-we're still in our same terminal emulator
+kita masih di emulator terminal yang sama
 
 0:44:02.630,0:44:09.529
-but right now SSH is kind of forwarding the
-entire virtual display to display what the
+tapi sekarang SSH semacam meneruskan
+seluruh tampilan virtual untuk menampilkan apa yang
 
 0:44:09.869,0:44:14.358
-remote shell is displaying. And
-we can execute commands here and
+shell remote tampilkan. Dan
+kita bisa menjalankan perintah di sini dan
 
 0:44:15.630,0:44:17.630
-we'll see the remote files
+kita akan melihat file remote
 
 0:44:18.390,0:44:22.819
-A couple of handy things to know about
-SSH, that were briefly covered in the
+Beberapa hal berguna yang perlu diketahui tentang
+SSH, yang briefly dibahas di
 
 0:44:23.220,0:44:27.080
-data wrangling lecture, is that
-SSH is not only good for just
+kuliah data wrangling, adalah bahwa
+SSH tidak hanya bagus untuk hanya
 
 0:44:28.280,0:44:33.760
-opening connections. It will also let
-you just execute commands remotely.
+membuka koneksi. Ini juga akan membiarkan
+kalian menjalankan perintah dari jarak jauh.
 
 0:44:33.770,0:44:36.979
-So for example, if I do that, it's gonna ask me
+Jadi misalnya, jika saya melakukan itu, ia akan meminta saya
 
 0:44:37.710,0:44:39.020
-what is my password?, again.
+apa password saya?, lagi.
 
 0:44:39.020,0:44:41.059
-And it's executing this command
+Dan ia menjalankan perintah ini
 
 0:44:41.279,0:44:43.420
-then coming back to my terminal
+lalu kembali ke terminal saya
 
 0:44:43.420,0:44:47.420
-and piping the output of what that
-command was, in the remote machine,
+dan menyalurkan output dari apa yang
+perintah itu lakukan, di mesin remote,
 
 0:44:47.420,0:44:50.480
-through the standard output in my current cell.
+melalui standard output di shell saya saat ini.
 
 0:44:50.480,0:44:53.940
-And I could have this in...
+Dan saya bisa memiliki ini di...
 
 0:44:58.100,0:45:00.480
-I could have this in a pipe, and
+Saya bisa memiliki ini di pipe, dan
 
 0:45:00.980,0:45:03.580
-this will work and we'll just
+ini akan berhasil dan kita hanya akan
 
 0:45:03.600,0:45:06.100
-drop all this output and then have a local pipe
+menghapus semua output ini dan kemudian memiliki pipe lokal
 
 0:45:06.100,0:45:07.879
-where I can keep working.
+di mana saya bisa terus bekerja.
 
 0:45:08.640,0:45:12.140
-So far, it has been kind of inconvenient,
-having to type our password.
+Sejauh ini, agak tidak nyaman,
+harus mengetik password kita.
 
 0:45:12.630,0:45:14.820
-There's one really good trick for this.
+Ada satu trik sangat bagus untuk ini.
 
 0:45:14.820,0:45:16.880
-It's we can use something called "SSH keys".
+Yaitu kita bisa menggunakan sesuatu yang disebut "SSH keys".
 
 0:45:17.140,0:45:20.660
-SSH keys just use public key encryption
+SSH keys hanya menggunakan enkripsi kunci publik
 
 0:45:20.660,0:45:24.980
-to create a pair of SSH keys, a public
-key and a private key, and then
+untuk membuat sepasang kunci SSH, kunci
+publik dan kunci privat, dan kemudian
 
 0:45:25.170,0:45:29.320
-you can give the server the
-public part of the key.
+kalian bisa memberi server bagian
+publik dari kunci itu.
 
 0:45:29.320,0:45:32.810
-So you copy the public key and
-then whenever you try to
+Jadi kalian menyalin kunci publik dan
+kemudian setiap kali kalian mencoba
 
 0:45:33.390,0:45:37.129
-authenticate instead of using your password,
-it's gonna use the private key to
+autentikasi alih-alih menggunakan password kalian,
+ia akan menggunakan kunci privat untuk
 
 0:45:37.820,0:45:40.800
-prove to the server that you are
-actually who you say you are.
+membuktikan ke server bahwa kalian adalah
+benar-benar siapa yang kalian katakan.
 
 0:45:43.860,0:45:48.020
-We can quickly showcase how you will go
+Kita bisa dengan cepat menunjukkan bagaimana kalian akan
 
 0:45:48.020,0:45:49.400
-about doing this.
+melakukan ini.
 
 0:45:49.400,0:45:53.180
-Right now I don't have any SSH keys,
-so I'm gonna create a couple of them.
+Sekarang saya tidak punya kunci SSH,
+jadi saya akan membuat beberapa.
 
 0:45:53.940,0:45:58.250
-First thing, it's just gonna ask
-me where I want this key to live.
+Hal pertama, ia hanya akan bertanya
+di mana saya ingin kunci ini tinggal.
 
 0:45:58.980,0:46:00.640
-Unsurprisingly, it's doing this.
+Tidak mengherankan, ia melakukan ini.
 
 0:46:00.640,0:46:04.820
-This is my home folder and then
-it's using this ".ssh" path,
+Ini folder home saya dan kemudian
+ia menggunakan path ".ssh" ini,
 
 0:46:05.460,0:46:08.750
-which refers back to the same concept
-that we covered earlier about having
+yang mengacu kembali ke konsep yang sama
+yang kita bahas sebelumnya tentang memiliki
 
 0:46:08.850,0:46:12.439
-dotfiles. Like ".ssh" is a folder
-that contains a lot of the
+dotfiles. Seperti ".ssh" adalah folder
+yang berisi banyak
 
 0:46:13.320,0:46:16.540
-configuration files for how
-you want SSH to behave.
+file konfigurasi untuk bagaimana
+kalian ingin SSH berperilaku.
 
 0:46:17.060,0:46:19.420
-So it will ask us a passphrase.
+Jadi ia akan meminta kita passphrase.
 
 0:46:19.680,0:46:23.120
-The passphrase is to encrypt
-the private part of the key
+Passphrase adalah untuk mengenkripsi
+bagian privat dari kunci
 
 0:46:23.120,0:46:27.160
-because if someone gets your private key,
-if you don't have a password protected
+karena jika seseorang mendapat kunci privat kalian,
+jika kalian tidak punya password yang melindungi
 
 0:46:27.920,0:46:29.580
-private key, if they get that key
+kunci privat, jika mereka mendapat kunci itu
 
 0:46:29.580,0:46:32.240
-they can use that key to impersonate
-you in any server.
+mereka bisa menggunakan kunci itu untuk menyamar
+sebagai kalian di server mana pun.
 
 0:46:32.310,0:46:34.360
-Whereas if you add a passphrase,
+Sedangkan jika kalian menambahkan passphrase,
 
 0:46:34.360,0:46:37.640
-they will have to know what the passphrase
-is to actually use the key.
+mereka harus tahu apa passphrase-nya
+untuk benar-benar menggunakan kunci itu.
 
 0:46:40.800,0:46:51.740
-It has created a keeper. We can check that
-these two files are now under ssh.
+Ini telah membuat key. Kita bisa memeriksa bahwa
+dua file ini sekarang ada di ssh.
 
 0:46:51.740,0:46:53.920
-And we can see...
+Dan kita bisa melihat...
 
 0:46:57.720,0:47:02.960
-We have these two files: we have
-the 25519 and the public key.
+Kita punya dua file ini: kita punya
+25519 dan kunci publik.
 
 0:47:03.320,0:47:06.300
-And if we "cat" through the output,
+Dan jika kita "cat" melalui output,
 
 0:47:06.300,0:47:09.760
-that key is actually not like
-any fancy binary file, it's
+kunci itu sebenarnya bukan seperti
+file biner yang mewah, itu
 
 0:47:15.430,0:47:20.760
-just a text file that has the contents
-of the public key and some
+hanya file teks yang punya konten
+dari kunci publik dan beberapa
 
 0:47:23.050,0:47:26.729
-alias name for it, so we can
-know what this public key is.
+nama alias untuk itu, sehingga kita bisa
+tahu apa kunci publik ini.
 
 0:47:26.950,0:47:32.220
-The way we can tell the server that
-we're authorized to SSH there
+Cara kita bisa memberi tahu server bahwa
+kita diotorisasi untuk SSH ke sana
 
 0:47:32.260,0:47:38.400
-is by just actually copying this file,
-like copying this string into a file,
+adalah dengan hanya benar-benar menyalin file ini,
+seperti menyalin string ini ke file,
 
 0:47:38.400,0:47:41.540
-that is ".ssh/authorized_keys".
+yaitu ".ssh/authorized_keys".
 
 0:47:42.100,0:47:46.160
-So here what I'm doing is I'm
+Jadi di sini yang saya lakukan adalah saya
 
 0:47:46.960,0:47:49.770
-catting the output of this file
+melakukan cat output dari file ini
 
 0:47:49.800,0:47:53.920
-which is just this line of
-text that we want to copy
+yang hanya baris teks
+ini yang ingin kita salin
 
 0:47:53.920,0:47:57.440
-and I'm piping that into SSH and then remotely
+dan saya menyalurkannya ke SSH dan kemudian dari jarak jauh
 
 0:47:57.960,0:48:02.080
-I'm asking "tee" to dump the contents
-of the standard input
+saya meminta "tee" untuk membuang konten
+dari standard input
 
 0:48:02.080,0:48:05.220
-into ".ssh/authorized_keys".
+ke ".ssh/authorized_keys".
 
 0:48:05.440,0:48:10.360
-And if we do that, obviously it's
-gonna ask us for a password.
+Dan jika kita melakukan itu, jelas ia akan
+meminta kita password.
 
 0:48:14.800,0:48:18.740
-It was copied, and now we
-can check that if we try
+Ini telah disalin, dan sekarang kita
+bisa memeriksa bahwa jika kita mencoba
 
 0:48:19.690,0:48:21.690
-to SSH again,
+untuk SSH lagi,
 
 0:48:21.960,0:48:24.840
-It's going to first ask us for a passphrase
+Ia akan pertama meminta kita passphrase
 
 0:48:24.840,0:48:29.100
-but you can arrange that so that
-it's saved in the session
+tapi kalian bisa mengatur sehingga
+itu disimpan di sesi
 
 0:48:29.460,0:48:34.840
-and we didn't actually have to
-type the key for the server.
+dan kita sebenarnya tidak harus
+mengetik kunci untuk server.
 
 0:48:34.840,0:48:36.840
-And I can kind of show that again.
+Dan saya bisa menunjukkan itu lagi.
 
 0:48:45.820,0:48:47.540
-More things that are useful.
+Lebih banyak hal yang berguna.
 
 0:48:47.540,0:48:49.040
-Oh, we can do...
+Oh, kita bisa melakukan...
 
 0:48:49.220,0:48:51.880
-If that command seemed a little bit janky,
+Jika perintah itu tampak agak janky,
 
 0:48:51.980,0:48:55.000
-you can actually use this command
-that is built for this,
+kalian sebenarnya bisa menggunakan perintah ini
+yang dibangun untuk ini,
 
 0:48:55.000,0:49:00.640
-so you don't have to kind of
-craft this "ssh t" command.
+sehingga kalian tidak harus
+merakit perintah "ssh t" ini.
 
 0:49:00.640,0:49:03.800
-That is just called "ssh-copy-id".
+Itu hanya disebut "ssh-copy-id".
 
 0:49:05.000,0:49:08.080
-And we can do the same
+Dan kita bisa melakukan hal yang sama
 
 0:49:08.080,0:49:09.660
-and it's gonna copy the key.
+dan ia akan menyalin kunci.
 
 0:49:09.660,0:49:14.280
-And now, if we try to SSH,
+Dan sekarang, jika kita mencoba SSH,
 
 0:49:14.500,0:49:18.320
-we can SSH without actually
-typing any key at all,
+kita bisa SSH tanpa benar-benar
+mengetik kunci apa pun,
 
 0:49:18.860,0:49:20.320
-or any password.
+atau password apa pun.
 
 0:49:20.660,0:49:21.520
-More things.
+Lebih banyak hal.
 
 0:49:21.520,0:49:23.520
-We will probably want to copy files.
+Kita mungkin ingin menyalin file.
 
 0:49:23.740,0:49:25.310
-You cannot use "CP"
+Kalian tidak bisa menggunakan "CP"
 
 0:49:25.310,0:49:29.720
-but you can use "SCP", for "SSH copy".
+tapi kalian bisa menggunakan "SCP", untuk "SSH copy".
 
 0:49:29.720,0:49:34.500
-And here we can specify that we want
-to copy this local file called notes
+Dan di sini kita bisa menentukan bahwa kita ingin
+menyalin file lokal ini yang disebut notes
 
 0:49:34.500,0:49:36.880
-and the syntax is kind of similar.
+dan sintaksnya agak mirip.
 
 0:49:36.880,0:49:39.760
-We want to copy to this remote and
+Kita ingin menyalin ke remote ini dan
 
 0:49:39.920,0:49:44.020
-then we have a semicolon to separate
-what the path is going to be.
+kemudian kita punya titik koma untuk memisahkan
+apa path yang akan menjadi.
 
 0:49:44.020,0:49:45.040
-And then we have
+Dan kemudian kita punya
 
 0:49:45.040,0:49:46.620
-oh, we want to copy this as notes
+oh, kita ingin menyalin ini sebagai notes
 
 0:49:46.620,0:49:51.000
-but we could also copy this as foobar.
+tapi kita juga bisa menyalin ini sebagai foobar.
 
 0:49:51.740,0:49:55.600
-And if we do that, it has been executed
+Dan jika kita melakukan itu, itu telah dijalankan
 
 0:49:55.780,0:49:59.280
-and it's telling us that all the
-contents have been copied there.
+dan ia memberi tahu kita bahwa semua
+konten telah disalin ke sana.
 
 0:49:59.540,0:50:02.200
-If you're gonna be copying a lot of files,
+Jika kalian akan menyalin banyak file,
 
 0:50:02.200,0:50:05.100
-there is a better command
-that you should be using
+ada perintah yang lebih baik
+yang harus kalian gunakan
 
 0:50:05.100,0:50:07.740
-that is called "RSYNC". For example, here
+yaitu disebut "RSYNC". Misalnya, di sini
 
 0:50:07.900,0:50:10.780
-just by specifying these three flags,
+hanya dengan menentukan tiga flag ini,
 
 0:50:10.820,0:50:15.960
-I'm telling RSYNC to kind of preserve
-all the permissions whenever possible
+saya memberi tahu RSYNC untuk mempertahankan
+semua izin kapan pun memungkinkan
 
 0:50:16.240,0:50:19.740
-to try to check if the file
-has already been copied.
+untuk mencoba memeriksa apakah file
+telah disalin.
 
 0:50:19.740,0:50:24.100
-For example, SCP will try to copy
-files that are already there.
+Misalnya, SCP akan mencoba menyalin
+file yang sudah ada di sana.
 
 0:50:24.200,0:50:26.440
-This will happen for example
-if you are trying to copy
+Ini akan terjadi misalnya
+jika kalian mencoba menyalin
 
 0:50:26.440,0:50:29.060
-and the connection interrupts
-in the middle of it.
+dan koneksi terputus
+di tengahnya.
 
 0:50:29.120,0:50:32.060
-SCP will start from the very beginning,
-trying to copy every file,
+SCP akan mulai dari awal,
+mencoba menyalin setiap file,
 
 0:50:32.080,0:50:36.600
-whereas RSYNC will continue
-from where it stopped.
+sedangkan RSYNC akan melanjutkan
+dari tempat ia berhenti.
 
 0:50:37.240,0:50:38.440
-And here,
+Dan di sini,
 
 0:50:39.060,0:50:42.760
-we ask it to copy the entire folder and
+kita memintanya untuk menyalin seluruh folder dan
 
 0:50:43.780,0:50:46.560
-it's just really quickly
-copied the entire folder.
+ia hanya dengan cepat
+menyalin seluruh folder.
 
 0:50:48.080,0:50:54.100
-One of the other things to know about SSH is that
+Salah satu hal lain yang perlu diketahui tentang SSH adalah bahwa
 
 0:50:54.320,0:50:59.860
-the equivalent of the dot file
-for SSH is the "SSH config".
+setara dari dot file
+untuk SSH adalah "SSH config".
 
 0:50:59.860,0:51:06.340
-So if we edit the SSH config to be
+Jadi jika kita mengedit SSH config menjadi
 
 0:51:13.120,0:51:17.940
-If I edit the SSH config to
-look something like this,
+Jika saya mengedit SSH config untuk
+terlihat seperti ini,
 
 0:51:17.940,0:51:22.900
-instead of having to, every
-time, type "ssh jjgo",
+alih-alih harus, setiap
+kali, mengetik "ssh jjgo",
 
 0:51:23.040,0:51:27.760
-having this really long string so I can
-like refer to this specific remote,
+memiliki string yang sangat panjang ini sehingga saya bisa
+merujuk ke remote spesifik ini,
 
 0:51:27.760,0:51:30.140
-I want to refer, with the specific user name,
+saya ingin merujuk, dengan nama user spesifik,
 
 0:51:30.140,0:51:32.760
-I can have something here that says
+saya bisa punya sesuatu di sini yang mengatakan
 
 0:51:33.160,0:51:35.680
-this is the username, this
-is the host name, that this
+ini adalah username, ini
+adalah hostname, bahwa host
 
 0:51:36.860,0:51:40.540
-host is referring to and you should
-use this identity file.
+ini merujuk dan kalian harus
+menggunakan identity file ini.
 
 0:51:41.460,0:51:43.960
-And if I copy this,
+Dan jika saya menyalin ini,
 
 0:51:43.960,0:51:46.100
-this is right now in my local folder,
+ini sekarang di folder lokal saya,
 
 0:51:46.100,0:51:49.000
-I can copy this into ssh.
+saya bisa menyalin ini ke ssh.
 
 0:51:49.600,0:51:53.520
-Now, instead of having to do this really
-long command, I can just say
+Sekarang, alih-alih harus melakukan perintah yang sangat
+panjang ini, saya bisa hanya mengatakan
 
 0:51:53.520,0:51:57.100
-I just want to SSH into the host called VM.
+saya hanya ingin SSH ke host yang disebut VM.
 
 0:51:58.260,0:52:03.220
-And by doing that, it's grabbing all that
-configuration from the SSH config
+Dan dengan melakukan itu, ia mengambil semua
+konfigurasi itu dari SSH config
 
 0:52:03.220,0:52:05.220
-and applying it here.
+dan menerapkannya di sini.
 
 0:52:05.240,0:52:10.060
-This solution is much better than something
-like creating an alias for SSH,
+Solusi ini jauh lebih baik daripada sesuatu
+seperti membuat alias untuk SSH,
 
 0:52:10.360,0:52:13.360
-because other programs like SCP and RSYNC
+karena program lain seperti SCP dan RSYNC
 
 0:52:13.360,0:52:19.440
-also know about the dotfiles for SSH and
-will use them whenever they are there.
+juga tahu tentang dotfiles untuk SSH dan
+akan menggunakannya kapan pun ada.
 
 0:52:22.820,0:52:30.400
-Last thing I want to cover about remote machines is
-that here, for example, we'll have tmux and we can,
+Hal terakhir yang ingin saya bahas tentang mesin remote adalah
+bahwa di sini, misalnya, kita akan punya tmux dan kita bisa,
 
 0:52:31.760,0:52:35.780
-like I was saying before, we
-can start editing some file
+seperti yang saya katakan sebelumnya, kita
+bisa mulai mengedit beberapa file
 
 0:52:39.160,0:52:44.500
-and we can start running some job.
+dan kita bisa mulai menjalankan beberapa job.
 
 0:52:54.200,0:52:56.180
-For example, something like HTOP.
+Misalnya, sesuatu seperti HTOP.
 
 0:52:56.180,0:52:58.720
-And this is running here, we can
+Dan ini berjalan di sini, kita bisa
 
 0:52:59.320,0:53:01.320
-detach from it,
+detach darinya,
 
 0:53:01.430,0:53:03.430
-close the connection and
+menutup koneksi dan
 
 0:53:03.740,0:53:07.780
-then SSH back. And then, if you do "tmux a",
+kemudian SSH kembali. Dan kemudian, jika kalian lakukan "tmux a",
 
 0:53:07.780,0:53:11.340
-everything is as you left it, like
-nothing has really changed.
+semuanya seperti yang kalian tinggalkan, seperti
+tidak ada yang benar-benar berubah.
 
 0:53:11.340,0:53:15.220
-And if you have things executing there in
-the background, they will keep executing.
+Dan jika kalian punya hal-hal yang berjalan di sana di
+latar belakang, mereka akan terus berjalan.
 
 0:53:17.500,0:53:23.300
-I think that, pretty much, ends
-all I have to say for this tool.
+Saya pikir itu, cukup, mengakhiri
+semua yang harus saya katakan untuk alat ini.
 
 0:53:23.300,0:53:26.420
-Any questions related to remote machines?
+Ada pertanyaan terkait mesin remote?
 
 0:53:32.860,0:53:36.780
-That's a really good question.
-So what I do for that,
+Itu pertanyaan yang sangat bagus.
+Jadi apa yang saya lakukan untuk itu,
 
 0:53:38.700,0:53:39.460
-Oh, yes, sorry.
+Oh, ya, maaf.
 
 0:53:39.460,0:53:44.880
-So the question is, how do you deal with
-trying to use tmux in your local machine,
+Jadi pertanyaannya adalah, bagaimana kalian menangani
+mencoba menggunakan tmux di mesin lokal kalian,
 
 0:53:44.880,0:53:47.640
-and also trying to use tmux
-in the remote machine?
+dan juga mencoba menggunakan tmux
+di mesin remote?
 
 0:53:48.400,0:53:50.760
-There are a couple of tricks
-for dealing with that.
+Ada beberapa trik
+untuk menangani itu.
 
 0:53:50.760,0:53:53.220
-The first one is changing the prefix.
+Yang pertama adalah mengubah prefix.
 
 0:53:53.360,0:53:55.340
-So what I do, for example, is
+Jadi apa yang saya lakukan, misalnya, adalah
 
 0:53:55.340,0:54:00.020
-in my local machine the prefix I have
-changed from "Ctrl+B" to "Ctrl+A" and
+di mesin lokal saya prefix yang saya
+ubah dari "Ctrl+B" ke "Ctrl+A" dan
 
 0:54:00.220,0:54:02.580
-then in remove machines this is still "Ctrl+B".
+kemudian di mesin remote ini masih "Ctrl+B".
 
 0:54:02.800,0:54:05.580
-So I can kind of swap between,
+Jadi saya bisa bertukar di antara,
 
 0:54:05.580,0:54:09.840
-if I want to do things to the
-local tmux I will do "Ctrl+A"
+jika saya ingin melakukan sesuatu ke
+tmux lokal saya akan lakukan "Ctrl+A"
 
 0:54:09.840,0:54:13.460
-and if I want to do things to the
-remote tmux I would do "Ctrl+B".
+dan jika saya ingin melakukan sesuatu ke
+tmux remote saya akan lakukan "Ctrl+B".
 
 0:54:15.080,0:54:19.900
-Another thing is that you
-can have separate configs,
+Hal lain adalah bahwa kalian
+bisa memiliki config terpisah,
 
 0:54:20.080,0:54:24.100
-so I can do something like this, and then...
+jadi saya bisa melakukan sesuatu seperti ini, dan kemudian...
 
 0:54:27.260,0:54:31.040
-Ah, because I don't have my own ssh config, yeah.
+Ah, karena saya tidak punya config ssh saya sendiri, ya.
 
 0:54:32.240,0:54:33.000
-But if you...
+Tapi jika kalian...
 
 0:54:33.000,0:54:34.420
-Um, I can SSH "VM".
+Um, saya bisa SSH "VM".
 
 0:54:36.820,0:54:38.900
-Here, what you see,
+Di sini, apa yang kalian lihat,
 
 0:54:38.900,0:54:41.000
-the difference between these
-two bars, for example,
+perbedaan antara dua
+bar ini, misalnya,
 
 0:54:41.000,0:54:43.680
-is because the tmux config is different.
+adalah karena config tmux berbeda.
 
 0:54:44.380,0:54:48.500
-As you will see in the exercises,
-the tmux configuration is in
+Seperti yang akan kalian lihat di latihan,
+konfigurasi tmux ada di
 
 0:54:50.320,0:54:53.780
-the tmux.conf
+tmux.conf
 
 0:54:56.720,0:54:58.140
-And in tmux.conf,
+Dan di tmux.conf,
 
 0:54:58.140,0:55:02.020
-here you can do a lot of things like changing
-the color depending on the host you are
+di sini kalian bisa melakukan banyak hal seperti mengubah
+warna tergantung pada host yang kalian gunakan
 
 0:55:02.210,0:55:06.879
-so you can get like quick visual
-feedback about where you are, or
+sehingga kalian bisa mendapat
+umpan balik visual cepat tentang di mana kalian berada, atau
 
 0:55:06.880,0:55:10.240
-if you have a nested session. Also, tmux will,
+jika kalian punya sesi bersarang. Juga, tmux akan,
 
 0:55:10.520,0:55:15.280
-if you're in the same host and you
-try to tmux within a tmux session,
+jika kalian di host yang sama dan kalian
+mencoba tmux dalam sesi tmux,
 
 0:55:15.290,0:55:18.759
-it will kind of prevent you from doing
-it so you don't run into issues.
+ia akan mencegah kalian melakukannya
+sehingga kalian tidak menemui masalah.
 
 0:55:21.700,0:55:25.400
-Any other questions related, to kind
-of all the topics we have covered.
+Ada pertanyaan lain terkait, tentang
+semua topik yang telah kita bahas.
 
 0:55:29.100,0:55:32.720
-Another answer to that question is
-also, if you type the prefix twice,
+Jawaban lain untuk pertanyaan itu adalah
+juga, jika kalian mengetik prefix dua kali,
 
 0:55:32.880,0:55:35.760
-it sends it once to the underlying shell.
+ia mengirimnya sekali ke shell yang mendasarinya.
 
 0:55:35.920,0:55:40.100
-So the local binding is "Ctrl+A" and
-the remote binding is "Ctrl+A",
+Jadi binding lokal adalah "Ctrl+A" dan
+binding remote adalah "Ctrl+A",
 
 0:55:40.100,0:55:45.260
-You could type "Ctrl+A", "Ctrl+A" and then "D", for
-example, detaches from the remote, basically.
+Kalian bisa mengetik "Ctrl+A", "Ctrl+A" lalu "D", misalnya,
+melepaskan dari remote, pada dasarnya.
 
 0:55:52.480,0:55:59.660
-I think that ends the class for today, there's a bunch
-of exercises related to all these main topics and
+Saya pikir itu mengakhiri kelas untuk hari ini, ada banyak
+latihan terkait semua topik utama ini dan
 
 0:56:00.380,0:56:05.410
-we're gonna be holding office hours today, too.
-So feel free to come and ask us any questions.
-
+kami akan mengadakan office hours hari ini juga.
+Jadi jangan ragu untuk datang dan bertanya.

--- a/static/files/subtitles/2020/debugging-profiling.sbv
+++ b/static/files/subtitles/2020/debugging-profiling.sbv
@@ -1,2573 +1,2566 @@
 0:00:00.000,0:00:04.200
-So welcome back. Today we are gonna
-cover debugging and profiling.
+Jadi selamat datang kembali. Hari ini kita akan
+membahas debugging dan profiling.
 
 0:00:04.720,0:00:09.340
-Before I get into it we're gonna make another
-reminder to fill in the survey.
+Sebelum saya mulai, kita akan mengingatkan
+lagi untuk mengisi survei.
 
 0:00:09.520,0:00:14.580
-Just one of the main things we want to get
-from you is questions, because the last day
+Salah satu hal utama yang kami inginkan
+dari kalian adalah pertanyaan, karena hari terakhir
 
 0:00:14.820,0:00:18.080
-is gonna be questions from
-you guys: about things that
+akan berisi pertanyaan dari
+kalian: tentang hal-hal yang
 
 0:00:18.080,0:00:22.020
-we haven't covered, or like you want
-us to kind of talk more in depth.
+belum kita bahas, atau yang ingin
+kalian bahas lebih mendalam.
 
 0:00:23.350,0:00:26.969
-The more questions we get, the more interesting
-we can make that section,
+Semakin banyak pertanyaan yang masuk, semakin menarik
+yang bisa kita buat untuk sesi tersebut,
 
 0:00:26.970,0:00:28.900
-so please go on and fill in the survey.
+jadi silakan isi surveinya.
 
 0:00:28.900,0:00:35.660
-So today's lecture is gonna be a lot of topics.
-All the topics revolve around the concept of
+Jadi kuliah hari ini akan mencakup banyak topik.
+Semua topik berputar di sekitar konsep
 
 0:00:35.820,0:00:39.920
-what do you do when you have
-a program that has some bugs.
+apa yang harus dilakukan ketika kamu
+memiliki program yang memiliki bug.
 
 0:00:39.920,0:00:42.520
-Which is most of the time, like when you
-are programming, you're kind of thinking
+Yang mana itu terjadi sebagian besar waktu, seperti saat
+kamu sedang memprogram, kamu cenderung memikirkan
 
 0:00:42.720,0:00:47.400
-about how you implement something and there's
-like a half life of fixing all the issues that
+bagaimana mengimplementasikan sesuatu dan ada
+masa paruh untuk memperbaiki semua masalah yang
 
 0:00:47.620,0:00:52.140
-that program has. And even if your program behaves
-like you want, it might be that it's
+dimiliki program tersebut. Dan bahkan jika programmu berjalan
+seperti yang kamu inginkan, mungkin saja program itu
 
 0:00:52.390,0:00:55.680
-really slow, or it's taking a lot
-of resources in the process.
+sangat lambat, atau memakan banyak
+sumber daya dalam prosesnya.
 
 0:00:55.680,0:01:00.569
-So today we're gonna see a lot of different
-approaches of dealing with these problems.
+Jadi hari ini kita akan melihat banyak pendekatan
+berbeda untuk menangani masalah-masalah ini.
 
 0:01:01.300,0:01:05.099
-So first, the first section is on debugging.
+Jadi pertama, bagian pertama adalah tentang debugging.
 
 0:01:06.159,0:01:08.279
-Debugging can be done in many different ways,
+Debugging bisa dilakukan dengan berbagai cara,
 
 0:01:08.380,0:01:10.119
-there are all kinds of...
+ada semua jenis...
 
 0:01:10.120,0:01:13.640
-The most simple approach that, pretty much, all
+Pendekatan paling sederhana yang, hampir semua
 
 0:01:13.640,0:01:17.140
-CS students will go through, will be just:
-you have some code, and it's not behaving
+mahasiswa CS akan lewati, adalah:
+kamu punya kode, dan kode itu tidak berjalan
 
 0:01:17.160,0:01:20.280
-like you want, so you probe the code by adding
+seperti yang kamu inginkan, jadi kamu memeriksa kode dengan menambahkan
 
 0:01:20.280,0:01:23.420
-print statements. This is called
-"printf debugging" and
+print statement. Ini disebut
+"printf debugging" dan
 
 0:01:23.440,0:01:24.450
-it works pretty well.
+cukup berhasil.
 
 0:01:24.450,0:01:26.680
-Like, I have to be honest,
+Seperti, saya harus jujur,
 
 0:01:26.820,0:01:33.120
-I use it a lot of the time because of how simple
-to set up and how quick the feedback can be.
+saya menggunakannya sering karena betapa mudahnya
+disiapkan dan seberapa cepat feedback yang didapat.
 
 0:01:34.360,0:01:39.320
-One of the issues with printf debugging
-is that you can get a lot of output
+Salah satu masalah dengan printf debugging
+adalah kamu bisa mendapatkan banyak output
 
 0:01:39.320,0:01:40.740
-and maybe you don't want
+dan mungkin kamu tidak ingin
 
 0:01:40.800,0:01:43.240
-to get as much output as you're getting.
+mendapatkan output sebanyak itu.
 
 0:01:43.780,0:01:49.349
-There has... people have thought of slightly more
-complex ways of doing printf debugging and
+Orang-orang telah memikirkan cara yang sedikit lebih
+kompleks untuk melakukan printf debugging dan
 
 0:01:53.920,0:01:58.320
-one of these ways is what is usually
-referred to as "logging".
+salah satu caranya adalah yang biasanya
+disebut sebagai "logging".
 
 0:01:58.420,0:02:04.530
-So the advantage of doing logging versus doing printf
-debugging is that, when you're creating logs,
+Jadi keuntungan melakukan logging dibandingkan printf
+debugging adalah bahwa, ketika kamu membuat log,
 
 0:02:05.080,0:02:09.780
-you're not necessarily creating the logs because
-there's a specific issue you want to fix;
+kamu tidak selalu membuat log karena
+ada masalah spesifik yang ingin diperbaiki;
 
 0:02:09.780,0:02:12.460
-it's mostly because you have built a
+ini lebih karena kamu telah membangun
 
 0:02:12.480,0:02:16.840
-more complex software system and you
-want to log when some events happen.
+sistem perangkat lunak yang lebih kompleks dan kamu
+ingin mencatat ketika beberapa event terjadi.
 
 0:02:17.360,0:02:21.560
-One of the core advantages of using
-a logging library is that
+Salah satu keuntungan utama menggunakan
+pustaka logging adalah
 
 0:02:22.180,0:02:27.040
-you can can define severity levels,
-and you can filter based on those.
+kamu bisa mendefinisikan level severity,
+dan kamu bisa memfilter berdasarkan level tersebut.
 
 0:02:27.400,0:02:31.620
-Let's see an example of how we
-can do something like that.
+Mari kita lihat contoh bagaimana kita
+bisa melakukan sesuatu seperti itu.
 
 0:02:32.320,0:02:35.840
-Yeah, everything fits here. This
-is a really silly example:
+Ya, semuanya muat di sini. Ini
+adalah contoh yang sangat sederhana:
 
 0:02:36.340,0:02:37.520
-We're just gonna
+Kita hanya akan
 
 0:02:37.520,0:02:40.980
-sample random numbers and, depending
-on the value of the number,
+mengambil sampel angka acak dan, tergantung
+pada nilai angkanya,
 
 0:02:41.120,0:02:44.720
-that we can interpret as a kind
-of "how wrong things are going".
+yang bisa kita artikan sebagai
+"seberapa buruk keadaannya".
 
 0:02:44.740,0:02:48.760
-We're going to log the value
-of the number and then
+Kita akan mencatat nilai
+angkanya dan kemudian
 
 0:02:49.340,0:02:51.640
-we can see what is going on.
+kita bisa melihat apa yang terjadi.
 
 0:02:52.580,0:02:59.280
-I need to disable these formatters...
+Saya perlu menonaktifkan formatter ini...
 
 0:02:59.620,0:03:03.720
-And if we were just to execute the code as it is,
+Dan jika kita hanya mengeksekusi kode apa adanya,
 
 0:03:04.160,0:03:07.420
-we just get the output and we just
-keep getting more and more output.
+kita hanya mendapatkan output dan kita terus
+mendapatkan lebih banyak output.
 
 0:03:07.420,0:03:13.599
-But you have to kind of stare at it and make
-sense of what is going on, and we don't know
+Tapi kamu harus menatapnya dan memahami
+apa yang terjadi, dan kita tidak tahu
 
 0:03:13.600,0:03:19.629
-what is the relative timing between printfs, we don't really
-know whether this is just an information message
+berapa waktu relatif antara printf, kita tidak benar-benar
+tahu apakah ini hanya pesan informasi
 
 0:03:19.630,0:03:22.960
-or a message of whether something went wrong.
+atau pesan yang menunjukkan sesuatu yang salah.
 
 0:03:23.810,0:03:25.810
-If we just go in,
+Jika kita hanya masuk,
 
 0:03:27.320,0:03:29.780
-and undo, not that one...
+dan undo, bukan yang itu...
 
 0:03:34.220,0:03:37.140
-That one, we can set that formatter.
+Yang itu, kita bisa mengatur formatter tersebut.
 
 0:03:38.620,0:03:41.600
-Now the output looks something more like this
+Sekarang outputnya terlihat lebih seperti ini
 
 0:03:41.620,0:03:44.840
-So for example, if you have several different
-modules that you are programming with,
+Jadi misalnya, jika kamu memiliki beberapa modul
+berbeda yang sedang kamu program,
 
 0:03:44.840,0:03:46.940
-you can identify them with like different levels.
+kamu bisa mengidentifikasinya dengan level yang berbeda.
 
 0:03:46.940,0:03:49.800
-Here, we have, we have debug levels,
+Di sini, kita memiliki level debug,
 
 0:03:50.330,0:03:51.890
-we have critical
+kita memiliki critical
 
 0:03:51.890,0:03:57.540
-info, different levels. And it might be handy because
-here we might only care about the error messages.
+info, level yang berbeda. Dan ini mungkin berguna karena
+di sini kita mungkin hanya peduli tentang pesan error.
 
 0:03:57.740,0:04:00.640
-Like those are like, the... We have been
+Seperti itu, kita telah
 
 0:04:00.700,0:04:03.960
-working on our code, so far so good,
-and suddenly we get some error.
+bekerja pada kode kita, sejauh ini baik-baik saja,
+dan tiba-tiba kita mendapat error.
 
 0:04:03.960,0:04:06.540
-We can log that to identify where it's happening.
+Kita bisa mencatatnya untuk mengidentifikasi di mana itu terjadi.
 
 0:04:06.580,0:04:11.640
-But maybe there's a lot of information
-messages, but we can deal with that
+Tapi mungkin ada banyak pesan
+informasi, tapi kita bisa mengatasinya
 
 0:04:12.709,0:04:16.809
-by just changing the level to error level.
+dengan hanya mengubah level ke error level.
 
 0:04:17.400,0:04:17.900
-And
+Dan
 
 0:04:18.890,0:04:22.960
-now if we were to run this again,
-we are only going to get those
+sekarang jika kita menjalankan ini lagi,
+kita hanya akan mendapatkan
 
 0:04:23.620,0:04:28.160
-errors in the output, and we can just look through
-those to make sense of what is going on.
+error-error tersebut di output, dan kita bisa melihatnya
+untuk memahami apa yang terjadi.
 
 0:04:28.920,0:04:33.320
-Another really useful tool when
-you're dealing with logs is
+Alat lain yang sangat berguna ketika
+kamu berurusan dengan log adalah
 
 0:04:34.130,0:04:36.670
-As you kind of look at this,
+Saat kamu melihat ini,
 
 0:04:36.670,0:04:42.580
-it has become easier because now we have this critical
-and error levels that we can quickly identify.
+ini menjadi lebih mudah karena sekarang kita punya level critical
+dan error yang bisa kita identifikasi dengan cepat.
 
 0:04:43.310,0:04:46.750
-But since humans are fairly visual creatures,
+Tapi karena manusia adalah makhluk yang cukup visual,
 
 0:04:48.680,0:04:53.109
-one thing that you can do is use
-colors from your terminal to
+salah satu hal yang bisa kamu lakukan adalah menggunakan
+warna dari terminal untuk
 
 0:04:53.630,0:04:57.369
-identify these things. So now,
-changing the formatter,
+mengidentifikasi hal-hal ini. Jadi sekarang,
+mengubah formatter,
 
 0:04:57.369,0:05:03.320
-what I've done is slightly change
-how the output is formatted.
+yang saya lakukan adalah sedikit mengubah
+bagaimana output diformat.
 
 0:05:03.580,0:05:09.340
-When I do that, now whenever I get a warning
-message, it's color coded by yellow;
+Ketika saya melakukan itu, sekarang setiap kali saya mendapat pesan
+warning, itu diberi kode warna kuning;
 
 0:05:09.340,0:05:10.880
-whenever I get like an error,
+setiap kali saya mendapat error,
 
 0:05:10.960,0:05:16.140
-faded red; and when it's critical, I have a
-bold red indicating something went wrong.
+merah pudar; dan ketika critical, saya punya
+merah tebal yang menunjukkan sesuatu yang salah.
 
 0:05:16.280,0:05:22.620
-And here it's a really short output, but when you start
-having thousands and thousands of lines of log,
+Dan di sini outputnya sangat singkat, tapi ketika kamu mulai
+memiliki ribuan dan ribuan baris log,
 
 0:05:22.620,0:05:26.380
-which is not unrealistic and happens
-every single day in a lot of apps,
+yang bukan hal tidak realistis dan terjadi
+setiap hari di banyak aplikasi,
 
 0:05:27.140,0:05:32.500
-quickly browsing through them and identifying
-where the error or the red patches are
+menjelajah dengan cepat dan mengidentifikasi
+di mana error atau bagian merah berada
 
 0:05:32.600,0:05:35.320
-can be really useful.
+bisa sangat berguna.
 
 0:05:35.600,0:05:41.400
-A quick aside is, you might be curious about
-how the terminal is displaying these colors.
+Sedikit penjelasan, kamu mungkin penasaran tentang
+bagaimana terminal menampilkan warna-warna ini.
 
 0:05:41.580,0:05:45.320
-At the end of the day, the terminal
-is only outputting characters.
+Pada akhirnya, terminal
+hanya mengeluarkan karakter.
 
 0:05:47.160,0:05:49.480
-Like, how is this program or how
-are other programs, like LS,
+Seperti, bagaimana program ini atau bagaimana
+program lain, seperti LS,
 
 0:05:50.060,0:05:56.050
-that has all these fancy colors. How are they telling the
-terminal that it should use these different colors?
+yang memiliki semua warna mewah ini. Bagaimana mereka memberi tahu
+terminal bahwa harus menggunakan warna-warna berbeda ini?
 
 0:05:56.360,0:05:58.779
-This is nothing extremely fancy,
+Ini bukan sesuatu yang sangat mewah,
 
 0:05:59.440,0:06:03.440
-what these tools are doing, is
-something along these lines.
+yang dilakukan alat-alat ini, adalah
+sesuatu seperti ini.
 
 0:06:03.740,0:06:04.540
-Here we have...
+Di sini kita punya...
 
 0:06:05.420,0:06:08.340
-I can clear the rest of the output,
-so we can focus on this.
+Saya bisa membersihkan sisa output,
+jadi kita bisa fokus pada ini.
 
 0:06:08.660,0:06:14.000
-There's some special characters,
-some escape characters here,
+Ada beberapa karakter khusus,
+beberapa escape character di sini,
 
 0:06:14.260,0:06:19.740
-then we have some text and then we have some other
-special characters. And if we execute this line
+lalu kita punya teks dan kemudian beberapa
+karakter khusus lainnya. Dan jika kita menjalankan baris ini
 
 0:06:19.940,0:06:22.360
-we get a red "This is red".
+kita mendapatkan "This is red" berwarna merah.
 
 0:06:22.480,0:06:26.640
-And you might have picked up on the
-fact that we have a "255;0;0" here,
+Dan kamu mungkin menyadari
+bahwa kita punya "255;0;0" di sini,
 
 0:06:26.720,0:06:31.400
-this is just telling the RGB values of
-the color we want in the terminal.
+ini hanya memberi tahu nilai RGB dari
+warna yang kita inginkan di terminal.
 
 0:06:31.400,0:06:38.100
-And you pretty much can do this in any piece of code that
-you have, and like that you can color code the output.
+Dan kamu bisa melakukan ini di hampir semua kode yang
+kamu miliki, dan seperti itu kamu bisa memberi kode warna pada output.
 
 0:06:38.100,0:06:42.540
-Your terminal is fairly fancy and supports
-a lot of different colors in the output.
+Terminalmu cukup canggih dan mendukung
+banyak warna berbeda di output.
 
 0:06:42.550,0:06:45.400
-This is not even all of them, this
-is like a sixteenth of them.
+Ini bahkan belum semuanya, ini
+baru seperenam belas dari semuanya.
 
 0:06:46.100,0:06:49.119
-I think it can be fairly useful
-to know about that.
+Saya pikir ini bisa cukup berguna
+untuk diketahui.
 
 0:06:52.100,0:06:55.960
-Another thing is maybe you don't
-enjoy or you don't think
+Hal lain adalah mungkin kamu tidak
+menyukai atau kamu tidak berpikir
 
 0:06:56.200,0:06:58.620
-logs are really fit for you.
+log benar-benar cocok untukmu.
 
 0:06:58.620,0:07:02.480
-The thing is a lot of other systems that
-you might start using will use logs.
+Masalahnya adalah banyak sistem lain yang
+mungkin mulai kamu gunakan akan menggunakan log.
 
 0:07:02.840,0:07:05.360
-As you start building larger and larger systems,
+Saat kamu mulai membangun sistem yang semakin besar,
 
 0:07:05.360,0:07:10.140
-you might rely on other dependencies. Common
-dependencies might be web servers or
+kamu mungkin mengandalkan dependensi lain. Dependensi
+umum mungkin berupa web server atau
 
 0:07:10.220,0:07:12.320
-databases, it's a really common one.
+database, yang sangat umum.
 
 0:07:12.440,0:07:17.740
-And those will be logging their errors
-or exceptions in their own logs.
+Dan mereka akan mencatat error
+atau exception mereka di log mereka sendiri.
 
 0:07:17.740,0:07:20.540
-Of course, you will get some client-side error,
+Tentu saja, kamu akan mendapat beberapa error di sisi client,
 
 0:07:20.620,0:07:25.140
-but those sometimes are not informative enough
-for you to figure out what is going on.
+tapi itu terkadang tidak cukup informatif
+bagimu untuk mengetahui apa yang terjadi.
 
 0:07:25.900,0:07:33.940
-In most UNIX systems, the logs are usually
-placed under a folder called "/var/log"
+Di sebagian besar sistem UNIX, log biasanya
+ditempatkan di folder bernama "/var/log"
 
 0:07:33.940,0:07:37.980
-and if we list it, we can see there's
-a bunch of logs in here.
+dan jika kita melihat isinya, kita bisa lihat ada
+banyak log di sini.
 
 0:07:42.680,0:07:48.040
-So we have like the shutdown monitor
-log, or some weekly logs.
+Jadi kita punya seperti log monitor shutdown,
+atau beberapa log mingguan.
 
 0:07:49.669,0:07:56.199
-Things related to the Wi-Fi, for
-example. And if we output the
+Hal-hal yang berkaitan dengan Wi-Fi, misalnya. Dan jika kita menampilkan
 
 0:07:57.560,0:08:00.840
-System log, which contains a lot
-of information about the system,
+System log, yang berisi banyak
+informasi tentang sistem,
 
 0:08:00.840,0:08:03.940
-we can get information about what's going on.
+kita bisa mendapatkan informasi tentang apa yang terjadi.
 
 0:08:04.120,0:08:06.780
-Similarly, there are tools that will let you
+Demikian pula, ada alat yang akan membiarkanmu
 
 0:08:07.460,0:08:13.090
-more sanely go through this output.
-But here, looking at the system log,
+melalui output ini dengan lebih masuk akal.
+Tapi di sini, melihat system log,
 
 0:08:13.090,0:08:15.520
-I can look at this, and say:
+saya bisa melihat ini, dan berkata:
 
 0:08:15.760,0:08:20.040
-oh there's some service that is
-exiting with some abnormal code
+oh ada beberapa service yang
+keluar dengan kode abnormal
 
 0:08:20.420,0:08:25.460
-and based on that information, I can go
-and try to figure out what's going on,
+dan berdasarkan informasi itu, saya bisa pergi
+dan mencoba mencari tahu apa yang terjadi,
 
 0:08:25.510,0:08:27.500
-like what's going wrong.
+apa yang salah.
 
 0:08:29.020,0:08:32.000
-One thing to know when you're
-working with logs is that
+Satu hal yang perlu diketahui ketika kamu
+bekerja dengan log adalah bahwa
 
 0:08:32.000,0:08:35.900
-more traditionally, every software had their own
+secara lebih tradisional, setiap perangkat lunak memiliki
 
 0:08:35.920,0:08:42.540
-log, but it has been increasingly more popular to have
-a unified system log where everything is placed.
+log mereka sendiri, tapi semakin populer untuk memiliki
+system log terpadu di mana semuanya ditempatkan.
 
 0:08:43.010,0:08:49.299
-Pretty much any application can log into the system
-log, but instead of being in a plain text format,
+Hampir semua aplikasi bisa mencatat ke system
+log, tapi alih-alih dalam format teks biasa,
 
 0:08:49.300,0:08:52.380
-it will be compressed in some special format.
+ini akan dikompresi dalam format khusus.
 
 0:08:52.380,0:08:56.460
-An example of this, it was what we covered
-in the data wrangling lecture.
+Contoh dari ini, adalah apa yang kita bahas
+di kuliah data wrangling.
 
 0:08:56.520,0:08:59.900
-In the data wrangling lecture we
-were using the "journalctl",
+Di kuliah data wrangling kita
+menggunakan "journalctl",
 
 0:09:00.200,0:09:04.280
-which is accessing the log and
-outputting all that output.
+yang mengakses log dan
+menampilkan semua output tersebut.
 
 0:09:04.340,0:09:07.380
-Here in Mac, now the command is "log show",
+Di Mac sini, sekarang perintahnya adalah "log show",
 
 0:09:07.380,0:09:10.020
-which will display a lot of information.
+yang akan menampilkan banyak informasi.
 
 0:09:10.100,0:09:15.760
-I'm gonna just display the last ten seconds,
-because logs are really, really verbose and
+Saya hanya akan menampilkan sepuluh detik terakhir,
+karena log sangat, sangat verbose dan
 
 0:09:17.060,0:09:23.720
-just displaying the last 10 seconds is still
-gonna output a fairly large amount of lines.
+menampilkan 10 detik terakhir saja masih
+akan menghasilkan jumlah baris yang cukup banyak.
 
 0:09:23.900,0:09:28.240
-So if we go back through what's going on,
+Jadi jika kita melihat kembali apa yang terjadi,
 
 0:09:28.240,0:09:33.460
-we here see that a lot of Apple things
-are going on, since this is a macbook.
+kita di sini melihat bahwa banyak hal Apple
+yang terjadi, karena ini adalah macbook.
 
 0:09:33.500,0:09:38.460
-Maybe we could find errors about
-like some system issue here.
+Mungkin kita bisa menemukan error tentang
+beberapa masalah sistem di sini.
 
 0:09:39.280,0:09:46.920
-Again they're fairly verbose, so you might want
-to practice your data wrangling techniques here,
+Sekali lagi mereka cukup verbose, jadi kamu mungkin ingin
+berlatih teknik data wrangling kamu di sini,
 
 0:09:46.920,0:09:50.440
-like 10 seconds equal to like 500
-lines of logs, so you can kind of
+seperti 10 detik sama dengan sekitar 500
+baris log, jadi kamu bisa
 
 0:09:50.960,0:09:54.960
-get an idea of how many lines
-per second you're getting.
+mendapat gambaran berapa banyak baris
+per detik yang kamu dapatkan.
 
 0:09:56.360,0:10:01.060
-They're not only useful for figuring
-out some other programs' output,
+Mereka tidak hanya berguna untuk mengetahui
+output program lain,
 
 0:10:01.060,0:10:05.619
-they're also useful for you, if you want to
-log there instead of into your own file.
+mereka juga berguna untukmu, jika kamu ingin
+mencatat di sana alih-alih di file kamu sendiri.
 
 0:10:05.779,0:10:11.319
-So using the "logger" command,
-in both linux and mac,
+Jadi menggunakan perintah "logger",
+di linux maupun mac,
 
 0:10:11.839,0:10:13.480
-You can say okay
+Kamu bisa bilang oke
 
 0:10:13.480,0:10:18.880
-I'm gonna log this "Hello Logs"
-into this system log.
+saya akan mencatat "Hello Logs" ini
+ke system log ini.
 
 0:10:18.880,0:10:21.939
-We execute the command and then
+Kita jalankan perintahnya dan kemudian
 
 0:10:22.760,0:10:27.640
-we can check by going through
-the last minute of logs,
+kita bisa memeriksa dengan melihat
+log satu menit terakhir,
 
 0:10:27.640,0:10:31.760
-since it's gonna be fairly recent,
-and grepping for that "Hello"
+karena ini akan cukup baru,
+dan grep untuk "Hello"
 
 0:10:31.760,0:10:38.260
-we find our entry. Fairly recent entry, that
-we just created that said "Hello Logs".
+kita menemukan entri kita. Entri yang cukup baru, yang
+baru saja kita buat yang bertuliskan "Hello Logs".
 
 0:10:39.220,0:10:46.840
-As you become more and more familiar with
-these tools, you will find yourself using
+Seiring kamu semakin terbiasa dengan
+alat-alat ini, kamu akan semakin sering menggunakan
 
 0:10:48.800,0:10:51.279
-the logs more and more often, since
+log, karena
 
 0:10:51.529,0:10:56.349
-even if you have some bug that you haven't detected,
-and the program has been running for a while,
+bahkan jika kamu punya bug yang belum terdeteksi,
+dan program sudah berjalan cukup lama,
 
 0:10:56.349,0:11:02.240
-maybe the information is already in the log and can
-tell you enough to figure out what is going on.
+mungkin informasinya sudah ada di log dan bisa
+memberitahu cukup banyak untuk mengetahui apa yang terjadi.
 
 0:11:02.800,0:11:08.260
-However, printf debugging is not everything.
-So now I'm going to be covering debuggers.
+Namun, printf debugging bukan segalanya.
+Jadi sekarang saya akan membahas debugger.
 
 0:11:08.260,0:11:10.380
-But first any questions on logs so far?
+Tapi pertama, ada pertanyaan tentang log sejauh ini?
 
 0:11:11.720,0:11:15.040
-So what kind of things can you
-figure out from the logs?
+Jadi hal apa yang bisa kamu
+ketahui dari log?
 
 0:11:15.040,0:11:18.800
-like this Hello Logs says that you did
-something with Hello at that time?
+seperti Hello Logs ini mengatakan bahwa kamu melakukan
+sesuatu dengan Hello pada waktu itu?
 
 0:11:18.940,0:11:25.040
-Yeah, like say, for example, I can
-write a bash script that detects...
+Ya, seperti misalnya, saya bisa
+menulis bash script yang mendeteksi...
 
 0:11:25.060,0:11:29.480
-Well, that checks every time what
-Wi-Fi network I'm connected to.
+Well, yang memeriksa setiap kali
+jaringan Wi-Fi yang saya terhubung.
 
 0:11:29.480,0:11:34.150
-And every time it detects that it has changed,
-it makes an entry in the logs and says
+Dan setiap kali terdeteksi berubah,
+ini membuat entri di log dan mengatakan
 
 0:11:34.150,0:11:37.440
-Oh now it looks like we have
-changed Wi-Fi networks.
+Oh sekarang sepertinya kita telah
+berpindah jaringan Wi-Fi.
 
 0:11:37.440,0:11:41.400
-and then you might go back and parse
-through the logs and take like, okay
+dan kemudian kamu bisa kembali dan mem-parse
+melalui log dan mengambil, oke
 
 0:11:41.510,0:11:47.559
-When did my computer change from one Wi-Fi network to
-another. And this is just kind of a simple example
+Kapan komputer saya berpindah dari satu jaringan Wi-Fi ke
+jaringan lain. Dan ini hanya contoh sederhana
 
 0:11:47.560,0:11:50.260
-But there are many, many ways,
+Tapi ada banyak, banyak cara,
 
 0:11:50.660,0:11:54.020
-many types of information that
-you could be logging here.
+banyak jenis informasi yang
+bisa kamu catat di sini.
 
 0:11:54.020,0:11:59.040
-More commonly, you will probably want to
-check if your computer, for example, is
+Lebih umum, kamu mungkin ingin
+memeriksa apakah komputer kamu, misalnya,
 
 0:11:59.100,0:12:02.540
-entering sleep, for example,
-for some unknown reason.
+masuk mode sleep, misalnya,
+karena alasan yang tidak diketahui.
 
 0:12:02.680,0:12:04.660
-Like it's on hibernation mode.
+Seperti sedang dalam mode hibernasi.
 
 0:12:04.820,0:12:09.100
-There's probably some information in the
-logs about who asked that to happen,
+Mungkin ada beberapa informasi di
+log tentang siapa yang meminta itu terjadi,
 
 0:12:09.100,0:12:10.240
-or why it's that happening.
+atau mengapa itu terjadi.
 
 0:12:11.720,0:12:14.880
-Any other questions? Okay.
+Ada pertanyaan lain? Oke.
 
 0:12:14.880,0:12:17.380
-So when printf debugging is not enough,
+Jadi ketika printf debugging tidak cukup,
 
 0:12:18.320,0:12:22.360
-the best alternative after that is using...
+alternatif terbaik setelah itu adalah menggunakan...
 
 0:12:23.360,0:12:25.360
-[Exit that]
+[Keluar dari itu]
 
 0:12:28.480,0:12:30.260
-So, it's using a debugger.
+Jadi, menggunakan debugger.
 
 0:12:30.580,0:12:37.620
-So a debugger is a tool that will wrap around
-your code and will let you run your code,
+Jadi debugger adalah alat yang akan membungkus
+kode kamu dan membiarkanmu menjalankan kode kamu,
 
 0:12:38.120,0:12:40.480
-but it will kind of keep control over it.
+tapi ini akan semacam menjaga kontrol atasnya.
 
 0:12:40.480,0:12:42.500
-So it will let you step
+Jadi ini akan membiarkanmu melangkah
 
 0:12:42.500,0:12:47.080
-through the code and execute
-it and set breakpoints.
+melalui kode dan menjalankannya
+serta mengatur breakpoint.
 
 0:12:47.080,0:12:50.020
-You probably have seen debuggers
-in some way, if you have
+Kamu mungkin pernah melihat debugger
+dalam beberapa bentuk, jika kamu
 
 0:12:50.020,0:12:55.800
-ever used something like an IDE, because IDEs have this
-kind of fancy: set a breakpoint here, execute, ...
+pernah menggunakan sesuatu seperti IDE, karena IDE memiliki
+fitur mewah: mengatur breakpoint di sini, jalankan, ...
 
 0:12:56.080,0:12:59.040
-But at the end of the day what
-these tools are using is just
+Tapi pada akhirnya yang
+digunakan alat-alat ini hanyalah
 
 0:12:59.040,0:13:04.740
-these command line debuggers and they're just
-presenting them in a really fancy format.
+debugger command line ini dan mereka hanya
+menampilkannya dalam format yang sangat mewah.
 
 0:13:04.850,0:13:09.969
-Here we have a completely broken bubble
-sort, a simple sorting algorithm.
+Di sini kita punya bubble sort yang benar-benar rusak,
+algoritma pengurutan sederhana.
 
 0:13:10.000,0:13:11.560
-Don't worry about the details,
+Jangan khawatirkan detailnya,
 
 0:13:11.560,0:13:14.980
-but we just want to sort this
-array that we have here.
+tapi kita hanya ingin mengurutkan
+array yang kita punya di sini.
 
 0:13:17.360,0:13:19.460
-We can try doing that by just doing
+Kita bisa mencoba melakukannya dengan
 
 0:13:21.340,0:13:23.340
 Python bubble.py
 
 0:13:23.500,0:13:28.360
-And when we do that... Oh there's some
+Dan ketika kita melakukan itu... Oh ada
 index error, list index out of range.
 
 0:13:28.480,0:13:31.200
-We could start adding prints
+Kita bisa mulai menambahkan print
 
 0:13:31.200,0:13:33.740
-but if have a really long string,
-we can get a lot of information.
+tapi jika punya string yang sangat panjang,
+kita bisa mendapatkan banyak informasi.
 
 0:13:33.820,0:13:37.820
-So how about we go up to the
-moment that we crashed?
+Jadi bagaimana jika kita pergi ke
+saat kita crash?
 
 0:13:37.900,0:13:41.020
-We can go to that moment and examine what the
+Kita bisa pergi ke saat itu dan memeriksa apa
 
 0:13:41.020,0:13:43.360
-current state of the program was.
+keadaan program saat itu.
 
 0:13:43.520,0:13:49.080
-So for doing that I'm gonna run the
-program using the Python debugger.
+Jadi untuk melakukan itu saya akan menjalankan
+program menggunakan Python debugger.
 
 0:13:49.080,0:13:53.820
-Here I'm using technically the ipython debugger,
-just because it has nice coloring syntax
+Di sini saya menggunakan secara teknis ipython debugger,
+hanya karena ini memiliki syntax coloring yang bagus
 
 0:13:54.060,0:13:59.140
-so it's probably easier for
-both of us to understand
+jadi mungkin lebih mudah bagi
+kita berdua untuk memahami
 
 0:13:59.300,0:14:01.300
-what's going on in the output.
+apa yang terjadi di output.
 
 0:14:01.310,0:14:04.929
-But they're pretty much identical anyway.
+Tapi mereka pada dasarnya identik.
 
 0:14:05.140,0:14:09.400
-So we execute this, and now we are given a prompt
+Jadi kita jalankan ini, dan sekarang kita diberi prompt
 
 0:14:09.400,0:14:13.080
-where we're being told that we are here,
-at the very first line of our program.
+di mana kita diberitahu bahwa kita berada di sini,
+di baris pertama program kita.
 
 0:14:13.100,0:14:15.440
-And we can...
+Dan kita bisa...
 
 0:14:15.980,0:14:20.380
-"L" stands for "List", so as
-with many of these tools
+"L" singkatan dari "List", jadi seperti
+banyak alat-alat ini
 
 0:14:21.140,0:14:24.400
-there's kind of like a language
-of operations that you can do,
+ada semacam bahasa
+operasi yang bisa kamu lakukan,
 
 0:14:24.400,0:14:28.220
-and they are often mnemonic, as it
-was the case with VIM or TMUX.
+dan mereka sering bersifat mnemonik, seperti
+kasusnya dengan VIM atau TMUX.
 
 0:14:28.860,0:14:32.940
-So here, "L" is for "Listing" the code,
-and we can see the entire code.
+Jadi di sini, "L" untuk "Listing" kode,
+dan kita bisa melihat seluruh kode.
 
 0:14:34.540,0:14:38.880
-"S" is for "Step" and will let us kind of one
+"S" untuk "Step" dan akan membiarkan kita satu
 
 0:14:38.880,0:14:42.180
-line at a time, go through the execution.
+baris pada satu waktu, melalui eksekusi.
 
 0:14:42.300,0:14:47.360
-The thing is we're only triggering
-the error some time later.
+Masalahnya adalah kita hanya memicu
+error beberapa waktu kemudian.
 
 0:14:47.360,0:14:48.710
-So
+Jadi
 
 0:14:48.710,0:14:55.150
-we can restart the program and instead of
-trying to step until we get to the issue,
+kita bisa restart program dan alih-alih
+mencoba melangkah sampai kita sampai ke masalah,
 
 0:14:55.150,0:15:00.820
-we can just ask for the program to continue
-which is the "C" command and
+kita bisa langsung meminta program untuk continue
+yang merupakan perintah "C" dan
 
 0:15:01.480,0:15:04.160
-hey, we reached the issue.
+hey, kita sampai ke masalahnya.
 
 0:15:04.640,0:15:08.080
-We got to this line where everything crashed,
+Kita sampai ke baris ini di mana semuanya crash,
 
 0:15:08.080,0:15:11.020
-we're getting this list index out of range.
+kita mendapat list index out of range ini.
 
 0:15:11.020,0:15:13.560
-And now that we are here we can say, huh?
+Dan sekarang kita di sini kita bisa bilang, huh?
 
 0:15:14.120,0:15:17.520
-Okay, first, let's print the value of the array.
+Oke, pertama, mari print nilai array.
 
 0:15:18.080,0:15:21.520
-This is the value of the current array
+Ini adalah nilai array saat ini
 
 0:15:23.120,0:15:26.840
-So we have six items. Okay. What
-is the value of "J" here?
+Jadi kita punya enam item. Oke. Apa
+nilai "J" di sini?
 
 0:15:27.200,0:15:31.929
-So we look at the value of "J". "J" is 5
-here, which will be the last element, but
+Jadi kita lihat nilai "J". "J" adalah 5
+di sini, yang akan menjadi elemen terakhir, tapi
 
 0:15:32.480,0:15:37.119
-"J" plus 1 is going to be 6, so that's
-triggering the out of bounds error.
+"J" plus 1 akan menjadi 6, jadi itu
+memicu error out of bounds.
 
 0:15:37.970,0:15:40.389
-So what we have to do is
+Jadi yang harus kita lakukan adalah
 
 0:15:40.660,0:15:47.660
-this "N", instead of "N" has to be "N minus one".
-We have identified that the error lies there.
+"N" ini, alih-alih "N" harusnya "N minus satu".
+Kita telah mengidentifikasi bahwa error ada di sana.
 
 0:15:47.660,0:15:50.800
-So we can quit, which is "Q".
+Jadi kita bisa quit, yaitu "Q".
 
 0:15:52.010,0:15:54.729
-Again, because it's a post-mortem debugger.
+Sekali lagi, karena ini adalah post-mortem debugger.
 
 0:15:56.090,0:16:00.219
-We go back to the code and say okay,
+Kita kembali ke kode dan bilang oke,
 
 0:16:02.860,0:16:06.180
-we need to append this "N minus one".
+kita perlu menambahkan "N minus satu" ini.
 
 0:16:06.760,0:16:11.140
-That will prevent the list index out of range and
+Itu akan mencegah list index out of range dan
 
 0:16:11.480,0:16:14.260
-if we run this again without the debugger,
+jika kita jalankan ini lagi tanpa debugger,
 
 0:16:15.020,0:16:18.729
-okay, no errors now. But this
-is not our sorted list.
+oke, tidak ada error sekarang. Tapi ini
+bukan daftar yang sudah diurutkan.
 
 0:16:18.729,0:16:21.200
-This is sorted, but it's not our list.
+Ini sudah diurutkan, tapi bukan daftar kita.
 
 0:16:21.300,0:16:23.000
-We are missing entries from our list,
+Kita kehilangan entri dari daftar kita,
 
 0:16:23.160,0:16:27.420
-so there is some behavioral issue
-that we're reaching here.
+jadi ada beberapa masalah perilaku
+yang kita temui di sini.
 
 0:16:27.920,0:16:32.409
-Again, we could start using printf
-debugging but kind of a hunch now
+Sekali lagi, kita bisa mulai menggunakan printf
+debugging tapi firasat sekarang
 
 0:16:32.409,0:16:37.940
-is that probably the way we're swapping entries
-in the bubble sort program is wrong.
+adalah mungkin cara kita menukar entri
+di program bubble sort salah.
 
 0:16:38.480,0:16:45.920
-We can use the debugger for this. We can go through
-them to the moment we're doing a swap and
+Kita bisa menggunakan debugger untuk ini. Kita bisa pergi
+ke saat kita melakukan swap dan
 
 0:16:46.120,0:16:48.320
-check how the swap is being performed.
+memeriksa bagaimana swap dilakukan.
 
 0:16:48.540,0:16:50.600
-So a quick overview,
+Jadi gambaran singkat,
 
 0:16:50.600,0:16:56.590
-we have two for loops and
-in the most nested loop,
+kita punya dua for loop dan
+di loop yang paling dalam,
 
 0:16:56.720,0:17:03.220
-we are checking if the array is larger than the other array.
-The thing is if we just try to execute until this line,
+kita memeriksa apakah array lebih besar dari array lainnya. Masalahnya jika kita hanya mencoba menjalankan sampai baris ini,
 
 0:17:03.589,0:17:06.609
-it's only going to trigger
-whenever we make a swap.
+itu hanya akan memicu
+kapanpun kita melakukan swap.
 
 0:17:06.700,0:17:11.640
-So what we can do is we can set
-a breakpoint in the sixth line.
+Jadi yang bisa kita lakukan adalah mengatur
+breakpoint di baris keenam.
 
 0:17:11.820,0:17:15.520
-We can create a breakpoint in this line and then
+Kita bisa membuat breakpoint di baris ini dan kemudian
 
 0:17:15.580,0:17:20.820
-the program will execute and the moment we try to swap
-variables is when the program is going to stop.
+program akan berjalan dan saat kita mencoba menukar
+variabel adalah saat program akan berhenti.
 
 0:17:21.080,0:17:22.940
-So we create a breakpoint there
+Jadi kita membuat breakpoint di sana
 
 0:17:22.940,0:17:27.000
-and then we continue the execution
-of the program. The program halts
+dan kemudian kita melanjutkan eksekusi
+program. Program berhenti
 
 0:17:27.000,0:17:30.520
-and says hey, I have executed
-and I have reached this line.
+dan bilang hey, saya telah berjalan
+dan saya telah sampai ke baris ini.
 
 0:17:30.820,0:17:31.860
-Now
+Sekarang
 
 0:17:31.920,0:17:39.120
-I can use "locals()", which is a Python function
-that returns a dictionary with all the values
+saya bisa menggunakan "locals()", yang merupakan fungsi Python
+yang mengembalikan dictionary dengan semua nilai
 
 0:17:39.120,0:17:41.220
-to quickly see the entire context.
+untuk melihat seluruh konteks dengan cepat.
 
 0:17:43.100,0:17:48.140
-The string, the array is fine and is
-six, again, just the beginning and
+String, array-nya baik-baik saja dan adalah
+enam, lagi, baru awal dan
 
 0:17:48.680,0:17:51.100
-I step, go to the next line.
+saya step, pergi ke baris berikutnya.
 
 0:17:51.780,0:17:52.620
 Oh,
 
 0:17:52.620,0:17:57.000
-and I identify the issue: I'm swapping one
-item at a time, instead of simultaneously,
+dan saya mengidentifikasi masalah: saya menukar satu
+item pada satu waktu, alih-alih secara bersamaan,
 
 0:17:57.020,0:18:01.840
-so that's what's triggering the fact that
-we're losing variables as we go through.
+jadi itulah yang memicu fakta bahwa
+kita kehilangan variabel saat kita melanjutkan.
 
 0:18:03.200,0:18:06.729
-That's kind of a very simple example, but
+Itu adalah contoh yang sangat sederhana, tapi
 
 0:18:07.490,0:18:09.050
-debuggers are really powerful.
+debugger sangat powerful.
 
 0:18:09.050,0:18:13.320
-Most programming languages will
-give you some sort of debugger,
+Sebagian besar bahasa pemrograman akan
+memberimu semacam debugger,
 
 0:18:13.540,0:18:19.920
-and when you go to more low level debugging
-you might run into tools like...
+dan ketika kamu beralih ke debugging level lebih rendah
+kamu mungkin menemui alat seperti...
 
 0:18:19.920,0:18:21.920
-You might want to use something like
+Kamu mungkin ingin menggunakan sesuatu seperti
 
 0:18:25.340,0:18:27.340
 GDB.
 
 0:18:31.580,0:18:34.360
-And GDB has one nice property:
+Dan GDB punya satu sifat yang bagus:
 
 0:18:34.460,0:18:37.740
-GDB works really well with C/C++
-and all these C-like languages.
+GDB bekerja sangat baik dengan C/C++
+dan semua bahasa mirip C.
 
 0:18:37.780,0:18:42.720
-But GDB actually lets you work with pretty
-much any binary that you can execute.
+Tapi GDB sebenarnya membiarkanmu bekerja dengan hampir
+semua biner yang bisa kamu jalankan.
 
 0:18:42.720,0:18:47.800
-So for example here we have sleep, which is just
-a program that's going to sleep for 20 seconds.
+Jadi misalnya di sini kita punya sleep, yang hanya
+program yang akan tidur selama 20 detik.
 
 0:18:48.520,0:18:55.340
-It's loaded and then we can do run, and then we
-can interrupt this sending an interrupt signal.
+Ini dimuat dan kemudian kita bisa melakukan run, dan kemudian kita
+bisa menginterupsi ini dengan mengirim sinyal interrupt.
 
 0:18:55.340,0:19:02.020
-And GDB is displaying for us, here, very low-level
-information about what's going on in the program.
+Dan GDB menampilkan untuk kita, di sini, informasi yang sangat low-level
+tentang apa yang terjadi di program.
 
 0:19:02.030,0:19:06.820
-So we're getting the stack trace, we're seeing
-we are in this nanosleep function,
+Jadi kita mendapat stack trace, kita melihat
+kita berada di fungsi nanosleep ini,
 
 0:19:07.060,0:19:11.660
-we can see the values of all the hardware
-registers in your machine. So
+kita bisa melihat nilai dari semua
+register hardware di mesin kita. Jadi
 
 0:19:12.300,0:19:17.160
-you can get a lot of low-level
-detail using these tools.
+kamu bisa mendapatkan banyak detail
+low-level menggunakan alat-alat ini.
 
 0:19:18.560,0:19:22.520
-I think that's all I want to cover for debuggers.
+Saya pikir itu semua yang ingin saya bahas untuk debugger.
 
 0:19:22.520,0:19:25.540
-Any questions related to that?
+Ada pertanyaan terkait itu?
 
 0:19:33.520,0:19:39.040
-Another interesting tool when you're trying to
-debug is that sometimes you want to debug as if
+Alat menarik lain ketika kamu mencoba
+debug adalah bahwa terkadang kamu ingin debug seolah-olah
 
 0:19:39.480,0:19:42.220
-your program is a black box.
+programmu adalah black box.
 
 0:19:42.220,0:19:46.059
-So you, maybe, know what the internals
-of the program but at the same time
+Jadi kamu, mungkin, tahu internal
+program tapi di saat yang sama
 
 0:19:46.430,0:19:52.119
-your computer knows whenever your program
-is trying to do some operations.
+komputermu tahu kapan programmu
+mencoba melakukan beberapa operasi.
 
 0:19:52.280,0:19:54.729
-So this is in UNIX systems,
+Jadi ini di sistem UNIX,
 
 0:19:54.760,0:19:58.060
-there's this notion of like user
-level code and kernel level code.
+ada konsep kode level user
+dan kode level kernel.
 
 0:19:58.060,0:20:03.180
-And when you try to do some operations like reading
-a file or like reading the network connection
+Dan ketika kamu mencoba melakukan beberapa operasi seperti membaca
+file atau membaca koneksi jaringan
 
 0:20:03.340,0:20:06.020
-you will have to do something
-called system calls.
+kamu harus melakukan sesuatu
+yang disebut system calls.
 
 0:20:06.180,0:20:12.560
-You can get a program and go through
-those operations and ask
+Kamu bisa mendapatkan program dan melalui
+operasi tersebut dan bertanya
 
 0:20:14.000,0:20:18.300
-what operations did this software do?
+operasi apa yang dilakukan perangkat lunak ini?
 
 0:20:18.300,0:20:20.920
-So for example, if you have
-like a Python function
+Jadi misalnya, jika kamu punya
+seperti fungsi Python
 
 0:20:20.980,0:20:26.660
-that is only supposed to do a mathematical operation
-and you run it through this program,
+yang seharusnya hanya melakukan operasi matematika
+dan kamu menjalankannya melalui program ini,
 
 0:20:26.660,0:20:28.460
-and it's actually reading files,
+dan ternyata ini membaca file,
 
 0:20:28.460,0:20:31.940
-Why is it reading files? It shouldn't
-be reading files. So, let's see.
+Mengapa ini membaca file? Seharusnya tidak
+membaca file. Jadi, mari kita lihat.
 
 0:20:34.520,0:20:37.200
-This is "strace".
+Ini adalah "strace".
 
 0:20:37.200,0:20:38.740
-So for example, we can do it something like this.
+Jadi misalnya, kita bisa melakukan sesuatu seperti ini.
 
 0:20:38.740,0:20:41.260
-So here we're gonna run the "LS - L"
+Jadi di sini kita akan menjalankan "LS -L"
 
 0:20:42.220,0:20:47.900
-And then we're ignoring the output of LS, but
-we are not ignoring the output of STRACE.
+Dan kemudian kita mengabaikan output dari LS, tapi
+kita tidak mengabaikan output dari STRACE.
 
 0:20:47.900,0:20:49.740
-So if we execute that...
+Jadi jika kita jalankan itu...
 
 0:20:52.300,0:20:54.720
-We're gonna get a lot of output.
+Kita akan mendapatkan banyak output.
 
 0:20:54.920,0:20:58.740
-This is all the different system calls
+Ini semua adalah system calls yang berbeda
 
 0:21:00.520,0:21:02.080
-That this
+Yang telah dijalankan
 
 0:21:02.090,0:21:07.510
-LS has executed. You will see a bunch
-of OPEN, you will see FSTAT.
+oleh LS ini. Kamu akan melihat banyak OPEN, kamu akan melihat FSTAT.
 
 0:21:08.150,0:21:14.170
-And for example, since it has to list all the properties
-of the files that are in this folder, we can
+Dan misalnya, karena ini harus mendaftar semua properti
+file yang ada di folder ini, kita bisa
 
 0:21:15.110,0:21:20.410
-check for the LSTAT call. So the LSTAT call will
-check for the properties of the files and
+memeriksa pemanggilan LSTAT. Jadi pemanggilan LSTAT akan
+memeriksa properti file dan
 
 0:21:21.020,0:21:27.420
-we can see that, effectively, all the files
-and folders that are in this directory
+kita bisa melihat bahwa, memang, semua file
+dan folder yang ada di direktori ini
 
 0:21:27.700,0:21:31.540
-have been accessed through
-a system call, through LS.
+telah diakses melalui
+system call, melalui LS.
 
 0:21:34.120,0:21:43.400
-Interestingly, sometimes you actually
-don't need to run your code to
+Menariknya, terkadang kamu sebenarnya
+tidak perlu menjalankan kode untuk
 
 0:21:44.360,0:21:47.000
-figure out that there is something
-wrong with your code.
+mengetahui bahwa ada sesuatu
+yang salah dengan kode kamu.
 
 0:21:47.960,0:21:52.449
-So far we have seen enough ways of identifying
-issues by running the code,
+Sejauh ini kita telah melihat cukup banyak cara untuk mengidentifikasi
+masalah dengan menjalankan kode,
 
 0:21:52.450,0:21:54.410
-but what if you...
+tapi bagaimana jika kamu...
 
 0:21:54.410,0:21:58.980
-you can look at a piece of code like this, like
-the one I have shown right now in this screen,
+kamu bisa melihat sepotong kode seperti ini, seperti
+yang saya tunjukkan di layar ini,
 
 0:21:58.980,0:22:00.560
-and identify an issue.
+dan mengidentifikasi masalah.
 
 0:22:00.560,0:22:02.030
-So for example here,
+Jadi misalnya di sini,
 
 0:22:02.030,0:22:06.670
-we have some really silly piece of code. It
-defines a function, prints a few variables,
+kita punya kode yang sangat sederhana. Ini
+mendefinisikan fungsi, mencetak beberapa variabel,
 
 0:22:07.720,0:22:11.780
-multiplies some variables, it sleeps for
-a while and then we try to print BAZ.
+mengalikan beberapa variabel, tidur selama
+beberapa waktu dan kemudian kita mencoba mencetak BAZ.
 
 0:22:12.020,0:22:14.840
-And you could try to look at
-this and say, hey, BAZ has
+Dan kamu bisa mencoba melihat
+ini dan bilang, hey, BAZ
 
 0:22:15.500,0:22:20.650
-never been defined anywhere. This is a new
-variable. You probably meant to say BAR
+tidak pernah didefinisikan di mana pun. Ini variabel
+baru. Kamu mungkin bermaksud mengatakan BAR
 
 0:22:20.650,0:22:22.540
-but you just mistyped it.
+tapi kamu salah ketik.
 
 0:22:22.540,0:22:26.480
-Thing is, if we try to run this program,
+Masalahnya, jika kita mencoba menjalankan program ini,
 
 0:22:28.820,0:22:36.820
-it's gonna take 60 seconds, because like we have to wait until
-this time.sleep function finishes. Here, sleep is just for
+ini akan memakan 60 detik, karena kita harus menunggu sampai
+fungsi time.sleep selesai. Di sini, sleep hanya untuk
 
 0:22:37.790,0:22:42.070
-motivating the example but in general you may
-be loading a data set that takes really long
+memotivasi contoh tapi secara umum kamu mungkin
+memuat dataset yang memakan waktu sangat lama
 
 0:22:42.140,0:22:44.740
-because you have to copy everything into memory.
+karena kamu harus menyalin semuanya ke memori.
 
 0:22:44.740,0:22:48.780
-And the thing is, there are programs
-that will take source code as input,
+Dan masalahnya, ada program
+yang akan mengambil source code sebagai input,
 
 0:22:49.340,0:22:54.940
-will process it and will say, oh probably this is
-wrong about this piece of code. So in Python,
+akan memprosesnya dan akan bilang, oh mungkin ini
+salah tentang kode ini. Jadi di Python,
 
 0:22:55.760,0:23:00.600
-or in general, these are called
-static analysis tools.
+atau secara umum, ini disebut
+alat static analysis.
 
 0:23:00.780,0:23:02.860
-In Python we have for example pyflakes.
+Di Python kita punya misalnya pyflakes.
 
 0:23:02.860,0:23:06.640
-If we get this piece of code
-and run it through pyflakes,
+Jika kita ambil kode ini
+dan jalankan melalui pyflakes,
 
 0:23:06.860,0:23:09.820
-pyflakes is gonna give us a couple of issues.
+pyflakes akan memberi kita beberapa masalah.
 
 0:23:10.040,0:23:15.700
-First one is the one.... The second one is the one
-we identified: here's an undefined name called BAZ.
+Yang pertama adalah yang.... Yang kedua adalah yang
+kita identifikasi: ini nama yang tidak terdefinisi bernama BAZ.
 
 0:23:15.700,0:23:17.760
-You probably should be doing
-something about that.
+Kamu mungkin harus melakukan
+sesuatu tentang itu.
 
 0:23:17.760,0:23:22.720
-And the other one is like
-oh, you're redefining the
+Dan yang lainnya adalah
+oh, kamu mendefinisikan ulang
 
 0:23:23.060,0:23:27.240
-the FOO variable name in that line.
+nama variabel FOO di baris itu.
 
 0:23:27.540,0:23:31.400
-So here we have a FOO function
-and then we are kind of
+Jadi di sini kita punya fungsi FOO
+dan kemudian kita
 
 0:23:31.400,0:23:34.620
-shadowing that function by
-using a loop variable here.
+shadow fungsi tersebut dengan
+menggunakan variabel loop di sini.
 
 0:23:34.760,0:23:38.460
-So now that FOO function that we
-defined is not accessible anymore
+Jadi sekarang fungsi FOO yang kita
+definisikan tidak bisa diakses lagi
 
 0:23:38.470,0:23:41.650
-and then if we try to call it afterwards,
-we will get into errors.
+dan kemudian jika kita mencoba memanggilnya setelahnya,
+kita akan mendapat error.
 
 0:23:43.520,0:23:45.520
-There are other types of
+Ada jenis lain dari
 
 0:23:46.250,0:23:53.170
-Static Analysis tools. MYPY is a different one. MYPY
-is gonna report the same two errors, but it's also
+alat Static Analysis. MYPY adalah yang berbeda. MYPY
+akan melaporkan dua error yang sama, tapi juga
 
 0:23:53.840,0:24:00.160
-going to complain about type checking. So it's gonna
-say, oh here you're multiplying an int by a float and
+akan mengeluh tentang type checking. Jadi ini akan
+bilang, oh di sini kamu mengalikan int dengan float dan
 
 0:24:00.680,0:24:06.320
-if you care about the type checking of your
-code, you should not be mixing those up.
+jika kamu peduli tentang type checking kode kamu,
+kamu seharusnya tidak mencampur mereka.
 
 0:24:07.490,0:24:12.219
-it can be kind of inconvenient, having to run
-this, look at the line, going back to your
+ini bisa agak merepotkan, harus menjalankan
+ini, melihat barisnya, kembali ke
 
 0:24:12.800,0:24:17.409
-VIM or like your editor, and figuring
-out what the error matches to.
+VIM atau editor kamu, dan mencari tahu
+error cocok dengan apa.
 
 0:24:18.380,0:24:21.190
-There are already solutions for that. One
+Sudah ada solusi untuk itu. Salah
 
 0:24:22.340,0:24:27.069
-way is that you can integrate most
-editors with these tools and here..
+satunya adalah kamu bisa mengintegrasikan sebagian besar
+editor dengan alat-alat ini dan di sini..
 
 0:24:28.279,0:24:34.059
-You can see there is like some red highlighting on
-the bash, and it will read the last line here.
+Kamu bisa melihat ada semacam highlight merah pada
+bash, dan ini akan membaca baris terakhir di sini.
 
 0:24:34.059,0:24:36.059
-So, undefined named 'baz'.
+Jadi, undefined named 'baz'.
 
 0:24:36.160,0:24:39.080
-So as I'm editing this piece of Python code,
+Jadi saat saya mengedit kode Python ini,
 
 0:24:39.080,0:24:43.360
-my editor is gonna give me feedback
-about what's going wrong with this.
+editor saya akan memberi saya feedback
+tentang apa yang salah dengan ini.
 
 0:24:43.560,0:24:48.480
-Or like here have another one saying
-the redefinition of unused foo.
+Atau seperti di sini ada yang lain yang mengatakan
+redefinisi dari foo yang tidak digunakan.
 
 0:24:49.849,0:24:51.849
-And
+Dan
 
 0:24:53.080,0:24:56.060
-even, there are some stylistic complaints.
+bahkan, ada beberapa keluhan stylistic.
 
 0:24:56.060,0:24:58.060
-So, oh, I will expect two empty lines.
+Jadi, oh, saya akan mengharapkan dua baris kosong.
 
 0:24:58.120,0:25:03.660
-So like in Python, you should be having two
-empty lines between a function definition.
+Jadi seperti di Python, kamu harus memiliki dua
+baris kosong antara definisi fungsi.
 
 0:25:05.779,0:25:07.009
-There are...
+Ada...
 
 0:25:07.009,0:25:09.280
-there is a resource on the lecture notes
+ada sumber di catatan kuliah
 
 0:25:09.280,0:25:13.160
-about pretty much static analyzers for a
-lot of different programming languages.
+tentang hampir semua static analyzer untuk
+banyak bahasa pemrograman yang berbeda.
 
 0:25:13.700,0:25:18.460
-There are even static analyzers for English.
+Bahkan ada static analyzer untuk bahasa Inggris.
 
 0:25:18.840,0:25:24.260
-So I have my notes
+Jadi saya punya catatan
 
 0:25:24.580,0:25:30.280
-for the class here, and if I run it through this
-static analyzer for English, that is "writegood".
+untuk kelas di sini, dan jika saya jalankan melalui
+static analyzer untuk bahasa Inggris, yaitu "writegood".
 
 0:25:30.409,0:25:33.008
-It's going to complain about
-some stylistic properties.
+Ini akan mengeluh tentang
+beberapa properti stylistic.
 
 0:25:33.009,0:25:33.489
-So like, oh,
+Jadi seperti, oh,
 
 0:25:33.489,0:25:37.460
-I'm using "very", which is a weasel
-word and I shouldn't be using it.
+saya menggunakan "very", yang merupakan kata
+weasel dan saya seharusnya tidak menggunakannya.
 
 0:25:37.480,0:25:43.080
-Or "quickly" can weaken meaning, and you can have
-this for spell checking, or for a lot of different
+Atau "quickly" bisa melemahkan makna, dan kamu bisa punya
+ini untuk spell checking, atau untuk banyak
 
 0:25:43.600,0:25:48.000
-types of stylistic analysis.
+jenis analisis stylistic yang berbeda.
 
 0:25:48.760,0:25:52.020
-Any questions so far?
+Ada pertanyaan sejauh ini?
 
 0:25:57.500,0:25:59.490
 Oh,
 
 0:25:59.490,0:26:01.490
-I forgot to mention...
+saya lupa menyebutkan...
 
 0:26:01.640,0:26:07.320
-Depending on the task that you're performing,
-there will be different types of debuggers.
+Tergantung pada tugas yang kamu lakukan,
+akan ada berbagai jenis debugger.
 
 0:26:07.320,0:26:09.740
-For example, if you're doing web development,
+Misalnya, jika kamu melakukan web development,
 
 0:26:09.860,0:26:13.520
-both Firefox and Chrome
+baik Firefox maupun Chrome
 
 0:26:13.740,0:26:20.600
-have a really really good set of tools
-for doing debugging for websites.
+memiliki set alat yang sangat, sangat bagus
+untuk melakukan debugging website.
 
 0:26:20.600,0:26:23.880
-So here we go and say inspect element,
+Jadi di sini kita pergi dan bilang inspect element,
 
 0:26:23.880,0:26:25.880
-we can get the... do you know?
-how to make this larger...
+kita bisa mendapatkan... kamu tahu?
+cara membuat ini lebih besar...
 
 0:26:27.660,0:26:29.220
-We're getting
+Kita mendapatkan
 
 0:26:29.220,0:26:33.380
-the entire source code for
-the web page for the class.
+seluruh source code untuk
+halaman web kelas.
 
 0:26:35.549,0:26:37.549
-Oh, yeah, here we go.
+Oh, ya, ini dia.
 
 0:26:38.640,0:26:40.640
-Is that better?
+Apakah ini lebih baik?
 
 0:26:40.799,0:26:47.149
-And we can actually go and change properties about
-the course. So we can say... we can edit the title.
+Dan kita sebenarnya bisa pergi dan mengubah properti tentang
+kursus. Jadi kita bisa bilang... kita bisa mengedit judul.
 
 0:26:47.400,0:26:51.280
-Say, this is not a class on
-debugging and profiling.
+Bilang, ini bukan kelas tentang
+debugging dan profiling.
 
 0:26:51.620,0:26:53.940
-And now the code for the website has changed.
+Dan sekarang kode untuk website telah berubah.
 
 0:26:54.120,0:26:56.000
-This is one of the reasons
-why you should never trust
+Ini adalah salah satu alasan
+mengapa kamu seharusnya tidak pernah mempercayai
 
 0:26:56.200,0:27:00.560
-any screenshots of websites, because
-they can be completely modified.
+screenshot website apa pun, karena
+mereka bisa dimodifikasi sepenuhnya.
 
 0:27:01.320,0:27:05.030
-And you can also modify this style.
-Like, here I have things
+Dan kamu juga bisa memodifikasi style ini.
+Seperti, di sini saya punya hal-hal
 
 0:27:06.120,0:27:07.559
-using the
+menggunakan
 
 0:27:07.560,0:27:09.500
-the dark mode preference,
+preferensi dark mode,
 
 0:27:09.680,0:27:11.900
-but we can alter that.
+tapi kita bisa mengubahnya.
 
 0:27:11.900,0:27:16.560
-Because at the end of the day, the
-browser is rendering this for us.
+Karena pada akhirnya,
+browser yang me-render ini untuk kita.
 
 0:27:17.840,0:27:21.780
-We can check the cookies, but there's
-like a lot of different operations.
+Kita bisa memeriksa cookie, tapi ada
+banyak operasi berbeda.
 
 0:27:21.799,0:27:27.619
-There's also a built-in debugger for JavaScript,
-so you can step through JavaScript code.
+Ada juga debugger bawaan untuk JavaScript,
+jadi kamu bisa melangkah melalui kode JavaScript.
 
 0:27:27.620,0:27:34.020
-So kind of the takeaway is, depending on what you are
-doing, you will probably want to search for what tools
+Jadi intinya adalah, tergantung apa yang kamu
+lakukan, kamu mungkin ingin mencari alat apa
 
 0:27:34.320,0:27:36.820
-programmers have built for them.
+yang telah dibangun programmer untuk mereka.
 
 0:27:44.880,0:27:47.630
-Now I'm gonna switch gears and
+Sekarang saya akan beralih dan
 
 0:27:48.200,0:27:51.800
-stop talking about debugging, which is kind
-of finding issues with the code, right?
+berhenti berbicara tentang debugging, yang merupakan
+mencari masalah dengan kode, kan?
 
 0:27:51.800,0:27:54.200
-kind of more about the behavior,
-and then start talking
+lebih tentang perilaku,
+dan kemudian mulai berbicara
 
 0:27:54.200,0:27:56.860
-about like how you can use profiling.
+tentang bagaimana kamu bisa menggunakan profiling.
 
 0:27:56.860,0:27:59.240
-And profiling is how to optimize the code.
+Dan profiling adalah bagaimana mengoptimalkan kode.
 
 0:28:01.100,0:28:05.940
-It might be because you want to optimize
-the CPU, the memory, the network, ...
+Mungkin karena kamu ingin mengoptimalkan
+CPU, memori, jaringan, ...
 
 0:28:06.330,0:28:09.889
-There are many different reasons that
-you want to be optimizing it.
+Ada banyak alasan berbeda yang
+membuatmu ingin mengoptimalkannya.
 
 0:28:10.440,0:28:14.000
-As it was the case with debugging,
-the kind of first-order approach
+Seperti halnya dengan debugging,
+pendekatan tingkat pertama
 
 0:28:14.000,0:28:16.680
-that a lot of people have
-experience with already is
+yang sudah banyak orang
+alami adalah
 
 0:28:16.880,0:28:21.880
-oh, let's use just printf profiling,
-so to say, like we can just take...
+oh, mari gunakan saja printf profiling,
+jadi bisa dibilang, kita bisa mengambil...
 
 0:28:22.770,0:28:25.610
-Let me make this larger. We can
+Biar saya buat ini lebih besar. Kita bisa
 
 0:28:26.130,0:28:28.110
-take the current time here,
+mengambil waktu saat ini di sini,
 
 0:28:28.110,0:28:34.610
-then we can check, we can do some execution
-and then we can take the time again and
+kemudian kita bisa memeriksa, kita bisa melakukan beberapa eksekusi
+dan kemudian kita bisa mengambil waktu lagi dan
 
 0:28:35.060,0:28:37.320
-subtract it from the original time.
+menguranginya dari waktu awal.
 
 0:28:37.320,0:28:39.320
-And by doing this you can kind of narrow down
+Dan dengan melakukan ini kamu bisa semacam membatasi
 
 0:28:39.540,0:28:46.040
-and fence some different parts of your code and try to figure
-out what is the time taken between those two parts.
+dan memagari beberapa bagian berbeda dari kode kamu dan mencoba mencari tahu
+berapa waktu yang dibutuhkan antara kedua bagian tersebut.
 
 0:28:47.040,0:28:52.639
-And that's good. But sometimes it can be interesting,
-the results. So here, we're sleeping for
+Dan itu bagus. Tapi terkadang bisa menarik,
+hasilnya. Jadi di sini, kita tidur selama
 
 0:28:53.730,0:28:59.809
-0.5 seconds and the output is saying,
-oh it's 0.5 plus some extra time,
+0,5 detik dan outputnya mengatakan,
+oh ini 0,5 ditambah beberapa waktu ekstra,
 
 0:28:59.810,0:29:05.929
-which is kind of interesting. And if we keep running it,
-we see there's like some small error and the thing is
+yang agak menarik. Dan jika kita terus menjalankannya,
+kita melihat ada beberapa error kecil dan masalahnya
 
 0:29:06.240,0:29:11.680
-here, what we're actually measuring is what
-is usually referred to as the "real time".
+di sini, yang sebenarnya kita ukur adalah apa
+yang biasanya disebut sebagai "real time".
 
 0:29:12.060,0:29:14.340
-Real time is as if you get
+Real time adalah seolah-olah kamu mengambil
 
 0:29:14.340,0:29:15.930
-like a
+seperti
 
 0:29:15.930,0:29:19.249
-clock, and you start it when your program starts,
-and you stop it when your program ends.
+jam, dan kamu memulainya saat program dimulai,
+dan kamu menghentikannya saat program berakhir.
 
 0:29:19.500,0:29:23.060
-But the thing is, in your computer it is
-not only your program that is running.
+Tapi masalahnya, di komputer kamu bukan
+hanya program kamu yang berjalan.
 
 0:29:23.060,0:29:27.460
-There are many other programs running
-at the same time and those might
+Ada banyak program lain yang berjalan
+pada saat yang sama dan itu mungkin
 
 0:29:27.760,0:29:34.640
-be the ones that are taking the CPU.
-So, to try to make sense of that,
+yang mengambil CPU.
+Jadi, untuk mencoba memahami itu,
 
 0:29:35.790,0:29:39.259
-A lot of... you'll see a lot of programs
+Banyak... kamu akan melihat banyak program
 
 0:29:40.620,0:29:43.250
-using the terminology that is
+menggunakan terminologi yaitu
 
 0:29:44.100,0:29:46.760
-real time, user time and system time.
+real time, user time dan system time.
 
 0:29:46.760,0:29:51.460
-Real time is what I explained, which is kind of
-the entire length of time from start to finish.
+Real time adalah apa yang saya jelaskan, yaitu
+seluruh durasi waktu dari awal sampai akhir.
 
 0:29:51.840,0:29:59.780
-Then there is the user time, which is the amount of time
-your program spent on the CPU doing user level cycles.
+Kemudian ada user time, yang merupakan jumlah waktu
+yang dihabiskan program kamu di CPU melakukan siklus level user.
 
 0:29:59.780,0:30:06.100
-So as I was mentioning, in UNIX, you can be running
-user level code or kernel level code.
+Jadi seperti yang saya sebutkan, di UNIX, kamu bisa menjalankan
+kode level user atau kode level kernel.
 
 0:30:06.920,0:30:12.940
-System is kind of the opposite, it's the amount of CPU, like
-the amount of time that your program spent on the CPU
+System adalah kebalikannya, yaitu jumlah CPU, seperti
+jumlah waktu yang dihabiskan program kamu di CPU
 
 0:30:13.500,0:30:18.480
-executing kernel mode instructions.
-So let's show this with an example.
+menjalankan instruksi mode kernel.
+Jadi mari tunjukkan ini dengan contoh.
 
 0:30:18.620,0:30:22.180
-Here I'm going to "time", which is a command,
+Di sini saya akan menggunakan "time", yang merupakan perintah,
 
 0:30:22.460,0:30:27.840
-a shell command that's gonna get these three metrics
-for the following command, and then I'm just
+perintah shell yang akan mendapatkan tiga metrik ini
+untuk perintah berikut, dan kemudian saya hanya
 
 0:30:28.100,0:30:30.560
-grabbing a URL from
+mengambil URL dari
 
 0:30:31.160,0:30:36.760
-a website that is hosted in Spain. So that's gonna take
-some extra time to go over there and then go back.
+website yang di-host di Spanyol. Jadi itu akan memakan
+waktu ekstra untuk pergi ke sana dan kembali.
 
 0:30:37.410,0:30:39.499
-If we see, here, if we were to just...
+Jika kita lihat, di sini, jika kita hanya...
 
 0:30:39.780,0:30:43.670
-We have two prints, between the beginning
-and the end of the program.
+Kita punya dua print, antara awal
+dan akhir program.
 
 0:30:43.670,0:30:49.039
-We could think that this program is taking like
-600 milliseconds to execute, but actually
+Kita bisa berpikir bahwa program ini memakan waktu seperti
+600 milidetik untuk dijalankan, tapi sebenarnya
 
 0:30:49.500,0:30:56.930
-most of that time was spent just waiting for the
-response on the other side of the network and
+sebagian besar waktu itu dihabiskan hanya menunggu
+respons di sisi lain jaringan dan
 
 0:30:57.330,0:31:04.880
-we actually only spent 16 milliseconds at the user level
-and like 9 seconds, in total 25 milliseconds, actually
+kita sebenarnya hanya menghabiskan 16 milidetik di level user
+dan seperti 9 detik, total 25 milidetik, sebenarnya
 
 0:31:05.280,0:31:08.149
-executing CURL code. Everything
-else was just waiting.
+menjalankan kode CURL. Semua
+yang lain hanya menunggu.
 
 0:31:12.090,0:31:14.480
-Any questions related to timing?
+Ada pertanyaan terkait timing?
 
 0:31:19.860,0:31:21.860
-Ok, so
+Oke, jadi
 
 0:31:21.990,0:31:23.580
-timing can be
+timing bisa
 
 0:31:23.580,0:31:29.480
-can become tricky, it's also kind of a black box solution.
-Or if you start adding print statements,
+menjadi rumit, ini juga semacam solusi black box.
+Atau jika kamu mulai menambahkan print statement,
 
 0:31:29.660,0:31:35.860
-it's kind of hard to add print statements, with time everywhere.
-So programmers have figured out better tools.
+ini agak sulit menambahkan print statement, dengan waktu di mana-mana.
+Jadi programmer telah menemukan alat yang lebih baik.
 
 0:31:36.140,0:31:38.700
-These are usually referred to as "profilers".
+Ini biasanya disebut sebagai "profiler".
 
 0:31:39.980,0:31:44.260
-One quick note that I'm gonna make, is that
+Satu catatan cepat yang akan saya buat, adalah bahwa
 
 0:31:44.720,0:31:46.720
-profilers, like usually when people
+profiler, seperti biasanya ketika orang
 
 0:31:46.800,0:31:48.800
-refer to profilers they usually talk about
+merujuk ke profiler mereka biasanya berbicara tentang
 
 0:31:49.050,0:31:55.190
-CPU profilers because they are the most common, at identifying
-where like time is being spent on the CPU.
+CPU profiler karena mereka yang paling umum, untuk mengidentifikasi
+di mana waktu dihabiskan di CPU.
 
 0:31:56.790,0:31:59.180
-Profilers usually come in kind of two flavors:
+Profiler biasanya datang dalam dua jenis:
 
 0:31:59.180,0:32:02.140
-there's tracing profilers and sampling profilers.
+ada tracing profiler dan sampling profiler.
 
 0:32:02.140,0:32:06.380
-and it's kind of good to know the difference
-because the output might be different.
+dan penting untuk mengetahui perbedaannya
+karena outputnya mungkin berbeda.
 
 0:32:07.640,0:32:10.300
-Tracing profilers kind of instrument your code.
+Tracing profiler semacam menginstrumentasi kode kamu.
 
 0:32:10.680,0:32:15.799
-So they kind of execute with your code and every
-time your code enters a function call,
+Jadi mereka berjalan bersama kode kamu dan setiap
+kali kode kamu memasuki function call,
 
 0:32:15.800,0:32:20.479
-they kind of take a note of it. It's like, oh we're entering
-this function call at this moment in time and
+mereka mencatatnya. Seperti, oh kita memasuki
+function call ini pada saat ini dan
 
 0:32:21.860,0:32:24.860
-they keep going and, once they
-finish, they can report
+mereka terus berjalan dan, setelah selesai,
+mereka bisa melaporkan
 
 0:32:24.860,0:32:28.300
-oh, you spent this much time executing
-in this function and
+oh, kamu menghabiskan waktu sebanyak ini
+di fungsi ini dan
 
 0:32:28.580,0:32:33.760
-this much time in this other function. So on, so forth,
-which is the example that we're gonna see now.
+waktu sebanyak ini di fungsi lainnya. Dan seterusnya,
+yang merupakan contoh yang akan kita lihat sekarang.
 
 0:32:34.590,0:32:38.329
-Another type of tools are tracing,
-sorry, sampling profilers.
+Jenis alat lain adalah tracing,
+maaf, sampling profiler.
 
 0:32:38.430,0:32:44.840
-The issue with tracing profilers is they add a lot of overhead.
-Like you might be running your code and having these kind of
+Masalah dengan tracing profiler adalah mereka menambahkan banyak overhead.
+Seperti kamu mungkin menjalankan kode kamu dan memiliki
 
 0:32:46.280,0:32:49.400
-profiling next to you making all these counts,
+profiling ini di sebelahmu membuat semua hitungan ini,
 
 0:32:49.400,0:32:54.340
-will hinder the performance of your program, so
-you might get counts that are slightly off.
+akan menghambat performa program kamu, jadi
+kamu mungkin mendapat hitungan yang sedikit meleset.
 
 0:32:55.380,0:32:59.450
-A sampling profiler, what it's gonna do
-is gonna execute your program and every
+Sampling profiler, yang akan dilakukannya
+adalah menjalankan program kamu dan setiap
 
 0:32:59.940,0:33:05.239
-100 milliseconds, 10 milliseconds, like some defined period,
-it's gonna stop your program. It's gonna halt it,
+100 milidetik, 10 milidetik, seperti periode yang ditentukan,
+ini akan menghentikan program kamu. Ini akan menghentikannya,
 
 0:33:05.580,0:33:12.379
-it's gonna look at the stack trace and say, oh, you're
-right now in this point in the hierarchy, and
+ini akan melihat stack trace dan bilang, oh, kamu
+sekarang berada di titik ini dalam hierarki, dan
 
 0:33:12.630,0:33:15.530
-identify which function is gonna
-be executing at that point.
+mengidentifikasi fungsi mana yang akan
+dijalankan pada titik itu.
 
 0:33:16.260,0:33:19.760
-The idea is that as long as you
-execute this for long enough,
+Idenya adalah selama kamu
+menjalankan ini cukup lama,
 
 0:33:19.760,0:33:24.290
-you're gonna get enough statistics to know
-where most of the time is being spent.
+kamu akan mendapat statistik yang cukup untuk mengetahui
+di mana sebagian besar waktu dihabiskan.
 
 0:33:25.800,0:33:28.800
-So, let's see an example of a tracing profiling.
+Jadi, mari lihat contoh tracing profiling.
 
 0:33:28.800,0:33:32.340
-So here we have a piece of
-code that is just like a
+Jadi di sini kita punya kode yang
 
 0:33:33.480,0:33:35.540
-really simple re-implementation of grep
+seperti implementasi ulang sederhana dari grep
 
 0:33:36.330,0:33:38.330
-done in Python.
+dalam Python.
 
 0:33:38.400,0:33:44.030
-What we want to check is what is the bottleneck of this
-program? Like we're just opening a bunch of files,
+Yang ingin kita periksa adalah apa bottleneck dari
+program ini? Kita hanya membuka banyak file,
 
 0:33:44.900,0:33:49.620
-trying to match this pattern, and then
-printing whenever we find a match.
+mencoba mencocokkan pola ini, dan kemudian
+mencetak kapanpun kita menemukan kecocokan.
 
 0:33:49.620,0:33:52.340
-And maybe it's the regex, maybe it's the print...
+Dan mungkin itu regex, mungkin itu print...
 
 0:33:52.460,0:33:53.940
-We don't really know.
+Kita tidak benar-benar tahu.
 
 0:33:53.940,0:33:59.040
-So to do this in Python, we have the "cProfile".
+Jadi untuk melakukan ini di Python, kita punya "cProfile".
 
 0:33:59.040,0:34:00.080
-And
+Dan
 
 0:34:00.990,0:34:06.620
-here I'm just calling this module and saying I want
-to sort this by the total amount of time, that
+di sini saya hanya memanggil modul ini dan bilang saya ingin
+mengurutkan ini berdasarkan total waktu, yang
 
 0:34:06.780,0:34:13.429
-we're gonna see briefly. I'm calling the
-program we just saw in the editor.
+akan kita lihat sebentar. Saya memanggil
+program yang baru kita lihat di editor.
 
 0:34:13.429,0:34:18.679
-I'm gonna execute this a thousand times
-and then I want to match (the grep
+Saya akan menjalankan ini seribu kali
+dan kemudian saya ingin mencocokkan (argumen grep
 
 0:34:18.960,0:34:21.770
-Arguments here) is I want to match these regex
+di sini) adalah saya ingin mencocokkan regex ini
 
 0:34:22.919,0:34:27.469
-to all the Python files in here.
-And this is gonna output some...
+ke semua file Python di sini.
+Dan ini akan menghasilkan beberapa...
 
 0:34:30.780,0:34:34.369
-This is gonna produce some output,
-then we're gonna look at it. First,
+Ini akan menghasilkan beberapa output,
+kemudian kita akan melihatnya. Pertama,
 
 0:34:34.369,0:34:38.539
-is all the output from the greps,
-but at the very end, we're getting
+adalah semua output dari grep,
+tapi di bagian paling akhir, kita mendapat
 
 0:34:39.119,0:34:42.979
-output from the profiler itself. If we go up
+output dari profiler itu sendiri. Jika kita naik
 
 0:34:44.129,0:34:46.939
-we can see that, hey,
+kita bisa melihat bahwa, hey,
 
 0:34:47.730,0:34:55.250
-by sorting we can see that the total number of calls. So we
-did 8000 calls, because we executed this 1000 times and
+dengan mengurutkan kita bisa melihat total jumlah panggilan. Jadi kita
+melakukan 8000 panggilan, karena kita menjalankan ini 1000 kali dan
 
 0:34:57.360,0:35:03.440
-this is the total amount of time we spent in this function
-(cumulative time). And here we can start to identify
+ini adalah total waktu yang kita habiskan di fungsi ini
+(waktu kumulatif). Dan di sini kita bisa mulai mengidentifikasi
 
 0:35:03.920,0:35:06.040
-where the bottleneck is.
+di mana bottleneck-nya.
 
 0:35:06.050,0:35:11.449
-So here, this built-in method IO open, is saying that
-we're spending a lot of the time just waiting for
+Jadi di sini, metode bawaan IO open ini, mengatakan bahwa
+kita menghabiskan banyak waktu hanya menunggu
 
 0:35:12.080,0:35:14.340
-reading from the disk or...
+membaca dari disk atau...
 
 0:35:14.340,0:35:15.680
-There, we can check, hey,
+Di sana, kita bisa memeriksa, hey,
 
 0:35:15.680,0:35:19.840
-a lot of time is also being spent
-trying to match the regex.
+banyak waktu juga dihabiskan
+mencoba mencocokkan regex.
 
 0:35:19.840,0:35:22.640
-Which is something that you will expect.
+Yang merupakan sesuatu yang kamu harapkan.
 
 0:35:22.640,0:35:26.220
-One of the caveats of using this
+Salah satu kelemahan menggunakan
 
 0:35:26.480,0:35:29.540
-tracing profiler is that, as you can see, here
+tracing profiler ini adalah bahwa, seperti yang kamu lihat, di sini
 
 0:35:29.540,0:35:35.239
-we're seeing our function but we're also seeing
-a lot of functions that correspond to built-ins.
+kita melihat fungsi kita tapi kita juga melihat
+banyak fungsi yang merupakan built-in.
 
 0:35:35.240,0:35:35.910
-So like,
+Jadi seperti,
 
 0:35:35.910,0:35:41.899
-functions that are third party functions from the libraries.
-And as you start building more and more complex code,
+fungsi yang merupakan fungsi pihak ketiga dari pustaka.
+Dan seiring kamu membangun kode yang semakin kompleks,
 
 0:35:41.900,0:35:43.560
-This is gonna be much harder.
+Ini akan menjadi jauh lebih sulit.
 
 0:35:44.200,0:35:44.760
-So
+Jadi
 
 0:35:46.080,0:35:49.720
-here is another piece of Python code that,
+di sini ada kode Python lain yang,
 
 0:35:51.540,0:35:53.779
-don't read through it, what it's doing is just
+jangan membacanya, yang dilakukannya hanya
 
 0:35:54.420,0:35:57.589
-grabbing the course website and
-then it's printing all the...
+mengambil website kursus dan
+kemudian mencetak semua...
 
 0:35:58.440,0:36:01.960
-It's parsing it, and then it's printing
-all the hyperlinks that it has found.
+Ini mem-parse-nya, dan kemudian mencetak
+semua hyperlink yang ditemukan.
 
 0:36:01.960,0:36:03.520
-So there are like these two operations:
+Jadi ada dua operasi ini:
 
 0:36:03.520,0:36:07.800
-going there, grabbing a website, and
-then parsing it, printing the links.
+pergi ke sana, mengambil website, dan
+kemudian mem-parse-nya, mencetak link.
 
 0:36:07.800,0:36:09.740
-And we might want to get a sense of
+Dan kita mungkin ingin mendapat gambaran
 
 0:36:09.740,0:36:16.180
-how those two operations compare to each
-other. If we just try to execute the
+bagaimana kedua operasi itu dibandingkan satu sama
+lain. Jika kita hanya mencoba menjalankan
 
 0:36:16.680,0:36:18.680
-cProfiler here and
+cProfiler di sini dan
 
 0:36:19.260,0:36:24.949
-we're gonna do the same, this is not gonna print anything.
-I'm using a tool we haven't seen so far,
+kita akan melakukan hal yang sama, ini tidak akan mencetak apa pun.
+Saya menggunakan alat yang belum kita lihat sejauh ini,
 
 0:36:24.950,0:36:25.700
-but I think it's pretty nice.
+tapi saya pikir ini cukup bagus.
 
 0:36:25.700,0:36:32.810
-It's "TAC", which is the opposite of "CAT", and it is going
-to reverse the output so I don't have to go up and look.
+Ini "TAC", yang merupakan kebalikan dari "CAT", dan ini akan
+membalik output jadi saya tidak harus naik dan melihat.
 
 0:36:33.430,0:36:35.430
-So we do this and...
+Jadi kita lakukan ini dan...
 
 0:36:36.250,0:36:39.179
-Hey, we get some interesting output.
+Hey, kita mendapat beberapa output menarik.
 
 0:36:39.880,0:36:46.200
-we're spending a bunch of time in this built-in method
-socket_getaddr_info and like in _imp_create_dynamic and
+kita menghabiskan banyak waktu di metode bawaan ini
+socket_getaddr_info dan seperti di _imp_create_dynamic dan
 
 0:36:46.510,0:36:48.540
-method_connect and posix_stat...
+method_connect dan posix_stat...
 
 0:36:49.210,0:36:55.740
-nothing in my code is directly calling these functions so I
-don't really know what is the split between the operation of
+tidak ada di kode saya yang secara langsung memanggil fungsi-fungsi ini jadi saya
+tidak benar-benar tahu apa pembagian antara operasi
 
 0:36:56.349,0:37:03.929
-making a web request and parsing the output of
-that web request. So, for that, we can use
+membuat web request dan mem-parse output dari
+web request tersebut. Jadi, untuk itu, kita bisa menggunakan
 
 0:37:04.900,0:37:07.920
-a different type of profiler which is
+jenis profiler berbeda yaitu
 
 0:37:09.819,0:37:14.309
-a line profiler. And the line profiler is
-just going to present the same results
+line profiler. Dan line profiler hanya
+akan menyajikan hasil yang sama
 
 0:37:14.310,0:37:20.879
-but in a more human-readable way, which is just, for this
-line of code, this is the amount of time things took.
+tapi dengan cara yang lebih mudah dibaca manusia, yaitu, untuk baris
+kode ini, ini adalah jumlah waktu yang dibutuhkan.
 
 0:37:24.819,0:37:31.079
-So it knows it has to do that, we have to add a
-decorator to the Python function, we do that.
+Jadi ini tahu harus melakukan itu, kita harus menambahkan
+decorator ke fungsi Python, kita lakukan itu.
 
 0:37:34.869,0:37:36.869
-And as we do that,
+Dan saat kita melakukan itu,
 
 0:37:37.119,0:37:39.749
-we now get slightly cropped output,
+kita sekarang mendapat output yang sedikit terpotong,
 
 0:37:39.750,0:37:46.169
-but the main idea, we can look at the percentage of time and
-we can see that making this request, get operation, took
+tapi ide utamanya, kita bisa melihat persentase waktu dan
+kita bisa melihat bahwa membuat request ini, operasi get, memakan
 
 0:37:46.450,0:37:52.829
-88% of the time, whereas parsing the
-response took only 10.9% of the time.
+88% waktu, sedangkan mem-parse
+respons hanya memakan 10,9% waktu.
 
 0:37:54.069,0:38:00.869
-This can be really informative and a lot of different programming
-languages will support this type of a line profiling.
+Ini bisa sangat informatif dan banyak bahasa pemrograman
+berbeda akan mendukung jenis line profiling ini.
 
 0:38:04.569,0:38:07.439
-Sometimes, you might not care about CPU.
+Terkadang, kamu mungkin tidak peduli tentang CPU.
 
 0:38:07.440,0:38:15.000
-Maybe you care about the memory or like some other resource.
-Similarly, there are memory profilers: in Python
+Mungkin kamu peduli tentang memori atau sumber daya lain.
+Demikian pula, ada memory profiler: di Python
 
 0:38:15.000,0:38:21.599
-there is "memory_profiler", for C you will have
-"Valgrind". So here is a fairly simple example,
+ada "memory_profiler", untuk C kamu akan punya
+"Valgrind". Jadi di sini contoh yang cukup sederhana,
 
 0:38:21.760,0:38:28.530
-we just create this list with a million elements. That's
-going to consume like megabytes of space and
+kita hanya membuat list ini dengan satu juta elemen. Itu
+akan memakan sekitar megabyte ruang dan
 
 0:38:29.200,0:38:33.920
-we do the same, creating another
-one with 20 million elements.
+kita melakukan hal yang sama, membuat
+satu lagi dengan 20 juta elemen.
 
 0:38:34.860,0:38:38.180
-To check, what was the memory allocation?
+Untuk memeriksa, berapa alokasi memori?
 
 0:38:38.980,0:38:44.369
-How it's gonna happen, what's the consumption?
-We can go through one memory profiler and
+Bagaimana itu terjadi, berapa konsumsinya?
+Kita bisa melalui satu memory profiler dan
 
 0:38:44.950,0:38:46.619
-we execute it,
+kita jalankan,
 
 0:38:46.620,0:38:51.380
-and it's telling us the total memory
-usage and the increments.
+dan ini memberi tahu kita penggunaan memori
+total dan kenaikannya.
 
 0:38:51.380,0:38:57.980
-And we can see that we have some overhead, because
-this is an interpreted language and when we create
+Dan kita bisa melihat bahwa kita punya beberapa overhead, karena
+ini adalah bahasa yang diinterpretasi dan ketika kita membuat
 
 0:38:58.450,0:39:00.599
-this million,
+satu juta
 
 0:39:03.520,0:39:07.340
-this list with a million entries, we're gonna
-need this many megabytes of information.
+list dengan satu juta entri ini, kita akan
+membutuhkan banyak megabyte informasi.
 
 0:39:07.660,0:39:15.299
-Then we were getting another 150 megabytes. Then, we're freeing
-this entry and that's decreasing the total amount.
+Kemudian kita mendapat 150 megabyte lagi. Kemudian, kita membebaskan
+entri ini dan itu mengurangi jumlah total.
 
 0:39:15.299,0:39:19.169
-We are not getting a negative increment because
-of a bug, probably in the profiler.
+Kita tidak mendapat kenaikan negatif karena
+bug, mungkin di profiler.
 
 0:39:19.509,0:39:26.549
-But if you know that your program is taking a huge amount of
-memory and you don't know why, maybe because you're copying
+Tapi jika kamu tahu program kamu memakan banyak
+memori dan kamu tidak tahu mengapa, mungkin karena kamu menyalin
 
 0:39:26.920,0:39:30.269
-objects where you should be
-doing things in place, then
+objek di mana kamu seharusnya
+melakukan sesuatu in-place, maka
 
 0:39:31.140,0:39:33.320
-using a memory profiler can be really useful.
+menggunakan memory profiler bisa sangat berguna.
 
 0:39:33.320,0:39:37.780
-And in fact there's an exercise that will
-kind of work you through that, comparing
+Dan sebenarnya ada latihan yang akan
+membimbingmu melalui itu, membandingkan
 
 0:39:37.980,0:39:39.980
-an in-place version of quicksort with like a
+versi in-place dari quicksort dengan
 
 0:39:40.059,0:39:44.008
-non-inplace, that keeps making new and new copies.
-And if you using the memory profiler
+yang bukan in-place, yang terus membuat salinan baru.
+Dan jika kamu menggunakan memory profiler
 
 0:39:44.009,0:39:47.909
-you can get a really good comparison
-between the two of them
+kamu bisa mendapat perbandingan yang sangat bagus
+antara keduanya
 
 0:39:51.069,0:39:53.459
-Any questions so far, with profiling?
+Ada pertanyaan sejauh ini, tentang profiling?
 
 0:39:53.460,0:39:57.940
-Is the memory profiler running the
-program in order to get that?
+Apakah memory profiler menjalankan
+program untuk mendapatkan itu?
 
 0:39:58.140,0:40:03.180
-Yeah... you might be able to figure
-out like just looking at the code.
+Ya... kamu mungkin bisa mencari tahu
+hanya dengan melihat kode.
 
 0:40:03.180,0:40:05.759
-But as you get more and more complex
-(for this code at least)
+Tapi seiring kamu mendapat lebih banyak program yang kompleks
+(setidaknya untuk kode ini)
 
 0:40:06.009,0:40:10.738
-But you get more and more complex programs what
-this is doing is running through the program
+Tapi kamu mendapat program yang semakin kompleks yang
+dilakukan alat ini adalah menjalankan melalui program
 
 0:40:10.739,0:40:16.739
-and for every line, at the very beginning,
-it's looking at the heap and saying
+dan untuk setiap baris, di awal,
+ini melihat heap dan bilang
 
 0:40:16.739,0:40:19.319
-"What are the objects that I have allocated now?"
+"Apa objek yang telah saya alokasikan sekarang?"
 
 0:40:19.319,0:40:22.979
-"I have seven megabytes of objects",
-and then goes to the next line,
+"Saya punya tujuh megabyte objek",
+dan kemudian pergi ke baris berikutnya,
 
 0:40:23.190,0:40:27.869
-looks again, "Oh now I have 50,
-so I have now added 43 there".
+melihat lagi, "Oh sekarang saya punya 50,
+jadi saya telah menambahkan 43 di sana".
 
 0:40:28.839,0:40:34.709
-Again, you could do this yourself by asking for those
-operations in your code, every single line.
+Sekali lagi, kamu bisa melakukan ini sendiri dengan meminta
+operasi tersebut di kode kamu, setiap baris.
 
 0:40:34.920,0:40:39.899
-But that's not how you should be doing things since people
-have already written these tools for you to use.
+Tapi itu bukan cara kamu seharusnya melakukan hal karena orang
+telah menulis alat-alat ini untuk kamu gunakan.
 
 0:40:43.089,0:40:46.078
-As it was the case with...
+Seperti halnya dengan...
 
 0:40:51.480,0:40:58.220
-So as in the case with strace, you can
-do something similar in profiling.
+Jadi seperti kasus dengan strace, kamu bisa
+melakukan hal serupa di profiling.
 
 0:40:58.340,0:41:03.380
-You might not care about the specific
-lines of code that you have,
+Kamu mungkin tidak peduli tentang baris
+kode spesifik yang kamu miliki,
 
 0:41:03.440,0:41:08.200
-but maybe you want to check for outside events.
-Like, you maybe want to check how many
+tapi mungkin kamu ingin memeriksa event eksternal.
+Seperti, kamu mungkin ingin memeriksa berapa banyak
 
 0:41:09.410,0:41:14.469
-CPU cycles your computer program is using,
-or how many page faults it's creating.
+siklus CPU yang digunakan program komputer kamu,
+atau berapa banyak page fault yang dibuat.
 
 0:41:14.469,0:41:19.239
-Maybe you have like bad cache locality
-and that's being manifested somehow.
+Mungkin kamu punya cache locality yang buruk
+dan itu termanifestasi entah bagaimana.
 
 0:41:19.340,0:41:22.960
-So for that, there is the "perf" command.
+Jadi untuk itu, ada perintah "perf".
 
 0:41:22.960,0:41:27.220
-The perf command is gonna do this, where it
-is gonna run your program and it's gonna
+Perintah perf akan melakukan ini, di mana ini
+akan menjalankan program kamu dan ini akan
 
 0:41:28.720,0:41:33.360
-keep track of all these statistics and report them back
-to you. And this can be really helpful if you are
+melacak semua statistik ini dan melaporkannya kembali
+kepadamu. Dan ini bisa sangat membantu jika kamu
 
 0:41:33.680,0:41:36.060
-working at a lower level. So
+bekerja di level yang lebih rendah. Jadi
 
 0:41:37.300,0:41:42.840
-we execute this command, I'm gonna
-explain briefly what it's doing.
+kita jalankan perintah ini, saya akan
+menjelaskan secara singkat apa yang dilakukannya.
 
 0:41:48.650,0:41:51.639
-And this stress program is just
+Dan program stress ini hanya
 
 0:41:52.219,0:41:54.698
-running in the CPU, and it's
-just a program to just
+berjalan di CPU, dan ini
+hanya program untuk
 
 0:41:54.829,0:41:59.528
-hog one CPU and like test that you can
-hog the CPU. And now if we Ctrl-C,
+memborong satu CPU dan seperti menguji bahwa kamu bisa
+memborong CPU. Dan sekarang jika kita Ctrl-C,
 
 0:42:00.619,0:42:02.708
-we can go back and
+kita bisa kembali dan
 
 0:42:03.410,0:42:08.559
-we get some information about the number of
-page faults that we have or the number of
+kita mendapat beberapa informasi tentang jumlah
+page fault yang kita miliki atau jumlah
 
 0:42:09.769,0:42:11.769
-CPU cycles that we utilize, and other
+siklus CPU yang kita gunakan, dan
 
 0:42:12.469,0:42:14.329
-useful
+metrik
 
 0:42:14.329,0:42:18.968
-metrics from our code. For some programs you can
+berguna lainnya dari kode kita. Untuk beberapa program kamu bisa
 
 0:42:21.469,0:42:25.089
-look at what the functions
-that were being used were.
+melihat fungsi apa
+yang digunakan.
 
 0:42:26.120,0:42:30.140
-So we can record what this program is doing,
+Jadi kita bisa merekam apa yang dilakukan program ini,
 
 0:42:30.940,0:42:34.920
-which we don't know about because it's
-a program someone else has written.
+yang kita tidak tahu karena ini
+adalah program yang ditulis orang lain.
 
 0:42:35.240,0:42:37.240
-And
+Dan
 
 0:42:38.180,0:42:42.279
-we can report what it was doing by looking
-at the stack trace and we can say oh,
+kita bisa melaporkan apa yang dilakukannya dengan melihat
+stack trace dan kita bisa bilang oh,
 
 0:42:42.279,0:42:44.279
-It's spending a bunch of time in this
+Ini menghabiskan banyak waktu di
 
-0:42:44.660,0:42:46.640
-__random_r
-
-0:42:46.640,0:42:53.229
-standard library function. And it's mainly because the way of hogging
-a CPU is by just creating more and more pseudo-random numbers.
+0:42:44.660,0:42:53.229
+fungsi pustaka standar __random_r ini. Dan itu terutama karena cara memborong
+CPU adalah dengan terus membuat angka pseudo-random.
 
 0:42:53.779,0:42:55.779
-There are some other
+Ada beberapa
 
 0:42:55.819,0:42:58.149
-functions that have not been mapped, because they
+fungsi lain yang belum dipetakan, karena mereka
 
 0:42:58.369,0:43:01.448
-belong to the program, but if
-you know about your program
+milik program, tapi jika
+kamu tahu tentang programmu
 
 0:43:01.448,0:43:05.140
-you can display this information
-using more flags, about perf.
+kamu bisa menampilkan informasi ini
+menggunakan flag lebih banyak, tentang perf.
 
 0:43:05.140,0:43:10.220
-There are really good tutorials online
-about how to use this tool.
+Ada tutorial yang sangat bagus online
+tentang cara menggunakan alat ini.
 
 0:43:12.010,0:43:14.010
 Oh
 
 0:43:14.119,0:43:17.349
-One one more thing regarding
-profilers is, so far,
+Satu hal lagi tentang
+profiler adalah, sejauh ini,
 
 0:43:17.350,0:43:20.109
-we have seen that these profilers
-are really good at
+kita telah melihat bahwa profiler ini
+sangat bagus dalam
 
 0:43:20.510,0:43:25.419
-aggregating all this information and giving
-you a lot of these numbers so you can
+mengagregasi semua informasi ini dan memberi
+banyak angka ini sehingga kamu bisa
 
 0:43:25.790,0:43:29.739
-optimize your code or you can reason
-about what is happening, but
+mengoptimalkan kode kamu atau kamu bisa bernalar
+tentang apa yang terjadi, tapi
 
 0:43:30.560,0:43:31.550
-the thing is
+masalahnya
 
 0:43:31.550,0:43:35.949
-humans are not really good at making
-sense of lots of numbers and since
+manusia tidak benar-benar bagus dalam memahami
+banyak angka dan karena
 
 0:43:36.080,0:43:39.249
-humans are more visual creatures, it's much
+manusia adalah makhluk yang lebih visual, jauh
 
 0:43:39.920,0:43:42.980
-easier to kind of have some
-sort of visualization.
+lebih mudah untuk memiliki semacam
+visualisasi.
 
 0:43:42.980,0:43:48.700
-Again, programmers have already thought about
-this and have come up with solutions.
+Sekali lagi, programmer sudah memikirkan
+ini dan telah datang dengan solusi.
 
 0:43:49.480,0:43:56.160
-A couple of popular ones, is a
-FlameGraph. A FlameGraph is a
+Beberapa yang populer, adalah
+FlameGraph. FlameGraph adalah
 
 0:43:56.780,0:44:00.160
-sampling profiler. So this is just running
-your code and taking samples
+sampling profiler. Jadi ini hanya menjalankan
+kode kamu dan mengambil sampel
 
 0:44:00.160,0:44:03.280
-And then on the y-axis here
+Dan kemudian di sumbu y di sini
 
 0:44:03.280,0:44:10.980
-we have the depth of the stack so we know that the bash function
-called this other function, and this called this other function,
+kita punya kedalaman stack jadi kita tahu bahwa fungsi bash
+memanggil fungsi lain ini, dan ini memanggil fungsi lain ini,
 
 0:44:11.260,0:44:14.480
-so on, so forth. And on the x-axis it's
+dan seterusnya. Dan di sumbu x ini
 
 0:44:14.630,0:44:17.500
-not time, it's not the timestamps.
+bukan waktu, ini bukan timestamp.
 
 0:44:17.500,0:44:23.290
-Like it's not this function run before, but it's just time
-taken. Because, again, this is a sampling profiler:
+Seperti bukan fungsi ini berjalan sebelumnya, tapi ini hanya waktu
+yang dihabiskan. Karena, sekali lagi, ini adalah sampling profiler:
 
 0:44:23.290,0:44:28.540
-we're just getting small glimpses of what was it going
-on in the program. But we know that, for example,
+kita hanya mendapat sekilas kecil tentang apa yang terjadi
+di program. Tapi kita tahu bahwa, misalnya,
 
 0:44:29.119,0:44:32.949
-this main program took the most time because the
+program utama ini memakan waktu paling banyak karena
 
 0:44:33.530,0:44:35.530
-x-axis is proportional to that.
+sumbu x proporsional dengan itu.
 
 0:44:36.020,0:44:43.090
-They are interactive and they can be really useful
-to identify the hot spots in your program.
+Mereka interaktif dan bisa sangat berguna
+untuk mengidentifikasi hot spot di program kamu.
 
 0:44:44.720,0:44:50.540
-Another way of displaying information, and there is also
-an exercise on how to do this, is using a call graph.
+Cara lain menampilkan informasi, dan ada juga
+latihan tentang cara melakukan ini, adalah menggunakan call graph.
 
 0:44:50.720,0:44:58.320
-So a call graph is going to be displaying information, and it's gonna
-create a graph of which function called which other function.
+Jadi call graph akan menampilkan informasi, dan ini akan
+membuat grafik fungsi mana yang memanggil fungsi lain mana.
 
 0:44:58.620,0:45:00.940
-And then you get information about, like,
+Dan kemudian kamu mendapat informasi tentang, seperti,
 
 0:45:00.940,0:45:05.770
-oh, we know that "__main__" called this
-"Person" function ten times and
+oh, kita tahu bahwa "__main__" memanggil
+fungsi "Person" ini sepuluh kali dan
 
 0:45:06.050,0:45:08.919
-it took this much time. And as you have
+ini memakan waktu sebanyak ini. Dan seiring kamu punya
 
 0:45:09.080,0:45:13.029
-larger and larger programs, looking at one of
-these call graphs can be useful to identify
+program yang semakin besar, melihat salah satu
+call graph ini bisa berguna untuk mengidentifikasi
 
 0:45:14.270,0:45:19.689
-what piece of your code is calling this really
-expensive IO operation, for example.
+bagian kode mana yang memanggil
+operasi IO yang sangat mahal ini, misalnya.
 
 0:45:24.560,0:45:30.360
-With that I'm gonna cover the last
-part of the lecture, which is that
+Dengan itu saya akan membahas bagian terakhir
+dari kuliah, yaitu bahwa
 
 0:45:30.360,0:45:36.600
-sometimes, you might not even know what exact
-resource is constrained in your program.
+terkadang, kamu mungkin tidak tahu sumber daya
+mana yang terbatas di program kamu.
 
 0:45:36.619,0:45:39.019
-Like how do I know how much CPU
+Seperti bagaimana saya tahu berapa banyak CPU
 
 0:45:39.380,0:45:44.060
-my program is using, and I can quickly
-look in there, or how much memory.
+yang digunakan program saya, dan saya bisa cepat
+melihat ke sana, atau berapa banyak memori.
 
 0:45:44.060,0:45:46.680
-So there are a bunch of really
+Jadi ada banyak alat
 
 0:45:46.700,0:45:49.760
-nifty tools for doing that one of them is
+bagus untuk melakukan itu, salah satunya adalah
 
 0:45:50.400,0:45:53.270
-HTOP. so HTOP is an
+HTOP. Jadi HTOP adalah
 
 0:45:54.000,0:45:59.810
-interactive command-line tool and here it's
-displaying all the CPUs this machine has,
+alat command-line interaktif dan di sini ini
+menampilkan semua CPU yang dimiliki mesin ini,
 
 0:46:00.160,0:46:07.740
-which is 12. It's displaying the amount of memory, it says I'm
-consuming almost a gigabyte of the 32 gigabytes my machine has.
+yaitu 12. Ini menampilkan jumlah memori, ini bilang saya
+mengonsumsi hampir satu gigabyte dari 32 gigabyte yang dimiliki mesin saya.
 
 0:46:07.740,0:46:11.660
-And then I'm getting all the different processes.
+Dan kemudian saya mendapat semua proses yang berbeda.
 
 0:46:11.730,0:46:13.290
-So for example we have
+Jadi misalnya kita punya
 
 0:46:13.290,0:46:20.300
-zsh, mysql and other processes that are running in this
-machine, and I can sort through the amount of CPU
+zsh, mysql dan proses lain yang berjalan di
+mesin ini, dan saya bisa mengurutkan berdasarkan jumlah CPU
 
 0:46:20.300,0:46:24.379
-they're consuming or through the
-priority they're running at.
+yang mereka konsumsi atau melalui
+prioritas yang mereka jalankan.
 
 0:46:25.980,0:46:28.129
-We can check this, for example. Here
+Kita bisa memeriksa ini, misalnya. Di sini
 
 0:46:28.130,0:46:30.230
-we have the stress command again
+kita punya perintah stress lagi
 
 0:46:30.230,0:46:31.470
-and we're going to
+dan kita akan
 
 0:46:31.470,0:46:37.040
-run it to take over four CPUs and check
-that we can see that in HTOP.
+menjalankannya untuk mengambil alih empat CPU dan memeriksa
+bahwa kita bisa melihatnya di HTOP.
 
 0:46:37.040,0:46:42.880
-So we did spot those four CPU
-jobs, and now I have seen that
+Jadi kita menemukan empat pekerjaan CPU
+itu, dan sekarang saya telah melihat bahwa
 
 0:46:43.710,0:46:46.429
-besides the ones we had before,
-now I have this...
+selain yang kita punya sebelumnya,
+sekarang saya punya ini...
 
 0:46:50.310,0:46:56.119
-Like this "stress -c" command running
-and taking a bunch of our CPU.
+Seperti perintah "stress -c" ini berjalan
+dan mengambil banyak CPU kita.
 
 0:46:56.849,0:47:03.169
-Even though you could use a profiler to get similar information to
-this, the way HTOP displays this kind of in a live interactive
+Meskipun kamu bisa menggunakan profiler untuk mendapat informasi serupa
+dengan ini, cara HTOP menampilkan ini secara live interaktif
 
 0:47:03.329,0:47:07.099
-fashion can be much quicker
-and much easier to parse.
+bisa jauh lebih cepat
+dan jauh lebih mudah untuk di-parse.
 
 0:47:07.890,0:47:09.890
-In the notes, there's a
+Di catatan, ada
 
 0:47:10.160,0:47:15.180
-really long list of different tools for evaluating
-different parts of your system.
+daftar yang sangat panjang dari alat berbeda untuk mengevaluasi
+bagian berbeda dari sistem kamu.
 
 0:47:15.180,0:47:17.180
-So that might be tools for analyzing the
+Jadi itu mungkin alat untuk menganalisis
 
 0:47:17.180,0:47:19.720
-network performance, about looking the
+performa jaringan, tentang melihat
 
 0:47:20.430,0:47:24.530
-number of IO operations, so you know
-whether you're saturating the
+jumlah operasi IO, jadi kamu tahu
+apakah kamu menjenuhkan
 
 0:47:26.040,0:47:28.040
-the reads from your disks,
+pembacaan dari disk kamu,
 
 0:47:28.829,0:47:31.429
-you can also look at what is the space usage.
+kamu juga bisa melihat berapa penggunaan ruang.
 
 0:47:32.069,0:47:34.369
-Which, I think, here...
+Yang, saya pikir, di sini...
 
 0:47:38.690,0:47:44.829
-So NCDU... There's a tool called "du"
-which stands for "disk usage" and
+Jadi NCDU... Ada alat bernama "du"
+yang merupakan singkatan dari "disk usage" dan
 
 0:47:45.440,0:47:49.480
-we have the "-h" flag for
+kita punya flag "-h" untuk
 "human readable output".
 
 0:47:51.740,0:47:58.959
-We can do videos and we can get output about
-the size of all the files in this folder.
+Kita bisa melakukan du dan kita bisa mendapat output tentang
+ukuran semua file di folder ini.
 
 0:48:08.059,0:48:10.059
-Yeah, there we go.
+Ya, ini dia.
 
 0:48:10.400,0:48:15.040
-There are also interactive versions,
-like HTOP was an interactive version.
+Ada juga versi interaktif,
+seperti HTOP adalah versi interaktif.
 
 0:48:15.280,0:48:21.200
-So NCDU is an interactive version that will let me navigate
-through the folders and I can see quickly that
+Jadi NCDU adalah versi interaktif yang akan membiarku bernavigasi
+melalui folder dan saya bisa melihat dengan cepat bahwa
 
 0:48:21.200,0:48:25.740
-oh, we have... This is one of the
-folders for the video lectures,
+oh, kita punya... Ini salah satu
+folder untuk kuliah video,
 
 0:48:26.329,0:48:29.049
-and we can see there are these four files
+dan kita bisa melihat ada empat file ini
 
 0:48:29.690,0:48:36.579
-that have like almost 9 GB each and I could
-quickly delete them through this interface.
+yang masing-masing hampir 9 GB dan saya bisa
+dengan cepat menghapusnya melalui antarmuka ini.
 
 0:48:37.760,0:48:43.839
-Another neat tool is "LSOF" which
-stands for "LIST OF OPEN FILES".
+Alat rapi lain adalah "LSOF" yang
+merupakan singkatan dari "LIST OF OPEN FILES".
 
 0:48:44.240,0:48:47.500
-Another pattern that you
-may encounter is you know
+Pola lain yang mungkin
+kamu temui adalah kamu tahu
 
 0:48:47.780,0:48:54.609
-some process is using a file, but you don't know exactly which process
-is using that file. Or, similarly, some process is listening in
+beberapa proses menggunakan file, tapi kamu tidak tahu persis proses mana
+yang menggunakan file itu. Atau, serupa, beberapa proses mendengarkan di
 
 0:48:55.400,0:48:59.020
-a port, but again, how do you
-find out which one it is?
+port, tapi lagi, bagaimana kamu
+mengetahui yang mana?
 
 0:48:59.020,0:49:00.820
-So to set an example.
+Jadi untuk memberi contoh.
 
 0:49:00.820,0:49:04.280
-We just run a Python HTTP server on port
+Kita hanya menjalankan Python HTTP server di port
 
 0:49:05.210,0:49:06.559
 444
 
 0:49:06.559,0:49:10.899
-Running there. Maybe we don't know that
-that's running, but then we can
+Berjalan di sana. Mungkin kita tidak tahu bahwa
+itu berjalan, tapi kemudian kita bisa
 
 0:49:13.130,0:49:15.130
-use...
+menggunakan...
 
 0:49:17.089,0:49:19.089
-we can use LSOF.
+kita bisa menggunakan LSOF.
 
 0:49:22.660,0:49:29.200
-Yeah, we can use LSOF, and the thing is LSOF
-is gonna print a lot of information.
+Ya, kita bisa menggunakan LSOF, dan masalahnya LSOF
+akan mencetak banyak informasi.
 
 0:49:30.440,0:49:32.740
-You need SUDO permissions because
+Kamu butuh izin SUDO karena
 
 0:49:34.069,0:49:39.219
-this is gonna ask for who has all these items.
+ini akan bertanya siapa yang memiliki semua item ini.
 
 0:49:39.829,0:49:43.929
-Since we only care about the one
-who is listening in this 444 port
+Karena kita hanya peduli tentang yang
+mendengarkan di port 444 ini
 
 0:49:44.630,0:49:46.369
-we can ask
+kita bisa meminta
 
 0:49:46.369,0:49:47.960
-grep for that.
+grep untuk itu.
 
 0:49:47.960,0:49:55.750
-And we can see, oh, there's like this Python process, with
-this identifier, that is using the port and then we can
+Dan kita bisa melihat, oh, ada proses Python ini, dengan
+identifier ini, yang menggunakan port dan kemudian kita bisa
 
 0:49:56.660,0:49:58.009
-kill it,
+kill itu,
 
 0:49:58.009,0:50:00.969
-and that terminates that process.
+dan itu mengakhiri proses tersebut.
 
 0:50:02.299,0:50:06.669
-Again, there's a lot of different
-tools. There's even tools for
+Sekali lagi, ada banyak
+alat berbeda. Bahkan ada alat untuk
 
 0:50:08.450,0:50:10.569
-doing what is called benchmarking.
+melakukan apa yang disebut benchmarking.
 
 0:50:11.660,0:50:18.789
-So in the shell tools and scripting lecture, I said
-like for some tasks "fd" is much faster than "find"
+Jadi di kuliah shell tools dan scripting, saya bilang
+seperti untuk beberapa tugas "fd" jauh lebih cepat daripada "find"
 
 0:50:18.950,0:50:21.519
-But like how will you check that?
+Tapi seperti bagaimana kamu akan memeriksa itu?
 
 0:50:22.059,0:50:30.038
-I can test that with "hyperfine" and I have here
-two commands: one with "fd" that is just
+Saya bisa menguji itu dengan "hyperfine" dan saya punya di sini
+dua perintah: satu dengan "fd" yang hanya
 
 0:50:30.500,0:50:34.029
-searching for JPEG files and
-the same one with "find".
+mencari file JPEG dan
+yang sama dengan "find".
 
 0:50:34.579,0:50:41.079
-If I execute them, it's gonna benchmark these
-scripts and give me some output about
+Jika saya jalankan, ini akan benchmark script ini
+dan memberi saya beberapa output tentang
 
 0:50:41.869,0:50:44.108
-how much faster "fd" is
+berapa kali lebih cepat "fd"
 
 0:50:45.380,0:50:47.380
-compared to "find".
+dibandingkan dengan "find".
 
 0:50:47.660,0:50:52.269
-So I think that kind of concludes...
-yeah, like 23 times for this task.
+Jadi saya pikir itu menyimpulkan...
+ya, seperti 23 kali untuk tugas ini.
 
 0:50:52.940,0:50:55.990
-So that kind of concludes the whole overview.
+Jadi itu menyimpulkan seluruh gambaran.
 
 0:50:56.539,0:51:00.309
-I know that there's like a lot of different
-topics and there's like a lot of
+Saya tahu ada banyak topik berbeda
+dan ada banyak
 
 0:51:00.650,0:51:04.539
-perspectives on doing these things, but
-again I want to reinforce the idea
+perspektif dalam melakukan hal-hal ini, tapi
+sekali lagi saya ingin memperkuat ide
 
 0:51:04.539,0:51:08.499
-that you don't need to be a master
-of all these topics but more...
+bahwa kamu tidak perlu menjadi master
+dari semua topik ini tapi lebih...
 
 0:51:08.750,0:51:11.229
-To be aware that all these things exist.
+Untuk menyadari bahwa semua hal ini ada.
 
 0:51:11.230,0:51:17.559
-So if you run into these issues you don't reinvent the wheel,
-and you reuse all that other programmers have done.
+Jadi jika kamu menemui masalah ini kamu tidak menemukan ulang roda,
+dan kamu menggunakan kembali apa yang telah dilakukan programmer lain.
 
 0:51:18.280,0:51:23.700
-Given that, I'm happy to take any questions related
-to this last section or anything in the lecture.
+Dengan itu, saya senang menerima pertanyaan terkait
+bagian terakhir ini atau apa pun di kuliah.
 
 0:51:25.900,0:51:30.060
-Is there any way to sort of think about
-how long a program should take?
+Apakah ada cara untuk memikirkan
+berapa lama program seharusnya berjalan?
 
 0:51:30.060,0:51:33.160
-You know, if it's taking a while to run
+Kamu tahu, jika ini memakan waktu lama untuk berjalan
 
 0:51:33.160,0:51:42.840
-you know, should you be worried? Or depending on your process, let me wait
-another ten minutes before I start looking at why it's taking so long.
+kamu tahu, haruskah kamu khawatir? Atau tergantung pada prosesmu, biarkan saya menunggu
+sepuluh menit lagi sebelum saya mulai melihat mengapa ini memakan waktu begitu lama.
 
 0:51:43.220,0:51:45.220
-Okay, so the...
+Oke, jadi...
 
 0:51:46.070,0:51:49.089
-The task of knowing how long a program
+Tugas mengetahui berapa lama program
 
 0:51:49.090,0:51:53.920
-should run is pretty infeasible to figure out.
-It will depend on the type of program.
+seharusnya berjalan cukup tidak mungkin untuk dicari tahu.
+Ini akan tergantung pada jenis program.
 
 0:51:54.290,0:52:01.899
-It depends on whether you're making HTTP requests or you're
-reading data... one thing that you can do is if you have
+Ini tergantung apakah kamu membuat HTTP request atau
+membaca data... satu hal yang bisa kamu lakukan adalah jika kamu punya
 
 0:52:02.390,0:52:02.980
-for example,
+misalnya,
 
 0:52:02.980,0:52:10.689
-if you know you have to read two gigabytes from memory,
-like from disk, and load that into memory, you can make
+jika kamu tahu kamu harus membaca dua gigabyte dari memori,
+seperti dari disk, dan memuatnya ke memori, kamu bisa membuat
 
 0:52:11.510,0:52:16.719
-back-of-the-envelope calculation. So like that shouldn't
-take longer than like X seconds because this is
+perkiraan kasar. Jadi seperti itu seharusnya tidak
+memakan waktu lebih dari X detik karena ini adalah
 
 0:52:16.940,0:52:20.050
-how things are set up. Or if you are
+bagaimana mọi sesuatu diatur. Atau jika kamu
 
 0:52:20.840,0:52:27.460
-reading some files from the network and you know kind of what the
-network link is and they are taking say five times longer than
+membaca beberapa file dari jaringan dan kamu tahu semacam apa
+link jaringan dan mereka memakan waktu katakan lima kali lebih lama dari
 
 0:52:27.460,0:52:29.460
-what you would expect then you could
+yang kamu harapkan maka kamu bisa
 
 0:52:29.990,0:52:31.190
-try to do that.
+mencoba melakukan itu.
 
 0:52:31.190,0:52:37.839
-Otherwise, if you don't really know. Say you're trying to do some
-mathematical operation in your code and you're not really sure
+Jika tidak, jika kamu tidak benar-benar tahu. Katakan kamu mencoba melakukan
+operasi matematika di kode kamu dan kamu tidak benar-benar yakin
 
 0:52:37.840,0:52:44.050
-about how long that will take you can use something
-like logging and try to kind of print intermediate
+berapa lama itu akan memakan waktu kamu bisa menggunakan sesuatu
+seperti logging dan mencoba mencetak
+tahap intermediate
 
 0:52:44.570,0:52:50.469
-stages to get a sense of like, oh I need
-to do a thousand operations of this and
+untuk mendapat gambaran seperti, oh saya perlu
+melakukan seribu operasi ini dan
 
 0:52:51.800,0:52:53.600
-three iterations
+tiga iterasi
 
 0:52:53.600,0:53:00.700
-took ten seconds. Then this is gonna take
-much longer than I can handle in my case.
+memakan sepuluh detik. Maka ini akan memakan
+waktu jauh lebih lama dari yang bisa saya tangani di kasus saya.
 
 0:53:00.920,0:53:04.599
-So I think there are there are ways, it
-will again like depend on the task,
+Jadi saya pikir ada cara, ini
+akan lagi tergantung pada tugas,
 
 0:53:04.600,0:53:08.800
-but definitely, given all the tools we've
-seen really, we probably have like
+tapi pasti, mengingat semua alat yang telah kita
+lihat, kita mungkin punya beberapa
 
 0:53:09.620,0:53:13.150
-a couple of really good ways
-to start tackling that.
+cara yang sangat bagus
+untuk mulai mengatasi itu.
 
 0:53:14.750,0:53:16.750
-Any other questions?
+Ada pertanyaan lain?
 
 0:53:16.750,0:53:18.750
-You can also do things like
+Kamu juga bisa melakukan hal seperti
 
 0:53:18.750,0:53:21.060
-run HTOP and see if anything is running.
+menjalankan HTOP dan melihat apakah ada yang berjalan.
 
 0:53:22.380,0:53:25.500
-Like if your CPU is at 0%, something
-is probably wrong.
+Seperti jika CPU kamu di 0%, sesuatu
+mungkin salah.
 
 0:53:31.140,0:53:32.579
-Okay.
+Oke.
 
 0:53:32.579,0:53:38.268
-There's a lot of exercises for all the topics
-that we have covered in today's class,
+Ada banyak latihan untuk semua topik
+yang telah kita bahas di kelas hari ini,
 
 0:53:38.269,0:53:41.419
-so feel free to do the ones
-that are more interesting.
+jadi silakan lakukan yang
+paling menarik.
 
 0:53:42.180,0:53:44.539
-We're gonna be holding office hours again today.
+Kita akan mengadakan office hours lagi hari ini.
 
 0:53:45.059,0:53:48.979
-Just a reminder, office hours. You can come
-and ask questions about any lecture.
+Sekadar pengingat, office hours. Kamu bisa datang
+dan bertanya tentang kuliah apa pun.
 
 0:53:48.980,0:53:53.510
-Like we're not gonna expect you to kind of
-do the exercises in a couple of minutes.
+Seperti kita tidak akan mengharapkan kamu untuk
+melakukan latihan dalam beberapa menit.
 
 0:53:53.510,0:53:57.979
-They take a really long while to get through
-them, but we're gonna be there
+Ini memakan waktu sangat lama untuk menyelesaikannya,
+tapi kita akan ada di sana
 
 0:53:58.529,0:54:04.339
-to answer any questions from previous classes, or even not related
-to exercises. Like if you want to know more about how you
+untuk menjawab pertanyaan dari kelas sebelumnya, atau bahkan yang tidak terkait
+dengan latihan. Seperti jika kamu ingin tahu lebih banyak tentang bagaimana kamu
 
 0:54:04.619,0:54:09.889
-would use TMUX in a way to kind of quickly switch
-between panes, anything that comes to your mind.
-
+akan menggunakan TMUX dengan cara untuk beralih dengan cepat
+antara panel, apa pun yang terlintas di pikiranmu.

--- a/static/files/subtitles/2020/qa.sbv
+++ b/static/files/subtitles/2020/qa.sbv
@@ -1,2874 +1,2863 @@
 0:00:00.000,0:00:06.540
-I guess we should do an intro to to this as well,
+Saya rasa kita harus melakukan intro untuk ini juga,
 
 0:00:06.540,0:00:09.580
-so this is a just sort of a
+jadi ini hanyalah semacam
 
 0:00:09.581,0:00:14.740
-free-form Q&A lecture where you, as in
-the two people sitting here, but also
+kuliah Q&A bebas di mana kalian, seperti dua orang yang duduk di sini,
+tapi juga
 
 0:00:14.740,0:00:19.841
-everyone at home who did not come here
-in person get to ask questions and we
+semua orang di rumah yang tidak datang langsung ke sini
+bisa bertanya dan kami
 
 0:00:19.841,0:00:22.961
-have a bunch of questions people asked
-in advance but you can also ask
+punya banyak pertanyaan yang diajukan sebelumnya
+tapi kalian juga bisa mengajukan
 
 0:00:22.961,0:00:27.371
-additional questions during, for the two
-of you who are here, you can do it either
+pertanyaan tambahan selama kuliah, untuk kalian berdua yang di sini,
+bisa melakukannya dengan
 
 0:00:27.371,0:00:33.611
-by raising your hand or you can submit it on
-the forum and be anonymous, it's up to you
+mengangkat tangan atau mengirimkannya di forum dan menjadi anonim, terserah kalian
 
 0:00:33.611,0:00:35.671
-regardless though, what we're gonna
-do is just go through some of the
+bagaimanapun, yang akan kami
+lakukan adalah melewati beberapa
 
 0:00:35.681,0:00:40.241
-questions have been asked and try to
-give as helpful answers as we can
+pertanyaan yang telah diajukan dan mencoba
+memberikan jawaban yang paling membantu
 
 0:00:40.241,0:00:43.691
-although they are unprepared on our side and
+meskipun tidak dipersiapkan dari sisi kami dan
 
 0:00:43.791,0:00:45.611
-yeah that's the plan I guess we go
+ya itu rencananya saya rasa kita mulai
 
 0:00:45.611,0:00:48.911
-from popular to least popular
+dari yang paling populer ke yang paling tidak populer
 
 0:00:48.911,0:00:49.991
-fire away
+silakan
 
 0:00:49.991,0:00:52.091
-all right so for our first question any
+baiklah jadi untuk pertanyaan pertama kami
 
 0:00:52.091,0:00:55.961
-recommendations on learning operating
-system related topics like processes,
+rekomendasi untuk mempelajari topik terkait sistem operasi
+seperti proses,
 
 0:00:55.961,0:00:59.861
-virtual memory, interrupts,
-memory management, etc
+memori virtual, interrupt,
+manajemen memori, dll
 
 0:00:59.861,0:01:01.811
-so I think this is a
+jadi saya pikir ini adalah
 
 0:01:01.811,0:01:07.181
-is an interesting question because these
-are really low level concepts that often
+pertanyaan yang menarik karena ini adalah konsep-konsep yang sangat low level
+yang seringkali
 
 0:01:07.181,0:01:11.391
-do not matter, unless you have to
-deal with this in some capacity,
+tidak penting, kecuali kalian harus
+menanganinya dalam kapasitas tertentu,
 
 0:01:11.391,0:01:12.771
-right so
+jadi
 
 0:01:12.891,0:01:17.671
-one instance where this matters is you're
-writing really low level code like
+salah satu kasus di mana ini penting adalah ketika kalian
+menulis kode yang sangat low level seperti
 
 0:01:17.681,0:01:20.500
-you're implementing a kernel or something
-like that, or you want to
+kalian mengimplementasikan kernel atau sesuatu
+seperti itu, atau kalian ingin
 
 0:01:20.500,0:01:22.811
-just hack on the Linux kernel.
+sekadar mengotak-atik kernel Linux.
 
 0:01:22.811,0:01:24.751
-It's rare otherwise that you need to work with
+Jarang sekali selain itu kalian perlu bekerja dengan
 
 0:01:24.751,0:01:27.711
-especially like virtual memory and
-interrupts and stuff yourself
+terutama seperti memori virtual dan
+interrupt dan semacamnya sendiri
 
 0:01:27.851,0:01:32.071
-processes, I think are a more general concept
-that we've talked a little bit about in
+proses, saya pikir adalah konsep yang lebih umum
+yang telah kita bahas sedikit di
 
 0:01:32.071,0:01:36.611
-this class as well and tools like
-htop, pgrep, kill, and signals and
+kelas ini juga dan alat-alat seperti
+htop, pgrep, kill, dan sinyal serta
 
 0:01:36.761,0:01:37.711
-that sort of stuff
+semacamnya
 
 0:01:37.711,0:01:39.311
-in terms of learning it
+dalam hal mempelajarinya
 
 0:01:39.311,0:01:45.371
-maybe one of the best ways, is to try to
-take either an introductory class on the
+mungkin salah satu cara terbaik adalah dengan mencoba
+mengambil kelas pengantar tentang
 
 0:01:45.371,0:01:51.401
-topic, so for example MIT has a class
-called 6.828, which is where
+topik tersebut, misalnya MIT memiliki kelas
+bernama 6.828, yang merupakan
 
 0:01:51.401,0:01:55.091
-you essentially build and develop your
-own operating system based on some code
+di mana kalian pada dasarnya membangun dan mengembangkan
+sistem operasi kalian sendiri berdasarkan beberapa kode
 
 0:01:55.091,0:01:58.631
-that you're given, and all of those labs
-are publicly available and all the
+yang diberikan kepada kalian, dan semua lab tersebut
+tersedia secara publik dan semua
 
 0:01:58.631,0:02:01.601
-resources for the class are publicly available,
-and so that is a good way to
+sumber daya untuk kelas tersebut tersedia secara publik,
+dan jadi itu adalah cara yang baik untuk
 
 0:02:01.601,0:02:04.001
-really learn them is by doing them yourself.
+benar-benar mempelajarinya adalah dengan melakukannya sendiri.
 
 0:02:04.001,0:02:05.201
-There are also various
+Ada juga berbagai
 
 0:02:05.201,0:02:11.201
-tutorials online that basically guide
-you through how do you write a kernel
+tutorial online yang pada dasarnya memandu
+kalian cara menulis kernel
 
 0:02:11.201,0:02:15.431
-from scratch. Not necessarily a very
-elaborate one, not one you would want
+dari nol. Bukan yang sangat
+canggih, bukan yang akan kalian ingin
 
 0:02:15.431,0:02:20.561
-to run any real software on, but just to
-teach you the basics and so that would
+jalankan software nyata di atasnya, tapi hanya untuk
+mengajarkan dasar-dasarnya dan jadi itu akan
 
 0:02:20.561,0:02:21.930
-be another thing to look up.
+menjadi hal lain untuk dicari.
 
 0:02:21.930,0:02:24.131
-Like how do I write a kernel in and then your
+Seperti bagaimana cara menulis kernel dalam dan kemudian
 
 0:02:24.131,0:02:27.611
-language of choice. You will probably not
-find one that lets you do it in Python
+bahasa pilihan kalian. Kalian mungkin tidak akan
+menemukan yang membiarkan kalian melakukannya dalam Python
 
 0:02:27.611,0:02:33.612
-but in like C, C++, Rust, there
-are a bunch of topics like this
+tapi dalam seperti C, C++, Rust, ada
+banyak topik seperti ini
 
 0:02:33.612,0:02:36.951
-one other note on operating systems
+satu catatan lagi tentang sistem operasi
 
 0:02:36.951,0:02:39.931
-so like Jon mentioned MIT has a 6.828 class but
+jadi seperti yang disebutkan Jon, MIT memiliki kelas 6.828 tapi
 
 0:02:39.941,0:02:43.391
-if you're looking for a more high-level
-overview, not necessarily programming or
+jika kalian mencari gambaran yang lebih tinggi,
+bukan pemrograman atau
 
 0:02:43.391,0:02:46.001
-an operating system, but just learning about
-the concepts another good resource
+sistem operasi, tapi hanya belajar tentang
+konsep-konsepnya, sumber daya lain yang bagus
 
 0:02:46.001,0:02:51.331
-is a book called "Modern Operating
-Systems" by Andy Tannenbaum
+adalah buku berjudul "Modern Operating
+Systems" oleh Andy Tannenbaum
 
 0:02:51.331,0:02:58.371
-there's also actually a book called the "The FreeBSD
-Operating System" which is really good,
+ada juga sebenarnya buku berjudul "The FreeBSD
+Operating System" yang sangat bagus,
 
 0:02:58.371,0:03:03.031
-It doesn't go through Linux, but it goes
-through FreeBSD and the BSD kernel is
+tidak membahas Linux, tapi membahas
+FreeBSD dan kernel BSD
 
 0:03:03.031,0:03:07.181
-arguably better organized than the Linux
-one and better documented and so it
+bisa dibilang lebih terorganisir daripada
+Linux dan lebih terdokumentasi dengan baik dan jadi
 
 0:03:07.181,0:03:11.591
-might be a gentler introduction to some of those
-topics than trying to understand Linux
+mungkin pengantar yang lebih lembut untuk beberapa topik
+tersebut daripada mencoba memahami Linux
 
 0:03:11.591,0:03:14.951
-You want to check it as answered?
+Mau dicek sebagai terjawab?
 
 0:03:14.951,0:03:16.511
-- Yes + Nice
+- Ya + Bagus
 
 0:03:16.511,0:03:17.451
-Answered
+Terjawab
 
 0:03:17.451,0:03:19.371
-For our next question
+Untuk pertanyaan berikutnya
 
 0:03:19.371,0:03:23.951
-What are some of the tools you'd
-prioritize learning first?
+Apa saja alat yang sebaiknya
+diprioritaskan untuk dipelajari pertama kali?
 
 0:03:23.951,0:03:29.551
-- Maybe we can all go through and
-give our opinion on this? + Yeah
+- Mungkin kita semua bisa memberikan
+pendapat masing-masing? + Ya
 
 0:03:29.551,0:03:31.713
-Tools to prioritize learning first?
+Alat yang diprioritaskan untuk dipelajari pertama kali?
 
 0:03:31.713,0:03:36.451
-I think learning your editor well,
-just serves you in all capacities
+Saya pikir mempelajari editor kalian dengan baik,
+layani kalian dalam semua kapasitas
 
 0:03:36.511,0:03:40.511
-like being efficient at editing files,
-is just like a majority of
+seperti menjadi efisien dalam mengedit file,
+hanya seperti sebagian besar
 
 0:03:40.511,0:03:45.041
-what you're going to spend your time doing.
-And in general, just using your
+apa yang akan kalian habiskan waktu untuk melakukannya.
+Dan secara umum, hanya menggunakan
 
 0:03:45.041,0:03:49.211
-keyboard more in your mouse less. It means
-that you get to spend more of your
+keyboard lebih banyak dan mouse lebih sedikit. Itu berarti
+kalian bisa menghabiskan lebih banyak
 
 0:03:49.311,0:03:53.751
-time doing useful things and
-less of your time moving
+waktu untuk melakukan hal-hal yang berguna dan
+lebih sedikit waktu untuk memindahkan
 
 0:03:53.751,0:03:56.251
-I think that would be my top priority,
+Saya pikir itu akan menjadi prioritas utama saya,
 
 0:04:04.511,0:04:06.751
-so I would say that for what
+jadi saya akan mengatakan bahwa untuk
 
 0:04:06.760,0:04:09.671
-tool to prioritize will depend
-on what exactly you're doing
+alat mana yang diprioritaskan akan tergantung
+pada apa yang sebenarnya kalian lakukan
 
 0:04:09.671,0:04:16.150
-I think the core idea is you should try
-to find the types of tasks that you are
+Saya pikir ide intinya adalah kalian harus mencoba
+menemukan jenis tugas yang kalian
 
 0:04:16.151,0:04:18.371
-doing repetitively and so
+lakukan secara berulang dan jadi
 
 0:04:18.371,0:04:23.791
-if you are doing some sort of like
-machine learning workload and
+jika kalian melakukan semacam
+beban kerja machine learning dan
 
 0:04:24.011,0:04:27.130
-you find yourself using jupyter notebooks,
-like the one we presented
+kalian menemukan diri kalian menggunakan jupyter notebook,
+seperti yang kami tunjukkan
 
 0:04:27.130,0:04:32.560
-yesterday, a lot. Then again, using
-a mouse for that might not be
+kemarin, banyak. Kemudian lagi, menggunakan
+mouse untuk itu mungkin bukan
 
 0:04:32.560,0:04:35.830
-the best idea and you want to familiarize
-with the keyboard shortcuts
+ide terbaik dan kalian ingin membiasakan diri
+dengan shortcut keyboard
 
 0:04:35.830,0:04:40.750
-and pretty much with anything you will
-end up figuring out that there are some
+dan hampir dengan apa pun kalian akan
+berakhir menemukan bahwa ada beberapa
 
 0:04:40.751,0:04:45.611
-repetitive tasks, and you're running a
-computer, and just trying to figure out
+tugas berulang, dan kalian menjalankan komputer,
+dan hanya mencoba mencari tahu
 
 0:04:45.611,0:04:48.311
-oh there's probably a better way to do this
+oh mungkin ada cara yang lebih baik untuk melakukan ini
 
 0:04:48.431,0:04:50.871
-be it a terminal, be it an editor
+baik itu terminal, baik itu editor
 
 0:04:51.111,0:04:55.891
-And it might be really interesting to
-learn to use some of the topics that
+Dan mungkin sangat menarik untuk
+mempelajari beberapa topik yang
 
 0:04:55.900,0:05:01.121
-we have covered, but if they're not
-extremely useful in a everyday
+telah kami bahas, tapi jika mereka tidak
+sangat berguna dalam sehari-hari
 
 0:05:01.121,0:05:05.431
-basis then it might not worth prioritizing them
+maka mungkin tidak layak diprioritaskan
 
 0:05:06.591,0:05:07.451
-out of the topics
+dari topik-topik
 
 0:05:07.531,0:05:11.611
-covered in this class in my opinion two
-of the most useful things are version
+yang dibahas di kelas ini menurut pendapat saya, dua
+hal yang paling berguna adalah version
 
 0:05:11.621,0:05:15.220
-control and text editors, and I think they're
-a little bit different from each
+control dan text editor, dan saya pikir mereka
+agak berbeda satu sama lain
 
 0:05:15.220,0:05:18.880
-other, in the sense that text editors I
-think are really useful to learn well
+dalam arti text editor saya pikir
+sangat berguna untuk dipelajari dengan baik
 
 0:05:18.880,0:05:21.970
-but it was probably the case that before
-we started using vim and all its fancy
+tapi mungkin kasusnya adalah sebelum
+kami mulai menggunakan vim dan semua shortcut
 
 0:05:21.970,0:05:25.390
-keyboard shortcuts you had some other
-text editor you were using before and
+keyboard mewahnya, kalian punya text editor lain
+yang kalian gunakan sebelumnya dan
 
 0:05:25.390,0:05:29.890
-you could edit text just fine maybe a little
-bit inefficiently whereas I think
+kalian bisa mengedit teks dengan cukup baik mungkin agak
+tidak efisien sedangkan saya pikir
 
 0:05:29.890,0:05:33.100
-version control is another really useful
-skill and that's one where if you don't
+version control adalah skill yang sangat berguna lainnya
+dan itu adalah salah satu di mana jika kalian tidak
 
 0:05:33.100,0:05:36.580
-really know the tool properly, it can actually
-lead to some problems like loss
+benar-benar mengenal alatnya dengan baik, itu bisa
+menyebabkan beberapa masalah seperti kehilangan
 
 0:05:36.580,0:05:39.490
-of data or just inability to collaborate
-properly with people so I
+data atau hanya ketidakmampuan untuk berkolaborasi
+dengan benar dengan orang lain jadi saya
 
 0:05:39.490,0:05:42.730
-think version control is one of the first
-things that's worth learning well
+pikir version control adalah salah satu hal pertama
+yang layak dipelajari dengan baik
 
 0:05:42.730,0:05:46.871
-yeah, I agree with that, I think
-learning a tool like Git is just
+ya, saya setuju dengan itu, saya pikir
+mempelajari alat seperti Git akan
 
 0:05:46.871,0:05:49.691
-gonna save you so much heartache down the line
+menyelamatkan kalian dari banyak masalah di kemudian hari
 
 0:05:49.691,0:05:51.431
-it also, to add on to that
+juga, untuk menambahkan itu
 
 0:05:51.571,0:05:57.310
-It really helps you collaborate with others
-and Anish touched a little bit on GitHub
+itu sangat membantu kalian berkolaborasi dengan orang lain
+dan Anish menyentuh sedikit tentang GitHub
 
 0:05:57.310,0:06:01.300
-in the last lecture, and just learning
-to use that tool well in order
+di kuliah terakhir, dan hanya belajar
+menggunakan alat itu dengan baik untuk
 
 0:06:01.300,0:06:05.321
-to work on larger software projects
-that other people are working on is
+bekerja pada proyek software yang lebih besar
+yang dikerjakan orang lain adalah
 
 0:06:05.321,0:06:06.431
-an invaluable skill
+skill yang sangat berharga
 
 0:06:10.071,0:06:11.391
-For our next question
+Untuk pertanyaan berikutnya
 
 0:06:11.391,0:06:12.871
-when do I use Python versus a
+kapan saya menggunakan Python versus
 
 0:06:12.881,0:06:16.051
-bash script, versus some other language
+bash script, versus bahasa lainnya
 
 0:06:16.051,0:06:19.661
-This is tough, because I think this comes
+Ini sulit, karena saya pikir ini
 
 0:06:19.661,0:06:21.631
-down to what Jose was saying earlier too
+kembali ke apa yang dikatakan Jose sebelumnya juga
 
 0:06:21.771,0:06:23.731
-that it really depends on
-what you're trying to do
+bahwa itu benar-benar tergantung pada
+apa yang coba kalian lakukan
 
 0:06:23.731,0:06:27.155
-For me, I think for bash scripts in particular
+Bagi saya, saya pikir untuk bash script khususnya
 
 0:06:27.155,0:06:28.791
-bash scripts are for
+bash script adalah untuk
 
 0:06:28.891,0:06:33.430
-automating running a bunch of commands,
-you don't want to write any
+mengotomatiskan menjalankan serangkaian perintah,
+kalian tidak ingin menulis
 
 0:06:33.430,0:06:35.411
-other like business logic in bash
+business logic lainnya dalam bash
 
 0:06:35.411,0:06:39.011
-it is just for I want to run these
+itu hanya untuk saya ingin menjalankan
 
 0:06:39.011,0:06:44.110
-commands, in this order. Maybe with
-arguments, but like even that
+perintah-perintah ini, dalam urutan ini. Mungkin dengan
+argumen, tapi bahkan itu
 
 0:06:44.110,0:06:47.581
-it's unclear do you want to bash script
-once you start taking arguments
+masih belum jelas apakah kalian ingin bash script
+setelah kalian mulai mengambil argumen
 
 0:06:47.581,0:06:52.691
-Similarly, once you start doing any
-kind of like text processing or
+Demikian juga, setelah kalian mulai melakukan
+pemrosesan teks atau
 
 0:06:52.691,0:06:55.131
-configuration, all that
+konfigurasi, semua itu
 
 0:06:55.131,0:06:59.111
-reach for a language that is a more serious
+gunakan bahasa yang lebih serius
 
 0:06:59.111,0:07:01.031
-programming language than bash is
+bahasa pemrograman daripada bash
 
 0:07:01.091,0:07:03.451
-bash is really for sort of short one-off
+bash benar-benar untuk script singkat sekali pakai
 
 0:07:03.461,0:07:10.211
-scripts or ones that have a very well-defined
-use case on the terminal in
+atau yang memiliki kasus penggunaan yang sangat terdefinisi
+di terminal dan
 
 0:07:10.211,0:07:12.851
-the shell, probably
+shell, mungkin
 
 0:07:12.851,0:07:15.941
-For a slightly more concrete guideline,
-you might say write a
+Untuk panduan yang sedikit lebih konkret,
+kalian bisa bilang tulis
 
 0:07:15.941,0:07:19.211
-bash script if it's less than a hundred
-lines of code or so, but once it gets
+bash script jika kurang dari seratus
+baris kode atau lebih, tapi setelah itu
 
 0:07:19.211,0:07:21.611
-beyond that point bash is kind of
-unwieldy and it's probably worth
+melebihi titik itu bash agak
+merepotkan dan mungkin layak
 
 0:07:21.611,0:07:25.091
-switching to a more serious programming
-language like Python
+beralih ke bahasa pemrograman yang lebih serius
+seperti Python
 
 0:07:25.091,0:07:26.511
-and to add to that
+dan untuk menambahkan itu
 
 0:07:26.511,0:07:32.211
-I would say that I found myself writing
-sometimes scripts in Python because
+saya akan mengatakan bahwa saya menemukan diri saya kadang-kadang menulis
+script dalam Python karena
 
 0:07:32.211,0:07:36.911
-If I have already solved some subproblem
-that covers part of the problem in Python
+Jika saya sudah menyelesaikan beberapa submasalah
+yang mencakup bagian dari masalah dalam Python
 
 0:07:36.911,0:07:40.631
-I find it much easier to compose the
-previous solution that I found out in
+saya merasa jauh lebih mudah untuk menggabungkan
+solusi sebelumnya yang saya temukan dalam
 
 0:07:40.631,0:07:45.731
-Python and just try to reuse bash code,
-that I don't find as reusable as Python
+Python dan hanya mencoba menggunakan kembali kode bash,
+yang saya rasa tidak bisa digunakan kembali seperti Python
 
 0:07:45.731,0:07:49.600
-And in the same way it's kind of nice that
-a lot of people have written something
+Dan dengan cara yang sama, cukup bagus bahwa
+banyak orang telah menulis sesuatu
 
 0:07:49.600,0:07:52.631
-like Python libraries or like Ruby libraries
-to do a lot of these things
+seperti library Python atau library Ruby
+untuk melakukan banyak hal ini
 
 0:07:52.631,0:07:58.451
-whereas in bash is kind of hard
-to have like code reuse
+sedangkan dalam bash agak sulit
+untuk memiliki penggunaan kembali kode
 
 0:07:58.451,0:08:01.720
-And in fact,
+Dan sebenarnya,
 
 0:08:01.720,0:08:07.631
-I think to add to that. Usually, if you
-find a library in some language that
+saya pikir untuk menambahkan itu. Biasanya, jika kalian
+menemukan library dalam bahasa tertentu yang
 
 0:08:07.631,0:08:12.091
-helps with the task you're trying to
-do, use that language for the job
+membantu dengan tugas yang coba kalian
+lakukan, gunakan bahasa itu untuk pekerjaannya
 
 0:08:12.091,0:08:15.671
-And in bash there are no libraries, there
-are only the programs on your computer
+Dan dalam bash tidak ada library, hanya ada
+program-program di komputer kalian
 
 0:08:15.771,0:08:18.931
-So you probably don't want to use
-it unless like there's a program
+Jadi kalian mungkin tidak ingin menggunakannya
+kecuali seperti ada program
 
 0:08:18.941,0:08:23.741
-you can just invoke I do think another
-thing worth remembering about bash
+yang bisa kalian panggil saja. Saya pikir hal lain yang layak diingat tentang bash
 
 0:08:23.741,0:08:26.451
-bash is really hard to get right.
+bash sangat sulit untuk dilakukan dengan benar.
 
 0:08:26.451,0:08:30.531
-It's very easy to get it right for the particular
-use case you're trying to solve right now
+Sangat mudah untuk melakukannya dengan benar untuk kasus penggunaan
+tertentu yang coba kalian selesaikan sekarang
 
 0:08:30.531,0:08:32.471
-but things like
+tapi hal-hal seperti
 
 0:08:32.471,0:08:35.891
-What if one of the filenames has a space in it?
+Bagaimana jika salah satu nama file memiliki spasi di dalamnya?
 
 0:08:35.891,0:08:38.891
-It has caused so many bugs and so
+Itu telah menyebabkan begitu banyak bug dan
 
 0:08:38.891,0:08:43.151
-many problems in bash scripts and if you
-use a real programming language then
+banyak masalah dalam bash script dan jika kalian
+menggunakan bahasa pemrograman yang sebenarnya maka
 
 0:08:43.151,0:08:46.642
-those problems just go away
+masalah-masalah itu hilang begitu saja
 
 0:08:46.651,0:08:50.491
-Checked it
+Sudah dicek
 
 0:08:50.571,0:08:51.571
-For our next question
+Untuk pertanyaan berikutnya
 
 0:08:51.571,0:08:56.211
-What is the difference between sourcing
-a script and executing that script ?
+Apa perbedaan antara sourcing
+script dan mengeksekusi script tersebut?
 
 0:08:57.071,0:09:02.711
-So this actually, we got in office
-hours a while back as well which is
+Jadi ini sebenarnya, kami mendapat pertanyaan ini di office
+hours beberapa waktu lalu juga yaitu
 
 0:09:02.871,0:09:06.991
-Aren't they the same? like aren't they
-both just running the bash script?
+Bukankah mereka sama? bukankah keduanya
+hanya menjalankan bash script?
 
 0:09:06.991,0:09:08.051
-and it is true
+dan itu benar
 
 0:09:08.051,0:09:12.191
-both of these will end up executing the
-lines of code that are in the script
+keduanya akan berakhir mengeksekusi
+baris-baris kode yang ada dalam script
 
 0:09:12.191,0:09:16.571
-the ways in which they differ is that
-sourcing a script is telling your
+cara mereka berbeda adalah bahwa
+sourcing script adalah memberitahu
 
 0:09:16.571,0:09:22.991
-current bash script, your current bash
-session to execute that program
+bash script kalian saat ini, sesi bash
+saat ini untuk mengeksekusi program tersebut
 
 0:09:23.131,0:09:28.911
-whereas the other one is, start up a new instance
-of bash and run the program there instead
+sedangkan yang lainnya adalah, memulai instance baru
+dari bash dan menjalankan program di sana
 
 0:09:29.291,0:09:34.931
-And this matters for things like imagine that
-"script.sh" tries to change directories
+Dan ini penting untuk hal-hal seperti bayangkan bahwa
+"script.sh" mencoba mengubah direktori
 
 0:09:34.931,0:09:37.841
-If you are running the script
-as in the second invocation
+Jika kalian menjalankan script
+seperti pemanggilan kedua
 
 0:09:37.841,0:09:42.761
-"./script.sh", then the new
-process is going to change
+"./script.sh", maka proses baru
+akan mengubah
 
 0:09:42.761,0:09:46.891
-directories but by the time that script
-exits and returns to your shell
+direktori tapi pada saat script itu
+keluar dan kembali ke shell kalian
 
 0:09:46.891,0:09:51.831
-your shell still remains in the same place. However,
-if you do CD in a script and you source it
+shell kalian tetap berada di tempat yang sama. Namun,
+jika kalian melakukan CD dalam script dan kalian source itu
 
 0:09:51.831,0:09:55.241
-Your current instance of bash is the
-one that ends up running it and
+Instance bash kalian saat ini adalah yang
+berakhir menjalankannya dan
 
 0:09:55.241,0:09:57.951
-so it ends up CDing where you are
+jadi itu berakhir melakukan CD ke mana kalian berada
 
 0:09:57.951,0:10:01.171
-This is also why if you define functions
+Ini juga alasan mengapa jika kalian mendefinisikan fungsi
 
 0:10:01.171,0:10:04.751
-For example, that you may want to
-execute in your shell session
+Misalnya, yang mungkin ingin kalian
+eksekusi dalam sesi shell kalian
 
 0:10:04.751,0:10:07.011
-You need to source the script, not run it
+Kalian perlu source scriptnya, bukan menjalankannya
 
 0:10:07.011,0:10:10.261
-Because if you run it, that function
-will be defined in the
+Karena jika kalian menjalankannya, fungsi itu
+akan didefinisikan dalam
 
 0:10:10.261,0:10:11.931
-instance of bash
+instance bash
 
 0:10:11.931,0:10:16.831
-In the bash process that gets launched but it
-will not be defined in your current shell
+Dalam proses bash yang diluncurkan tapi itu
+tidak akan didefinisikan dalam shell kalian saat ini
 
 0:10:16.831,0:10:22.871
-I think those are two of the biggest
-differences between the two
+Saya pikir itu adalah dua perbedaan terbesar
+antara keduanya
 
 0:10:29.211,0:10:29.711
-Next question,
+Pertanyaan berikutnya,
 
 0:10:29.873,0:10:35.131
-What are the places where various packages and tools
-are stored and how does referencing them work?
+Di mana berbagai paket dan alat
+disimpan dan bagaimana cara mereferensikannya?
 
 0:10:35.131,0:10:39.171
-What even is /bin or /lib?
+Apa itu /bin atau /lib?
 
 0:10:39.171,0:10:45.091
-So as we covered in the first lecture,
-there is this PATH environment variable
+Jadi seperti yang kami bahas di kuliah pertama,
+ada variabel lingkungan PATH
 
 0:10:45.091,0:10:49.551
-which is a semicolon separated
-string of all the places
+yang merupakan string terpisah titik koma
+dari semua tempat
 
 0:10:49.551,0:10:55.111
-where your shell is gonna look for binaries
-and if you just do something
+di mana shell kalian akan mencari binary
+dan jika kalian hanya melakukan sesuatu
 
 0:10:55.111,0:10:58.171
-like "echo $PATH", you're gonna get this list
+seperti "echo $PATH", kalian akan mendapatkan daftar ini
 
 0:10:58.171,0:11:02.251
-and all these places are gonna
-be consulted in order.
+dan semua tempat ini akan
+dikonsultasikan secara berurutan.
 
 0:11:02.251,0:11:03.601
-It's gonna go through all of them and in fact
+Ini akan melewati semuanya dan sebenarnya
 
 0:11:03.601,0:11:07.011
-- There is already... Did we cover which? + Yeah
+- Sudah ada... Apakah kita sudah membahas which? + Ya
 
 0:11:07.211,0:11:10.011
-So if you run "which" and a specific command
+Jadi jika kalian menjalankan "which" dan perintah tertentu
 
 0:11:10.021,0:11:14.071
-the shell is actually is gonna tell
-you where it's finding this
+shell sebenarnya akan memberitahu
+kalian di mana ia menemukan ini
 
 0:11:14.071,0:11:15.391
-Beyond that,
+Selain itu,
 
 0:11:15.391,0:11:20.431
-there is like some conventions where a lot
-of programs will install their binaries
+ada beberapa konvensi di mana banyak
+program akan menginstal binary mereka
 
 0:11:20.431,0:11:24.071
-and they're like /usr/bin (or at
-least they will include symlinks)
+dan mereka seperti /usr/bin (atau setidaknya
+mereka akan menyertakan symlink)
 
 0:11:24.071,0:11:26.051
-in /usr/bin so you can find them
+di /usr/bin sehingga kalian bisa menemukannya
 
 0:11:26.191,0:11:28.211
-There's also a /usr/local/bin
+Ada juga /usr/local/bin
 
 0:11:28.211,0:11:33.951
-There are special directories. For example,
-/usr/sbin it's only for sudo user and
+Ada direktori khusus. Misalnya,
+/usr/sbin hanya untuk sudo user dan
 
 0:11:33.951,0:11:38.491
-some of these conventions are slightly
-different between different distros so
+beberapa konvensi ini sedikit
+berbeda antara distro yang berbeda jadi
 
 0:11:38.491,0:11:47.571
-I know like some distros for example install
-the user libraries under /opt for example
+saya tahu beberapa distro misalnya menginstal
+library user di bawah /opt misalnya
 
 0:11:51.191,0:11:55.491
-Yeah I think one thing just
-to talk a little bit of more
+Ya saya pikir satu hal
+untuk berbicara sedikit lebih banyak
 
 0:11:55.651,0:12:00.631
-about /bin and then Anish maybe you can
-do the other folders so when it comes to
+tentang /bin dan kemudian Anish mungkin kalian bisa
+menjelaskan folder lainnya jadi ketika datang ke
 
 0:12:00.631,0:12:02.791
-/bin the convention
+/bin konvensinya
 
 0:12:02.791,0:12:10.051
-There are conventions, and the conventions are
-usually /bin are for essential system utilities
+Ada konvensi, dan konvensinya biasanya
+/bin adalah untuk utilitas sistem penting
 
 0:12:10.051,0:12:12.531
-/usr/bin are for user programs and
+/usr/bin adalah untuk program user dan
 
 0:12:12.531,0:12:17.431
-/usr/local/bin are for user
-compiled programs, sort of
+/usr/local/bin adalah untuk program yang
+dikompilasi user, semacam
 
 0:12:17.431,0:12:21.691
-so things that you installed that you intend
-the user to run, are in /usr/bin
+jadi hal-hal yang kalian instal yang kalian niatkan
+untuk dijalankan user, ada di /usr/bin
 
 0:12:21.691,0:12:26.711
-things that a user has compiled themselves and stuck
-on your system, probably goes in /usr/local/bin
+hal-hal yang dikompilasi user sendiri dan diletakkan
+di sistem kalian, mungkin masuk ke /usr/local/bin
 
 0:12:26.711,0:12:29.991
-but again, this varies a lot from machine
-to machine, and distro to distro
+tapi sekali lagi, ini sangat bervariasi dari mesin
+ke mesin, dan distro ke distro
 
 0:12:29.991,0:12:33.971
-On Arch Linux, for example, /bin
-is a symlink to /usr/bin
+Di Arch Linux, misalnya, /bin
+adalah symlink ke /usr/bin
 
 0:12:33.971,0:12:40.261
-They're the same and as Jose mentioned, there's
-also /sbin which is for programs that are
+Mereka sama dan seperti yang disebutkan Jose, ada juga
+/sbin yang untuk program-program yang
 
 0:12:40.261,0:12:43.801
-intended to only be run as root, that
-also varies from distro to distro
+dimaksudkan hanya untuk dijalankan sebagai root, itu
+juga bervariasi dari distro ke distro
 
 0:12:43.801,0:12:47.251
-whether you even have that directory, and
-on many systems like /usr/local/bin
+apakah kalian bahkan memiliki direktori itu, dan
+di banyak sistem seperti /usr/local/bin
 
 0:12:47.251,0:12:51.151
-might not even be in your PATH, or
-might not even exist on your system
+mungkin bahkan tidak ada di PATH kalian, atau
+mungkin bahkan tidak ada di sistem kalian
 
 0:12:51.151,0:12:55.831
-On BSD on the other hand /usr/local/bin
-is often used a lot more heavily
+Di BSD sebaliknya /usr/local/bin
+sering digunakan lebih banyak
 
 0:12:56.731,0:12:57.231
-yeah so
+ya jadi
 
 0:12:57.231,0:13:01.111
-What we were talking about so far, these
-are all ways that files and folders are
+Apa yang kita bicarakan sejauh ini, ini
+semua adalah cara file dan folder
 
 0:13:01.111,0:13:05.071
-organized on Linux things or Linux or
-BSD things vary a little bit between
+diorganisir di Linux hal-hal atau Linux atau
+hal-hal BSD sedikit berbeda antara
 
 0:13:05.071,0:13:07.151
-that and macOS or other platforms
+itu dan macOS atau platform lainnya
 
 0:13:07.151,0:13:09.301
-I think for the specific locations,
+Saya pikir untuk lokasi spesifik,
 
 0:13:09.301,0:13:11.471
-if you to know exactly what it's
-used for, you can look it up
+jika kalian ingin tahu persis apa fungsinya,
+kalian bisa mencarinya
 
 0:13:11.471,0:13:17.291
-But some general patterns to keep in mind or anything
-with /bin in it has binary executable programs in it,
+Tapi beberapa pola umum untuk diingat atau apa pun
+dengan /bin di dalamnya memiliki program eksekutable biner di dalamnya,
 
 0:13:17.291,0:13:19.891
-anything with \lib in it, has
-libraries in it so things that
+apa pun dengan \lib di dalamnya, memiliki
+library di dalamnya jadi hal-hal yang
 
 0:13:19.891,0:13:25.081
-programs can link against, and then some
-other things that are useful to know are
+program bisa link terhadapnya, dan kemudian beberapa
+hal lain yang berguna untuk diketahui adalah
 
 0:13:25.081,0:13:29.431
-there's a /etc on many systems, which
-has configuration files in it and
+ada /etc di banyak sistem, yang
+memiliki file konfigurasi di dalamnya dan
 
 0:13:29.431,0:13:34.311
-then there's /home, which underneath that directory
-contains each user's home directory
+kemudian ada /home, yang di bawah direktori itu
+berisi direktori home setiap user
 
 0:13:34.311,0:13:38.521
-so like on a linux box my username
-or if it's Anish will
+jadi seperti di linux box username saya
+atau jika itu Anish akan
 
 0:13:38.651,0:13:41.351
-correspond to a home directory /home/anish
+sesuai dengan direktori home /home/anish
 
 0:13:42.071,0:13:43.351
-Yeah I guess there are
+Ya saya rasa ada
 
 0:13:43.351,0:13:47.671
-a couple of others like /tmp is usually
-a temporary directory that gets
+beberapa lainnya seperti /tmp biasanya
+direktori sementara yang dihapus
 
 0:13:47.671,0:13:51.351
-erased when you reboot not always but sometimes,
-you should check on your system
+saat kalian reboot tidak selalu tapi kadang-kadang,
+kalian harus memeriksa di sistem kalian
 
 0:13:51.731,0:13:59.211
-There's a /var which often holds like
-files the change over time so
+Ada /var yang sering menyimpan
+file yang berubah seiring waktu jadi
 
 0:13:59.211,0:14:06.151
-these these are usually going to be things
-like lock files for package managers
+ini biasanya akan menjadi hal-hal
+seperti file lock untuk package manager
 
 0:14:06.151,0:14:12.431
-they're gonna be things like log files
-files to keep track of process IDs
+mereka akan menjadi hal-hal seperti file log
+file untuk melacak process ID
 
 0:14:12.431,0:14:16.471
-then there's /dev which shows devices so
+kemudian ada /dev yang menunjukkan perangkat jadi
 
 0:14:16.471,0:14:20.551
-usually so these are special files that
-correspond to devices on your system we
+biasanya ini adalah file khusus yang
+sesuai dengan perangkat di sistem kalian kami
 
 0:14:20.551,0:14:27.391
-talked about /sys, Anish mentioned /etc
+membahas tentang /sys, Anish menyebutkan /etc
 
 0:14:29.051,0:14:36.031
-/opt is a common one for just like third-party
-software that basically it's usually for
+/opt adalah yang umum untuk hanya seperti software pihak ketiga
+yang biasanya untuk
 
 0:14:36.031,0:14:40.951
-companies ported their software to Linux
-but they don't actually understand what
+perusahaan yang mem-port software mereka ke Linux
+tapi mereka tidak benar-benar paham apa
 
 0:14:40.951,0:14:45.391
-running software on Linux is like, and
-so they just have a directory with all
+menjalankan software di Linux itu seperti apa, dan
+jadi mereka hanya memiliki direktori dengan semua
 
 0:14:45.391,0:14:51.411
-their stuff in it and when those get installed
-they usually get installed into /opt
+barang-barang mereka di dalamnya dan ketika itu diinstal
+mereka biasanya diinstal ke /opt
 
 0:14:51.411,0:14:55.651
-I think those are the ones off the top of my head
+Saya pikir itu yang saya ingat di kepala saya
 
 0:14:55.651,0:14:57.771
-yeah
+ya
 
 0:14:57.771,0:15:02.271
-And we will list these in our lecture notes
-which will produce after this lecture
+Dan kami akan mencantumkan ini di catatan kuliah kami
+yang akan kami buat setelah kuliah ini
 
 0:15:02.271,0:15:04.431
-Next question
+Pertanyaan berikutnya
 
 0:15:04.431,0:15:07.080
-Should I apt-get install a Python whatever
+Haruskah saya apt-get install paket Python apa pun
 
 0:15:07.080,0:15:10.691
-package or pip install that package
+atau pip install paket tersebut
 
 0:15:10.691,0:15:13.890
-so this is a good question that I think at
+jadi ini pertanyaan bagus yang saya pikir di
 
 0:15:13.890,0:15:17.310
-a higher level this question is asking
-should I use my systems package manager
+tingkat yang lebih tinggi pertanyaan ini menanyakan
+haruskah saya menggunakan package manager sistem saya
 
 0:15:17.310,0:15:20.850
-to install things or should I use some other
-package manager. Like in this case
+untuk menginstal sesuatu atau haruskah saya menggunakan package manager lain.
+Seperti dalam kasus ini
 
 0:15:20.850,0:15:25.021
-one that's more specific to a particular
-language. And the answer here is also
+yang lebih spesifik untuk bahasa tertentu.
+Dan jawabannya di sini juga
 
 0:15:25.021,0:15:28.590
-kind of it depends, sometimes it's nice
-to manage things using a system package
+agak tergantung, kadang-kadang bagus
+mengelola sesuatu menggunakan package manager
 
 0:15:28.590,0:15:31.950
-manager so everything can be installed
-and upgraded in a single place but
+sistem sehingga semuanya bisa diinstal
+dan di-upgrade di satu tempat tapi
 
 0:15:31.950,0:15:35.160
-I think oftentimes whatever is available
-in the system repositories the things
+saya pikir seringkali apa yang tersedia
+di repositori sistem hal-hal
 
 0:15:35.160,0:15:37.800
-you can get via a tool like
-apt-get or something similar
+yang bisa kalian dapatkan melalui alat seperti
+apt-get atau yang serupa
 
 0:15:37.800,0:15:41.040
-might be slightly out of date compared to
-the more language specific repository
+mungkin agak ketinggalan zaman dibandingkan dengan
+repositori yang lebih spesifik untuk bahasa
 
 0:15:41.040,0:15:45.060
-so for example a lot of the Python packages
-I use I really want the most
+jadi misalnya banyak paket Python
+yang saya gunakan saya benar-benar ingin versi
 
 0:15:45.060,0:15:47.771
-up-to-date version and so
-I use pip to install them
+terbaru dan jadi
+saya menggunakan pip untuk menginstalnya
 
 0:15:48.551,0:15:51.091
-Then, to extend on that is
+Kemudian, untuk memperluas itu
 
 0:15:51.091,0:15:57.751
-sometimes the case the system packages
-might require some other
+kadang-kadang kasus paket sistem
+mungkin memerlukan beberapa
 
 0:15:57.751,0:16:02.461
-dependencies that you might not have realized
-about, and it's also might be
+dependensi lain yang mungkin tidak kalian sadari,
+dan mungkin juga
 
 0:16:02.461,0:16:07.201
-the case or like for some systems,
-at least for like alpine Linux they
+kasus atau seperti untuk beberapa sistem,
+setidaknya untuk seperti alpine Linux mereka
 
 0:16:07.201,0:16:11.221
-don't have wheels for like a lot of the
-Python packages so it will just take
+tidak memiliki wheel untuk banyak
+paket Python jadi itu akan memakan
 
 0:16:11.221,0:16:15.331
-longer to compile them, it will take more
-space because they have to compile them
+waktu lebih lama untuk mengompilasinya, akan memakan lebih banyak
+ruang karena mereka harus mengompilasinya
 
 0:16:15.331,0:16:20.761
-from scratch. Whereas if you just go
-to pip, pip has binaries for a lot of
+dari awal. Sedangkan jika kalian hanya pergi
+ke pip, pip memiliki binary untuk banyak
 
 0:16:20.761,0:16:23.471
-different platforms and that will probably work
+platform berbeda dan itu mungkin akan berhasil
 
 0:16:23.471,0:16:29.191
-You also should be aware that pip might not do
-the exact same thing in different computers
+Kalian juga harus sadar bahwa pip mungkin tidak melakukan
+hal yang persis sama di komputer yang berbeda
 
 0:16:29.191,0:16:33.601
-So, for example, if you are in a kind of laptop
-or like a desktop that is running like
+Jadi, misalnya, jika kalian di laptop
+atau desktop yang menjalankan
 
 0:16:33.601,0:16:38.971
-a x86 or x86_64 you probably have binaries,
-but if you're running something
+x86 atau x86_64 kalian mungkin memiliki binary,
+tapi jika kalian menjalankan sesuatu
 
 0:16:38.971,0:16:43.471
-like Raspberry Pi or some other kind of
-embedded device. These are running on a
+seperti Raspberry Pi atau beberapa jenis
+perangkat embedded lainnya. Ini berjalan di
 
 0:16:43.471,0:16:47.611
-different kind of hardware architecture
-and you might not have binaries
+arsitektur hardware yang berbeda
+dan kalian mungkin tidak memiliki binary
 
 0:16:47.611,0:16:51.841
-I think that's also good to take into account,
-in that case in might be worthwhile to
+Saya pikir itu juga baik untuk diperhitungkan,
+dalam kasus itu mungkin layak untuk
 
 0:16:51.841,0:16:58.551
-use the system packages just because they
-will take much shorter to get them
+menggunakan paket sistem hanya karena mereka
+akan memakan waktu jauh lebih singkat untuk mendapatkannya
 
 0:16:58.551,0:17:01.691
-than to just to compile from scratch
-the entire Python installation
+daripada harus mengompilasi dari awal
+seluruh instalasi Python
 
 0:17:01.691,0:17:06.741
-Apart from that, I don't think I can think of any exceptions
-where I would actually use the system packages
+Selain itu, saya tidak pikir saya bisa memikirkan pengecualian apa pun
+di mana saya benar-benar akan menggunakan paket sistem
 
 0:17:06.741,0:17:09.251
-instead of the Python provided ones
+daripada yang disediakan Python
 
 0:17:19.011,0:17:20.851
-So, one other thing to keep in mind is that
+Jadi, satu hal lain yang perlu diingat adalah bahwa
 
 0:17:20.861,0:17:26.180
-sometimes you will have more than one
-program on your computer and you might
+kadang-kadang kalian akan memiliki lebih dari satu
+program di komputer kalian dan kalian mungkin
 
 0:17:26.180,0:17:29.961
-be developing more than one program on
-your computer and for some reason not
+mengembangkan lebih dari satu program di
+komputer kalian dan untuk beberapa alasan tidak
 
 0:17:29.961,0:17:33.861
-all programs are always built with the latest
-version of things, sometimes they
+semua program selalu dibangun dengan versi terbaru
+dari sesuatu, kadang-kadang mereka
 
 0:17:33.861,0:17:39.351
-are a little bit behind, and when you
-install something system-wide you can
+sedikit tertinggal, dan ketika kalian
+menginstal sesuatu secara system-wide kalian bisa
 
 0:17:39.351,0:17:44.691
-only... depends on your exact system,
-but often you just have one version
+hanya... tergantung pada sistem kalian yang tepat,
+tapi seringkali kalian hanya memiliki satu versi
 
 0:17:44.691,0:17:49.711
-what pip lets you do, especially combined
-with something like python's virtualenv,
+apa yang memungkinkan pip lakukan, terutama dikombinasikan
+dengan sesuatu seperti virtualenv Python,
 
 0:17:49.711,0:17:54.531
-and similar concepts exist for other
-languages, where you can sort of say
+dan konsep serupa ada untuk bahasa
+lainnya, di mana kalian bisa semacam bilang
 
 0:17:54.531,0:17:59.660
-I want to (NPM does the same thing as well
-with its node modules, for example) where
+saya akan (NPM melakukan hal yang sama juga
+dengan node modulesnya, misalnya) di mana
 
 0:17:59.660,0:18:05.991
-I'm gonna compile the dependencies of
-this package in sort of a subdirectory
+saya akan mengompilasi dependensi dari
+paket ini dalam semacam subdirektori
 
 0:18:05.991,0:18:10.431
-of its own, and all of the versions that it
-requires are going to be built in there
+sendiri, dan semua versi yang dibutuhkannya
+akan dibangun di sana
 
 0:18:10.431,0:18:13.910
-and you can do this separately for separate
-projects so there they have
+dan kalian bisa melakukan ini secara terpisah untuk proyek yang berbeda
+jadi mereka memiliki
 
 0:18:13.910,0:18:16.910
-different dependencies or the same dependencies
-with different versions
+dependensi yang berbeda atau dependensi yang sama
+dengan versi yang berbeda
 
 0:18:16.910,0:18:20.930
-they still sort of kept separate. And that
-is one thing that's hard to achieve
+mereka masih tetap terpisah. Dan itu
+adalah satu hal yang sulit dicapai
 
 0:18:20.931,0:18:22.651
-with system packages
+dengan paket sistem
 
 0:18:27.131,0:18:27.851
-Next question
+Pertanyaan berikutnya
 
 0:18:27.911,0:18:32.771
-What's the easiest and best profiling tools
-to use to improve performance of my code?
+Apa alat profiling yang paling mudah dan terbaik
+untuk digunakan meningkatkan performa kode saya?
 
 0:18:34.351,0:18:39.231
-This is a topic we could talk
-about for a very long time
+Ini adalah topik yang bisa kita bicarakan
+untuk waktu yang sangat lama
 
 0:18:39.231,0:18:42.881
-The easiest and best is to print stuff using time
+Yang paling mudah dan terbaik adalah mencetak sesuatu menggunakan time
 
 0:18:42.881,0:18:48.431
-Like, I'm not joking, very often
-the easiest thing is in your code
+Seperti, saya tidak bercanda, sangat sering
+hal termudah adalah dalam kode kalian
 
 0:18:48.971,0:18:53.751
-At the top you figure out what the current
-time is, and then you do sort of
+Di atas kalian cari tahu apa waktu saat ini,
+dan kemudian kalian lakukan semacam
 
 0:18:53.751,0:18:57.920
-a binary search over your program of add
-a print statement that prints how much
+pencarian biner atas program kalian dengan menambahkan
+pernyataan print yang mencetak berapa banyak
 
 0:18:57.920,0:19:02.511
-time has elapsed since the start of your
-program and then you do that until you
+waktu yang telah berlalu sejak awal program kalian
+dan kemudian kalian lakukan itu sampai kalian
 
 0:19:02.511,0:19:06.320
-find the segment of code that took the
-longest. And then you go into that
+menemukan segmen kode yang memakan
+waktu paling lama. Dan kemudian kalian masuk ke
 
 0:19:06.320,0:19:09.531
-function and then you do the same thing
-again and you keep doing this until you
+fungsi itu dan kemudian kalian lakukan hal yang sama
+lagi dan kalian terus melakukan ini sampai kalian
 
 0:19:09.531,0:19:14.031
-find roughly where the time was spent. It's
-not foolproof, but it is really easy
+menemukan kira-kira di mana waktu dihabiskan. Ini
+bukan solusi yang pasti, tapi sangat mudah
 
 0:19:14.031,0:19:16.721
-and it gives you good information quickly
+dan memberi kalian informasi yang bagus dengan cepat
 
 0:19:16.721,0:19:25.361
-if you do need more advanced information
-Valgrind has a tool called cache-grind?
+jika kalian memang butuh informasi yang lebih canggih
+Valgrind memiliki alat bernama cache-grind?
 
 0:19:25.361,0:19:29.431
-call grind? Cache grind? One of the two.
+call grind? Cache grind? Salah satu dari keduanya.
 
 0:19:29.431,0:19:33.310
-and this tool lets you run your program and
+dan alat ini memungkinkan kalian menjalankan program kalian dan
 
 0:19:33.310,0:19:38.741
-measure how long everything takes and
-all of the call stacks, like which
+mengukur berapa lama waktu yang dibutuhkan semuanya dan
+semua call stack, seperti fungsi
 
 0:19:38.741,0:19:42.521
-function called which function, and what
-you end up with is a really neat
+mana yang memanggil fungsi mana, dan apa
+yang kalian dapatkan adalah
 
 0:19:42.521,0:19:47.081
-annotation of your entire program source
-with the heat of every line basically
+anotasi yang sangat rapi dari seluruh sumber program kalian
+dengan panas setiap baris pada dasarnya
 
 0:19:47.081,0:19:51.761
-how much time was spent there. It does
-slow down your program by like an order
+berapa banyak waktu yang dihabiskan di sana. Ini memang
+memperlambat program kalian sekitar satu orde
 
 0:19:51.761,0:19:56.021
-of magnitude or more, and it doesn't really
-support threads but it is really
+besaran atau lebih, dan tidak benar-benar
+mendukung thread tapi itu sangat
 
 0:19:56.021,0:20:01.121
-useful if you can use it. If you can't,
-then tools like perf or similar tools
+berguna jika kalian bisa menggunakannya. Jika tidak bisa,
+maka alat seperti perf atau alat serupa
 
 0:20:01.121,0:20:05.201
-for other languages that do usually some
-kind of sampling profiling like we
+untuk bahasa lain yang biasanya melakukan
+profiling sampling semacam seperti yang kami
 
 0:20:05.201,0:20:09.811
-talked about in the profiler lecture, can
-give you pretty useful data quickly,
+bahas di kuliah profiler, bisa
+memberi kalian data yang cukup berguna dengan cepat,
 
 0:20:09.811,0:20:15.160
-but it's a lot of data around
-this, but they're a little bit
+tapi ada banyak data di sekitar ini, tapi mereka agak
 
 0:20:15.160,0:20:18.971
-biased and what kind of things they usually
-highlight as a problem and it
+bias dan hal-hal seperti apa yang biasanya
+mereka soroti sebagai masalah dan
 
 0:20:18.971,0:20:22.961
-can sometimes be hard to extract meaningful
-information about what should
+kadang-kadang bisa sulit untuk mengekstrak informasi yang bermakna
+tentang apa yang harus
 
 0:20:22.961,0:20:27.701
-I change in response to them. Whereas the
-sort of print approach very quickly
+saya ubah sebagai respons terhadapnya. Sedangkan
+pendekatan print semacam itu dengan cepat
 
 0:20:27.701,0:20:32.171
-gives you like this section
-of code is bad or slow
+memberi kalian seperti bagian kode ini
+buruk atau lambat
 
 0:20:32.171,0:20:34.871
-I think would be my answer
+Saya pikir itu akan menjadi jawaban saya
 
 0:20:34.871,0:20:40.431
-Flamegraphs are great, they're a good way
-to visualize some of this information
+Flamegraph sangat bagus, mereka adalah cara yang baik
+untuk memvisualisasikan beberapa informasi ini
 
 0:20:41.491,0:20:45.550
-Yeah I just have one thing to add,
-oftentimes programming languages
+Ya saya hanya punya satu hal untuk ditambahkan,
+seringkali bahasa pemrograman
 
 0:20:45.550,0:20:48.910
-have language specific tools for profiling
-so to figure out what's the
+memiliki alat khusus bahasa untuk profiling
+jadi untuk mencari tahu apa
 
 0:20:48.910,0:20:52.191
-right tool to use for your language like if
-you're doing JavaScript in the web browser
+alat yang tepat untuk digunakan untuk bahasa kalian seperti jika
+kalian melakukan JavaScript di browser web
 
 0:20:52.191,0:20:55.411
-the web browser has a really nice tool for
-doing profiling you should just use that
+browser web memiliki alat yang sangat bagus untuk
+melakukan profiling kalian harus menggunakannya saja
 
 0:20:55.411,0:21:00.471
-or if you are using go, for example, go has a built-in
-profiler is really good you should just use that
+atau jika kalian menggunakan go, misalnya, go memiliki profiler built-in
+yang sangat bagus kalian harus menggunakannya saja
 
 0:21:01.711,0:21:04.251
-A last thing to add to that
+Satu hal terakhir untuk ditambahkan
 
 0:21:04.251,0:21:09.951
-Sometimes you might find that doing this binary
-search over time that you're kind of
+Kadang-kadang kalian mungkin menemukan bahwa melakukan pencarian biner
+ini atas waktu bahwa kalian semacam
 
 0:21:09.961,0:21:14.351
-finding where the time is going, but this
-time is sometimes happening because
+menemukan ke mana waktu pergi, tapi waktu ini
+kadang-kadang terjadi karena
 
 0:21:14.351,0:21:18.461
-you're waiting on the network, or you're
-waiting for some file, and in that case
+kalian menunggu di jaringan, atau kalian
+menunggu beberapa file, dan dalam kasus itu
 
 0:21:18.461,0:21:23.440
-you want to make sure that the time
-that is, if I want to write
+kalian ingin memastikan bahwa waktu
+yang, jika saya ingin menulis
 
 0:21:23.440,0:21:27.310
-like 1 gigabyte file or like read 1
-gigabyte file and put it into memory
+file 1 gigabyte atau seperti membaca file 1
+gigabyte dan memasukkannya ke memori
 
 0:21:27.310,0:21:32.260
-you want to check that the actual time
-there, is the minimum amount of time
+kalian ingin memeriksa bahwa waktu aktual
+di sana, adalah jumlah waktu minimum
 
 0:21:32.260,0:21:36.221
-you actually have to wait. If it's ten times
-longer, you should try to use some
+yang sebenarnya harus kalian tunggu. Jika sepuluh kali
+lebih lama, kalian harus mencoba menggunakan beberapa
 
 0:21:36.221,0:21:39.371
-other tools that we covered in the debugging
-and profiling section to see
+alat lain yang kami bahas di bagian debugging
+dan profiling untuk melihat
 
 0:21:39.371,0:21:45.671
-why you're not utilizing all your
-resources because that might...
+mengapa kalian tidak memanfaatkan semua sumber daya kalian
+karena itu mungkin...
 
 0:21:50.511,0:21:56.071
-Because that might be a lot of what's happening
-thing, like for example, in my research
+Karena itu mungkin banyak dari apa yang terjadi,
+seperti misalnya, dalam penelitian saya
 
 0:21:56.081,0:21:59.410
-in machine learning workloads, a lot of
-time is loading data and you have to
+dalam beban kerja machine learning, banyak
+waktu adalah memuat data dan kalian harus
 
 0:21:59.410,0:22:02.981
-make sure well like the time it takes to
-load data is actually the minimum amount
+memastikan dengan baik seperti waktu yang dibutuhkan untuk
+memuat data adalah benar-benar jumlah minimum
 
 0:22:02.981,0:22:07.500
-of time you want to have that happening
+waktu yang kalian ingin terjadi
 
 0:22:08.040,0:22:13.481
-And to build on that, there are actually
-specialized tools for doing things like
+Dan untuk membangun di atas itu, sebenarnya ada
+alat khusus untuk melakukan hal-hal seperti
 
 0:22:13.481,0:22:17.351
-analyzing wait times. Very often when
-you're waiting for something what's
+menganalisis waktu tunggu. Sangat sering ketika
+kalian menunggu sesuatu yang
 
 0:22:17.351,0:22:20.591
-really happening is you're issuing your
-system call, and that system call takes
+sebenarnya terjadi adalah kalian mengeluarkan
+system call kalian, dan system call itu memakan
 
 0:22:20.591,0:22:24.191
-some amount of time to respond. Like you do
-a really large write, or a really large read
+beberapa waktu untuk merespons. Seperti kalian melakukan
+write yang sangat besar, atau read yang sangat besar
 
 0:22:24.191,0:22:28.361
-or you do many of them, and one thing
-that can be really handy here is
+atau kalian melakukan banyak dari mereka, dan satu hal
+yang bisa sangat berguna di sini adalah
 
 0:22:28.361,0:22:31.841
-to try to get information out of the
-kernel about where your program is
+untuk mencoba mendapatkan informasi dari
+kernel tentang di mana program kalian
 
 0:22:31.841,0:22:37.000
-spending its time. And so there's (it's
-not new), but there's a relatively
+menghabiskan waktunya. Dan jadi ada (itu
+bukan hal baru), tapi ada yang relatif
 
 0:22:37.000,0:22:42.820
-newly available thing called BPF or eBPF.
-Which is essentially kernel tracing
+baru tersedia yang disebut BPF atau eBPF.
+Yang pada dasarnya adalah kernel tracing
 
 0:22:42.820,0:22:48.531
-and you can do some really cool things with
-it, and that includes tracing user programs.
+dan kalian bisa melakukan beberapa hal yang sangat keren dengannya,
+dan itu termasuk tracing program user.
 
 0:22:48.531,0:22:51.760
-It can be a little bit awkward to
-get started with, there's a tool
+Ini bisa agak canggung untuk
+dimulai, ada alat
 
 0:22:51.760,0:22:56.201
-called BPF trace that i would recommend
-you looking to, if you need to do like
+bernama BPF trace yang saya akan rekomendasikan
+kalian lihat, jika kalian perlu melakukan
 
 0:22:56.201,0:23:00.040
-this kind of low-level performance debugging.
-But it is really good for this
+debugging performa low-level semacam ini.
+Tapi itu sangat bagus untuk
 
 0:23:00.040,0:23:04.601
-kind of stuff. You can get things like
-histograms over how much time was spent
+hal-hal semacam ini. Kalian bisa mendapatkan hal-hal seperti
+histogram atas berapa banyak waktu yang dihabiskan
 
 0:23:04.601,0:23:06.671
-in particular system calls
+dalam system call tertentu
 
 0:23:06.671,0:23:09.721
-It's a great tool
+Itu alat yang hebat
 
 0:23:12.251,0:23:15.351
-What browser plugins do you use?
+Plugin browser apa yang kalian gunakan?
 
 0:23:16.731,0:23:19.731
-I try to use as few as I can get away with using
+Saya mencoba menggunakan sesedikit mungkin
 
 0:23:19.731,0:23:25.991
-because I don't like things being in
-my browser, but there are a couple of
+karena saya tidak suka ada hal-hal di
+browser saya, tapi ada beberapa
 
 0:23:25.991,0:23:30.311
-ones that are sort of staples.
-The first one is uBlock Origin.
+yang menjadi pokok. Yang pertama adalah uBlock Origin.
 
 0:23:30.311,0:23:36.611
-So uBlock Origin is one of many ad blockers but
-it's a little bit more than an ad blocker.
+Jadi uBlock Origin adalah salah satu dari banyak ad blocker tapi
+itu sedikit lebih dari ad blocker.
 
 0:23:36.611,0:23:42.530
-It is (a what do they call it?) a
-network filtering tool so it lets
+Itu adalah (apa mereka menyebutnya?) alat
+penyaringan jaringan jadi itu memungkinkan
 
 0:23:42.530,0:23:47.331
-you do more things than just block ads.
-It also lets you like block connections
+kalian melakukan lebih banyak hal daripada hanya memblokir iklan.
+Itu juga memungkinkan kalian seperti memblokir koneksi
 
 0:23:47.331,0:23:51.351
-to certain domains, block connections
-for certain types of resources
+ke domain tertentu, memblokir koneksi
+untuk jenis sumber daya tertentu
 
 0:23:51.351,0:23:56.031
-So I have mine set up in what they call
-the Advanced Mode, where basically
+Jadi saya mengatur milik saya dalam apa yang mereka sebut
+Mode Lanjutan, di mana pada dasarnya
 
 0:23:56.031,0:24:02.451
-you can disable basically all network requests.
-But it's not just Network requests,
+kalian bisa menonaktifkan pada dasarnya semua permintaan jaringan.
+Tapi bukan hanya permintaan jaringan,
 
 0:24:02.451,0:24:07.430
-It's also like I have disabled all inline
-scripts on every page and all
+itu juga seperti saya telah menonaktifkan semua
+script inline di setiap halaman dan semua
 
 0:24:07.430,0:24:11.540
-third-party images and resources, and then
-you can sort of create a whitelist
+gambar dan sumber daya pihak ketiga, dan kemudian
+kalian bisa semacam membuat whitelist
 
 0:24:11.540,0:24:16.351
-for every page so it gives you really
-low-level tools around how to
+untuk setiap halaman jadi itu memberi kalian alat yang sangat
+low-level tentang bagaimana cara
 
 0:24:16.351,0:24:20.331
-how to improve the security of your browsing.
-But you can also set it in not the
+meningkatkan keamanan penjelajahan kalian. Tapi kalian juga bisa mengaturnya dalam bukan
 
 0:24:20.331,0:24:23.991
-advanced mode, and then it does much of
-the same as a regular ad blocker would
+mode lanjutan, dan kemudian itu melakukan banyak
+hal yang sama seperti yang dilakukan ad blocker biasa
 
 0:24:23.991,0:24:28.101
-do, although in a fairly efficient way
-if you're looking at an ad blocker it's
+meskipun dengan cara yang cukup efisien
+jika kalian mencari ad blocker itu
 
 0:24:28.101,0:24:31.510
-probably the one to use and it
-works on like every browser
+mungkin yang harus digunakan dan itu
+bekerja di hampir setiap browser
 
 0:24:31.511,0:24:34.451
-That would be my top pick I think,
+Itu akan menjadi pilihan utama saya saya pikir,
 
 0:24:39.111,0:24:44.391
-I think probably the one I
-use like the most actively
+saya pikir mungkin yang paling
+saya gunakan secara aktif
 
 0:24:44.391,0:24:50.391
-is one called Stylus. It lets you modify
-the CSS or like the stylesheets
+adalah yang disebut Stylus. Itu memungkinkan kalian memodifikasi
+CSS atau seperti stylesheet
 
 0:24:50.391,0:24:54.560
-that webpages have. And it's pretty
-neat, because sometimes you're
+yang dimiliki halaman web. Dan itu cukup
+keren, karena kadang-kadang kalian
 
 0:24:54.560,0:24:58.550
-looking at a website and you want
-to hide some part of the website
+melihat situs web dan kalian ingin
+menyembunyikan beberapa bagian situs web
 
 0:24:58.550,0:25:04.211
-you don't care about. Like maybe a ad, maybe
-some sidebar you're not finding useful
+yang tidak kalian pedulikan. Seperti mungkin iklan, mungkin
+sidebar yang tidak kalian temukan berguna
 
 0:25:04.211,0:25:06.290
-The thing is, at the end of
-the day these things are
+Masalahnya, pada akhirnya
+hal-hal ini
 
 0:25:06.290,0:25:09.591
-displaying in your browser, and you
-have control of what code is
+ditampilkan di browser kalian, dan kalian
+memiliki kontrol atas kode apa yang
 
 0:25:09.591,0:25:13.131
-executing and similar to what Jon was
-saying, like you can customize this
+dieksekusi dan mirip dengan apa yang dikatakan Jon,
+seperti kalian bisa menyesuaikan ini
 
 0:25:13.131,0:25:18.491
-to no end, and what I have for a lot of
-web pages like hide this this part, or
+tanpa batas, dan apa yang saya miliki untuk banyak
+halaman web seperti sembunyikan bagian ini, atau
 
 0:25:18.491,0:25:23.390
-also trying to make like dark modes for
-them like you can change pretty much the
+juga mencoba membuat seperti dark mode untuk
+mereka seperti kalian bisa mengubah hampir
 
 0:25:23.390,0:25:26.810
-color for every single website. And what
-is actually pretty neat is that there's
+warna untuk setiap situs web. Dan apa
+yang sebenarnya cukup keren adalah bahwa ada
 
 0:25:26.810,0:25:31.461
-like a repository online of people that
-have contributed this is stylesheets
+seperti repositori online orang-orang yang
+telah berkontribusi stylesheet
 
 0:25:31.461,0:25:35.031
-for the websites. So someone probably
-has (done) one for GitHub
+untuk situs web. Jadi seseorang mungkin
+telah (melakukan) satu untuk GitHub
 
 0:25:35.031,0:25:38.780
-Like I want dark GitHub and someone has
-already contributed one that makes
+Seperti saya ingin dark GitHub dan seseorang sudah
+berkontribusi satu yang membuat
 
 0:25:38.780,0:25:44.631
-that much more pleasing to browse. Apart
-from that, one that it's not really
+itu jauh lebih menyenangkan untuk dijelajahi. Selain
+itu, satu yang tidak benar-benar
 
 0:25:44.631,0:25:49.491
-fancy, but I have found incredibly helpful
-is one that just takes a screenshot an
+mewah, tapi saya temukan sangat membantu
+adalah yang hanya mengambil screenshot seluruh
 
 0:25:49.491,0:25:53.121
-entire website. And It will
-scroll for you and make
+situs web. Dan itu akan
+scroll untuk kalian dan membuat
 
 0:25:53.121,0:25:57.711
-compound image of the entire website and that's
-really great for when you're trying to
+gambar gabungan dari seluruh situs web dan itu
+sangat bagus untuk ketika kalian mencoba
 
 0:25:57.711,0:26:00.111
-print a website and is just terrible.
+mencetak situs web dan hasilnya buruk.
 
 0:26:00.111,0:26:00.611
-(It's built into Firefox)
+(Itu sudah built-in di Firefox)
 
 0:26:00.611,0:26:02.671
-oh interesting
+oh menarik
 
 0:26:02.671,0:26:05.751
-oh now that you mention builtin to Firefox,
-another one that I really like about
+oh sekarang yang kalian sebutkan built-in di Firefox,
+yang lain yang sangat saya sukai tentang
 
 0:26:05.751,0:26:09.071
-Firefox is the multi account containers
+Firefox adalah multi account containers
 
 0:26:09.071,0:26:10.831
-(Oh yeah, it's fantastic)
+(Oh ya, itu fantastis)
 
 0:26:10.831,0:26:12.291
-Which kind of lets you
+Yang semacam memungkinkan kalian
 
 0:26:12.291,0:26:16.670
-By default a lot of web browsers, like
-for example Chrome, have this
+Secara default banyak web browser, seperti
+misalnya Chrome, memiliki
 
 0:26:16.670,0:26:20.601
-notion of like there's session that you
-have, where you have all your cookies
+notion seperti ada sesi yang kalian
+miliki, di mana kalian memiliki semua cookie kalian
 
 0:26:20.601,0:26:24.560
-and they are kind of all shared from the
-different websites in the sense of
+dan mereka semua dibagi dari
+situs web yang berbeda dalam arti
 
 0:26:24.560,0:26:30.811
-you keep opening new tabs and unless you go into
-incognito you kind of have the same profile
+kalian terus membuka tab baru dan kecuali kalian masuk ke
+incognito kalian memiliki profil yang sama
 
 0:26:30.811,0:26:34.190
-And that profile is the same for
-all websites, there is this
+Dan profil itu sama untuk
+semua situs web, ada ini
 
 0:26:34.191,0:26:35.851
-Is it an extension or is it built in?
+Apakah itu ekstensi atau built-in?
 
 0:26:35.851,0:26:40.571
-(it's a mix, it's complicated)
+(itu campuran, itu rumit)
 
 0:26:41.091,0:26:46.211
-So I think you actually have to say you want
-to install it or enable it and again
+Jadi saya pikir kalian sebenarnya harus bilang kalian ingin
+menginstalnya atau mengaktifkannya dan lagi
 
 0:26:46.221,0:26:49.881
-the name is Multi Account Containers and
-these let you tell Firefox to have
+namanya adalah Multi Account Containers dan
+ini memungkinkan kalian memberitahu Firefox untuk memiliki
 
 0:26:49.881,0:26:53.961
-separate isolated sessions. So
-for example, you want to say
+sesi terisolasi yang terpisah. Jadi
+misalnya, kalian ingin bilang
 
 0:26:53.961,0:26:58.851
-I have a separate sessions for whenever I
-visit to Google or whenever I visit Amazon
+saya memiliki sesi terpisah setiap kali saya
+mengunjungi Google atau setiap kali saya mengunjungi Amazon
 
 0:26:58.851,0:27:01.791
-and that can be pretty neat, because then you can
+dan itu bisa cukup keren, karena kemudian kalian bisa
 
 0:27:01.791,0:27:08.171
-At a browser level it's ensuring that no information
-sharing is happening between the two of them
+Di tingkat browser itu memastikan bahwa tidak ada berbagi informasi
+yang terjadi antara keduanya
 
 0:27:08.171,0:27:11.961
-And it's much more convenient than
-having to open a incognito window
+Dan itu jauh lebih nyaman daripada
+harus membuka jendela incognito
 
 0:27:11.961,0:27:14.471
-where it's gonna clean all the time the stuff
+di mana itu akan membersihkan semua waktu hal-hal
 
 0:27:14.471,0:27:17.311
-(One thing to mention is Stylus vs Stylish)
+(Satu hal yang disebutkan adalah Stylus vs Stylish)
 
 0:27:17.531,0:27:19.651
-Oh yeah, I forgot about that
+Oh ya, saya lupa tentang itu
 
 0:27:19.651,0:27:24.931
-One important thing is the browser extension
-for side loading CSS Stylesheets
+Satu hal penting adalah ekstensi browser
+untuk memuat CSS Stylesheet
 
 0:27:24.931,0:27:31.851
-it's called a Stylus and that's different
-from the older one that was
+disebut Stylus dan itu berbeda
+dari yang lama yang
 
 0:27:31.851,0:27:37.400
-called Stylish, because that one got
-bought at some point by some shady
+disebut Stylish, karena itu dibeli
+pada suatu waktu oleh beberapa perusahaan yang mencurigakan,
 
 0:27:37.400,0:27:40.711
-company, that started abusing it not only to have
+yang mulai menyalahgunakannya tidak hanya untuk memiliki
+fungsi itu, tapi juga untuk membaca
 
 0:27:40.711,0:27:45.780
-that functionality, but also to read your
-entire browser history and send that
-
-0:27:45.780,0:27:48.491
-back to their servers so they could data mine it.
+seluruh riwayat browser kalian dan mengirim itu
+kembali ke server mereka sehingga mereka bisa menambang data.
 
 0:27:48.491,0:27:53.731
-So, then people just built this open-source alternative
-that is called Stylus, and that's the one
+Jadi, kemudian orang-orang hanya membangun alternatif open-source ini
+yang disebut Stylus, dan itu yang
 
 0:27:53.731,0:27:58.951
-we recommend. Said that, I think the repository
-for styles is the same for the
+kami rekomendasikan. Dikatakan demikian, saya pikir repositori
+untuk gaya adalah sama untuk
 
 0:27:58.951,0:28:03.611
-two of them, but I would have
-to double check that.
+keduanya, tapi saya harus
+memeriksa ulang itu.
 
 0:28:03.611,0:28:05.951
-Do you have any browser plugins Anish?
+Apakah kalian punya plugin browser Anish?
 
 0:28:06.071,0:28:09.311
-Yes, so I also have some recommendations
-for browser plugins
+Ya, jadi saya juga punya beberapa rekomendasi
+untuk plugin browser
 
 0:28:09.311,0:28:13.991
-I also use uBlock Origin and I also use Stylus,
+Saya juga menggunakan uBlock Origin dan saya juga menggunakan Stylus,
 
 0:28:13.991,0:28:18.511
-but one other one that I'd recommend is
-integration with a password manager
+tapi satu lagi yang saya rekomendasikan adalah
+integrasi dengan password manager
 
 0:28:18.511,0:28:21.631
-So this is a topic that we have in
-the lecture notes for the security
+Jadi ini adalah topik yang kami miliki di
+catatan kuliah untuk kuliah keamanan
 
 0:28:21.631,0:28:24.841
-lecture, but we didn't really get to talk
-about in detail. But basically password
+tapi kami tidak benar-benar mendapat kesempatan untuk membicarakannya
+secara detail. Tapi pada dasarnya password
 
 0:28:24.841,0:28:27.810
-managers do a really good job of increasing
-your security when working
+manager melakukan pekerjaan yang sangat baik dalam meningkatkan
+keamanan kalian saat bekerja
 
 0:28:27.810,0:28:31.831
-with online accounts, and having browser
-integration with your password manager
+dengan akun online, dan memiliki integrasi browser
+dengan password manager kalian
 
 0:28:31.831,0:28:34.410
-can save you a lot of time like you
-can open up a website then it can
+bisa menghemat banyak waktu seperti kalian
+bisa membuka situs web lalu itu bisa
 
 0:28:34.410,0:28:37.381
-autofill your login information for you
-sir and you go and copy and paste it
+mengisi otomatis informasi login kalian untuk
+kalian dan kalian pergi dan copy dan paste
 
 0:28:37.381,0:28:40.320
-back and forth between a separate program
-if it's not integrated with your
+bolak-balik antara program terpisah
+jika tidak terintegrasi dengan
 
 0:28:40.320,0:28:43.410
-web browser, and it can also, this integration,
-can save you from certain
+web browser kalian, dan itu juga, integrasi ini,
+bisa menyelamatkan kalian dari serangan tertentu
 
 0:28:43.410,0:28:47.651
-attacks that would otherwise be possible if
-you were doing this manual copy pasting.
+yang sebaliknya mungkin terjadi jika
+kalian melakukan copy paste manual ini.
 
 0:28:47.651,0:28:50.790
-For example, phishing attacks. So
-you find a website that looks very
+Sebagai contoh, serangan phishing. Jadi
+kalian menemukan situs web yang terlihat sangat
 
 0:28:50.790,0:28:54.211
-similar to Facebook and you go to log in
-with your facebook login credentials and
+mirip dengan Facebook dan kalian pergi untuk login
+dengan kredensial login Facebook kalian dan
 
 0:28:54.211,0:28:56.851
-you go to your password manager and copy
-paste the correct credentials into this
+kalian pergi ke password manager kalian dan copy
+paste kredensial yang benar ke
 
 0:28:56.851,0:29:00.060
-funny web site and now all of a sudden
-it has your password but if you have
+situs web aneh ini dan tiba-tiba
+itu memiliki password kalian tapi jika kalian memiliki
 
 0:29:00.060,0:29:03.091
-browser integration then the extension
-can automatically check
+integrasi browser maka ekstensi
+bisa secara otomatis memeriksa
 
 0:29:03.091,0:29:06.951
-like. Am I on F A C E B O O K.com,or
-is it some other domain
+seperti. Apakah saya di F A C E B O O K.com, atau
+apakah itu domain lain
 
 0:29:06.951,0:29:10.671
-that maybe look similar and it will not enter
-the login information if it's the wrong domain
+yang mungkin terlihat mirip dan itu tidak akan memasukkan
+informasi login jika itu domain yang salah
 
 0:29:10.671,0:29:15.791
-so browser extension for
-password managing is good
+jadi ekstensi browser untuk
+mengelola password itu bagus
 
 0:29:15.791,0:29:17.930
-Yeah I agree
+Ya saya setuju
 
 0:29:19.491,0:29:20.711
-Next question
+Pertanyaan berikutnya
 
 0:29:20.711,0:29:23.991
-What are other useful data wrangling tools?
+Apa alat data wrangling lain yang berguna?
 
 0:29:23.991,0:29:32.421
-So in yesterday's lecture, I mentioned curl, so
-curl is a fantastic tool for just making web
+Jadi di kuliah kemarin, saya menyebutkan curl, jadi
+curl adalah alat yang fantastis hanya untuk membuat permintaan
 
 0:29:32.421,0:29:35.811
-requests and dumping them to your terminal.
-You can also use it for things
+web dan membuangnya ke terminal kalian. Kalian juga bisa menggunakannya untuk hal-hal
 
 0:29:35.811,0:29:41.191
-like uploading files which is really handy.
+seperti mengunggah file yang sangat berguna.
 
 0:29:41.191,0:29:48.431
-In the exercises of that lecture we also talked about
-JQ and pup which are command line tools that let you
+Di latihan kuliah itu kami juga berbicara tentang
+JQ dan pup yang merupakan alat baris perintah yang memungkinkan kalian
 
 0:29:48.431,0:29:52.991
-basically write queries over JSON
-and HTML documents respectively
+pada dasarnya menulis query atas dokumen JSON
+dan HTML masing-masing
 
 0:29:52.991,0:30:00.391
-that can be really handy. Other
-data wrangling tools?
+itu bisa sangat berguna. Alat
+data wrangling lainnya?
 
 0:30:00.391,0:30:03.821
-Ah Perl, the Perl programming language is
+Ah Perl, bahasa pemrograman Perl
 
 0:30:03.821,0:30:08.061
-often referred to as a write only
-programming language because it's
+sering disebut sebagai bahasa pemrograman
+write only karena
 
 0:30:08.061,0:30:13.431
-impossible to read even if you wrote it.
-But it is fantastic at doing just like
+mustahil untuk dibaca bahkan jika kalian yang menulisnya.
+Tapi itu fantastis dalam melakukan
 
 0:30:13.431,0:30:21.561
-straight up text processing, like nothing
-beats it there, so maybe worth learning
+pemrosesan teks langsung, seperti tidak ada
+yang bisa mengalahkannya di sana, jadi mungkin layak mempelajari
 
 0:30:21.561,0:30:24.331
-some very rudimentary Perl just
-to write some of those scripts
+beberapa Perl yang sangat dasar hanya
+untuk menulis beberapa script tersebut
 
 0:30:24.331,0:30:29.371
-It's easier often than writing some like hacked-up
-combination of grep and awk and sed,
+Itu seringkali lebih mudah daripada menulis semacam kombinasi
+grep dan awk dan sed yang diotak-atik,
 
 0:30:29.371,0:30:36.311
-and it will be much faster to just tack something
-up than writing it up in Python, for example
+dan itu akan jauh lebih cepat hanya untuk menambahkan sesuatu
+daripada menulisnya dalam Python, misalnya
 
 0:30:36.311,0:30:44.031
-but apart from that, other data wrangling
+tapi selain itu, data wrangling lainnya
 
 0:30:44.031,0:30:47.071
-No, not off the top of my head really
+Tidak, tidak ada yang terlintas di kepala saya
 
 0:30:47.071,0:30:53.661
-column -t, if you pipe any white space separated
+column -t, jika kalian pipe input terpisah whitespace apa pun
 
 0:30:53.661,0:30:58.821
-input into column -t it will align all
-the white space of the columns so that
+ke column -t itu akan menyelaraskan semua
+whitespace kolom sehingga
 
 0:30:58.821,0:31:05.771
-you get nicely aligned columns that's, and
-head and tail but we talked about those
+kalian mendapatkan kolom yang sejajar dengan rapi, itu, dan
+head dan tail tapi kita sudah membahas itu
 
 0:31:09.011,0:31:13.791
-I think a couple of additions to that,
-that I find myself using commonly
+saya pikir beberapa tambahan untuk itu,
+yang saya temukan sering saya gunakan
 
 0:31:13.791,0:31:19.881
-one is vim. Vim can be pretty useful
-for like data wrangling on itself
+satu adalah vim. Vim bisa cukup berguna
+untuk seperti data wrangling sendiri
 
 0:31:19.881,0:31:22.461
-Sometimes you might find that the operation
-that you're trying to do is
+Kadang-kadang kalian mungkin menemukan bahwa operasi
+yang coba kalian lakukan
 
 0:31:22.461,0:31:27.711
-hard to put down in terms of piping
-different operators but if you
+sulit dituangkan dalam hal piping
+operator yang berbeda tapi jika kalian
 
 0:31:27.711,0:31:32.531
-can just open the file and just record
+bisa hanya membuka file dan hanya merekam
 
 0:31:32.531,0:31:37.301
-a couple of quick vim macros to do what you
-want it to do, it might be like much,
+beberapa macro vim cepat untuk melakukan apa yang
+kalian inginkan, itu mungkin jauh,
 
 0:31:37.301,0:31:42.311
-much easier. That's one, and then the other
-one, if you're dealing with tabular
+jauh lebih mudah. Itu satu, dan kemudian yang lain,
+jika kalian berurusan dengan data tabular
 
 0:31:42.311,0:31:46.091
-data and you want to do more complex operations
-like sorting by one column,
+dan kalian ingin melakukan operasi yang lebih kompleks
+seperti mengurutkan berdasarkan satu kolom,
 
 0:31:46.091,0:31:51.161
-then grouping and then computing some sort
-of statistic, I think a lot of that
+kemudian mengelompokkan dan kemudian menghitung semacam
+statistik, saya pikir banyak beban kerja itu
 
 0:31:51.161,0:31:55.951
-workload I ended up just using Python
-and pandas because it's built for that
+saya berakhir hanya menggunakan Python
+dan pandas karena itu dibangun untuk itu
 
 0:31:55.951,0:32:00.190
-And one of the pretty neat features that
-I find myself also using is that it
+Dan salah satu fitur yang cukup keren yang
+saya temukan juga saya gunakan adalah bahwa itu
 
 0:32:00.190,0:32:03.931
-will export to many different formats.
-So this intermediate state
+akan mengekspor ke banyak format berbeda.
+Jadi keadaan perantara ini
 
 0:32:03.931,0:32:09.221
-has its own kind of pandas dataframe
-object but it can
+memiliki objek pandas dataframe
+sendiri tapi itu bisa
 
 0:32:09.221,0:32:14.171
-export to HTM, LaTeX, a lot of different
-like table formats so if your end
+mengeksport ke HTM, LaTeX, banyak
+format tabel berbeda jadi jika produk akhir kalian
 
 0:32:14.171,0:32:19.531
-product is some sort of summary table, then pandas
-I think it's a fantastic choice for that
+adalah semacam tabel ringkasan, maka pandas
+saya pikir itu pilihan yang fantastis untuk itu
 
 0:32:21.111,0:32:24.791
-I would second the vim and also
-Python I think those are
+saya akan mendukung vim dan juga
+Python saya pikir itu adalah
 
 0:32:24.791,0:32:29.051
-two of my most used data wrangling tools.
-For the vim one, last year we had a demo
+dua alat data wrangling yang paling sering saya gunakan.
+Untuk vim, tahun lalu kami punya demo
 
 0:32:29.051,0:32:31.841
-in the series in the lecture notes, but
-we didn't cover it in class we had a
+di serial di catatan kuliah, tapi
+kami tidak membahasnya di kelas kami punya
 
 0:32:31.841,0:32:38.051
-demo of turning an XML file into a JSON version
-of that same data using only vim macros
+demo mengubah file XML menjadi versi JSON
+dari data yang sama hanya menggunakan macro vim
 
 0:32:38.051,0:32:40.331
-And I think that's actually the
-way I would do it in practice
+Dan saya pikir itu sebenarnya cara
+yang akan saya lakukan dalam praktik
 
 0:32:40.331,0:32:43.241
-I don't want to go find a tool that does
-this conversion it is actually simple
+Saya tidak ingin pergi mencari alat yang melakukan
+konversi ini itu sebenarnya sederhana
 
 0:32:43.241,0:32:45.431
-to encode as a vim macro,
-then I just do it that way
+untuk dienkode sebagai macro vim,
+maka saya hanya melakukannya dengan cara itu
 
 0:32:45.431,0:32:48.991
-And then also Python especially in an interactive
-tool like a Jupyter notebook
+Dan kemudian juga Python terutama dalam alat interaktif
+seperti Jupyter notebook
 
 0:32:48.991,0:32:51.171
-is a really great way of doing data wrangling
+adalah cara yang sangat bagus untuk melakukan data wrangling
 
 0:32:51.171,0:32:52.951
-A third tool I'd mention which
-I don't remember if we
+Alat ketiga yang saya sebutkan yang
+saya tidak ingat apakah kami
 
 0:32:52.961,0:32:55.361
-covered in the data wrangling
-lecture or elsewhere
+bahas di kuliah data wrangling
+atau di tempat lain
 
 0:32:55.361,0:32:58.751
-is a tool called pandoc which can do transformations
-between different text
+adalah alat bernama pandoc yang bisa melakukan transformasi
+antara format dokumen teks yang berbeda
 
 0:32:58.751,0:33:02.981
-document formats so you can convert from
-plaintext to HTML or HTML to markdown
+jadi kalian bisa mengkonversi dari
+plaintext ke HTML atau HTML ke markdown
 
 0:33:02.981,0:33:07.361
-or LaTeX to HTML or many other formats
-it actually it supports a large
+atau LaTeX ke HTML atau banyak format lainnya
+itu sebenarnya mendukung banyak
 
 0:33:07.361,0:33:10.471
-list of input formats and a
-large list of output formats
+daftar format input dan
+daftar format output yang besar
 
 0:33:10.471,0:33:16.361
-I think there's one last one which I mentioned briefly
-in the lecture on data wrangling which is
+Saya pikir ada satu terakhir yang saya sebutkan secara singkat
+di kuliah tentang data wrangling yaitu
 
 0:33:16.361,0:33:20.441
-the R programming language, it's
-an awful (I think it's an awful)
+bahasa pemrograman R, itu
+adalah (saya pikir itu) bahasa yang buruk
 
 0:33:20.441,0:33:25.120
-language to program in. And i would never
-use it in the middle of a data wrangling
+untuk diprogram. Dan saya tidak akan pernah
+menggunakannya di tengah pipeline data wrangling
 
 0:33:25.120,0:33:30.951
-pipeline, but at the end, in order to like produce
-pretty plots and statistics R is great
+tapi di akhir, untuk seperti menghasilkan
+plot dan statistik yang bagus R sangat bagus
 
 0:33:30.951,0:33:35.581
-Because R is built for doing
-statistics and plotting
+Karena R dibangun untuk melakukan
+statistik dan plotting
 
 0:33:35.581,0:33:40.591
-there's a library for are called
-ggplot which is just amazing
+ada library bernama
+ggplot yang luar biasa
 
 0:33:40.591,0:33:46.551
-ggplot2 i guess technically It's
-great, it produces very
+ggplot2 saya kira secara teknis itu
+sangat bagus, itu menghasilkan
 
 0:33:46.551,0:33:51.431
-nice visualizations and it lets you do,
-it does very easily do things like
+visualisasi yang sangat bagus dan memungkinkan kalian melakukan,
+itu melakukan hal-hal dengan sangat mudah seperti
 
 0:33:51.431,0:33:57.561
-If you have a data set that has like multiple
-facets like it's not just X and Y
+Jika kalian memiliki dataset yang memiliki seperti beberapa
+facet seperti bukan hanya X dan Y
 
 0:33:57.561,0:34:03.111
-it's like X Y Z and some other variable,
-and then you want to plot like the
+itu seperti X Y Z dan beberapa variabel lainnya,
+dan kemudian kalian ingin memplot seperti
 
 0:34:03.111,0:34:07.581
-throughput grouped by all of those parameters
-at the same time and produce
+throughput yang dikelompokkan oleh semua parameter tersebut
+pada saat yang sama dan menghasilkan
 
 0:34:07.581,0:34:11.991
-a visualization. R very easily let's you
-do this and I haven't seen anywhere
+visualisasi. R dengan sangat mudah membiarkan kalian
+melakukan ini dan saya belum melihat di mana pun
 
 0:34:11.991,0:34:14.891
-that lets you do that as easily
+yang membiarkan kalian melakukan itu semudah itu
 
 0:34:16.971,0:34:17.951
-Next question,
+Pertanyaan berikutnya,
 
 0:34:17.951,0:34:20.511
-What's the difference between
-Docker and a virtual machine
+Apa perbedaan antara
+Docker dan virtual machine
 
 0:34:23.271,0:34:27.731
-What's the easiest way to explain this? So docker
+Cara termudah untuk menjelaskan ini? Jadi docker
 
 0:34:27.741,0:34:31.221
-starts something called containers and
-docker is not the only program that
+memulai sesuatu yang disebut container dan
+docker bukan satu-satunya program yang
 
 0:34:31.221,0:34:36.561
-starts containers. There are many others
-and usually they rely on some feature of
+memulai container. Ada banyak lainnya
+dan biasanya mereka mengandalkan beberapa fitur dari
 
 0:34:36.561,0:34:40.401
-the underlying kernel in the case of
-docker they use something called LXC
+kernel yang mendasari dalam kasus
+docker mereka menggunakan sesuatu yang disebut LXC
 
 0:34:40.401,0:34:47.571
-which are Linux containers and the basic
-premise there is if you want to start
+yang merupakan Linux container dan premis
+dasarnya adalah jika kalian ingin memulai
 
 0:34:47.571,0:34:53.181
-what looks like a virtual machine that
-is running roughly the same operating
+apa yang tampak seperti virtual machine yang
+menjalankan kira-kira sistem operasi yang
 
 0:34:53.181,0:34:57.411
-system as you are already running on your
-computer then you don't really need
+sama dengan yang sudah kalian jalankan di
+komputer kalian maka kalian tidak benar-benar perlu
 
 0:34:57.411,0:35:04.701
-to run another instance of the kernel
-really that other virtual machine can
+menjalankan instance lain dari kernel
+benar-benar virtual machine lain itu bisa
 
 0:35:04.701,0:35:09.951
-share a kernel. And you can just use the
-kernels built in isolation mechanisms to
+berbagi kernel. Dan kalian bisa hanya menggunakan
+mekanisme isolasi built-in kernel untuk
 
 0:35:09.951,0:35:13.791
-spin up a program that thinks it's
-running on its own hardware but in
+memulai program yang pikir itu
+berjalan di hardware sendiri tapi dalam
 
 0:35:13.791,0:35:18.501
-reality it's sharing the kernel and so this
-means that containers can often run
+kenyataannya itu berbagi kernel dan jadi ini
+berarti container sering bisa berjalan
 
 0:35:18.501,0:35:22.611
-with much lower overhead than a full virtual
-machine will do but you should
+dengan overhead yang jauh lebih rendah daripada virtual machine
+penuh akan lakukan tapi kalian harus
 
 0:35:22.611,0:35:26.391
-keep in mind that it also has somewhat weaker
-isolation because you are sharing
+ingat bahwa itu juga memiliki isolasi yang agak lebih lemah
+karena kalian berbagi
 
 0:35:26.391,0:35:30.831
-a kernel between the two if you spin up
-a virtual machine the only thing that's
+kernel antara keduanya jika kalian memulai
+virtual machine satu-satunya yang
 
 0:35:30.831,0:35:35.931
-shared is sort of the hardware and to
-some extent the hypervisor, whereas
+dibagi adalah semacam hardware dan sampai
+batas tertentu hypervisor, sedangkan
 
 0:35:35.931,0:35:40.791
-with a docker container you're sharing
-the full kernel and the that is a
+dengan docker container kalian berbagi
+kernel penuh dan itu adalah
 
 0:35:40.791,0:35:44.921
-different threat model that you
-might have to keep in mind
+model ancaman yang berbeda yang
+mungkin harus kalian ingat
 
 0:35:47.341,0:35:52.361
-One another small note there as Jon pointed
-out, to use containers something
+Satu catatan kecil lagi di sini seperti yang ditunjukkan Jon,
+untuk menggunakan container sesuatu
 
 0:35:52.361,0:35:55.631
-like Docker you need the underlying operating
-system to be roughly the same
+seperti Docker kalian perlu sistem operasi yang mendasari
+kira-kira sama
 
 0:35:55.631,0:36:00.071
-as whatever the program that's running
-on top of the container expects and so
+dengan apa pun yang diharapkan program yang berjalan
+di atas container dan jadi
 
 0:36:00.071,0:36:03.791
-if you're using macOS for example, the
-way you use docker is you run Linux
+jika kalian menggunakan macOS misalnya, cara
+kalian menggunakan docker adalah kalian menjalankan Linux
 
 0:36:03.791,0:36:08.261
-inside a virtual machine and then you can
-run Docker on top of Linux so maybe
+di dalam virtual machine dan kemudian kalian bisa
+menjalankan Docker di atas Linux jadi mungkin
 
 0:36:08.261,0:36:11.741
-if you're going for containers in order
-to get better performance your trading
+jika kalian menggunakan container untuk
+mendapatkan performa yang lebih baik kalian menukar
 
 0:36:11.741,0:36:15.131
-isolation for performance if you're running
-on Mac OS that may not work out
+isolasi untuk performa jika kalian berjalan
+di Mac OS itu mungkin tidak berhasil
 
 0:36:15.131,0:36:17.451
-exactly as expected
+persis seperti yang diharapkan
 
 0:36:17.451,0:36:21.221
-And one last note is that there
-is a slight difference, so
+Dan satu catatan terakhir adalah bahwa ada
+sedikit perbedaan, jadi
 
 0:36:21.221,0:36:25.721
-with Docker and containers,
-one of the gotchas you have
+dengan Docker dan container,
+salah satu hal yang harus kalian
 
 0:36:25.721,0:36:29.411
-to be familiar with is that containers
-are more similar to virtual
+kenali adalah bahwa container
+lebih mirip virtual
 
 0:36:29.411,0:36:33.071
-machines in the sense of that they will
-persist all the storage that you
+machine dalam arti bahwa mereka akan
+mempertahankan semua penyimpanan yang kalian
 
 0:36:33.071,0:36:35.971
-have where Docker by default won't have that.
+miliki di mana Docker secara default tidak akan memilikinya.
 
 0:36:35.971,0:36:37.791
-Like Docker is supposed to be running
+Seperti Docker seharusnya berjalan
 
 0:36:37.791,0:36:41.771
-So the main idea is like I want
-to run some software and
+Jadi ide utamanya adalah seperti saya ingin
+menjalankan beberapa software dan
 
 0:36:41.771,0:36:45.671
-I get the image and it runs and if you
-want to have any kind of persistent
+saya mendapat image dan itu berjalan dan jika kalian
+ingin memiliki penyimpanan persisten apa pun
 
 0:36:45.671,0:36:50.081
-storage that links to the host system
-you have to kind of manually specify
+yang terhubung ke sistem host
+kalian harus secara manual menentukan
 
 0:36:50.081,0:36:56.051
-that, whereas a virtual machine is using
-some virtual disk that is being provided
+itu, sedangkan virtual machine menggunakan
+beberapa disk virtual yang disediakan
 
 0:36:56.051,0:37:02.671
-Next question
+Pertanyaan berikutnya
 
 0:37:02.671,0:37:05.111
-What are the advantages of each operating system
+Apa keuntungan dari masing-masing sistem operasi
 
 0:37:05.111,0:37:08.531
-and how can we choose between them?
-For example, choosing the best Linux
+dan bagaimana kita bisa memilih di antara mereka?
+Misalnya, memilih Linux
 
 0:37:08.531,0:37:10.551
-distribution for our purposes
+distribution terbaik untuk tujuan kita
 
 0:37:14.251,0:37:16.811
-I will say that for many, many tasks the
+Saya akan mengatakan bahwa untuk banyak, banyak tugas
 
 0:37:16.811,0:37:20.171
-specific Linux distribution that you're
-running is not that important
+distribusi Linux spesifik yang kalian
+jalankan tidak terlalu penting
 
 0:37:20.171,0:37:23.731
-the thing is, it's just what kind of
+masalahnya, hanya apa jenis
 
 0:37:23.731,0:37:27.651
-knowing that there are different types
-or like groups of distributions,
+mengetahui bahwa ada jenis atau kelompok
+distribusi yang berbeda,
 
 0:37:27.651,0:37:32.251
-So for example, there are some distributions
-that have really frequent updates
+Jadi misalnya, ada beberapa distribusi
+yang memiliki update yang sangat sering
 
 0:37:32.251,0:37:38.971
-but they kind of break more easily. So for
-example Arch Linux has a rolling update
+tapi mereka agak lebih mudah rusak. Jadi misalnya
+Arch Linux memiliki update bergulir
 
 0:37:38.971,0:37:43.511
-way of pushing updates, where things might
-break but they're fine with the things
+cara mendorong update, di mana hal-hal mungkin
+rusak tapi mereka baik-baik saja dengan hal-hal
 
 0:37:43.511,0:37:47.891
-being that way. Where maybe where you
-have some really important web server
+menjadi seperti itu. Di mana mungkin di mana kalian
+memiliki beberapa web server yang sangat penting
 
 0:37:47.891,0:37:51.401
-that is hosting all your business
-analytics you want that thing
+yang meng-host semua analitik bisnis kalian
+kalian ingin hal itu
 
 0:37:51.401,0:37:55.961
-to have like a much more steady way of
-updates. So that's for example why you
+memiliki cara update yang jauh lebih stabil.
+Jadi itu misalnya mengapa kalian
 
 0:37:55.961,0:37:58.121
-will see distributions like Debian being
+akan melihat distribusi seperti Debian
 
 0:37:58.121,0:38:02.951
-much more conservative about what they push, or
-even for example Ubuntu makes a difference
+jauh lebih konservatif tentang apa yang mereka dorong, atau
+bahkan misalnya Ubuntu membuat perbedaan
 
 0:38:02.951,0:38:07.001
-between the Long Term Releases
-that they are only update every
+antara Long Term Releases
+yang hanya diupdate setiap
 
 0:38:07.001,0:38:12.281
-two years and the more periodic
-releases of one there is a
+dua tahun dan rilis yang lebih periodik
+satu tahun ada
 
 0:38:12.281,0:38:16.661
-it's like two a year that they make.
-So, kind of knowing that there's the
+seperti dua setahun yang mereka buat.
+Jadi, mengetahui bahwa ada
 
 0:38:16.661,0:38:21.341
-difference apart from that some distributions
-have different ways
+perbedaan selain itu beberapa distribusi
+memiliki cara yang berbeda
 
 0:38:21.341,0:38:27.191
-of providing the binaries
-to you and the way they
+untuk menyediakan binary
+kepada kalian dan cara mereka
 
 0:38:27.191,0:38:33.791
-have the repositories so I think a lot of Red
-Hat Linux don't want non free drivers in
+memiliki repositori jadi saya pikir banyak Red
+Hat Linux tidak ingin driver non-free di
 
 0:38:33.791,0:38:37.361
-their official repositories where I
-think Ubuntu is fine with some of
+repositori resmi mereka di mana saya
+pikir Ubuntu baik-baik saja dengan beberapa
 
 0:38:37.361,0:38:42.491
-them, apart from that I think like just
-a lot of what is core to most Linux
+dari mereka, selain itu saya pikir hanya
+banyak dari apa yang inti dari sebagian besar distro Linux
 
 0:38:42.491,0:38:47.411
-distros is kind of shared between them
-and there's a lot of learning in the
+adalah semacam dibagi di antara mereka
+dan ada banyak pembelajaran di
 
 0:38:47.411,0:38:51.431
-common ground. So you don't have
-to worry about the specifics
+dasar yang sama. Jadi kalian tidak perlu
+khawatir tentang hal-hal spesifik
 
 0:38:52.391,0:38:56.351
-Keeping with the theme of this class being somewhat
-opinionated, I'm gonna go ahead and say
+Tetap dengan tema kelas ini yang agak
+opini, saya akan melanjutkan dan mengatakan
 
 0:38:56.351,0:39:00.041
-that if you're using Linux especially for
-the first time choose something like
+bahwa jika kalian menggunakan Linux terutama untuk
+pertama kali pilih sesuatu seperti
 
 0:39:00.041,0:39:03.851
-Ubuntu or Debian. So you Ubuntu to is a
-Debian based distribution but maybe is a
+Ubuntu atau Debian. Jadi Ubuntu adalah
+distribusi berbasis Debian tapi mungkin
 
 0:39:03.851,0:39:07.421
-little bit more friendly, Debian is a little
-bit more minimalist. I use Debian
+sedikit lebih ramah, Debian sedikit
+lebih minimalis. Saya menggunakan Debian
 
 0:39:07.421,0:39:10.451
-and all my servers, for example. And I use
-Debian desktop on my desktop computers
+di semua server saya, misalnya. Dan saya menggunakan
+Debian desktop di komputer desktop saya
 
 0:39:10.451,0:39:15.431
-that run Linux if you're going for maybe
-trying to learn more things and you want
+yang menjalankan Linux jika kalian mungkin
+mencoba mempelajari lebih banyak hal dan kalian ingin
 
 0:39:15.431,0:39:19.391
-a distribution that trades stability for
-having more up-to-date software maybe
+distribusi yang menukar stabilitas untuk
+memiliki software yang lebih terkini mungkin
 
 0:39:19.391,0:39:21.911
-at the expense of you having to fix a
-broken distribution every once in a
+dengan mengorbankan kalian harus memperbaiki
+distribusi yang rusak sesekali
 
 0:39:21.911,0:39:26.911
-while then maybe you can consider something
-like Arch Linux or Gentoo
+maka mungkin kalian bisa mempertimbangkan sesuatu
+seperti Arch Linux atau Gentoo
 
 0:39:26.911,0:39:32.681
-or Slackware. Oh man, I'd say that like
-if you're installing Linux and just like
+atau Slackware. Oh ya, saya akan bilang seperti
+jika kalian menginstal Linux dan hanya ingin
 
 0:39:32.681,0:39:34.891
-want to get work done Debian is a great choice
+menyelesaikan pekerjaan Debian adalah pilihan yang hebat
 
 0:39:35.911,0:39:38.271
-Yeah I think I agree with that.
+Ya saya pikir saya setuju dengan itu.
 
 0:39:38.271,0:39:40.971
-The other observation is like
-you couldn't install BSD
+Pengamatan lainnya adalah seperti
+kalian bisa menginstal BSD
 
 0:39:40.971,0:39:46.691
-BSD has gotten, has come a long way from
-where it was. There's still a bunch of
+BSD telah, telah berkembang jauh dari
+di mana itu dulu. Masih ada banyak
 
 0:39:46.691,0:39:50.921
-software you can't really get for BSD but
-it gives you a very well-documented
+software yang tidak bisa kalian dapatkan untuk BSD tapi
+itu memberi kalian pengalaman yang sangat terdokumentasi
 
 0:39:50.921,0:39:55.841
-experience and and one thing that's different
-about BSD compared to Linux is
+dan satu hal yang berbeda
+tentang BSD dibandingkan dengan Linux adalah
 
 0:39:55.841,0:40:02.531
-that in an BSD when you install BSD you
-get a full operating system, mostly
+bahwa dalam BSD ketika kalian menginstal BSD kalian
+mendapatkan sistem operasi lengkap, sebagian besar
 
 0:40:02.651,0:40:07.531
-So many of the programs are maintained by
-the same team that maintains the kernel
+Jadi banyak program dipelihara oleh
+tim yang sama yang memelihara kernel
 
 0:40:07.541,0:40:11.351
-and everything is sort of upgraded together,
-which is a little different
+dan semuanya semacam di-upgrade bersama,
+yang sedikit berbeda
 
 0:40:11.351,0:40:13.271
-than how thanks work in the Linux world it does
+dari bagaimana hal-hal bekerja di dunia Linux itu memang
 
 0:40:13.271,0:40:16.751
-mean that things often move a little bit
-slower. I would not use it for things
+berarti hal-hal sering bergerak sedikit
+lebih lambat. Saya tidak akan menggunakannya untuk hal-hal
 
 0:40:16.751,0:40:21.791
-like gaming either, because drivers support
-is meh. But it is an interesting
+seperti gaming juga, karena dukungan driver
+biasa saja. Tapi itu adalah lingkungan yang menarik
 
 0:40:21.791,0:40:30.661
-environment to look at. And then for things
-like Mac OS and Windows I think
+untuk dilihat. Dan kemudian untuk hal-hal
+seperti Mac OS dan Windows saya pikir
 
 0:40:30.661,0:40:36.041
-If you are a programmer, I don't know why
-you are using Windows unless you are
+Jika kalian adalah programmer, saya tidak tahu mengapa
+kalian menggunakan Windows kecuali kalian
 
 0:40:36.041,0:40:42.401
-building things for Windows; or you want
-to be able to do gaming and stuff
+membangun sesuatu untuk Windows; atau kalian ingin
+bisa melakukan gaming dan semacamnya
 
 0:40:42.401,0:40:46.891
-but in that case, maybe try dual booting,
-even though that's a pain too
+tapi dalam kasus itu, mungkin coba dual boot,
+meskipun itu juga merepotkan
 
 0:40:46.891,0:40:52.031
-Mac OS is a is a good sort of middle point
-between the two where you get a system
+Mac OS adalah semacam titik tengah yang baik
+antara keduanya di mana kalian mendapatkan sistem
 
 0:40:52.031,0:40:57.851
-that is like relatively nicely polished
-for you. But you still have access to
+yang relatif dipoles dengan baik
+untuk kalian. Tapi kalian masih memiliki akses ke
 
 0:40:57.851,0:41:01.191
-some of the lower-level bits
-at least to a certain extent.
+beberapa bagian yang lebih low-level
+setidaknya sampai batas tertentu.
 
 0:41:01.191,0:41:07.451
-it's also really easy to dual boot Mac OS and Windows
-it is not quite the case with like Mac OS and
+itu juga sangat mudah untuk dual boot Mac OS dan Windows
+itu tidak begitu dengan seperti Mac OS dan
 
 0:41:07.451,0:41:09.651
-Linux or Linux and Windows
+Linux atau Linux dan Windows
 
 0:41:13.911,0:41:15.751
-Alright, for the rest of the
-questions so these are
+Baiklah, untuk sisa
+pertanyaan jadi ini semua
 
 0:41:15.761,0:41:18.761
-all 0 upvote questions so maybe we can go
-through them quickly in the last five
+pertanyaan dengan 0 upvote jadi mungkin kita bisa
+melewatinya dengan cepat dalam lima menit
 
 0:41:18.761,0:41:23.471
-or so minutes of class. So the next
-one is Vim versus Emacs? Vim!
+terakhir kelas. Jadi berikutnya
+adalah Vim versus Emacs? Vim!
 
 0:41:23.471,0:41:30.911
-Easy answer, but a more serious answer is like I think
-all three of us use vim as our primary editor
+Jawaban mudah, tapi jawaban yang lebih serius adalah seperti saya pikir
+kita bertiga menggunakan vim sebagai editor utama
 
 0:41:30.911,0:41:34.931
-I use Emacs for some research specific
-stuff which requires Emacs but
+Saya menggunakan Emacs untuk beberapa hal spesifik penelitian
+yang membutuhkan Emacs tapi
 
 0:41:34.931,0:41:38.681
-at a higher level both editors have interesting
-ideas behind them and if you
+di tingkat yang lebih tinggi kedua editor memiliki ide menarik
+di belakangnya dan jika kalian
 
 0:41:38.681,0:41:43.061
-have the time is worth exploring both
-to see which fits you better and also
+punya waktu layak menjelajahi keduanya
+untuk melihat mana yang lebih cocok untuk kalian dan juga
 
 0:41:43.061,0:41:46.811
-you can use Emacs and run it in a vim
-emulation mode. I actually know a
+kalian bisa menggunakan Emacs dan menjalankannya dalam mode
+emulasi vim. Saya sebenarnya tahu cukup
 
 0:41:46.811,0:41:49.091
-good number of people who do that so
-they get access to some of the cool
+banyak orang yang melakukan itu jadi
+mereka mendapatkan akses ke beberapa fungsi keren
 
 0:41:49.091,0:41:52.631
-Emacs functionality and some of the cool
-philosophy behind that like Emacs is
+Emacs dan beberapa filosofi keren
+di belakang itu seperti Emacs
 
 0:41:52.631,0:41:55.391
-programmable through Lisp which is kind of cool.
+bisa diprogram melalui Lisp yang cukup keren.
 
 0:41:55.391,0:41:59.411
-Much better than vimscript, but people like
-vim's modal editing, so there's an
+Jauh lebih baik daripada vimscript, tapi orang suka
+modal editing vim, jadi ada
 
 0:41:59.411,0:42:04.481
-emacs plugin called evil mode which gives
-you vim modal editing within Emacs so
+plugin emacs bernama evil mode yang memberi
+kalian vim modal editing dalam Emacs jadi
 
 0:42:04.481,0:42:08.081
-it's not necessarily a binary choice you
-can kind of combine both tools if you
+itu tidak harus pilihan biner kalian
+bisa semacam menggabungkan kedua alat jika kalian
 
 0:42:08.081,0:42:11.151
-want to. And it's worth exploring
-both if you have the time.
+ingin. Dan layak menjelajahi
+keduanya jika kalian punya waktu.
 
 0:42:11.151,0:42:12.731
-Next question
+Pertanyaan berikutnya
 
 0:42:12.731,0:42:15.671
-Any tips or tricks for machine
-learning applications?
+Ada tips atau trik untuk aplikasi
+machine learning?
 
 0:42:19.271,0:42:22.351
-I think, like knowing how
+Saya pikir, seperti mengetahui bagaimana
 
 0:42:22.361,0:42:24.791
-a lot of these tools, mainly the data wrangling
+banyak alat ini, terutama data wrangling
 
 0:42:24.791,0:42:30.041
-a lot of the shell tools, it's really
-important because it seems a lot
+banyak alat shell, itu sangat
+penting karena tampaknya banyak
 
 0:42:30.041,0:42:33.851
-of what you're doing as machine learning
-researcher is trying different things
+dari apa yang kalian lakukan sebagai peneliti
+machine learning adalah mencoba hal-hal berbeda
 
 0:42:33.851,0:42:39.491
-but I think one core aspect of doing that,
-and like a lot of scientific work is being
+tapi saya pikir satu aspek inti dari melakukan itu,
+dan seperti banyak pekerjaan ilmiah adalah bisa
 
 0:42:39.491,0:42:44.501
-able to have reproducible results
-and logging them in a sensible way
+memiliki hasil yang dapat direproduksi
+dan mencatatnya dengan cara yang masuk akal
 
 0:42:44.501,0:42:47.711
-So for example, instead of trying to come
-up with really hacky solutions of how
+Jadi misalnya, alih-alih mencoba datang
+dengan solusi yang sangat diotak-atik tentang bagaimana
 
 0:42:47.711,0:42:51.151
-you name your folders to make
-sense of the experiments
+kalian menamai folder kalian untuk membuat
+arti dari eksperimen
 
 0:42:51.151,0:42:53.251
-Maybe it's just worth having for example
+Mungkin hanya layak memiliki misalnya
 
 0:42:53.251,0:42:55.931
-what I do is have like a JSON
-file that describes the
+apa yang saya lakukan adalah memiliki file JSON
+yang menggambarkan
 
 0:42:55.931,0:43:00.371
-entire experiment I know like all the parameters
-that are within and then I can
+seluruh eksperimen saya tahu seperti semua parameter
+yang ada di dalamnya dan kemudian saya bisa
 
 0:43:00.371,0:43:05.111
-really quickly, using the tools that
-we have covered, query for all the
+dengan sangat cepat, menggunakan alat yang
+telah kami bahas, query untuk semua
 
 0:43:05.111,0:43:09.701
-experiments that have some specific
-purpose or use some data set
+eksperimen yang memiliki tujuan spesifik tertentu
+atau menggunakan dataset tertentu
 
 0:43:09.701,0:43:15.071
-Things like that. Apart from that, the other
-side of this is, if you are running
+Hal-hal seperti itu. Selain itu, sisi lain
+dari ini adalah, jika kalian menjalankan
 
 0:43:15.071,0:43:19.871
-kind of things for training machine
-learning applications and you
+hal-hal untuk melatih aplikasi
+machine learning dan kalian
 
 0:43:19.871,0:43:23.981
-are not already using some sort of
-cluster, like university or your
+belum menggunakan semacam
+cluster, seperti yang disediakan universitas atau perusahaan kalian
 
 0:43:23.981,0:43:28.301
-company is providing and you're just kind
-of manually sshing, like a lot of
+dan kalian hanya semacam
+ssh secara manual, seperti yang dilakukan banyak lab,
 
 0:43:28.301,0:43:31.231
-labs do, because that's kind of the easy way
+karena itu semacam cara mudah
 
 0:43:31.231,0:43:36.671
-It's worth automating a lot of that job
-because it might not seem like it but
+Layak mengotomatiskan banyak pekerjaan itu
+karena mungkin tidak tampak seperti itu tapi
 
 0:43:36.671,0:43:40.601
-manually doing a lot of these operations
-takes away a lot of your time and also
+melakukan banyak operasi ini secara manual
+mengambil banyak waktu kalian dan juga
 
 0:43:40.601,0:43:45.031
-kind of your mental energy
-for running these things
+semacam energi mental kalian
+untuk menjalankan hal-hal ini
 
 0:43:48.551,0:43:51.691
-Anymore vim tips?
+Ada tips vim lagi?
 
 0:43:51.691,0:43:56.771
-I have one. So in the vim lecture we tried
-not to link you to too many different
+Saya punya satu. Jadi di kuliah vim kami mencoba
+tidak menautkan kalian ke terlalu banyak
 
 0:43:56.771,0:44:00.131
-vim plugins because we didn't want that
-lecture to be overwhelming but I think
+plugin vim berbeda karena kami tidak ingin kuliah itu
+kewalahan tapi saya pikir
 
 0:44:00.131,0:44:02.921
-it's actually worth exploring vim plugins
-because there are lots and lots
+sebenarnya layak menjelajahi plugin vim
+karena ada banyak dan banyak
 
 0:44:02.921,0:44:07.091
-of really cool ones out there.
-One resource you can use is the
+yang sangat keren di luar sana.
+Satu sumber daya yang bisa kalian gunakan adalah
 
 0:44:07.091,0:44:10.571
-different instructors dotfiles like a lot
-of us, I think I use like two dozen
+dotfile instruktur yang berbeda seperti banyak
+dari kita, saya pikir saya menggunakan seperti dua lusin
 
 0:44:10.571,0:44:14.321
-vim plugins and I find a lot of them quite
-helpful and I use them every day
+plugin vim dan saya menemukan banyak dari mereka cukup
+membantu dan saya menggunakannya setiap hari
 
 0:44:14.321,0:44:18.311
-we all use slightly different subsets of
-them. So go look at what we use or look
+kita semua menggunakan subset yang sedikit berbeda dari
+mereka. Jadi pergi lihat apa yang kita gunakan atau lihat
 
 0:44:18.311,0:44:22.131
-at some of the other resources we've linked
-to and you might find some stuff useful
+beberapa sumber daya lain yang telah kami tautkan
+dan kalian mungkin menemukan beberapa hal berguna
 
 0:44:22.791,0:44:26.951
-A thing to add to that is, I don't think
-we went into a lot detail in the
+Satu hal untuk ditambahkan adalah, saya tidak pikir
+kami masuk ke banyak detail di
 
 0:44:27.041,0:44:31.571
-lecture, correct me if I'm wrong. It's
-getting familiar with the leader key
+kuliah, koreksi saya jika saya salah. Itu
+mengenal leader key
 
 0:44:31.571,0:44:35.021
-Which is kind of a special key
-that a lot of programs will
+Yang merupakan semacam kunci khusus
+yang akan banyak program,
 
 0:44:35.021,0:44:39.081
-especially plugins, that will link to
-and for a lot of the common operations
+terutama plugin, tautkan ke
+dan untuk banyak operasi umum
 
 0:44:39.081,0:44:44.661
-vim has short ways of doing it, but you
-can just figure out like quicker
+vim memiliki cara singkat untuk melakukannya, tapi kalian
+bisa mencari tahu seperti versi lebih cepat
 
 0:44:44.661,0:44:50.031
-versions for doing them. So for example, like
-I know that you can do like semicolon WQ
+untuk melakukannya. Jadi misalnya, seperti
+saya tahu bahwa kalian bisa melakukan seperti semicolon WQ
 
 0:44:50.031,0:44:55.521
-to save and exit or that you
-can do like capital ZZ but I
+untuk menyimpan dan keluar atau bahwa kalian
+bisa melakukan seperti ZZ kapital tapi saya
 
 0:44:55.521,0:44:59.241
-just actually just do leader (which for
-me is the space) and then W. And I have
+hanya benar-benar melakukan leader (yang untuk
+saya adalah spasi) dan kemudian W. Dan saya telah
 
 0:44:59.241,0:45:04.131
-done that for a lot of a lot of kind of
-common operations that I keep doing all
+melakukan itu untuk banyak jenis
+operasi umum yang terus saya lakukan sepanjang
 
 0:45:04.131,0:45:08.091
-the time. Because just saving one keystroke
-for an extremely common operation
+waktu. Karena hanya menghemat satu keystroke
+untuk operasi yang sangat umum
 
 0:45:08.091,0:45:11.371
-is just saving thousands a month
+hanya menghemat ribuan sebulan
 
 0:45:11.371,0:45:12.951
-Yeah just to expand a little bit
+Ya hanya untuk memperluas sedikit
 
 0:45:12.951,0:45:17.031
-on what the leader key is so in vim you
-can bind some keys I can do like ctrl J
+tentang apa itu leader key jadi di vim kalian
+bisa mengikat beberapa kunci saya bisa melakukan seperti ctrl J
 
 0:45:17.031,0:45:20.481
-does something like holding one key and
-then pressing another I can bind that to
+melakukan sesuatu seperti menahan satu kunci dan
+kemudian menekan yang lain saya bisa mengikat itu ke
 
 0:45:20.481,0:45:23.781
-something or I can bind a single keystroke
-to something. What the leader
+sesuatu atau saya bisa mengikat satu keystroke
+ke sesuatu. Apa yang memungkinkan
 
 0:45:23.781,0:45:26.031
-key lets you do, is bind
+leader key lakukan, adalah mengikat
 
 0:45:26.031,0:45:28.311
-So you can assign any key
-to be the leader key and
+Jadi kalian bisa menetapkan kunci apa pun
+untuk menjadi leader key dan
 
 0:45:28.311,0:45:32.841
-then you can assign leader followed by
-some other key to some action so for
+kemudian kalian bisa menetapkan leader diikuti oleh
+beberapa kunci lain ke beberapa tindakan jadi misalnya
 
 0:45:32.841,0:45:36.831
-example like Jose's leader key is space
-and they can combine space and then
+seperti leader key Jose adalah spasi
+dan mereka bisa menggabungkan spasi dan kemudian
 
 0:45:36.831,0:45:41.601
-releasing space followed by some other
-key to an arbitrary vim command so it
+melepaskan spasi diikuti oleh beberapa kunci
+lain ke perintah vim arbitrer jadi itu
 
 0:45:41.601,0:45:45.631
-just gives you yet another way of binding
-like a whole set of key combinations.
+hanya memberi kalian cara lain untuk mengikat
+seperti seluruh rangkaian kombinasi kunci.
 
 0:45:45.631,0:45:49.751
-Leader key plus kind of any key on
-the keyboard to some functionality
+Leader key ditambah kunci apa pun di
+keyboard ke beberapa fungsionalitas
 
 0:45:49.751,0:45:53.751
-I think I've I forget whether
-we covered macros in the vim
+Saya pikir saya lupa apakah
+kami membahas macro di kuliah
 
 0:45:53.751,0:45:58.581
-uh sure but like vim macros are worth
-learning they're not that complicated
+vim uh tentu tapi seperti macro vim layak
+dipelajari mereka tidak terlalu rumit
 
 0:45:58.581,0:46:03.141
-but knowing that they're there and knowing
-how to use them is going to save
+tapi mengetahui bahwa mereka ada dan mengetahui
+cara menggunakannya akan menghemat
 
 0:46:03.141,0:46:09.501
-you so much time. The other one is something
-called marks. So in vim you can
+banyak waktu kalian. Yang lain adalah sesuatu
+yang disebut marks. Jadi di vim kalian bisa
 
 0:46:09.501,0:46:13.491
-press m and then any letter on your keyboard
-to make a mark in that file and
+menekan m dan kemudian huruf apa pun di keyboard kalian
+untuk membuat mark di file itu dan
 
 0:46:13.491,0:46:18.021
-then you can press apostrophe on the
-same letter to jump back to the same
+kemudian kalian bisa menekan apostrof pada
+huruf yang sama untuk melompat kembali ke
 
 0:46:18.021,0:46:21.801
-place. This is really useful if you're
-like moving back and forth
+tempat yang sama. Ini sangat berguna jika kalian
+seperti bergerak bolak-balik
 
 0:46:21.801,0:46:25.491
-between two different parts of your code
-for example. You can mark one as A and
+antara dua bagian berbeda dari kode kalian
+misalnya. Kalian bisa menandai satu sebagai A dan
 
 0:46:25.491,0:46:29.611
-one as B and you can then jump between
-them with tick A and tick B.
+satu sebagai B dan kalian bisa melompat di antara
+mereka dengan tick A dan tick B.
 
 0:46:29.611,0:46:34.851
-There's also Ctrl+O which jumps to the previous
-place you were in the file no matter
+Ada juga Ctrl+O yang melompat ke tempat sebelumnya
+kalian berada di file tidak peduli
 
 0:46:34.851,0:46:40.611
-what caused you to move. So for example
-if I am in a some line and then I jump
+apa yang menyebabkan kalian berpindah. Jadi misalnya
+jika saya berada di beberapa baris dan kemudian saya melompat
 
 0:46:40.611,0:46:45.201
-to B and then I jump to A, Ctrl+O will
-take me back to B and then back to the
+ke B dan kemudian saya melompat ke A, Ctrl+O akan
+membawa saya kembali ke B dan kemudian kembali ke
 
 0:46:45.201,0:46:48.831
-place I originally was. This can also be
-handy for things like if you're doing a
+tempat saya awalnya berada. Ini juga bisa
+berguna untuk hal-hal seperti jika kalian melakukan
 
 0:46:48.831,0:46:52.671
-search then the place that you
-started the search is a part of
+pencarian maka tempat yang kalian
+mulai pencarian adalah bagian dari
 
 0:46:52.671,0:46:56.211
-that stack. So I can do a search I can
-then like step through the results
+stack itu. Jadi saya bisa melakukan pencarian saya bisa
+kemudian seperti melangkah melalui hasil
 
 0:46:56.211,0:47:00.801
-and like change them and then Ctrl+O
-all the way back up to the search
+dan seperti mengubahnya dan kemudian Ctrl+O
+semua jalan kembali ke pencarian
 
 0:47:00.801,0:47:06.201
-Ctrl+O also lets you move across files so
-if I go from one file to somewhere else in
+Ctrl+O juga memungkinkan kalian berpindah antar file jadi
+jika saya pergi dari satu file ke tempat lain di
 
 0:47:06.201,0:47:09.681
-different file and somewhere else in the
-first file Ctrl+O will move me back
+file berbeda dan ke tempat lain di
+file pertama Ctrl+O akan membawa saya kembali
 
 0:47:09.681,0:47:15.261
-through that stack and then there's
-Ctrl+I to move forward in that
+melalui stack itu dan kemudian ada
+Ctrl+I untuk bergerak maju di
 
 0:47:15.261,0:47:20.841
-stack and so it's not as though you
-pop it and it goes away forever
+stack itu dan jadi tidak seperti kalian
+pop itu dan itu hilang selamanya
 
 0:47:20.841,0:47:26.541
-The command colon earlier is really handy.
-So, colon earlier gives you an earlier
+Perintah colon earlier sangat berguna.
+Jadi, colon earlier memberi kalian versi
 
 0:47:26.541,0:47:32.870
-version of the same file and it it does
-this based on time not based on actions
+yang lebih awal dari file yang sama dan itu melakukan
+ini berdasarkan waktu bukan berdasarkan tindakan
 
 0:47:32.870,0:47:36.651
-so for example if you press a bunch of like
-undo and redo and make some changes
+jadi misalnya jika kalian menekan banyak seperti
+undo dan redo dan membuat beberapa perubahan
 
 0:47:36.651,0:47:42.561
-and stuff, earlier will take a literally
-earlier as in time version of your file
+dan semacamnya, earlier akan mengambil secara harfiah
+yang lebih awal dalam arti waktu versi file kalian
 
 0:47:42.561,0:47:46.971
-and restore it to your buffer. This can
-sometimes be good if you like undid and
+dan mengembalikannya ke buffer kalian. Ini bisa
+kadang-kadang bagus jika kalian seperti mengundo dan
 
 0:47:46.971,0:47:50.841
-then rewrote something and then realize
-you actually wanted the version that was
+kemudian menulis ulang sesuatu dan kemudian menyadari
+kalian sebenarnya menginginkan versi yang ada
 
 0:47:50.841,0:47:55.100
-there before you started undoing earlier
-let's you do this. And there's a plug-in
+sebelum kalian mulai mengundo earlier
+membiarkan kalian melakukan ini. Dan ada plugin
 
 0:47:55.100,0:48:01.971
-called undo tree or something like
-that There are several of these,
+bernama undo tree atau sesuatu seperti
+itu Ada beberapa dari ini,
 
 0:48:01.971,0:48:05.781
-that let you actually explore the full
-tree of undo history the vim keeps
+yang membiarkan kalian sebenarnya menjelajahi seluruh
+pohon riwayat undo yang disimpan vim
 
 0:48:05.781,0:48:09.201
-because it doesn't just keep a linear history
-it actually keeps the full tree
+karena itu tidak hanya menyimpan riwayat linear
+itu sebenarnya menyimpan pohon penuh
 
 0:48:09.201,0:48:12.771
-and letting you explore that might in
-some cases save you from having to
+dan membiarkan kalian menjelajahi itu mungkin dalam
+beberapa kasus menyelamatkan kalian dari harus
 
 0:48:12.771,0:48:16.461
-re-type stuff you typed in the past or
-stuff you just forgot exactly what you
+mengetik ulang hal-hal yang kalian ketik di masa lalu atau
+hal-hal yang kalian lupa persis apa yang
 
 0:48:16.461,0:48:21.081
-had there that used to work and no longer
-works. And this is one final one I
+kalian miliki di sana yang dulu berfungsi dan tidak lagi
+berfungsi. Dan ini adalah satu terakhir yang
 
 0:48:21.081,0:48:26.751
-want to mention which is, we mentioned
-how in vim you have verbs and nouns
+saya ingin sebutkan yaitu, kami menyebutkan
+bagaimana di vim kalian memiliki verb dan noun
 
 0:48:26.751,0:48:33.201
-right to your verbs like delete or yank
-and then you have nouns like next of
+kan ke verb kalian seperti delete atau yank
+dan kemudian kalian memiliki noun seperti next dari
 
 0:48:33.201,0:48:37.401
-this character or percent to swap brackets
-and that sort of stuff the
+karakter ini atau percent untuk swap bracket
+dan semacamnya
 
 0:48:37.401,0:48:44.571
-search command is a noun so you can do
-things like D slash and then a string
+perintah search adalah noun jadi kalian bisa melakukan
+hal-hal seperti D slash dan kemudian string
 
 0:48:44.571,0:48:50.261
-and it will delete up to the next match
-of that pattern this is extremely useful
+dan itu akan menghapus sampai ke match berikutnya
+dari pola itu ini sangat berguna
 
 0:48:50.261,0:48:54.251
-and I use it all the time
+dan saya menggunakannya sepanjang waktu
 
 0:48:58.500,0:49:03.520
-One another neat addition on the undo stuff
-that I find incredibly valuable in
+Satu tambahan yang rapi pada hal undo
+yang saya temukan sangat berharga dalam
 
 0:49:03.520,0:49:08.201
-an everyday basis is that like one of
-the built-in functionalities of vim
+basis sehari-hari adalah bahwa seperti salah satu
+fungsionalitas built-in dari vim
 
 0:49:08.201,0:49:13.510
-is that you can specify an undo directory
-and if you have a specified an
+adalah bahwa kalian bisa menentukan direktori undo
+dan jika kalian memiliki direktori undo yang ditentukan
 
 0:49:13.510,0:49:17.620
-undo directory by default vim, if you
-don't have this enabled, whenever you
+secara default vim, jika kalian tidak mengaktifkan ini, setiap kali kalian
 
 0:49:17.620,0:49:23.091
-enter a file your undo history is
-clean, there's nothing in there
+memasuki file riwayat undo kalian
+bersih, tidak ada apa-apa di sana
 
 0:49:23.091,0:49:26.371
-and as you make changes and then
-undo them you kind of create this
+dan saat kalian membuat perubahan dan kemudian
+mengundonya kalian semacam membuat
 
 0:49:26.380,0:49:32.800
-history but as soon as you exit the
-file that's lost. Sorry, as soon
+riwayat ini tapi begitu kalian keluar dari
+file itu hilang. Maaf, begitu
 
 0:49:32.800,0:49:37.181
-as you exit vim, that's lost. However
-if you have an undodir, vim is
+kalian keluar dari vim, itu hilang. Namun
+jika kalian memiliki undodir, vim akan
 
 0:49:37.181,0:49:41.651
-gonna persist all those changes into
-this directory so no matter how many
+mempertahankan semua perubahan itu ke
+direktori ini jadi tidak peduli berapa kali
 
 0:49:41.651,0:49:45.580
-times you enter and leave that history
-is persisted and it's incredibly
+kalian masuk dan keluar riwayat itu
+dipertahankan dan itu sangat
 
 0:49:45.580,0:49:48.191
-helpful because even like
+membantu karena bahkan seperti
 
 0:49:48.191,0:49:50.290
-it can be very helpful for
-some files that you modify
+itu bisa sangat membantu untuk
+beberapa file yang kalian modifikasi
 
 0:49:50.290,0:49:54.760
-often because then you can kind of keep
-the flow. But it's also sometimes really
+sering karena kemudian kalian bisa semacam menjaga
+flow. Tapi itu juga kadang-kadang sangat
 
 0:49:54.760,0:50:00.010
-helpful if you modify your bashrc see and
-something broke like five days later and
+membantu jika kalian memodifikasi bashrc kalian dan
+sesuatu rusak seperti lima hari kemudian dan
 
 0:50:00.010,0:50:03.070
-then you've vim again. Like what actually
-did I change ,if you don't
+kemudian kalian vim lagi. Seperti apa yang sebenarnya
+saya ubah, jika kalian tidak
 
 0:50:03.070,0:50:06.760
-have say like version control, then
-you can just check the undos and
+memiliki seperti version control, maka
+kalian bisa hanya memeriksa undo dan
 
 0:50:06.760,0:50:10.661
-that's actually what happened. And
-the last one, it's also really
+itu sebenarnya apa yang terjadi. Dan
+yang terakhir, itu juga sangat
 
 0:50:10.661,0:50:14.891
-worth familiarizing yourself with registers
-and what different special
+layak membiasakan diri dengan register
+dan register khusus apa yang
 
 0:50:14.891,0:50:20.380
-registers vim uses. So for example if
-you want to copy/paste really that's
+digunakan vim. Jadi misalnya jika
+kalian ingin copy/paste yang benar-benar
 
 0:50:20.380,0:50:26.201
-gone into in a specific register and if you
-want to for example use the a OS a copy
+masuk ke register tertentu dan jika kalian
+ingin misalnya menggunakan clipboard OS a
 
 0:50:26.201,0:50:30.040
-like the OS clipboard, you should
-be copying or yanking
+seperti clipboard OS, kalian harus
+mengcopy atau yanking
 
 0:50:30.040,0:50:36.250
-copying and pasting from a different register
-and there's a lot of them and yeah
+copy dan paste dari register yang berbeda
+dan ada banyak dari mereka dan ya
 
 0:50:36.251,0:50:41.310
-I think that you should explore, there's
-a lot of things to know about registers
+saya pikir kalian harus menjelajahi, ada
+banyak hal yang harus diketahui tentang register
 
 0:50:42.271,0:50:45.070
-The next question is asking about two-factor
-authentication and I'll just give
+Pertanyaan berikutnya bertanya tentang autentikasi dua faktor
+dan saya hanya akan memberi
 
 0:50:45.070,0:50:48.490
-a very quick answer to this one in the interest
-of time. So it's worth using two
+jawaban yang sangat cepat untuk ini demi
+waktu. Jadi layak menggunakan autentikasi dua
 
 0:50:48.490,0:50:52.480
-factor auth for anything security sensitive
-so I use it for my GitHub
+faktor untuk apa pun yang sensitif terhadap keamanan
+jadi saya menggunakannya untuk GitHub saya
 
 0:50:52.480,0:50:56.710
-account and for my email and stuff like
-that. And there's a bunch of different
+akun dan untuk email saya dan hal-hal seperti
+itu. Dan ada banyak jenis
 
 0:50:56.710,0:51:01.360
-types of two-factor auth. From SMS based
-to factor auth where you get special
+autentikasi dua faktor yang berbeda. Dari berbasis SMS
+ke autentikasi dua faktor di mana kalian mendapat
 
 0:51:01.360,0:51:04.630
-like a number texted to you when you try
-to log in you have to type that number
+seperti nomor yang di-text ke kalian ketika kalian mencoba
+untuk login kalian harus mengetik nomor itu
 
 0:51:04.630,0:51:08.710
-and to other tools like universal to
-factor this is like those Yubikeys
+dan ke alat lain seperti universal two
+factor ini seperti Yubikey
 
 0:51:08.710,0:51:11.350
-that you plug into your you have
-to tap it every time you login
+yang kalian colokkan ke kalian harus
+mengetuknya setiap kali kalian login
 
 0:51:11.350,0:51:18.130
-so not all, (yeah Jon is holding a
-Yubikey), not all two-factor auth is
+jadi tidak semua, (ya Jon memegang
+Yubikey), tidak semua autentikasi dua faktor
 
 0:51:18.130,0:51:22.240
-created equal and you really want to be
-using something like U2F rather than SMS
+dibuat sama dan kalian benar-benar ingin
+menggunakan sesuatu seperti U2F daripada berbasis
 
 0:51:22.240,0:51:25.300
-based to factor auth. There something
-based on one-time pass codes that you
+SMS. Ada sesuatu berdasarkan one-time pass code yang
 
 0:51:25.300,0:51:28.810
-have to type in we don't have time to get
-into the details of why some methods
+harus kalian ketik kita tidak punya waktu untuk masuk
+ke detail mengapa beberapa metode
 
 0:51:28.810,0:51:32.020
-are better than others but at a high
-level use U2F and the Internet has
+lebih baik daripada yang lain tapi di tingkat tinggi
+gunakan U2F dan Internet memiliki
 
 0:51:32.020,0:51:37.560
-plenty of explanations for why other
-methods are not a great idea
+banyak penjelasan mengapa metode lain
+bukan ide yang bagus
 
 0:51:37.711,0:51:41.851
-Last question, any comments on differences
-between web browsers?
+Pertanyaan terakhir, ada komentar tentang perbedaan
+antara web browser?
 
 0:51:48.171,0:51:50.171
-Yes
+Ya
 
 0:51:54.711,0:52:00.451
-Differences between web browsers, there
-are fewer and fewer differences between
+Perbedaan antara web browser, ada
+semakin sedikit perbedaan antara
 
 0:52:00.461,0:52:06.000
-web browsers these day. At this point
-almost all web browsers are chrome
+web browser sekarang ini. Pada titik ini
+hampir semua web browser adalah chrome
 
 0:52:06.000,0:52:09.580
-Either because you're using Chrome or
-because you're using a browser that's
+Baik karena kalian menggunakan Chrome atau
+karena kalian menggunakan browser yang
 
 0:52:09.580,0:52:15.550
-using the same browser engine as Chrome.
-It's a little bit sad, one might say, but
+menggunakan browser engine yang sama dengan Chrome.
+Agak menyedihkan, bisa dibilang, tapi
 
 0:52:15.550,0:52:20.511
-I think these days whether you choose
+saya pikir sekarang ini apakah kalian memilih
 
 0:52:20.511,0:52:24.451
-Chrome is a great browser for security reasons
+Chrome adalah browser yang hebat untuk alasan keamanan
 
 0:52:24.451,0:52:28.471
-if you want to have something
-that's more customizable or
+jika kalian ingin memiliki sesuatu
+yang lebih bisa dikustomisasi atau
 
 0:52:28.471,0:52:39.490
-you don't want to be tied to Google then
-use Firefox, don't use Safari it's a
+kalian tidak ingin terikat ke Google maka
+gunakan Firefox, jangan gunakan Safari itu
 
 0:52:39.490,0:52:45.701
-worse version of Chrome. The new Internet
-Explorer edge is pretty decent and also
+versi Chrome yang lebih buruk. Internet Explorer edge yang baru cukup bagus dan juga
 
 0:52:45.701,0:52:50.820
-uses the same browser engine as
-Chrome and that's probably fine
+menggunakan browser engine yang sama dengan
+Chrome dan itu mungkin baik-baik saja
 
 0:52:50.820,0:52:54.641
-although avoid it if you can because it
-has some like legacy modes you don't
+meskipun hindari jika kalian bisa karena itu
+memiliki beberapa mode legacy yang tidak ingin
 
 0:52:54.641,0:52:58.064
-want to deal with. I think that's
+kalian urus. Saya pikir itu
 
 0:52:58.064,0:53:03.091
-Oh, there's a cool new browser called flow
+Oh, ada browser baru yang keren bernama flow
 
 0:53:03.091,0:53:05.500
-that you can't use for anything useful
-yet but they're actually writing
+yang belum bisa kalian gunakan untuk apa pun yang berguna
+tapi mereka sebenarnya menulis
 
 0:53:05.500,0:53:08.693
-their own browser engine and that's really neat
+browser engine mereka sendiri dan itu sangat keren
 
 0:53:08.693,0:53:14.951
-Firefox also has this project called servo which is
-they're really implementing their browser engine
+Firefox juga memiliki proyek ini bernama servo yang
+mereka benar-benar mengimplementasikan browser engine mereka
 
 0:53:14.951,0:53:19.570
-in Rust in order to write it to be like
-super concurrent and what they've done
+dalam Rust untuk menulisnya agar seperti
+super concurrent dan apa yang mereka lakukan
 
 0:53:19.570,0:53:24.961
-is they've started to take modules
-from that version and port them
+adalah mereka mulai mengambil modul
+dari versi itu dan mem-port mereka
 
 0:53:24.961,0:53:29.041
-over to gecko or integrate them with gecko
-which is the main browser engine
+ke gecko atau mengintegrasikan mereka dengan gecko
+yang merupakan browser engine utama
 
 0:53:29.041,0:53:32.221
-for Firefox just to get those
-speed ups there as well
+untuk Firefox hanya untuk mendapatkan
+percepatan kecepatan di sana juga
 
 0:53:32.221,0:53:37.031
-and that's a neat neat thing
-you can be watching out for
+dan itu adalah hal yang keren
+yang bisa kalian perhatikan
 
 0:53:39.231,0:53:41.851
-That is all the questions, hey we did it. Nice
+Itu semua pertanyaannya, hei kita berhasil. Bagus
 
 0:53:41.851,0:53:50.751
-I guess thanks for taking the missing semester
-class and let's do it again next year
+Saya rasa terima kasih telah mengambil kelas missing semester
+dan mari lakukan lagi tahun depan

--- a/static/files/subtitles/2020/shell-tools.sbv
+++ b/static/files/subtitles/2020/shell-tools.sbv
@@ -1,2625 +1,2625 @@
 0:00:00.400,0:00:02.860
-Okay, welcome back.
+Oke, selamat datang kembali.
 
 0:00:02.860,0:00:05.920
-Today we're gonna cover a couple separate
+Hari ini kita akan membahas dua
 
 0:00:05.920,0:00:07.620
-two main topics related to the shell.
+topik utama yang berkaitan dengan shell.
 
 0:00:07.620,0:00:11.240
-First, we're gonna do some kind of shell
-scripting, mainly related to bash,
+Pertama, kita akan melakukan beberapa shell
+scripting, terutama terkait bash,
 
 0:00:11.240,0:00:14.160
-which is the shell that most of you will start
+yaitu shell yang akan digunakan sebagian besar dari kalian
 
 0:00:14.160,0:00:18.520
-in Mac, or like in most Linux systems,
-that's the default shell.
+di Mac, atau di sebagian besar sistem Linux,
+sebagai shell default.
 
 0:00:18.520,0:00:22.720
-And it's also kind of backward compatible through
-other shells like zsh, it's pretty nice.
+Dan juga cukup kompatibel ke belakang melalui
+shell lain seperti zsh, cukup bagus.
 
 0:00:22.740,0:00:25.940
-And then we're gonna cover some other shell
-tools that are really convenient,
+Kemudian kita akan membahas beberapa tool shell
+lainnya yang sangat berguna,
 
 0:00:26.060,0:00:29.320
-so you avoid doing really repetitive tasks,
+sehingga kalian bisa menghindari tugas yang sangat repetitif,
 
 0:00:29.320,0:00:31.580
-like looking for some piece of code
+seperti mencari potongan kode
 
 0:00:31.580,0:00:33.420
-or for some elusive file.
+atau file yang sulit ditemukan.
 
 0:00:33.420,0:00:36.160
-And there are already really
-nice built-in commands
+Dan sudah ada
+perintah bawaan yang sangat bagus
 
 0:00:36.160,0:00:40.960
-that will really help you to do those things.
+yang akan sangat membantu kalian melakukan hal-hal tersebut.
 
 0:00:40.960,0:00:43.260
-So yesterday we already kind of introduced
+Jadi kemarin kita sudah sedikit memperkenalkan
 
 0:00:43.260,0:00:46.160
-you to the shell and some of it's quirks,
+kalian pada shell dan beberapa keunikannya,
 
 0:00:46.160,0:00:48.720
-and like how you start executing commands,
+dan cara mengeksekusi perintah,
 
 0:00:48.720,0:00:50.600
-redirecting them.
+serta melakukan redirect.
 
 0:00:50.600,0:00:52.400
-Today, we're going to kind of cover more about
+Hari ini, kita akan membahas lebih lanjut tentang
 
 0:00:52.460,0:00:56.120
-the syntax of the variables, the control flow,
+sintaks variabel, control flow,
 
 0:00:56.120,0:00:57.720
-functions of the shell.
+dan fungsi-fungsi dalam shell.
 
 0:00:57.720,0:01:02.700
-So for example, once you drop
-into a shell, say you want to
+Jadi misalnya, setelah masuk
+ke shell, kalian ingin
 
 0:01:02.760,0:01:06.360
-define a variable, which is
-one of the first things you
+mendefinisikan variabel, yang merupakan
+salah satu hal pertama yang kalian
 
 0:01:06.360,0:01:09.340
-learn to do in a programming language.
+pelajari dalam bahasa pemrograman.
 
 0:01:09.340,0:01:12.740
-Here you could do something like foo equals bar.
+Di sini kalian bisa melakukan sesuatu seperti foo sama dengan bar.
 
 0:01:12.860,0:01:18.400
-And now we can access the value
-of foo by doing "$foo".
+Dan sekarang kita bisa mengakses nilai
+foo dengan melakukan "$foo".
 
 0:01:18.460,0:01:21.400
-And that's bar, perfect.
+Dan hasilnya bar, sempurna.
 
 0:01:21.400,0:01:24.480
-One quirk that you need to be aware of is that
+Satu hal yang perlu kalian perhatikan adalah
 
 0:01:24.480,0:01:27.900
-spaces are really critical when
-you're dealing with bash.
+spasi sangat penting saat
+berurusan dengan bash.
 
 0:01:27.900,0:01:33.380
-Mainly because spaces are reserved, and
-that will be for separating arguments.
+Terutama karena spasi digunakan untuk
+memisahkan argumen.
 
 0:01:33.380,0:01:36.700
-So, for example, something like foo equals bar
+Jadi, misalnya, sesuatu seperti foo sama dengan bar
 
 0:01:36.700,0:01:42.000
-won't work, and the shell is gonna
-tell you why it's not working.
+tidak akan berfungsi, dan shell akan
+memberitahu kalian alasannya.
 
 0:01:42.000,0:01:46.280
-It's because the foo command is not
-working, like foo is non-existent.
+Karena perintah foo tidak
+ditemukan, foo tidak ada.
 
 0:01:46.280,0:01:47.780
-And here what is actually happening,
-we're not assigning foo to bar,
+Dan yang sebenarnya terjadi di sini,
+kita tidak menetapkan foo ke bar,
 
 0:01:47.780,0:01:52.260
-what is happening is we're
-calling the foo program
+yang terjadi adalah kita
+memanggil program foo
 
 0:01:52.260,0:01:57.520
-with the first argument "=" and
-the second argument "bar".
+dengan argumen pertama "=" dan
+argumen kedua "bar".
 
 0:01:57.520,0:02:03.880
-And in general, whenever you are having
-some issues, like some files with spaces
+Dan secara umum, kapan pun kalian mengalami
+masalah, seperti file dengan spasi
 
 0:02:03.880,0:02:06.160
-you will need to be careful about that.
+kalian harus berhati-hati.
 
 0:02:06.160,0:02:10.620
-You need to be careful about quoting strings.
+Kalian harus berhati-hati dalam memberikan quote pada string.
 
 0:02:10.640,0:02:16.480
-So, going into that, how you do strings in bash.
-There are two ways that you can define a string:
+Jadi, bagaimana cara membuat string di bash.
+Ada dua cara mendefinisikan string:
 
 0:02:16.540,0:02:24.720
-You can define strings using double quotes
-and you can define strings using single,
+Kalian bisa mendefinisikan string menggunakan double quote
+dan kalian bisa menggunakan single quote,
 
 0:02:24.720,0:02:26.540
-sorry,
+maaf,
 
 0:02:26.540,0:02:28.880
-using single quotes.
+menggunakan single quote.
 
 0:02:29.140,0:02:32.760
-However, for literal strings they are equivalent,
+Namun, untuk string literal keduanya setara,
 
 0:02:32.760,0:02:35.460
-but for the rest they are not equivalent.
+tetapi untuk lainnya tidak setara.
 
 0:02:35.460,0:02:42.980
-So, for example, if we do value is $foo,
+Jadi, misalnya, jika kita melakukan value is $foo,
 
 0:02:43.440,0:02:48.480
-the $foo has been expanded like
-a string, substituted to the
+$foo telah di-expand seperti
+string, disubstitusi dengan
 
 0:02:48.480,0:02:50.820
-value of the foo variable in the shell.
+nilai variabel foo di shell.
 
 0:02:50.960,0:02:58.940
-Whereas if we do this with a simple quote,
-we are just getting the $foo as it is
+Sedangkan jika kita menggunakan single quote,
+kita hanya mendapatkan $foo apa adanya
 
 0:02:58.940,0:03:02.280
-and single quotes won't be replacing. Again,
+dan single quote tidak akan melakukan substitusi. Lagi,
 
 0:03:02.280,0:03:07.290
-it's really easy to write a script, assume that
-this is kind of like Python, that you might be
+sangat mudah menulis script dan mengira
+ini seperti Python, yang mungkin lebih
 
 0:03:07.290,0:03:10.860
-more familiar with, and not realize all that.
+kalian kuasai, dan tidak menyadari semua itu.
 
 0:03:10.860,0:03:14.180
-And this is the way you will assign variables.
+Dan ini adalah cara kalian menetapkan variabel.
 
 0:03:14.180,0:03:17.849
-Then bash also has control flow
-techniques that we'll see later,
+Kemudian bash juga memiliki teknik control flow
+yang akan kita lihat nanti,
 
 0:03:17.849,0:03:24.440
-like for loops, while loops, and one main
-thing is you can define functions.
+seperti for loop, while loop, dan satu hal utama
+adalah kalian bisa mendefinisikan fungsi.
 
 0:03:24.440,0:03:27.820
-We can access a function I have defined here.
+Kita bisa mengakses fungsi yang telah saya definisikan di sini.
 
 0:03:28.220,0:03:34.220
-Here we have the MCD function, that
-has been defined, and the thing is
+Di sini kita memiliki fungsi MCD yang
+telah didefinisikan, dan
 
 0:03:34.220,0:03:38.400
-so far, we have just kind of seen how
-to execute several commands by piping
+sejauh ini, kita baru melihat cara
+mengeksekusi beberapa perintah dengan piping
 
 0:03:38.400,0:03:40.720
-into them, kind of saw that briefly yesterday.
+ke dalamnya, yang sedikit kita bahas kemarin.
 
 0:03:40.940,0:03:44.980
-But a lot of times you want to do first
-one thing and then another thing.
+Tapi seringkali kalian ingin melakukan satu hal
+terlebih dahulu lalu hal lainnya.
 
 0:03:44.980,0:03:47.580
-And that's kind of like the
+Dan itu adalah
 
 0:03:47.740,0:03:50.880
-sequential execution that we get here.
+eksekusi berurutan yang kita dapatkan di sini.
 
 0:03:50.880,0:03:54.260
-Here, for example, we're
-calling the MCD function.
+Di sini, misalnya, kita
+memanggil fungsi MCD.
 
 0:03:56.860,0:03:57.800
-We, first,
+Kita, pertama,
 
 0:03:57.800,0:04:02.960
-are calling the makedir command,
-which is creating this directory.
+memanggil perintah makedir,
+yang membuat direktori ini.
 
 0:04:02.960,0:04:05.600
-Here, $1 is like a special variable.
+Di sini, $1 adalah variabel khusus.
 
 0:04:05.600,0:04:07.440
-This is the way that bash works,
+Beginilah cara bash bekerja,
 
 0:04:07.440,0:04:12.160
-whereas in other scripting languages
-there will be like argv,
+sedangkan di bahasa scripting lain
+akan ada argv,
 
 0:04:12.160,0:04:16.620
-the first item of the array argv
-will contain the argument.
+item pertama dari array argv
+akan berisi argumen.
 
 0:04:16.620,0:04:19.160
-In bash it's $1. And in general, a lot
+Di bash, itu adalah $1. Dan secara umum, banyak
 
 0:04:19.160,0:04:21.640
-of things in bash will be dollar something
+hal di bash akan berupa dollar sesuatu
 
 0:04:21.640,0:04:26.680
-and will be reserved, we will
-be seeing more examples later.
+dan akan menjadi reserved, kita akan
+melihat lebih banyak contoh nanti.
 
 0:04:26.680,0:04:30.290
-And once we have created the folder,
-we CD into that folder,
+Dan setelah kita membuat folder,
+kita CD ke folder tersebut,
 
 0:04:30.290,0:04:34.687
-which is kind of a fairly common
-pattern that you will see.
+yang merupakan pola yang cukup umum
+yang akan kalian lihat.
 
 0:04:34.687,0:04:39.060
-We will actually type this directly
-into our shell, and it will work and
+Kita sebenarnya bisa mengetik ini langsung
+ke shell kita, dan akan berfungsi
 
 0:04:39.120,0:04:45.260
-it will define this function. But sometimes
-it's nicer to write things in a file.
+serta mendefinisikan fungsi ini. Tapi terkadang
+lebih baik menulisnya dalam file.
 
 0:04:45.260,0:04:50.040
-What we can do is we can source
-this. And that will
+Yang bisa kita lakukan adalah source
+file ini. Dan itu akan
 
 0:04:50.080,0:04:53.960
-execute this script in our shell and load it.
+mengeksekusi script ini di shell kita dan memuatnya.
 
 0:04:53.960,0:04:59.340
-So now it looks like nothing happened,
-but now the MCD function has
+Jadi sepertinya tidak ada yang terjadi,
+tapi sekarang fungsi MCD telah
 
 0:04:59.340,0:05:03.460
-been defined in our shell. So
-we can now for example do
+didefinisikan di shell kita. Jadi
+kita sekarang bisa melakukan
 
 0:05:03.463,0:05:09.150
-MCD test, and now we move from
-the tools directory to the test
+MCD test, dan sekarang kita pindah dari
+direktori tools ke direktori
 
 0:05:09.160,0:05:14.200
-directory. We both created the
-folder and we moved into it.
+test. Kita membuat folder
+dan pindah ke dalamnya.
 
 0:05:15.760,0:05:18.820
-What else. So a result is...
+Apa lagi. Jadi hasilnya...
 
 0:05:18.820,0:05:22.160
-We can access the first argument with $1.
+Kita bisa mengakses argumen pertama dengan $1.
 
 0:05:22.160,0:05:26.100
-There's a lot more reserved commands,
+Ada banyak reserved command lainnya,
 
 0:05:26.100,0:05:30.020
-for example $0 will be the name of the script,
+misalnya $0 akan menjadi nama script,
 
 0:05:30.020,0:05:35.260
-$2 through $9 will be the second
-through the ninth arguments
+$2 hingga $9 akan menjadi argumen kedua
+hingga kesembilan
 
 0:05:35.260,0:05:38.070
-that the bash script takes.
-Some of these reserved
+yang diterima bash script.
+Beberapa reserved
 
 0:05:38.070,0:05:43.080
-keywords can be directly used
-in the shell, so for example
+keyword ini bisa langsung digunakan
+di shell, jadi misalnya
 
 0:05:43.420,0:05:50.300
-$? will get you the error code
-from the previous command,
+$? akan memberikan kalian error code
+dari perintah sebelumnya,
 
 0:05:50.300,0:05:53.580
-which I'll also explain briefly.
+yang juga akan saya jelaskan secara singkat.
 
 0:05:53.580,0:05:58.320
-But for example, $_ will get
-you the last argument of the
+Tapi misalnya, $_ akan memberikan
+argumen terakhir dari
 
 0:05:58.320,0:06:03.460
-previous command. So another way
-we could have done this is
+perintah sebelumnya. Jadi cara lain
+yang bisa kita lakukan adalah
 
 0:06:03.460,0:06:07.380
-we could have said like "mkdir test"
+kita bisa bilang "mkdir test"
 
 0:06:07.380,0:06:12.020
-and instead of rewriting test, we
-can access that last argument
+dan alih-alih menulis ulang test, kita
+bisa mengakses argumen terakhir
 
 0:06:12.020,0:06:18.400
-as part of the (previous command), using $_
+tersebut menggunakan $_
 
 0:06:18.400,0:06:23.160
-like, that will be replaced with
-test and now we go into test.
+yang akan digantikan dengan
+test dan sekarang kita masuk ke test.
 
 0:06:25.040,0:06:27.480
-There are a lot of them, you
-should familiarize with them.
+Ada banyak dari mereka, kalian
+harus familiar dengan mereka.
 
 0:06:27.480,0:06:32.900
-Another one I often use is called "bang
-bang" ("!!"), you will run into this
+Satu lagi yang sering saya gunakan disebut "bang
+bang" ("!!"), kalian akan menemuinya
 
 0:06:32.910,0:06:37.300
-whenever you, for example, are trying
-to create something and you don't have
+kapan pun, misalnya, kalian mencoba
+membuat sesuatu tapi tidak memiliki
 
 0:06:37.320,0:06:41.000
-enough permissions. Then, you can do "sudo !!"
+izin yang cukup. Kemudian, kalian bisa melakukan "sudo !!"
 
 0:06:41.010,0:06:43.400
-and then that will replace the command in
+dan itu akan menggantikan perintah
 
 0:06:43.470,0:06:46.400
-there and now you can just try doing
+di sana dan sekarang kalian bisa mencoba
 
 0:06:46.440,0:06:48.380
-that. And now it will prompt you for a password,
+melakukannya. Dan sekarang akan meminta password,
 
 0:06:48.380,0:06:50.080
-because you have sudo permissions.
+karena kalian memiliki izin sudo.
 
 0:06:53.800,0:06:57.180
-Before, I mentioned the, kind
-of the error command.
+Sebelumnya, saya menyebutkan
+error command.
 
 0:06:57.180,0:06:59.400
-Yesterday we saw that, in general, there are
+Kemarin kita melihat bahwa, secara umum, ada
 
 0:06:59.400,0:07:02.400
-different ways a process can communicate
+berbagai cara sebuah proses bisa berkomunikasi
 
 0:07:02.400,0:07:05.091
-with other processes or commands.
+dengan proses atau perintah lain.
 
 0:07:05.100,0:07:08.420
-We mentioned the standard
-input, which also was like
+Kita menyebutkan standard
+input, yang juga seperti
 
 0:07:09.160,0:07:11.380
-getting stuff through the standard input,
+memasukkan sesuatu melalui standard input,
 
 0:07:11.640,0:07:13.840
-putting stuff into the standard output.
+mengeluarkan sesuatu melalui standard output.
 
 0:07:13.840,0:07:16.830
-There are a couple more interesting
-things, there's also like a
+Ada beberapa hal menarik lainnya,
+ada juga seperti
 
 0:07:16.830,0:07:19.837
-standard error, a stream where you write errors
+standard error, stream tempat kalian menulis error
 
 0:07:19.837,0:07:23.900
-that happen with your program and you don't
-want to pollute the standard output.
+yang terjadi pada program kalian dan kalian tidak
+ingin mencemari standard output.
 
 0:07:23.900,0:07:27.420
-There's also the error code,
-which is like a general
+Ada juga error code,
+yang seperti hal umum
 
 0:07:27.420,0:07:29.520
-thing in a lot of programming languages,
+di banyak bahasa pemrograman,
 
 0:07:29.520,0:07:34.460
-some way of reporting how the
-entire run of something went.
+suatu cara melaporkan bagaimana
+keseluruhan jalannya sesuatu.
 
 0:07:34.460,0:07:36.060
-So if we do
+Jadi jika kita melakukan
 
 0:07:36.060,0:07:41.020
-something like echo hello and we
+sesuatu seperti echo hello dan kita
 
 0:07:41.580,0:07:43.920
-query for the value, it's zero. And it's zero
+tanya nilainya, hasilnya nol. Dan nol
 
 0:07:43.920,0:07:45.840
-because everything went okay and there
+karena semuanya berjalan baik dan tidak
 
 0:07:45.840,0:07:49.170
-weren't any issues. And a zero exit code is
+ada masalah. Dan exit code nol adalah
 
 0:07:49.170,0:07:50.940
-the same as you will get in a language
+sama seperti yang akan kalian dapatkan di bahasa
 
 0:07:50.940,0:07:54.980
-like C, like 0 means everything
-went fine, there were no errors.
+seperti C, yaitu 0 berarti semuanya
+baik-baik saja, tidak ada error.
 
 0:07:54.980,0:07:57.600
-However, sometimes things won't work.
+Namun, terkadang ada yang tidak berhasil.
 
 0:07:57.600,0:08:04.600
-Sometimes, like if we try to grep
-for foobar in our MCD script,
+Terkadang, misalnya jika kita mencoba grep
+untuk foobar di script MCD kita,
 
 0:08:04.600,0:08:08.130
-and now we check for that
-value, it's 1. And that's
+dan sekarang kita cek nilainya,
+hasilnya 1. Dan itu
 
 0:08:08.130,0:08:10.770
-because we tried to search for the foobar
+karena kita mencoba mencari string foobar
 
 0:08:10.770,0:08:13.620
-string in the MCD script and it wasn't there.
+di script MCD dan tidak menemukannya.
 
 0:08:13.620,0:08:17.190
-So grep doesn't print anything, but
+Jadi grep tidak mencetak apa-apa, tapi
 
 0:08:17.190,0:08:19.950
-let us know that things didn't work by
+memberi tahu kita bahwa ada yang tidak berhasil dengan
 
 0:08:19.950,0:08:22.260
-giving us a 1 error code.
+memberikan error code 1.
 
 0:08:22.260,0:08:24.420
-There are some interesting commands like
+Ada beberapa perintah menarik seperti
 
 0:08:24.420,0:08:29.160
-"true", for example, will always have a zero
+"true", misalnya, akan selalu memiliki error code
 
 0:08:29.160,0:08:35.060
-error code, and false will always
-have a one error code.
+nol, dan false akan selalu
+memiliki error code satu.
 
 0:08:35.060,0:08:37.919
-Then there are like
+Kemudian ada
 
 0:08:37.919,0:08:40.080
-these logical operators that you can use
+operator logika yang bisa kalian gunakan
 
 0:08:40.080,0:08:43.808
-to do some sort of conditionals.
-For example, one way...
+untuk melakukan beberapa kondisional.
+Misalnya, satu cara...
 
 0:08:43.808,0:08:47.160
-you also have IF's and ELSE's, that
-we will see later, but you can do
+kalian juga punya IF dan ELSE, yang
+akan kita lihat nanti, tapi kalian bisa melakukan
 
 0:08:47.160,0:08:51.920
-something like "false", and echo "Oops fail".
+sesuatu seperti "false", dan echo "Oops fail".
 
 0:08:51.920,0:08:56.300
-So here we have two commands connected
-by this OR operator.
+Jadi di sini kita memiliki dua perintah yang dihubungkan
+oleh operator OR ini.
 
 0:08:56.300,0:09:00.250
-What bash is gonna do here, it's
-gonna execute the first one
+Yang akan dilakukan bash di sini adalah
+mengeksekusi yang pertama
 
 0:09:00.250,0:09:04.450
-and if the first one didn't work, then it's
+dan jika yang pertama tidak berhasil, maka
 
 0:09:04.450,0:09:07.380
-gonna execute the second one. So here we get it,
+akan mengeksekusi yang kedua. Jadi di sini kita mendapatkannya,
 
 0:09:07.380,0:09:12.000
-because it's gonna try to do a logical
-OR. If the first one didn't have
+karena akan mencoba melakukan OR logika.
+Jika yang pertama tidak memiliki
 
 0:09:12.000,0:09:15.960
-a zero error code, it's gonna try to
-do the second one. Similarly, if we
+error code nol, akan mencoba
+yang kedua. Begitu juga, jika kita
 
 0:09:15.960,0:09:19.580
-instead of use "false", we
-use something like "true",
+alih-alih menggunakan "false", kita
+menggunakan sesuatu seperti "true",
 
 0:09:19.580,0:09:22.180
-since true will have a zero error code, then the
+karena true akan memiliki error code nol, maka
 
 0:09:22.180,0:09:24.700
-second one will be short-circuited and
+yang kedua akan di-short-circuit dan
 
 0:09:24.700,0:09:27.500
-it won't be printed.
+tidak akan dicetak.
 
 0:09:32.560,0:09:36.970
-Similarly, we have an AND
-operator which will only
+Demikian juga, kita memiliki operator
+AND yang hanya akan
 
 0:09:36.970,0:09:39.430
-execute the second part if the first one
+mengeksekusi bagian kedua jika yang pertama
 
 0:09:39.430,0:09:41.440
-ran without errors.
+berjalan tanpa error.
 
 0:09:41.440,0:09:44.820
-And the same thing will happen.
+Dan hal yang sama akan terjadi.
 
 0:09:44.820,0:09:50.340
-If the first one fails, then the second
-part of this thing won't be executed.
+Jika yang pertama gagal, maka bagian kedua
+tidak akan dieksekusi.
 
 0:09:50.340,0:09:57.280
-Kind of not exactly related to that, but
-another thing that you will see is
+Yang agak tidak terkait dengan itu, tapi
+hal lain yang akan kalian lihat adalah
 
 0:10:00.020,0:10:04.120
-that no matter what you execute,
-then you can concatenate
+bahwa apa pun yang kalian eksekusi,
+kalian bisa menggabungkan
 
 0:10:04.120,0:10:07.120
-commands using a semicolon in the same line,
+perintah menggunakan titik koma di baris yang sama,
 
 0:10:07.120,0:10:10.300
-and that will always print.
+dan itu akan selalu dicetak.
 
 0:10:10.300,0:10:13.630
-Beyond that, what we haven't
-seen, for example, is how
+Selain itu, yang belum kita
+lihat, misalnya, adalah bagaimana
 
 0:10:13.630,0:10:19.460
-you go about getting the output
-of a command into a variable.
+kalian menyimpan output
+perintah ke dalam variabel.
 
 0:10:19.630,0:10:24.120
-And the way we can do that is
-doing something like this.
+Dan cara melakukannya adalah
+dengan melakukan sesuatu seperti ini.
 
 0:10:24.120,0:10:29.480
-What we're doing here is we're getting
-the output of the PWD command,
+Yang kita lakukan di sini adalah mendapatkan
+output dari perintah PWD,
 
 0:10:29.480,0:10:32.720
-which is just printing the
+yang mencetak
 present working directory
 
 0:10:32.720,0:10:33.740
-where we are right now.
+tempat kita berada sekarang.
 
 0:10:33.740,0:10:37.220
-And then we're storing that
-into the foo variable.
+Kemudian kita menyimpannya
+ke variabel foo.
 
 0:10:37.220,0:10:42.279
-So we do that and then we ask
-for foo, we view our string.
+Jadi kita lakukan itu dan kemudian kita minta
+foo, kita melihat string kita.
 
 0:10:42.280,0:10:48.460
-More generally, we can do this thing
-called command substitution
+Secara lebih umum, kita bisa melakukan hal
+yang disebut command substitution
 
 0:10:50.110,0:10:51.500
-by putting it into any string.
+dengan memasukkannya ke string mana pun.
 
 0:10:51.500,0:10:55.162
-And since we're using double quotes
-instead of single quotes
+Dan karena kita menggunakan double quote
+alih-alih single quote
 
 0:10:55.162,0:10:57.440
-that thing will be expanded and
+hal tersebut akan di-expand dan
 
 0:10:57.440,0:11:02.740
-it will tell us that we are
-in this working folder.
+memberi tahu kita bahwa kita
+berada di folder kerja ini.
 
 0:11:02.740,0:11:09.240
-Another interesting thing is, right now,
-what this is expanding to is a string
+Hal menarik lainnya adalah, saat ini,
+yang di-expand ini adalah string
 
 0:11:09.400,0:11:10.300
-instead of
+alih-alih
 
 0:11:11.920,0:11:13.320
-It's just expanding as a string.
+Hanya mengembang sebagai string.
 
 0:11:13.460,0:11:17.640
-Another nifty and lesser known tool
-is called process substitution,
+Tool lain yang berguna dan kurang dikenal
+disebut process substitution,
 
 0:11:17.640,0:11:20.540
-which is kind of similar. What it will do...
+yang agak mirip. Yang akan dilakukan...
 
 0:11:24.360,0:11:30.041
-it will, here for example, the "<(",
-some command and another parenthesis,
+di sini misalnya, "<(",
+suatu perintah dan tanda kurung lainnya,
 
 0:11:30.041,0:11:34.840
-what that will do is: that will execute,
-that will get the output to
+yang akan dilakukan adalah: itu akan mengeksekusi,
+akan mendapatkan output ke
 
 0:11:34.840,0:11:39.120
-kind of like a temporary file and it will
-give the file handle to the command.
+semacam file sementara dan akan
+memberikan file handle ke perintah.
 
 0:11:39.120,0:11:42.020
-So here what we're doing is we're getting...
+Jadi di sini yang kita lakukan adalah mendapatkan...
 
 0:11:42.020,0:11:45.760
-we're LS'ing the directory, putting
-it into a temporary file,
+kita melakukan LS pada direktori, memasukkannya
+ke file sementara,
 
 0:11:45.760,0:11:48.040
-doing the same thing for the
-parent folder and then
+melakukan hal yang sama untuk
+folder induk dan kemudian
 
 0:11:48.040,0:11:51.310
-we're concatenating both files. And this
+menggabungkan kedua file. Ini
 
 0:11:51.310,0:11:55.520
-will, may be really handy, because
-some commands instead of expecting
+bisa sangat berguna, karena
+beberapa perintah alih-alih mengharapkan
 
 0:11:55.520,0:11:59.500
-the input coming from the stdin,
-they are expecting things to
+input dari stdin,
+mereka mengharapkan sesuatu dari
 
 0:11:59.500,0:12:03.560
-come from some file that is giving
-some of the arguments.
+file yang menjadi salah satu
+argumen.
 
 0:12:04.700,0:12:07.620
-So we get both things concatenated.
+Jadi kita mendapatkan kedua hal tersebut digabungkan.
 
 0:12:12.880,0:12:17.040
-I think so far there's been a lot of
-information, let's see a simple,
+Saya pikir sejauh ini sudah banyak
+informasi, mari kita lihat contoh sederhana,
 
 0:12:17.040,0:12:22.920
-an example script where we
-see a few of these things.
+contoh script yang
+memperlihatkan beberapa hal ini.
 
 0:12:23.200,0:12:27.220
-So for example here we have a string and we
+Jadi misalnya di sini kita punya string dan
 
 0:12:27.220,0:12:30.327
-have this $date. So $date is a program.
+ada $date. Jadi $date adalah program.
 
 0:12:30.327,0:12:34.540
-Again there's a lot of programs
-in UNIX you will kind of slowly
+Lagi, ada banyak program
+di UNIX yang perlahan-lahan
 
 0:12:34.540,0:12:36.120
-familiarize with a lot of them.
+akan kalian kenal.
 
 0:12:36.120,0:12:42.820
-Date just prints what the current date is
-and you can specify different formats.
+Date hanya mencetak tanggal saat ini
+dan kalian bisa menentukan format yang berbeda.
 
 0:12:43.800,0:12:48.700
-Then, we have these $0 here. $0 is the name
+Kemudian, kita punya $0 di sini. $0 adalah nama
 
 0:12:48.700,0:12:50.540
-of the script that we're running.
+script yang sedang kita jalankan.
 
 0:12:50.550,0:12:56.590
-Then we have $#, that's the number
-of arguments that we are giving
+Kemudian kita punya $#, itu adalah jumlah
+argumen yang kita berikan
 
 0:12:56.590,0:13:01.920
-to the command, and then $$ is the process
-ID of this command that is running.
+ke perintah, dan $$ adalah process
+ID dari perintah yang sedang berjalan.
 
 0:13:01.920,0:13:06.160
-Again, there's a lot of these dollar
-things, they're not intuitive
+Lagi, ada banyak dollar
+berbagai macam, tidak intuitif
 
 0:13:06.160,0:13:07.690
-because they don't have like a mnemonic
+karena tidak ada cara mnemonik
 
 0:13:07.690,0:13:10.450
-way of remembering, maybe, $#. But
+untuk mengingatnya, mungkin, $#. Tapi
 
 0:13:10.450,0:13:12.880
-it can be... you will just be
+kalian akan semakin
 
 0:13:12.880,0:13:14.660
-seeing them and getting familiar with them.
+familiar dengan mereka.
 
 0:13:14.660,0:13:19.200
-Here we have this $@, and that will
-expand to all the arguments.
+Di sini kita punya $@, dan itu akan
+mengembang menjadi semua argumen.
 
 0:13:19.200,0:13:21.480
-So, instead of having to assume that,
+Jadi, alih-alih harus mengasumsikan,
 
 0:13:21.490,0:13:25.840
-maybe say, we have three arguments
-and writing $1, $2, $3,
+misalnya, kita punya tiga argumen
+dan menulis $1, $2, $3,
 
 0:13:25.840,0:13:29.760
-if we don't know how many arguments we
-can put all those arguments there.
+jika kita tidak tahu berapa banyak argumen, kita
+bisa menaruh semua argumen di sana.
 
 0:13:29.760,0:13:33.670
-And that has been given to a
-for loop. And the for loop
+Dan itu diberikan ke
+for loop. Dan for loop
 
 0:13:33.670,0:13:39.020
-will, in time, get the file variable
+akan, pada setiap iterasi, mendapatkan variabel file
 
 0:13:39.020,0:13:43.880
-and it will be giving each one of the arguments.
+dan akan memberikan masing-masing argumen.
 
 0:13:43.880,0:13:47.529
-So what we're doing is, for every
-one of the arguments we're giving.
+Jadi yang kita lakukan adalah, untuk setiap
+argumen yang kita berikan.
 
 0:13:47.529,0:13:51.699
-Then, in the next line we're running the
+Kemudian, di baris berikutnya kita menjalankan
 
 0:13:51.699,0:13:56.920
-grep command which is just search for
-a substring in some file and we're
+perintah grep yang hanya mencari
+substring dalam suatu file dan kita
 
 0:13:56.920,0:14:01.380
-searching for the string foobar in the file.
+mencari string foobar dalam file.
 
 0:14:01.380,0:14:06.490
-Here, we have put the variable
-that the file took, to expand.
+Di sini, kita telah membuat variabel
+yang diambil file untuk mengembang.
 
 0:14:06.490,0:14:11.559
-And yesterday we saw that if we care
-about the output of a program, we can
+Dan kemarin kita melihat bahwa jika kita peduli
+pada output program, kita bisa
 
 0:14:11.560,0:14:15.680
-redirect it to somewhere, to save it
-or to connect it to some other file.
+me-redirect-nya ke suatu tempat, untuk menyimpannya
+atau menghubungkannya ke file lain.
 
 0:14:15.680,0:14:18.939
-But sometimes you want the opposite.
+Tapi terkadang kalian menginginkan kebalikannya.
 
 0:14:18.939,0:14:21.260
-Sometimes, here for example, we care...
+Terkadang, di sini misalnya, kita peduli...
 
 0:14:21.260,0:14:25.119
-we're gonna care about the error code. About
-this script, we're gonna care whether the
+kita akan peduli pada error code. Tentang
+script ini, kita akan peduli apakah
 
 0:14:25.120,0:14:28.440
-grep ran successfully or it didn't.
+grep berhasil dijalankan atau tidak.
 
 0:14:28.440,0:14:33.220
-So we can actually discard
-entirely what the output...
+Jadi kita sebenarnya bisa mengabaikan
+seluruh output...
 
 0:14:33.220,0:14:37.480
-like both the standard output and the
-standard error of the grep command.
+baik standard output maupun
+standard error dari perintah grep.
 
 0:14:37.480,0:14:39.970
-And what we're doing is we're
+Dan yang kita lakukan adalah
 
 0:14:39.970,0:14:43.029
-redirecting the output to /dev/null which
+me-redirect output ke /dev/null yang
 
 0:14:43.029,0:14:46.540
-is kind of like a special device in UNIX
+merupakan semacam device khusus di sistem
 
 0:14:46.540,0:14:49.119
-systems where you can like write and
+UNIX tempat kalian bisa menulis dan
 
 0:14:49.119,0:14:51.129
-it will be discarded. Like you can
+akan dibuang. Kalian bisa
 
 0:14:51.129,0:14:52.869
-write no matter how much you want,
+menulis sebanyak apa pun
 
 0:14:52.869,0:14:57.730
-there, and it will be discarded.
-And here's the ">" symbol
+di sana, dan akan dibuang.
+Dan di sini simbol ">"
 
 0:14:57.730,0:15:02.199
-that we saw yesterday for redirecting
-output. Here you have a "2>"
+yang kita lihat kemarin untuk me-redirect
+output. Di sini kalian punya "2>"
 
 0:15:02.199,0:15:04.689
-and, as some of you might have
+dan, seperti yang mungkin beberapa dari kalian
 
 0:15:04.689,0:15:06.519
-guessed by now, this is for redirecting the
+sudah duga, ini untuk me-redirect
 
 0:15:06.519,0:15:08.589
-standard error, because those those two
+standard error, karena kedua
 
 0:15:08.589,0:15:11.709
-streams are separate, and you kind of have to
+stream tersebut terpisah, dan kalian harus
 
 0:15:11.709,0:15:14.639
-tell bash what to do with each one of them.
+memberi tahu bash apa yang harus dilakukan dengan masing-masing.
 
 0:15:14.639,0:15:17.529
-So here, we run, we check if the file has
+Jadi di sini, kita menjalankan, kita cek apakah file memiliki
 
 0:15:17.529,0:15:20.649
-foobar, and if the file has foobar then it's
+foobar, dan jika file memiliki foobar maka
 
 0:15:20.649,0:15:22.959
-going to have a zero code. If it
+akan memiliki code nol. Jika tidak
 
 0:15:22.959,0:15:24.369
-doesn't have foobar, it's gonna have a
+memiliki foobar, akan memiliki
 
 0:15:24.369,0:15:26.980
-nonzero error code. So that's exactly what we
+error code bukan nol. Jadi itulah yang kita
 
 0:15:26.980,0:15:31.120
-check. In this if part of the command we
+cek. Di bagian if dari perintah ini kita
 
 0:15:31.120,0:15:34.840
-say "get me the error code". Again, this $?
+bilang "beri saya error code". Lagi, $? ini
 
 0:15:34.840,0:15:37.240
-And then we have a comparison operator
+Dan kemudian kita punya operator perbandingan
 
 0:15:37.240,0:15:41.590
-which is "-ne", for "non equal". And some
+yaitu "-ne", untuk "tidak sama". Dan beberapa
 
 0:15:41.590,0:15:47.650
-other programming languages
-will have "==", "!=", these
+bahasa pemrograman lain
+akan memiliki "==", "!=", simbol-simbol
 
 0:15:47.650,0:15:51.070
-symbols. In bash there's
+ini. Di bash ada
 
 0:15:51.070,0:15:53.650
-like a reserved set of comparisons and
+sekumpulan reserved comparison
 
 0:15:53.650,0:15:54.970
-it's mainly because there's a lot of
+dan itu terutama karena ada banyak
 
 0:15:54.970,0:15:57.520
-things you might want to test for when
+hal yang mungkin ingin kalian uji saat
 
 0:15:57.520,0:15:59.080
-you're in the shell. Here for example
+berada di shell. Di sini misalnya
 
 0:15:59.080,0:16:03.970
-we're just checking for two values, two
-integer values, being the same. Or for
+kita hanya mengecek dua nilai, dua
+nilai integer, apakah sama. Atau
 
 0:16:03.970,0:16:08.380
-example here, the "-F" check will let
+misalnya di sini, cek "-F" akan memberi
 
 0:16:08.380,0:16:10.420
-us know if a file exists, which is
+tahu kita apakah file ada, yang
 
 0:16:10.420,0:16:12.220
-something that you will run into very,
+merupakan sesuatu yang akan sering
 
 0:16:12.220,0:16:17.530
-very commonly. I'm going back to the
+kalian temui. Saya kembali ke
 
 0:16:17.530,0:16:23.020
-example. Then, what happens when we
+contoh. Kemudian, apa yang terjadi ketika
 
 0:16:24.400,0:16:28.600
-if the file did not have
-foobar, like there was a
+jika file tidak memiliki
+foobar, yaitu ada
 
 0:16:28.600,0:16:31.990
-nonzero error code, then we print
+error code bukan nol, maka kita cetak
 
 0:16:31.990,0:16:33.400
-"this file doesn't have any foobar,
+"file ini tidak memiliki foobar,
 
 0:16:33.400,0:16:36.400
-we're going to add one". And what we do is
+kita akan menambahkan satu". Dan yang kita lakukan adalah
 
 0:16:36.400,0:16:40.750
-we echo this "# foobar", hoping this
+kita echo "# foobar" ini, dengan harapan ini
 
 0:16:40.750,0:16:43.200
-is a comment to the file and then we're
+adalah komentar ke file dan kemudian kita
 
 0:16:43.200,0:16:47.620
-using the operator ">>" to append at the end of
+menggunakan operator ">>" untuk menambahkan di akhir
 
 0:16:47.620,0:16:50.800
-the file. Here since the file has
+file. Di sini karena file telah
 
 0:16:50.800,0:16:54.490
-been fed through the script, and we don't
-know it beforehand, we have to substitute
+diberikan melalui script, dan kita tidak
+tahu sebelumnya, kita harus mensubstitusi
 
 0:16:54.490,0:17:03.430
-the variable of the filename. We can
-actually run this. We already have
+variabel nama file. Kita
+bisa benar-benar menjalankan ini. Kita sudah memiliki
 
 0:17:03.430,0:17:05.260
-correct permissions in this script and
+izin yang benar dalam script ini dan
 
 0:17:05.260,0:17:10.540
-we can give a few examples. We have a
-few files in this folder, "mcd" is the
+kita bisa memberikan beberapa contoh. Kita punya beberapa
+file di folder ini, "mcd" adalah
 
 0:17:10.540,0:17:12.760
-one we saw at the beginning for the MCD
+yang kita lihat di awal untuk fungsi
 
 0:17:12.760,0:17:15.040
-function, some other "script" function and
+MCD, beberapa fungsi "script" lainnya dan
 
 0:17:15.040,0:17:21.700
-we can even feed the own script to itself
-to check if it has foobar in it.
+kita bahkan bisa memasukkan script itu sendiri
+untuk mengecek apakah ada foobar di dalamnya.
 
 0:17:21.700,0:17:26.680
-And we run it and first we can
-see that there's different
+Dan kita jalankan dan pertama kita bisa
+melihat bahwa ada berbagai
 
 0:17:26.680,0:17:29.460
-variables that we saw, that have been
+variabel yang kita lihat, yang telah
 
 0:17:29.460,0:17:33.400
-successfully expanded. We have the date, that has
+berhasil di-expand. Kita punya date, yang telah
 
 0:17:33.400,0:17:36.700
-been replaced to the current time, then
+diganti dengan waktu saat ini, kemudian
 
 0:17:36.700,0:17:39.100
-we're running this program, with three
+kita menjalankan program ini, dengan tiga
 
 0:17:39.100,0:17:44.560
-arguments, this randomized PID, and then
+argumen, PID yang di-randomize, dan kemudian
 
 0:17:44.560,0:17:46.510
-it's telling us MCD doesn't have any
+memberi tahu kita bahwa MCD tidak memiliki
 
 0:17:46.510,0:17:48.169
-foobar, so we are adding a new one,
+foobar, jadi kita menambahkan yang baru,
 
 0:17:48.169,0:17:50.450
-and this script file doesn't
+dan file script ini tidak
 
 0:17:50.450,0:17:52.970
-have one. So now for example let's look at MCD
+memilikinya. Jadi sekarang misalnya mari kita lihat MCD
 
 0:17:52.970,0:17:55.820
-and it has the comment that we were looking for.
+dan ia memiliki komentar yang kita cari.
 
 0:17:59.000,0:18:05.619
-One other thing to know when you're
-executing scripts is that
+Satu hal lagi yang perlu diketahui saat
+mengeksekusi script adalah bahwa
 
 0:18:05.619,0:18:07.759
-here we have like three completely
+di sini kita punya tiga argumen yang benar-benar
 
 0:18:07.759,0:18:10.279
-different arguments but very commonly
+berbeda tapi sangat sering
 
 0:18:10.279,0:18:12.889
-you will be giving arguments that
+kalian akan memberikan argumen yang
 
 0:18:12.889,0:18:16.100
-can be more succinctly given in some way.
+bisa diberikan dengan lebih ringkas.
 
 0:18:16.100,0:18:20.179
-So for example here if we wanted to
+Jadi misalnya di sini jika kita ingin
 
 0:18:20.179,0:18:25.429
-refer to all the ".sh" scripts we
+merujuk ke semua script ".sh" kita
 
 0:18:25.429,0:18:31.120
-could just do something like "ls *.sh"
+bisa melakukan sesuatu seperti "ls *.sh"
 
 0:18:31.120,0:18:36.120
-and this is a way of filename expansion
-that most shells have
+dan ini adalah cara filename expansion
+yang dimiliki sebagian besar shell
 
 0:18:36.120,0:18:38.450
-that's called "globbing". Here, as you
+yang disebut "globbing". Di sini, seperti yang
 
 0:18:38.450,0:18:39.919
-might expect, this is gonna say
+kalian duga, ini akan mengatakan
 
 0:18:39.919,0:18:42.559
-anything that has any kind of sort of
+apa pun yang memiliki jenis karakter apa pun
 
 0:18:42.559,0:18:45.940
-characters and ends up with "sh".
+dan diakhiri dengan "sh".
 
 0:18:45.940,0:18:52.159
-Unsurprisingly, we get "example.sh"
-and "mcd.sh". We also have these
+Seperti yang diharapkan, kita mendapatkan "example.sh"
+dan "mcd.sh". Kita juga punya
 
 0:18:52.159,0:18:54.769
-"project1" and "project2", and if there
+"project1" dan "project2" ini, dan jika ada
 
 0:18:54.769,0:19:00.100
-were like a... we can do a
-"project42", for example
+misalnya... kita bisa membuat
+"project42", misalnya
 
 0:19:00.620,0:19:04.220
-And now if we just want to refer
-to the projects that have
+Dan sekarang jika kita hanya ingin merujuk
+ke project yang memiliki
 
 0:19:04.220,0:19:07.279
-a single character, but not two characters
+satu karakter, tapi bukan dua karakter
 
 0:19:07.279,0:19:08.720
-afterwards, like any other characters,
+setelahnya, seperti karakter lainnya,
 
 0:19:08.720,0:19:13.879
-we can use the question mark. So "?"
-will expand to only a single one.
+kita bisa menggunakan tanda tanya. Jadi "?"
+akan mengembang hanya untuk satu karakter.
 
 0:19:13.880,0:19:17.360
-And we get, LS'ing, first
+Dan kita mendapatkan, dengan LS, pertama
 
 0:19:17.360,0:19:21.049
-"project1" and then "project2".
+"project1" lalu "project2".
 
 0:19:21.049,0:19:27.580
-In general, globbing can be very powerful.
-You can also combine it.
+Secara umum, globbing bisa sangat kuat.
+Kalian juga bisa menggabungkannya.
 
 0:19:31.880,0:19:35.480
-A common pattern is to use what
-is called curly braces.
+Pola yang umum adalah menggunakan apa
+yang disebut curly braces.
 
 0:19:35.480,0:19:39.320
-So let's say we have an image,
-that we have in this folder
+Jadi misalnya kita punya gambar,
+yang ada di folder ini
 
 0:19:39.320,0:19:43.620
-and we want to convert this image from PNG to JPG
+dan kita ingin mengonversi gambar ini dari PNG ke JPG
 
 0:19:43.620,0:19:46.320
-or we could maybe copy it, or...
+atau kita mungkin menyalinnya, atau...
 
 0:19:46.320,0:19:49.609
-it's a really common pattern, to have
-two or more arguments that are
+itu adalah pola yang sangat umum, memiliki
+dua argumen atau lebih yang cukup
 
 0:19:49.609,0:19:55.240
-fairly similar and you want to do something
-with them as arguments to some command.
+mirip dan kalian ingin melakukan sesuatu
+dengan mereka sebagai argumen ke suatu perintah.
 
 0:19:55.240,0:20:01.290
-You could do it this way, or more
-succinctly, you can just do
+Kalian bisa melakukannya dengan cara ini, atau lebih
+ringkas, kalian bisa melakukan
 
 0:20:01.290,0:20:08.880
 "image.{png,jpg}"
 
 0:20:09.410,0:20:13.590
-And here, I'm getting some color feedback,
-but what this will do, is
+Dan di sini, saya mendapat beberapa feedback warna,
+tapi yang akan dilakukan ini adalah
 
 0:20:13.590,0:20:17.610
-it'll expand into the line above.
+akan mengembang menjadi baris di atas.
 
 0:20:17.610,0:20:23.990
-Actually, I can ask zsh to do that for
-me. And that what's happening here.
+Sebenarnya, saya bisa meminta zsh melakukan itu untuk
+saya. Dan itulah yang terjadi di sini.
 
 0:20:23.990,0:20:26.550
-This is really powerful. So for example
+Ini sangat kuat. Jadi misalnya
 
 0:20:26.550,0:20:29.220
-you can do something like... we could do...
+kalian bisa melakukan sesuatu seperti... kita bisa melakukan...
 
 0:20:29.220,0:20:34.220
-"touch" on a bunch of foo's, and
-all of this will be expanded.
+"touch" pada banyak foo, dan
+semua ini akan di-expand.
 
 0:20:35.520,0:20:41.880
-You can also do it at several levels
-and you will do the Cartesian...
+Kalian juga bisa melakukannya di beberapa level
+dan kalian akan melakukan Cartesian...
 
 0:20:41.880,0:20:49.980
-if we have something like this,
-we have one group here, "{1,2}"
+jika kita punya sesuatu seperti ini,
+kita punya satu grup di sini, "{1,2}"
 
 0:20:49.980,0:20:53.310
-and then here there's "{1,2,3}",
-and this is going to do
+dan kemudian di sini ada "{1,2,3}",
+dan ini akan melakukan
 
 0:20:53.310,0:20:54.990
-the Cartesian product of these
+produk Cartesian dari kedua
 
 0:20:54.990,0:20:59.920
-two expansions and it will expand
-into all these things,
+expansi ini dan akan mengembang
+menjadi semua hal ini,
 
 0:20:59.960,0:21:03.540
-that we can quickly "touch".
+yang bisa kita "touch" dengan cepat.
 
 0:21:03.540,0:21:10.520
-You can also combine the asterisk
-glob with the curly braces glob.
+Kalian juga bisa menggabungkan glob asterisk
+dengan glob curly braces.
 
 0:21:10.520,0:21:16.840
-You can even use kind of ranges.
-Like, we can do "mkdir"
+Kalian bahkan bisa menggunakan semacam range.
+Seperti, kita bisa melakukan "mkdir"
 
 0:21:16.840,0:21:21.420
-and we create the "foo" and the
-"bar" directories, and then we
+dan kita membuat direktori "foo" dan
+"bar", lalu kita
 
 0:21:21.420,0:21:25.680
-can do something along these lines. This
+bisa melakukan sesuatu seperti ini. Ini
 
 0:21:25.680,0:21:28.890
-is going to expand to "fooa", "foob"...
+akan mengembang menjadi "fooa", "foob"...
 
 0:21:28.890,0:21:31.430
-like all these combinations, through "j", and
+seperti semua kombinasi ini, sampai "j", dan
 
 0:21:31.430,0:21:35.250
-then the same for "bar". I haven't
+kemudian sama untuk "bar". Saya belum
 
 0:21:35.250,0:21:38.610
-really tested it... but yeah, we're getting
-all these combinations that we
+benar-benar mengujinya... tapi ya, kita mendapatkan
+semua kombinasi ini yang bisa
 
 0:21:38.610,0:21:41.850
-can "touch". And now, if we touch something
+kita "touch". Dan sekarang, jika kita touch sesuatu
 
 0:21:41.850,0:21:47.970
-that is different between these
-two [directories], we
+yang berbeda antara kedua
+[direktori] ini, kita
 
 0:21:47.970,0:21:55.890
-can again showcase the process
-substitution that we saw
+bisa lagi menunjukkan process
+substitution yang kita lihat
 
 0:21:55.890,0:21:59.610
-earlier. Say we want to check what
-files are different between these
+sebelumnya. Katakanlah kita ingin mengecek file apa
+yang berbeda antara kedua
 
 0:21:59.610,0:22:03.400
-two folders. For us it's obvious,
-we just saw it, it's X and Y,
+folder ini. Bagi kita jelas,
+kita baru saja melihatnya, yaitu X dan Y,
 
 0:22:03.400,0:22:07.410
-but we can ask the shell to do
-this "diff" for us between the
+tapi kita bisa meminta shell melakukan
+"diff" ini untuk kita antara
 
 0:22:07.410,0:22:10.200
-output of one LS and the other LS.
+output dari satu LS dan LS lainnya.
 
 0:22:10.200,0:22:12.810
-Unsurprisingly we're getting: X is
+Seperti yang diharapkan kita mendapat: X hanya
 
 0:22:12.810,0:22:14.700
-only in the first folder and Y is
+ada di folder pertama dan Y hanya
 
 0:22:14.700,0:22:20.970
-only in the second folder. What is more
+ada di folder kedua. Yang lebih
 
 0:22:20.970,0:22:26.519
-is, right now, we have only seen
-bash scripts. If you like other
+lanjut, saat ini, kita baru hanya melihat
+bash script. Jika kalian lebih suka script
 
 0:22:26.520,0:22:30.260
-scripts, like for some tasks bash
-is probably not the best,
+lain, karena untuk beberapa tugas bash
+mungkin bukan yang terbaik,
 
 0:22:30.260,0:22:33.119
-it can be tricky. You can actually
-write scripts that
+bisa jadi rumit. Kalian sebenarnya bisa
+menulis script yang
 
 0:22:33.119,0:22:35.700
-interact with the shell implemented in a lot
+berinteraksi dengan shell yang diimplementasikan dalam banyak
 
 0:22:35.700,0:22:39.710
-of different languages. So for
-example, let's see here a
+bahasa yang berbeda. Jadi misalnya,
+mari kita lihat
 
 0:22:39.710,0:22:43.139
-Python script that has a magic line at the
+script Python yang memiliki baris ajaib di
 
 0:22:43.139,0:22:45.539
-beginning that I'm not explaining for now.
+awal yang belum saya jelaskan untuk saat ini.
 
 0:22:45.540,0:22:48.330
-Then we have "import sys",
+Kemudian kita punya "import sys",
 
 0:22:48.330,0:22:53.629
-it's kind of like... Python is not,
-by default, trying to interact
+ini agak seperti... Python tidak,
+secara default, mencoba berinteraksi
 
 0:22:53.629,0:22:56.999
-with the shell so you will have to import
+dengan shell jadi kalian harus mengimpor
 
 0:22:56.999,0:22:58.799
-some library. And then we're doing a
+beberapa library. Dan kemudian kita melakukan
 
 0:22:58.799,0:23:01.529
-really silly thing of just iterating
+hal yang sangat sederhana yaitu hanya melakukan iterasi
 
 0:23:01.529,0:23:06.440
-over "sys.argv[1:]".
+melalui "sys.argv[1:]".
 
 0:23:06.440,0:23:12.809
-"sys.argv" is kind of similar to what
-in bash we're getting as $0, $1, &c.
+"sys.argv" agak mirip dengan apa
+yang di bash kita dapatkan sebagai $0, $1, dst.
 
 0:23:12.809,0:23:16.649
-Like the vector of the arguments, we're
-printing it in the reversed order.
+Seperti vektor argumen, kita
+mencetaknya dalam urutan terbalik.
 
 0:23:16.649,0:23:21.179
-And the magic line at the beginning is
+Dan baris ajaib di awal
 
 0:23:21.179,0:23:23.999
-called a shebang and is the way that the
+disebut shebang dan merupakan cara shell
 
 0:23:23.999,0:23:26.159
-shell will know how to run this program.
+akan tahu cara menjalankan program ini.
 
 0:23:26.159,0:23:30.509
-You can always do something like
+Kalian selalu bisa melakukan sesuatu seperti
 
 0:23:30.509,0:23:34.379
-"python script.py", and then "a b c" and that
+"python script.py", lalu "a b c" dan itu
 
 0:23:34.379,0:23:36.659
-will work, always, like that. But
+akan selalu berhasil, seperti itu. Tapi
 
 0:23:36.659,0:23:39.119
-what if we want to make this to be
+bagaimana jika kita ingin membuat ini bisa
 
 0:23:39.119,0:23:41.309
-executable from the shell? The way the
+dieksekusi dari shell? Cara
 
 0:23:41.309,0:23:44.190
-shell knows that it has to use python as the
+shell tahu bahwa ia harus menggunakan python sebagai
 
 0:23:44.190,0:23:48.450
-interpreter to run this file is using
+interpreter untuk menjalankan file ini adalah menggunakan
 
 0:23:48.450,0:23:52.440
-that first line. And that first line is
+baris pertama. Dan baris pertama itu
 
 0:23:52.440,0:23:56.620
-giving it the path to where that thing lives.
+memberikan path ke tempat program itu berada.
 
 0:23:58.500,0:23:59.600
-However, you might not know.
+Namun, kalian mungkin tidak tahu.
 
 0:23:59.609,0:24:01.830
-Like, different machines will have probably
+Seperti, mesin yang berbeda mungkin memiliki
 
 0:24:01.830,0:24:04.049
-different places where they put python
+tempat yang berbeda untuk menyimpan python
 
 0:24:04.049,0:24:06.090
-and you might not want to assume where
+dan kalian mungkin tidak ingin mengasumsikan di mana
 
 0:24:06.090,0:24:08.789
-python is installed, or any other interpreter.
+python diinstal, atau interpreter lainnya.
 
 0:24:08.789,0:24:16.379
-So one thing that you can do is use the
+Jadi satu hal yang bisa kalian lakukan adalah menggunakan
 
 0:24:16.380,0:24:17.720
-"env" command.
+perintah "env".
 
 0:24:18.280,0:24:21.560
-You can also give arguments in the shebang, so
+Kalian juga bisa memberikan argumen di shebang, jadi
 
 0:24:21.570,0:24:23.940
-what we're doing here is specifying
+yang kita lakukan di sini adalah menentukan
 
 0:24:23.940,0:24:29.720
-run the "env" command, that is for pretty much every
-system, there are some exceptions, but like for
+jalankan perintah "env", yang ada di hampir setiap
+sistem, ada beberapa pengecualian, tapi untuk
 
 0:24:29.720,0:24:31.550
-pretty much every system it's is in
+hampir setiap sistem ada di
 
 0:24:31.550,0:24:33.620
-"usr/bin", where a lot of binaries live,
+"usr/bin", tempat banyak binary berada,
 
 0:24:33.620,0:24:36.200
-and then we're calling it with the
+dan kemudian kita memanggilnya dengan
 
 0:24:36.200,0:24:38.570
-argument "python". And then that will make
+argumen "python". Dan kemudian itu akan
 
 0:24:38.570,0:24:42.020
-use of the path environment variable
+menggunakan variabel environment path
 
 0:24:42.020,0:24:43.580
-that we saw in the first lecture. It's
+yang kita lihat di kuliah pertama. Itu
 
 0:24:43.580,0:24:45.680
-gonna search in that path for the Python
+akan mencari di path tersebut untuk binary
 
 0:24:45.680,0:24:48.620
-binary and then it's gonna use that to
+Python dan kemudian akan menggunakannya untuk
 
 0:24:48.620,0:24:50.480
-interpret this file. And that will make
+menginterpretasikan file ini. Dan itu akan membuat
 
 0:24:50.480,0:24:52.490
-this more portable so it can be run in
+ini lebih portabel sehingga bisa dijalankan di
 
 0:24:52.490,0:24:57.520
-my machine, and your machine
-and some other machine.
+mesin saya, dan mesin kalian
+dan mesin lainnya.
 
 0:25:08.020,0:25:12.140
-Another thing is that the bash is not
+Hal lain adalah bahwa bash tidak
 
 0:25:12.140,0:25:14.300
-really like modern, it was
+benar-benar modern, dikembangkan
 
 0:25:14.300,0:25:16.340
-developed a while ago. And sometimes
+sudah lama. Dan terkadang
 
 0:25:16.340,0:25:18.890
-it can be tricky to debug. By
+bisa rumit untuk di-debug. Secara
 
 0:25:18.890,0:25:21.980
-default, and the ways it will fail
+default, dan cara ia gagal
 
 0:25:21.980,0:25:24.020
-sometimes are intuitive like the way we
+kadang-kadang intuitif seperti cara yang kita
 
 0:25:24.020,0:25:26.180
-saw before of like foo command not
+lihat sebelumnya yaitu perintah foo tidak
 
 0:25:26.180,0:25:28.610
-existing, sometimes it's not. So there's
+ada, terkadang tidak. Jadi ada
 
 0:25:28.610,0:25:31.280
-like a really nifty tool that we have
+tool yang sangat berguna yang telah kami
 
 0:25:31.280,0:25:34.310
-linked in the lecture notes, which is called
+tautkan di catatan kuliah, yang disebut
 
 0:25:34.310,0:25:37.580
-"shellcheck", that will kind of give you
+"shellcheck", yang akan memberikan
 
 0:25:37.580,0:25:40.010
-both warnings and syntactic errors
+peringatan dan error sintaks
 
 0:25:40.010,0:25:43.250
-and other things that you might
-not have quoted properly,
+dan hal-hal lain yang mungkin
+belum kalian quote dengan benar,
 
 0:25:43.250,0:25:46.040
-or you might have misplaced spaces in
+atau kalian mungkin salah menempatkan spasi di
 
 0:25:46.040,0:25:50.060
-your files. So for example for
-extremely simple "mcd.sh"
+file kalian. Jadi misalnya untuk
+file "mcd.sh" yang sangat sederhana
 
 0:25:50.060,0:25:51.980
-file we're getting a couple
+kita mendapat beberapa
 
 0:25:51.980,0:25:54.800
-of errors saying hey, surprisingly,
+error yang mengatakan, secara mengejutkan,
 
 0:25:54.800,0:25:56.090
-we're missing a shebang, like this
+kita kehilangan shebang, seperti ini
 
 0:25:56.090,0:25:59.060
-might not interpret it correctly if you're
+mungkin tidak menginterpretasikannya dengan benar jika kalian
 
 0:25:59.060,0:26:02.000
-it at a different system. Also, this
+menjalankannya di sistem yang berbeda. Juga,
 
 0:26:02.000,0:26:05.620
-CD is taking a command and it might not
+CD ini mengambil perintah dan mungkin tidak
 
 0:26:05.620,0:26:08.960
-expand properly so instead of using CD
+mengembang dengan benar jadi alih-alih menggunakan CD
 
 0:26:08.960,0:26:11.300
-you might want to use something like CD
+kalian mungkin ingin menggunakan sesuatu seperti CD
 
 0:26:11.300,0:26:14.540
-and then an OR and then an "exit". We go
+lalu OR lalu "exit". Kita kembali
 
 0:26:14.540,0:26:16.490
-back to what we explained earlier, what
+ke apa yang kita jelaskan sebelumnya, apa
 
 0:26:16.490,0:26:18.920
-this will do is like if the
+yang akan dilakukan ini adalah jika
 
 0:26:18.920,0:26:21.860
-CD doesn't end correctly, you cannot CD
+CD tidak berakhir dengan benar, kalian tidak bisa CD
 
 0:26:21.860,0:26:23.720
-into the folder because either you
+ke folder karena kalian
 
 0:26:23.720,0:26:25.250
-don't have permissions, it doesn't exist...
+tidak punya izin, tidak ada...
 
 0:26:25.250,0:26:28.780
-That will give a nonzero error
+Itu akan memberikan error bukan nol
 
 0:26:28.780,0:26:32.420
-command, so you will execute exit
+sehingga kalian akan mengeksekusi exit
 
 0:26:32.420,0:26:33.920
-and that will stop the script
+dan itu akan menghentikan script
 
 0:26:33.920,0:26:35.810
-instead of continue executing as if
+alih-alih melanjutkan eksekusi seolah-olah
 
 0:26:35.810,0:26:37.240
-you were in a place that you are
+kalian berada di tempat yang sebenarnya
 
 0:26:37.240,0:26:42.900
-actually not in. And actually
-I haven't tested, but I
+tidak kalian tempati. Dan sebenarnya
+saya belum menguji, tapi saya
 
 0:26:42.920,0:26:47.179
-think we can check for "example.sh"
+pikir kita bisa mengecek "example.sh"
 
 0:26:47.179,0:26:50.809
-and here we're getting that we should be
+dan di sini kita mendapat bahwa kita seharusnya
 
 0:26:50.809,0:26:55.070
-checking the exit code in a
-different way, because it's
+mengecek exit code dengan cara
+yang berbeda, karena mungkin bukan
 
 0:26:55.070,0:26:57.710
-probably not the best way, doing it this
+cara terbaik, melakukannya seperti
 
 0:26:57.710,0:27:01.580
-way. One last remark I want to make
+ini. Satu hal terakhir yang ingin saya sampaikan
 
 0:27:01.580,0:27:05.090
-is that when you're writing bash scripts
+adalah bahwa ketika kalian menulis bash script
 
 0:27:05.090,0:27:07.159
-or functions for that matter,
+atau fungsi,
 
 0:27:07.159,0:27:09.080
-there's kind of a difference between
+ada semacam perbedaan antara
 
 0:27:09.080,0:27:12.590
-writing bash scripts in isolation like a
+menulis bash script secara terisolasi seperti
 
 0:27:12.590,0:27:14.149
-thing that you're gonna run, and a thing
+sesuatu yang akan kalian jalankan, dan sesuatu
 
 0:27:14.149,0:27:16.100
-that you're gonna load into your shell.
+yang akan kalian muat ke shell kalian.
 
 0:27:16.100,0:27:19.850
-We will see some of this in the command
+Kita akan melihat beberapa hal ini di kuliah
 
 0:27:19.850,0:27:23.090
-line environment lecture, where we will kind of
+command line environment, di mana kita akan
 
 0:27:23.090,0:27:29.059
-be tooling with the bashrc and the
-sshrc. But in general, if you make
+bermain dengan bashrc dan
+sshrc. Tapi secara umum, jika kalian membuat
 
 0:27:29.059,0:27:31.370
-changes to for example where you are,
+perubahan misalnya pada posisi kalian,
 
 0:27:31.370,0:27:34.009
-like if you CD into a bash script and you
+seperti jika kalian CD ke bash script dan kalian
 
 0:27:34.009,0:27:36.919
-just execute that bash script, it won't CD
+hanya mengeksekusi bash script itu, tidak akan CD
 
 0:27:36.919,0:27:39.980
-into the shell are right now. But if you
+ke shell tempat kalian berada sekarang. Tapi jika kalian
 
 0:27:39.980,0:27:42.980
-have loaded the code directly into
+telah memuat kode langsung ke
 
 0:27:42.980,0:27:45.559
-your shell, for example you load...
+shell kalian, misalnya kalian me-load...
 
 0:27:45.559,0:27:48.440
-you source the function and then you execute
+kalian source fungsi tersebut lalu mengeksekusi
 
 0:27:48.440,0:27:50.269
-the function then you will get those
+fungsi tersebut maka kalian akan mendapatkan
 
 0:27:50.269,0:27:52.000
-side effects. And the same goes for
+efek samping tersebut. Dan hal yang sama berlaku untuk
 
 0:27:52.000,0:27:57.220
-defining variables into the shell.
+mendefinisikan variabel ke shell.
 
 0:27:57.220,0:28:03.950
-Now I'm going to talk about some
-tools that I think are nifty when
+Sekarang saya akan membahas beberapa
+tool yang saya pikir berguna saat
 
 0:28:03.950,0:28:07.580
-working with the shell. The first was
+bekerja dengan shell. Yang pertama juga
 
 0:28:07.580,0:28:09.799
-also briefly introduced yesterday.
+sedikit diperkenalkan kemarin.
 
 0:28:09.799,0:28:13.309
-How do you know what flags, or like
+Bagaimana kalian tahu flag apa, atau
 
 0:28:13.309,0:28:15.320
-what exact commands are. Like how I am
+perintah persis apa. Seperti bagaimana saya
 
 0:28:15.320,0:28:21.889
-supposed to know that LS minus L will list
-the files in a list format, or that
+tahu bahwa LS minus L akan mendaftar
+file dalam format daftar, atau bahwa
 
 0:28:21.889,0:28:25.789
-if I do "move - i", it's gonna like prom me
+jika saya melakukan "move -i", akan meminta
 
 0:28:25.789,0:28:28.639
-for stuff. For that what you have is the "man"
+sesuatu. Untuk itu kalian punya perintah "man"
 
 0:28:28.639,0:28:30.730
-command. And the man command will kind of
+perintah. Dan perintah man akan
 
 0:28:30.730,0:28:33.590
-have like a lot of information of how
+memiliki banyak informasi tentang bagaimana
 
 0:28:33.590,0:28:35.809
-will you go about... so for example here it
+kalian akan... jadi misalnya di sini akan
 
 0:28:35.809,0:28:40.340
-will explain for the "-i" flag, there are
+menjelaskan untuk flag "-i", ada
 
 0:28:40.340,0:28:43.970
-all these options you can do. That's
+semua opsi yang bisa kalian lakukan. Itu
 
 0:28:43.970,0:28:45.620
-actually pretty useful and it will work
+sangat berguna dan akan berfungsi
 
 0:28:45.620,0:28:51.540
-not only for really simple commands
-that come packaged with your OS
+tidak hanya untuk perintah sederhana
+yang datang bersama OS kalian
 
 0:28:51.540,0:28:55.809
-but will also work with some tools
-that you install from the internet
+tapi juga akan berfungsi dengan beberapa tool
+yang kalian instal dari internet
 
 0:28:55.809,0:28:58.240
-for example, if the person that did the
+misalnya, jika orang yang membuat
 
 0:28:58.240,0:29:01.390
-installation made it so that the man
+instalasi membuatnya sehingga paket man
 
 0:29:01.390,0:29:03.399
-package were also installed. So for example
+juga terinstal. Jadi misalnya
 
 0:29:03.399,0:29:06.490
-a tool that we're gonna cover in a bit
+tool yang akan kita bahas sebentar lagi
 
 0:29:06.490,0:29:12.370
-which is called "ripgrep" and
-is called with RG, this didn't
+yang disebut "ripgrep" dan
+dipanggil dengan RG, ini tidak
 
 0:29:12.370,0:29:14.980
-come with my system but it has installed
+datang dengan sistem saya tapi telah menginstal
 
 0:29:14.980,0:29:17.230
-its own man page and I have it here and
+halaman man-nya sendiri dan saya memilikinya di sini dan
 
 0:29:17.230,0:29:21.700
-I can access it. For some commands the
+saya bisa mengaksesnya. Untuk beberapa perintah
 
 0:29:21.700,0:29:25.029
-man page is useful but sometimes it can be
+halaman man berguna tapi terkadang bisa
 
 0:29:25.029,0:29:28.270
-tricky to decipher because it's more
+sulit diurai karena lebih
 
 0:29:28.270,0:29:30.399
-kind of a documentation and a
+merupakan dokumentasi dan
 
 0:29:30.399,0:29:32.679
-description of all the things the tool
+deskripsi semua hal yang bisa dilakukan tool
 
 0:29:32.679,0:29:35.860
-can do. Sometimes it will have
+tersebut. Terkadang akan ada
 
 0:29:35.860,0:29:37.720
-examples but sometimes not, and sometimes
+contoh tapi terkadang tidak, dan terkadang
 
 0:29:37.720,0:29:41.620
-the tool can do a lot of things so a
+tool bisa melakukan banyak hal jadi beberapa
 
 0:29:41.620,0:29:45.250
-couple of good tools that I use commonly
+tool bagus yang sering saya gunakan
 
 0:29:45.250,0:29:50.289
-are "convert" or "ffmpeg", which deal
-with images and video respectively and
+adalah "convert" atau "ffmpeg", yang menangani
+gambar dan video masing-masing dan
 
 0:29:50.289,0:29:52.419
-the man pages are like enormous. So there's
+halaman man-nya sangat besar. Jadi ada
 
 0:29:52.419,0:29:54.850
-one neat tool called "tldr" that
+satu tool rapi yang disebut "tldr" yang
 
 0:29:54.850,0:29:58.240
-you can install and you will have like
+bisa kalian instal dan kalian akan memiliki
 
 0:29:58.240,0:30:02.710
-some nice kind of explanatory examples
+beberapa contoh penjelasan yang bagus
 
 0:30:02.710,0:30:05.470
-of how you want to use this command. And you
+tentang bagaimana kalian ingin menggunakan perintah ini. Dan kalian
 
 0:30:05.470,0:30:07.840
-can always Google for this, but I find
+bisa selalu mencari di Google, tapi saya merasa
 
 0:30:07.840,0:30:10.120
-myself saving going into the
+menghemat waktu untuk masuk ke
 
 0:30:10.120,0:30:12.640
-browser, looking about some examples and
+browser, mencari contoh dan
 
 0:30:12.640,0:30:14.919
-coming back, whereas "tldr" are
+kembali, sedangkan "tldr" adalah
 
 0:30:14.919,0:30:16.870
-community contributed and
+kontribusi komunitas dan
 
 0:30:16.870,0:30:19.210
-they're fairly useful. Then,
+cukup berguna. Kemudian,
 
 0:30:19.210,0:30:23.020
-the one for "ffmpeg" has a lot of
+yang untuk "ffmpeg" memiliki banyak
 
 0:30:23.020,0:30:24.940
-useful examples that are more nicely
+contoh berguna yang lebih rapi
 
 0:30:24.940,0:30:26.799
-formatted (if you don't have a huge
+formatnya (jika kalian tidak memiliki ukuran font
 
 0:30:26.799,0:30:30.820
-font size for recording). Or even
+yang besar untuk merekam). Atau bahkan
 
 0:30:30.820,0:30:33.250
-simple commands like "tar", that have a lot
+perintah sederhana seperti "tar", yang memiliki banyak
 
 0:30:33.250,0:30:35.470
-of options that you are combining. So for
+opsi yang kalian gabungkan. Jadi misalnya
 
 0:30:35.470,0:30:37.840
-example, here you can be combining 2, 3...
+di sini kalian bisa menggabungkan 2, 3...
 
 0:30:37.840,0:30:41.710
-different flags and it can not be
+flag yang berbeda dan mungkin tidak
 
 0:30:41.710,0:30:43.419
-obvious, when you want to combine
+jelas, ketika kalian ingin menggabungkan
 
 0:30:43.419,0:30:48.429
-different ones. That's how you
+yang berbeda. Begitulah cara kalian
 
 0:30:48.429,0:30:54.850
-would go about finding more about these tools.
-On the topic of finding, let's try
+mencari lebih lanjut tentang tool-tool ini.
+Dalam topik mencari, mari kita coba
 
 0:30:54.850,0:30:58.690
-learning how to find files. You can
+belajar cara mencari file. Kalian bisa
 
 0:30:58.690,0:31:03.100
-always go "ls", and like you can go like
+selalu melakukan "ls", dan kalian bisa melakukan
 
 0:31:03.100,0:31:05.950
-"ls project1", and
+"ls project1", dan
 
 0:31:05.950,0:31:08.559
-keep LS'ing all the way through. But
+terus melakukan LS sepanjang jalan. Tapi
 
 0:31:08.559,0:31:11.740
-maybe, if we already know that we want
+mungkin, jika kita sudah tahu bahwa kita ingin
 
 0:31:11.740,0:31:15.450
-to look for all the folders called
+mencari semua folder yang disebut
 
 0:31:15.450,0:31:19.000
-"src", then there's probably a better command
+"src", maka mungkin ada perintah yang lebih baik
 
 0:31:19.000,0:31:21.400
-for doing that. And that's "find".
+untuk melakukannya. Dan itu adalah "find".
 
 0:31:21.460,0:31:26.679
-Find is the tool that, pretty much comes
-with every UNIX system. And find,
+Find adalah tool yang, kurang lebih datang
+dengan setiap sistem UNIX. Dan find,
 
 0:31:26.679,0:31:35.230
-we're gonna give it... here we're
-saying we want to call find in the
+kita akan memberinya... di sini kita
+bilang kita ingin memanggil find di
 
 0:31:35.230,0:31:37.510
-current folder, remember that "." stands
+folder saat ini, ingat bahwa "." adalah
 
 0:31:37.510,0:31:40.149
-for the current folder, and we want the
+folder saat ini, dan kita ingin
 
 0:31:40.149,0:31:46.539
-name to be "src" and we want the type to
-be a directory. And by typing that it's
+namanya "src" dan kita ingin tipenya
+direktori. Dan dengan mengetik itu akan
 
 0:31:46.539,0:31:49.870
-gonna recursively go through the current
+secara rekursif melewati direktori saat ini
 
 0:31:49.870,0:31:52.330
-directory and look for all these files,
+dan mencari semua file ini,
 
 0:31:52.330,0:31:58.659
-or folders in this case, that match this
-pattern. Find has a lot of useful
+atau folder dalam kasus ini, yang cocok dengan pola
+ini. Find memiliki banyak
 
 0:31:58.659,0:32:01.840
-flags. So for example, you can even test
+flag berguna. Jadi misalnya, kalian bahkan bisa menguji
 
 0:32:01.840,0:32:05.440
-for the path to be in a way. Here we're
+apakah path berada dalam cara tertentu. Di sini kita
 
 0:32:05.440,0:32:08.230
-saying we want some number of folders,
+bilang kita ingin beberapa jumlah folder,
 
 0:32:08.230,0:32:09.909
-we don't really care how many folders,
+kita tidak peduli berapa banyak folder,
 
 0:32:09.909,0:32:13.179
-and then we care about all the Python
+dan kemudian kita peduli pada semua script
 
 0:32:13.179,0:32:17.830
-scripts, all the things with the extension
-".py", that are within a
+Python, semua yang memiliki ekstensi
+".py", yang berada dalam
 
 0:32:17.830,0:32:19.899
-test folder. And we're also checking, just in
+folder test. Dan kita juga mengecek, hanya untuk
 
 0:32:19.899,0:32:21.519
-cases really but we're checking just
+berjaga-jaga tapi kita mengecek bahwa
 
 0:32:21.519,0:32:24.460
-that it's also a type F, which stands for
+itu juga tipe F, yang berarti
 
 0:32:24.460,0:32:28.710
-file. We're getting all these files.
+file. Kita mendapatkan semua file ini.
 
 0:32:28.710,0:32:32.169
-You can also use different flags for things
+Kalian juga bisa menggunakan flag berbeda untuk hal-hal
 
 0:32:32.169,0:32:34.000
-that are not the path or the name.
+yang bukan path atau nama.
 
 0:32:34.000,0:32:38.160
-You could check things that have been
+Kalian bisa mengecek hal-hal yang telah
 
 0:32:38.160,0:32:42.060
-modified ("-mtime" is for the modification
-time), things that have been
+dimodifikasi ("-mtime" adalah untuk waktu
+modifikasi), hal-hal yang telah
 
 0:32:42.070,0:32:44.540
-modified in the last day, which is gonna
+dimodifikasi dalam sehari terakhir, yang akan
 
 0:32:44.559,0:32:46.659
-be pretty much everything. So this is gonna print
+menjadi hampir semuanya. Jadi ini akan mencetak
 
 0:32:46.659,0:32:49.029
-a lot of the files we created and files
+banyak file yang kita buat dan file
 
 0:32:49.029,0:32:51.850
-that were already there. You can even
+yang sudah ada. Kalian bahkan bisa
 
 0:32:51.850,0:32:54.960
-use other things like size, the owner,
+menggunakan hal lain seperti ukuran, pemilik,
 
 0:32:54.960,0:32:59.080
-permissions, you name it. What is even more
+izin, apa pun. Yang lebih
 
 0:32:59.080,0:33:01.870
-powerful is, "find" can find stuff
+kuat adalah, "find" bisa menemukan sesuatu
 
 0:33:01.870,0:33:04.269
-but it also can do stuff when you
+tapi juga bisa melakukan sesuatu ketika kalian
 
 0:33:04.269,0:33:10.690
-find those files. So we could look for all
+menemukan file tersebut. Jadi kita bisa mencari semua
 
 0:33:10.690,0:33:14.080
-the files that have a TMP
+file yang memiliki ekstensi
 
 0:33:14.080,0:33:18.160
-extension, which is a temporary extension, and
+TMP, yang merupakan ekstensi sementara, dan
 
 0:33:18.160,0:33:22.720
-then, we can tell "find" that
-for every one of those files,
+kemudian, kita bisa memberi tahu "find" bahwa
+untuk setiap file tersebut,
 
 0:33:22.720,0:33:26.350
-just execute the "rm" command for them. And
+jalankan saja perintah "rm" untuk mereka. Dan
 
 0:33:26.350,0:33:29.050
-that will just be calling "rm" with all
+itu hanya akan memanggil "rm" dengan semua
 
 0:33:29.050,0:33:32.350
-these files. So let's first execute it
+file ini. Jadi mari kita jalankan dulu
 
 0:33:32.350,0:33:35.760
-without, and then we execute it with it.
+tanpa, lalu kita jalankan dengannya.
 
 0:33:35.760,0:33:38.950
-Again, as with the command line
+Lagi, seperti filosofi command line,
 
 0:33:38.950,0:33:41.470
-philosophy, it looks like nothing
+sepertinya tidak ada yang terjadi.
 
 0:33:41.470,0:33:48.070
-happened. But since we have
-a zero error code, something
+Tapi karena kita memiliki
+error code nol, sesuatu
 
 0:33:48.070,0:33:49.540
-happened - just that everything went
+telah terjadi - hanya saja semuanya berjalan
 
 0:33:49.540,0:33:51.490
-correct and everything is fine. And now,
+benar dan semuanya baik-baik saja. Dan sekarang,
 
 0:33:51.490,0:33:57.810
-if we look for these files,
-they aren't there anymore.
+jika kita mencari file-file ini,
+mereka tidak ada lagi.
 
 0:33:57.810,0:34:02.950
-Another nice thing about the shell
-in general is that there are
+Hal bagus lainnya tentang shell
+secara umum adalah ada
 
 0:34:02.950,0:34:05.890
-these tools, but people will keep
+tool-tool ini, tapi orang akan terus
 
 0:34:05.890,0:34:08.230
-finding new ways, so alternative
+menemukan cara baru, jadi alternatif
 
 0:34:08.230,0:34:12.220
-ways of writing these tools. It's
-nice to know about it. So, for
+cara menulis tool-tool ini. Bagus
+untuk mengetahuinya. Jadi, misalnya
 
 0:34:12.220,0:34:20.020
-example find if you just want to match
-the things that end in "tmp"
+find jika kalian hanya ingin mencocokkan
+hal-hal yang diakhiri dengan "tmp"
 
 0:34:20.020,0:34:24.190
-it can be sometimes weird to do this
-thing, it has a long command.
+kadang-kadang bisa aneh melakukan hal
+ini, memiliki perintah yang panjang.
 
 0:34:24.190,0:34:27.760
-There's things like "fd",
+Ada hal-hal seperti "fd",
 
 0:34:27.760,0:34:32.320
-for example, that is a shorter command
-that by default will use regex
+misalnya, yang merupakan perintah lebih pendek
+yang secara default akan menggunakan regex
 
 0:34:32.320,0:34:34.899
-and will ignore your gitfiles, so you
+dan akan mengabaikan file git kalian, sehingga kalian
 
 0:34:34.899,0:34:38.020
-don't even search for them. It
+bahkan tidak mencarinya. Ini
 
 0:34:38.020,0:34:42.879
-will color-code, it will have better
-Unicode support... It's nice to
+akan memberi kode warna, akan memiliki dukungan
+Unicode yang lebih baik... Bagus untuk
 
 0:34:42.879,0:34:45.040
-know about some of these tools. But, again,
+mengetahui beberapa tool ini. Tapi, lagi,
 
 0:34:45.040,0:34:52.149
-the main idea is that if you are aware
-that these tools exist, you can
+ide utamanya adalah jika kalian sadar
+bahwa tool-tool ini ada, kalian bisa
 
 0:34:52.149,0:34:53.740
-save yourself a lot of time from doing
+menghemat banyak waktu dari melakukan
 
 0:34:53.740,0:34:57.660
-kind of menial and repetitive tasks.
+tugas-tugas yang sepele dan repetitif.
 
 0:34:57.660,0:35:00.010
-Another command to bear in mind is like
+Perintah lain yang perlu diingat adalah seperti
 
 0:35:00.010,0:35:01.990
-"find". Some of you may be
+"find". Beberapa dari kalian mungkin
 
 0:35:01.990,0:35:04.300
-wondering, "find" is probably just
+bertanya-tanya, "find" mungkin hanya
 
 0:35:04.300,0:35:06.520
-actually going through a directory
+melalui struktur direktori
 
 0:35:06.520,0:35:09.580
-structure and looking for things but
+dan mencari sesuatu tapi
 
 0:35:09.580,0:35:11.260
-what if I'm doing a lot of "finds" a day?
+bagaimana jika saya melakukan banyak "find" sehari?
 
 0:35:11.260,0:35:12.850
-Wouldn't it be better, doing kind of
+Bukankah lebih baik, melakukan semacam
 
 0:35:12.850,0:35:18.790
-a database approach and build an index
-first, and then use that index
+pendekatan database dan membangun indeks
+terlebih dahulu, lalu menggunakan indeks itu
 
 0:35:18.790,0:35:21.520
-and update it in some way. Well, actually
+dan memperbaruinya dengan beberapa cara. Sebenarnya
 
 0:35:21.520,0:35:23.380
-most Unix systems already do it and
+sebagian besar sistem UNIX sudah melakukannya dan
 
 0:35:23.380,0:35:28.170
-this is through the "locate" command and
+ini melalui perintah "locate" dan
 
 0:35:28.170,0:35:31.690
-the way that the locate will
+cara locate
 
 0:35:31.690,0:35:35.470
-be used... it will just look for paths in
+digunakan... hanya akan mencari path di
 
 0:35:35.470,0:35:38.680
-your file system that have the substring
+sistem file kalian yang memiliki substring
 
 0:35:38.680,0:35:44.710
-that you want. I actually don't know if it
-will work... Okay, it worked. Let me try to
+yang kalian inginkan. Saya sebenarnya tidak tahu apakah
+akan berfungsi... Oke, berhasil. Mari saya coba
 
 0:35:44.710,0:35:49.840
-do something like "missing-semester".
+melakukan sesuatu seperti "missing-semester".
 
 0:35:51.840,0:35:53.950
-You're gonna take a while but
+Ini akan memakan waktu sebentar tapi
 
 0:35:53.950,0:35:56.109
-it found all these files that are somewhere
+menemukan semua file ini yang ada di suatu tempat
 
 0:35:56.109,0:35:57.730
-in my file system and since it has
+di sistem file saya dan karena telah
 
 0:35:57.730,0:36:01.750
-built an index already on them, it's much
+membangun indeks untuk mereka, ini jauh
 
 0:36:01.750,0:36:05.680
-faster. And then, to keep it updated,
+lebih cepat. Dan kemudian, untuk menjaganya tetap terbaru,
 
 0:36:05.680,0:36:11.980
-using the "updatedb" command
-that is running through cron,
+menggunakan perintah "updatedb"
+yang berjalan melalui cron,
 
 0:36:13.840,0:36:18.490
-to update this database. Finding files, again, is
+untuk memperbarui database ini. Mencari file, lagi,
 
 0:36:18.490,0:36:23.230
-really useful. Sometimes you're actually concerned
-about, not the files themselves,
+sangat berguna. Terkadang kalian sebenarnya peduli
+bukan pada file itu sendiri,
 
 0:36:23.230,0:36:26.740
-but the content of the files. For that
+tapi pada konten file. Untuk itu
 
 0:36:26.740,0:36:31.420
-you can use the grep command that we
+kalian bisa menggunakan perintah grep yang telah
 
 0:36:31.420,0:36:33.880
-have seen so far. So you could do
+kita lihat sejauh ini. Jadi kalian bisa melakukan
 
 0:36:33.880,0:36:37.740
-something like grep foobar in MCD, it's there.
+sesuatu seperti grep foobar di MCD, ada di sana.
 
 0:36:37.740,0:36:43.690
-What if you want to, again, recursively
-search through the current
+Bagaimana jika kalian ingin, lagi, secara rekursif
+mencari melalui struktur
 
 0:36:43.690,0:36:45.760
-structure and look for more files, right?
+saat ini dan mencari lebih banyak file, kan?
 
 0:36:45.760,0:36:48.700
-We don't want to do this manually.
+Kita tidak ingin melakukan ini secara manual.
 
 0:36:48.700,0:36:51.220
-We could use "find", and the "-exec", but
+Kita bisa menggunakan "find", dan "-exec", tapi
 
 0:36:51.220,0:36:58.920
-actually "grep" has the "-R" flag
-that will go through the entire
+sebenarnya "grep" memiliki flag "-R"
+yang akan melewati seluruh
 
 0:36:58.920,0:37:03.609
-directory, here. And it's telling us
+direktori, di sini. Dan memberi tahu kita
 
 0:37:03.609,0:37:06.579
-that oh we have the foobar line in example.sh
+bahwa oh kita punya baris foobar di example.sh
 
 0:37:06.579,0:37:09.279
-at these three places and in
+di tiga tempat ini dan di
 
 0:37:09.279,0:37:14.589
-this other two places in foobar. This can be
+dua tempat lain di foobar. Ini bisa
 
 0:37:14.589,0:37:16.900
-really convenient. Mainly, the
+sangat berguna. Terutama,
 
 0:37:16.900,0:37:18.940
-use case for this is you know you have
+kasus penggunaan untuk ini adalah kalian tahu kalian telah
 
 0:37:18.940,0:37:21.910
-written some code in some programming
+menulis beberapa kode dalam beberapa bahasa
 
 0:37:21.910,0:37:23.859
-language, and you know it's somewhere in
+pemrograman, dan kalian tahu itu ada di suatu tempat di
 
 0:37:23.859,0:37:26.200
-your file system but you actually don't
+sistem file kalian tapi kalian sebenarnya tidak
 
 0:37:26.200,0:37:28.599
-know. But you can actually quickly search.
+tahu. Tapi kalian bisa dengan cepat mencari.
 
 0:37:28.600,0:37:32.980
-So for example, I can quickly search
+Jadi misalnya, saya bisa dengan cepat mencari
 
 0:37:35.660,0:37:40.320
-for all the Python files that I have in my
+semua file Python yang saya miliki di folder
 
 0:37:40.329,0:37:45.460
-scratch folder where I used the request library.
+scratch saya tempat saya menggunakan library request.
 
 0:37:45.460,0:37:47.589
-And if I run this, it's giving me
+Dan jika saya menjalankan ini, memberi saya
 
 0:37:47.589,0:37:50.890
-through all these files, exactly in
+melalui semua file ini, tepatnya di
 
 0:37:50.890,0:37:53.650
-what line it has been found. And here
+baris mana ditemukan. Dan di sini
 
 0:37:53.650,0:37:56.260
-instead of using grep, which is fine,
+alih-alih menggunakan grep, yang baik-baik saja,
 
 0:37:56.260,0:37:58.930
-you could also do this, I'm using "ripgrep",
+kalian juga bisa melakukan ini, saya menggunakan "ripgrep",
 
 0:37:58.930,0:38:05.260
-which is kind of the same idea but
-again trying to bring some more
+yang merupakan ide yang sama tapi
+lagi mencoba membawa beberapa
 
 0:38:05.260,0:38:09.730
-niceties like color coding or file
+kelebihan seperti kode warna atau pemrosesan
 
 0:38:09.730,0:38:16.480
-processing and other things. It think it has,
-also, unicode support. It's also pretty
+file dan hal-hal lain. Saya pikir ini memiliki,
+juga, dukungan unicode. Ini juga cukup
 
 0:38:16.480,0:38:22.829
-fast so you are not paying like a
-trade-off on this being slower and
+cepat sehingga kalian tidak membayar trade-off
+karena lebih lambat dan
 
 0:38:22.829,0:38:25.420
-there's a lot of useful flags. You
+ada banyak flag berguna. Kalian
 
 0:38:25.420,0:38:27.670
-can say, oh, I actually want to get some
+bisa bilang, oh, saya sebenarnya ingin mendapatkan beberapa
 
 0:38:27.670,0:38:30.460
-context around those results.
+konteks di sekitar hasil tersebut.
 
 0:38:33.040,0:38:36.400
-So I want to get like five
-lines of context around
+Jadi saya ingin mendapatkan seperti lima
+baris konteks di sekitar
 
 0:38:36.400,0:38:42.819
-that, so you can see where that import
-lives and see code around it.
+itu, sehingga kalian bisa melihat di mana import
+itu berada dan melihat kode di sekitarnya.
 
 0:38:42.819,0:38:44.170
-Here in the import it's not really useful
+Di sini pada import tidak terlalu berguna
 
 0:38:44.170,0:38:45.819
-but like if you're looking for where you
+tapi seperti jika kalian mencari di mana kalian
 
 0:38:45.819,0:38:49.720
-use the function, for example, it will
+menggunakan fungsi, misalnya, akan
 
 0:38:49.720,0:38:54.010
-be very handy. We can also do things like
+sangat berguna. Kita juga bisa melakukan hal-hal seperti
 
 0:38:54.010,0:38:59.170
-we can search, for example here,.
+kita bisa mencari, misalnya di sini.
 
 0:38:59.170,0:39:04.839
-A more advanced use, we can say,
+Penggunaan yang lebih lanjut, kita bisa bilang,
 
 0:39:04.840,0:39:11.580
-"-u" is for don't ignore hidden files, sometimes
+"-u" adalah untuk tidak mengabaikan file tersembunyi, terkadang
 
 0:39:12.520,0:39:16.359
-you want to be ignoring hidden
-files, except if you want to
+kalian ingin mengabaikan file
+tersembunyi, kecuali jika kalian ingin
 
 0:39:16.359,0:39:23.500
-search config files, that are by default
-hidden. Then, instead of printing
+mencari file config, yang secara default
+tersembunyi. Kemudian, alih-alih mencetak
 
 0:39:23.500,0:39:28.400
-the matches, we're asking to do something
-that would be kind of hard, I think,
+yang cocok, kita meminta untuk melakukan sesuatu
+yang menurut saya agak sulit,
 
 0:39:28.400,0:39:31.380
-to do with grep, out of my head, which is
+yang
 
 0:39:31.390,0:39:34.569
-"I want you to print all the files that
+"saya ingin kalian mencetak semua file yang
 
 0:39:34.569,0:39:37.750
-don't match the pattern I'm giving you", which
+tidak cocok dengan pola yang kalian berikan", yang
 
 0:39:37.750,0:39:40.030
-may be a weird thing to ask here but
+mungkin permintaan aneh di sini tapi
 
 0:39:40.030,0:39:42.940
-then we keep going... And this pattern here
+kemudian kita lanjutkan... Dan pola di sini
 
 0:39:42.940,0:39:45.790
-is a small regex which is saying
+adalah regex kecil yang mengatakan
 
 0:39:45.790,0:39:48.099
-at the beginning of the line I have a
+di awal baris saya punya
 
 0:39:48.099,0:39:51.190
-"#" and a "!", and that's a shebang.
+"#" dan "!", dan itu adalah shebang.
 
 0:39:51.190,0:39:53.470
-Like that, we're searching here for all
+Seperti itu, kita mencari di sini untuk semua
 
 0:39:53.470,0:39:56.650
-the files that don't have a shebang
+file yang tidak memiliki shebang
 
 0:39:56.650,0:39:59.369
-and then we're giving it, here,
+dan kemudian kita memberinya, di sini,
 
 0:39:59.369,0:40:02.470
-a "-t sh" to only look for "sh"
+"-t sh" untuk hanya mencari file
 
 0:40:02.470,0:40:07.660
-files, because maybe all your
-Python or text files are fine
+"sh", karena mungkin semua file
+Python atau teks kalian baik-baik saja
 
 0:40:07.660,0:40:10.000
-without a shebang. And here it's telling us
+tanpa shebang. Dan di sini memberi tahu kita
 
 0:40:10.000,0:40:13.020
-"oh, MCD is obviously missing a shebang"
+"oh, MCD jelas kehilangan shebang"
 
 0:40:14.760,0:40:16.660
-We can even... It has like some
+Kita bahkan bisa... Ini memiliki beberapa
 
 0:40:16.660,0:40:19.119
-nice flags, so for example if we
+flag bagus, jadi misalnya jika kita
 
 0:40:19.120,0:40:21.360
-include the "stats" flag
+menyertakan flag "stats"
 
 0:40:28.700,0:40:34.119
-it will get all these results but it will
-also tell us information about all
+akan mendapatkan semua hasil ini tapi juga
+akan memberi tahu kita informasi tentang semua
 
 0:40:34.119,0:40:35.410
-the things that it searched. For example,
+hal yang dicarinya. Misalnya,
 
 0:40:35.410,0:40:40.390
-the number of matches that it found,
-the lines, the file searched,
+jumlah match yang ditemukan,
+baris, file yang dicari,
 
 0:40:40.390,0:40:44.040
-the bytes that it printed, &c.
+byte yang dicetak, dst.
 
 0:40:44.040,0:40:47.160
-Similar as with "fd", sometimes
-it's not as useful
+Sama seperti dengan "fd", terkadang
+tidak terlalu berguna
 
 0:40:48.400,0:40:50.619
-using one specific tool or another and
+menggunakan satu tool tertentu atau yang lain dan
 
 0:40:50.620,0:40:55.780
-in fact, as ripgrep, there are several
-other tools. Like "ack",
+faktanya, seperti ripgrep, ada beberapa
+tool lain. Seperti "ack",
 
 0:40:55.780,0:40:57.700
-is the original grep alternative that was
+adalah alternatif grep asli yang
 
 0:40:57.700,0:41:00.670
-written. Then the silver searcher,
+ditulis. Kemudian the silver searcher,
 
 0:41:00.670,0:41:04.089
-"ag", was another one... and they're all
+"ag", adalah yang lain... dan semuanya
 
 0:41:04.089,0:41:05.589
-pretty much interchangeable so
+kurang lebih dapat dipertukarkan sehingga
 
 0:41:05.589,0:41:07.630
-maybe you're at a system that has one and
+mungkin kalian berada di sistem yang memiliki satu dan
 
 0:41:07.630,0:41:09.670
-not the other, just knowing that you can
+bukan yang lain, hanya mengetahui bahwa kalian bisa
 
 0:41:09.670,0:41:12.040
-use these things with these tools can be
+menggunakan hal-hal ini dengan tool-tool ini bisa
 
 0:41:12.040,0:41:15.549
-fairly useful. Lastly, I want to cover
+sangat berguna. Terakhir, saya ingin membahas
 
 0:41:15.549,0:41:19.780
-how you go about, not finding files
-or code, but how you go about
+bagaimana kalian mencari, bukan file
+atau kode, tapi bagaimana kalian mencari
 
 0:41:19.780,0:41:22.540
-finding commands that you already
+perintah yang sudah pernah
 
 0:41:22.540,0:41:30.160
-some time figured out. The first, obvious
-way is just using the up arrow,
+kalian temukan sebelumnya. Yang pertama, jelas
+cara adalah hanya menggunakan panah atas,
 
 0:41:30.160,0:41:34.540
-and slowly going through all your history,
-looking for these matches.
+dan perlahan melewati semua history kalian,
+mencari kecocokan ini.
 
 0:41:34.540,0:41:36.490
-This is actually not very efficient, as
+Ini sebenarnya tidak sangat efisien, seperti
 
 0:41:36.490,0:41:42.579
-you probably guessed. So the bash
-has ways to do this more easily.
+yang mungkin kalian duga. Jadi bash
+memiliki cara untuk melakukan ini dengan lebih mudah.
 
 0:41:42.579,0:41:44.619
-There is the "history" command, that will
+Ada perintah "history", yang akan
 
 0:41:44.619,0:41:49.180
-print your history. Here I'm in zsh and
-it only prints some of my history, but
+mencetak history kalian. Di sini saya di zsh dan
+hanya mencetak beberapa history saya, tapi
 
 0:41:49.180,0:41:54.069
-if I say, I want you to print everything
-from the beginning of time, it will print
+jika saya bilang, saya ingin kalian mencetak semuanya
+dari awal waktu, akan mencetak
 
 0:41:54.069,0:41:58.220
-everything from the beginning
-of whatever this history is.
+semuanya dari awal
+apa pun history ini.
 
 0:41:58.220,0:42:00.700
-And since this is a lot of results,
+Dan karena ini banyak hasil,
 
 0:42:00.700,0:42:02.589
-maybe we care about the ones where we
+mungkin kita peduli pada yang kita
 
 0:42:02.589,0:42:08.490
-use the "convert" command to go from some
-type of file to some other type of file.
+gunakan perintah "convert" untuk pergi dari beberapa
+jenis file ke jenis file lain.
 
 0:42:08.490,0:42:12.940
-Some image, sorry. Then, we're getting all
+Beberapa gambar, maaf. Kemudian, kita mendapatkan semua
 
 0:42:12.940,0:42:15.849
-these results here, about all the ones
+hasil ini di sini, tentang semua yang
 
 0:42:15.849,0:42:18.120
-that match this substring.
+cocok dengan substring ini.
 
 0:42:21.280,0:42:24.609
-Even more, pretty much all shells by default will
+Lebih lanjut, hampir semua shell secara default akan
 
 0:42:24.609,0:42:27.130
-link "Ctrl+R", the keybinding,
+menautkan "Ctrl+R", keybinding,
 
 0:42:27.130,0:42:29.680
-to do backward search. Here we
+untuk melakukan pencarian mundur. Di sini kita
 
 0:42:29.680,0:42:31.569
-have backward search, where we can
+memiliki pencarian mundur, di mana kita bisa
 
 0:42:31.569,0:42:34.750
-type "convert" and it's finding the
+mengetik "convert" dan menemukan
 
 0:42:34.750,0:42:36.609
-command that we just typed. And if we just
+perintah yang baru saja kita ketik. Dan jika kita hanya
 
 0:42:36.609,0:42:38.619
-keep hitting "Ctrl+R", it will
+terus menekan "Ctrl+R", akan
 
 0:42:38.619,0:42:41.740
-kind of go through these matches and
+melewati kecocokan-kecocokan ini dan
 
 0:42:41.740,0:42:44.260
-it will let re-execute it
+akan membiarkan kita mengeksekusi ulang
 
 0:42:44.260,0:42:49.240
-in place. Another thing that you can do,
+di tempat. Hal lain yang bisa kalian lakukan,
 
 0:42:49.240,0:42:51.069
-related to that, is you can use this
+terkait dengan itu, adalah kalian bisa menggunakan
 
 0:42:51.069,0:42:53.829
-really nifty tool called "fzf", which is
+tool yang sangat rapi ini disebut "fzf", yang
 
 0:42:53.829,0:42:56.280
-like a fuzzy finder, like it will...
+seperti fuzzy finder, yang akan...
 
 0:42:57.100,0:42:58.480
-It will let you do kind of
+Ini akan membiarkan kalian melakukan semacam
 
 0:42:58.480,0:43:02.200
-like an interactive grep. We could do
+grep interaktif. Kita bisa melakukan
 
 0:43:02.200,0:43:06.369
-for example this, where we can cat our
+misalnya ini, di mana kita bisa cat
 
 0:43:06.369,0:43:10.030
-example.sh command, that will print
+perintah example.sh kita, yang akan mencetak
 
 0:43:10.030,0:43:11.680
-print to the standard output, and then we
+ke standard output, dan kemudian kita
 
 0:43:11.680,0:43:14.290
-can pipe it through fzf. It's just getting
+bisa pipe melalui fzf. Hanya mendapatkan
 
 0:43:14.290,0:43:18.490
-all the lines and then we can
-interactively look for the
+semua baris dan kemudian kita bisa
+secara interaktif mencari
 
 0:43:18.490,0:43:21.849
-string that we care about. And the nice
+string yang kita pedulikan. Dan hal bagus
 
 0:43:21.849,0:43:26.349
-thing about fzf is that, if you enable
-the default bindings, it will bind to
+tentang fzf adalah, jika kalian mengaktifkan
+binding default, akan mengikat ke
 
 0:43:26.349,0:43:33.670
-your "Ctrl+R" shell execution and now
+eksekusi shell "Ctrl+R" kalian dan sekarang
 
 0:43:33.670,0:43:36.490
-you can quickly and dynamically like
+kalian bisa dengan cepat dan dinamis
 
 0:43:36.490,0:43:41.700
-look for all the times you try to
-convert a favicon in your history.
+mencari semua kali kalian mencoba
+mengonversi favicon di history kalian.
 
 0:43:42.020,0:43:46.375
-And it's also like fuzzy matching,
-whereas like by default in grep
+Dan juga seperti fuzzy matching,
+sedangkan secara default di grep
 
 0:43:46.375,0:43:49.420
-or these things you have to write a regex or some
+atau hal-hal ini kalian harus menulis regex atau beberapa
 
 0:43:49.420,0:43:52.360
-expression that will match within here.
+ekspresi yang akan cocok di sini.
 
 0:43:52.360,0:43:54.609
-Here I'm just typing "convert" and "favicon" and
+Di sini saya hanya mengetik "convert" dan "favicon" dan
 
 0:43:54.609,0:43:57.369
-it's just trying to do the best scan,
+hanya mencoba melakukan pemindaian terbaik,
 
 0:43:57.369,0:44:01.349
-doing the match in the lines it has.
+mencocokkan di baris yang dimilikinya.
 
 0:44:01.349,0:44:06.190
-Lastly, a tool that probably you have
-already seen, that I've been using
+Terakhir, tool yang mungkin sudah kalian
+lihat, yang telah saya gunakan
 
 0:44:06.190,0:44:08.410
-for not retyping these extremely long
+untuk tidak mengetik ulang perintah yang sangat panjang
 
 0:44:08.410,0:44:13.080
-commands is this "history
-substring search", where
+ini adalah "history
+substring search", di mana
 
 0:44:13.940,0:44:15.660
-as I type in my shell,
+saat saya mengetik di shell saya,
 
 0:44:15.670,0:44:19.630
-and both F fail to mention but both face
+(dan kedua F gagal menyebutkan tapi kedua face
 
 0:44:19.630,0:44:22.760
-which I think was originally introduced,
-this concept, and then
+yang saya pikir awalnya memperkenalkan
+konsep ini, dan kemudian
 
 0:44:22.760,0:44:25.760
-zsh has a really nice implementation)
+zsh memiliki implementasi yang sangat bagus)
 
 0:44:25.760,0:44:26.800
-what it'll let you do is
+yang akan membiarkan kalian melakukan adalah
 
 0:44:26.800,0:44:31.300
-as you type the command, it will
-dynamically search back in your
+saat kalian mengetik perintah, akan
+secara dinamis mencari kembali di
 
 0:44:31.300,0:44:34.420
-history to the same command
-that has a common prefix,
+history kalian ke perintah yang sama
+yang memiliki prefiks umum,
 
 0:44:34.980,0:44:36.900
-and then, if you...
+dan kemudian, jika kalian...
 
 0:44:39.100,0:44:42.100
-it will change as the match list stops
+akan berubah saat daftar kecocokan berhenti
 
 0:44:42.100,0:44:44.110
-working and then as you do the
+berfungsi dan kemudian saat kalian melakukan
 
 0:44:44.120,0:44:49.760
-right arrow you can select that
-command and then re-execute it.
+panah kanan kalian bisa memilih
+perintah itu dan kemudian mengeksekusi ulang.
 
 0:45:05.800,0:45:09.920
-We've seen a bunch of stuff... I think I have
+Kita telah melihat banyak hal... saya pikir saya punya
 
 0:45:09.940,0:45:16.180
-a few minutes left so I'm going
-to cover a couple of tools to do
+beberapa menit tersisa jadi saya akan
+membahas beberapa tool untuk melakukan
 
 0:45:16.180,0:45:20.060
-really quick directory listing
-and directory navigation.
+daftar direktori dan navigasi direktori
+dengan sangat cepat.
 
 0:45:20.060,0:45:30.020
-So you can always use the "-R" to recursively
-list some directory structure,
+Jadi kalian bisa selalu menggunakan "-R" untuk secara rekursif
+mendaftar beberapa struktur direktori,
 
 0:45:30.020,0:45:35.160
-but that can be suboptimal, I cannot
-really make sense of this easily.
+tapi itu bisa suboptimal, saya tidak bisa
+benar-benar memahami ini dengan mudah.
 
 0:45:36.340,0:45:44.460
-There's tool called "tree" that will
-be the much more friendly form of
+Ada tool yang disebut "tree" yang akan
+menjadi cara yang jauh lebih ramah untuk
 
 0:45:44.460,0:45:47.500
-printing all the stuff, it will
-also color code based on...
+mencetak semua hal, juga akan
+memberi kode warna berdasarkan...
 
 0:45:47.500,0:45:50.680
-here for example "foo" is blue
-because it's a directory and
+di sini misalnya "foo" berwarna biru
+karena itu adalah direktori dan
 
 0:45:50.680,0:45:55.100
-this is red because it has execute permissions.
+ini merah karena memiliki izin eksekusi.
 
 0:45:55.100,0:46:00.220
-But we can go even further than
-that. There's really nice tools
+Tapi kita bisa melangkah lebih jauh dari
+itu. Ada tool yang sangat bagus
 
 0:46:00.220,0:46:04.580
-like a recent one called "broot" that
-will do the same thing but here
+seperti yang baru-baru ini disebut "broot" yang
+akan melakukan hal yang sama tapi di sini
 
 0:46:04.580,0:46:07.300
-for example instead of doing
-this thing of listing
+misalnya alih-alih melakukan
+hal mendaftar
 
 0:46:07.300,0:46:09.160
-every single file, for example in bar
+setiap file, misalnya di bar
 
 0:46:09.160,0:46:11.400
-we have these "a" through "j" files,
+kita punya file "a" sampai "j",
 
 0:46:11.400,0:46:14.260
-it will say "oh there are more, unlisted here".
+akan bilang "oh ada lebih banyak, tidak tercantum di sini".
 
 0:46:15.080,0:46:18.200
-I can actually start typing and it will again
+Saya sebenarnya bisa mulai mengetik dan akan lagi
 
 0:46:18.200,0:46:21.540
-again facily match to the files that are there
+secara fuzzy mencocokkan ke file yang ada
 
 0:46:21.540,0:46:24.800
-and I can quickly select them
-and navigate through them.
+dan saya bisa dengan cepat memilih mereka
+dan menavigasi melalui mereka.
 
 0:46:24.800,0:46:28.380
-So, again, it's good to know that
+Jadi, lagi, bagus untuk mengetahui bahwa
 
 0:46:28.380,0:46:33.340
-these things exist so you don't
-lose a large amount of time
+hal-hal ini ada sehingga kalian tidak
+kehilangan banyak waktu
 
 0:46:34.240,0:46:36.180
-going for these files.
+untuk mencari file-file ini.
 
 0:46:37.880,0:46:40.500
-There are also, I think I have it installed
+Ada juga, saya pikir saya punya terinstal
 
 0:46:40.500,0:46:44.829
-also something more similar to what
-you would expect your OS to have,
+juga sesuatu yang lebih mirip dengan apa
+yang kalian harapkan dari OS kalian,
 
 0:46:44.829,0:46:49.960
-like Nautilus or one of the Mac
-finders that have like an
+seperti Nautilus atau salah satu finder Mac
+yang memiliki
 
 0:46:49.960,0:46:59.260
-interactive input where you can just use your
-navigation arrows and quickly explore.
+input interaktif di mana kalian bisa hanya menggunakan
+panah navigasi kalian dan menjelajah dengan cepat.
 
 0:46:59.260,0:47:03.849
-It might be overkill but you'll
-be surprised how quickly you can
+Mungkin berlebihan tapi kalian akan
+terkejut betapa cepatnya kalian bisa
 
 0:47:03.849,0:47:07.839
-make sense of some directory structure
-by just navigating through it.
+memahami beberapa struktur direktori
+hanya dengan menavigasi melaluinya.
 
 0:47:07.840,0:47:12.780
-And pretty much all of these tools
-will let you edit, copy files...
+Dan hampir semua tool ini
+akan membiarkan kalian mengedit, menyalin file...
 
 0:47:12.780,0:47:16.880
-if you just look for the options for them.
+jika kalian hanya mencari opsi untuk mereka.
 
 0:47:17.600,0:47:20.100
-The last addendum is kind of going places.
+Tambahan terakhir adalah tentang berpindah tempat.
 
 0:47:20.100,0:47:24.480
-We have "cd", and "cd" is nice, it will get you
+Kita punya "cd", dan "cd" bagus, akan membawa kalian
 
 0:47:26.120,0:47:30.060
-to a lot of places. But it's pretty handy if
+ke banyak tempat. Tapi cukup berguna jika
 
 0:47:30.069,0:47:33.190
-you can like quickly go places,
+kalian bisa dengan cepat pergi ke tempat,
 
 0:47:33.190,0:47:36.730
-either you have been to recently or that
+baik yang baru-baru ini kalian kunjungi atau yang
 
 0:47:36.730,0:47:40.599
-you go frequently. And you can do this in
+sering kalian kunjungi. Dan kalian bisa melakukan ini dalam
 
 0:47:40.599,0:47:42.520
-many ways there's probably... you can start
+banyak cara mungkin... kalian bisa mulai
 
 0:47:42.520,0:47:44.319
-thinking, oh I can make bookmarks, I can
+berpikir, oh saya bisa membuat bookmark, saya bisa
 
 0:47:44.319,0:47:46.660
-make... I can make aliases in the shell,
+membuat... saya bisa membuat alias di shell,
 
 0:47:46.660,0:47:49.020
-that we will cover at some point,
+yang akan kita bahas nanti,
 
 0:47:49.020,0:47:53.020
-symlinks... But at this point,
+symlink... Tapi pada titik ini,
 
 0:47:53.020,0:47:54.910
-programmers have like built all these
+programmer telah membangun semua tool ini,
 
 0:47:54.910,0:47:56.799
-tools, so programmers have already figured
+jadi programmer sudah menemukan
 
 0:47:56.799,0:47:59.520
-out a really nice way of doing this.
+cara yang sangat bagus untuk melakukan ini.
 
 0:47:59.520,0:48:01.930
-One way of doing this is using what is
+Salah satu cara melakukan ini adalah menggunakan apa yang
 
 0:48:01.930,0:48:05.760
-called "auto jump", which I
-think is not loaded here...
+disebut "auto jump", yang saya
+pikir tidak dimuat di sini...
 
 0:48:14.140,0:48:20.100
-Okay, don't worry. I will cover it
-in the command line environment.
+Oke, tidak apa-apa. Saya akan membahasnya
+di command line environment.
 
 0:48:21.960,0:48:25.579
-I think it's because I disabled
-the "Ctrl+R" and that also
+Saya pikir itu karena saya menonaktifkan
+"Ctrl+R" dan itu juga
 
 0:48:25.579,0:48:31.309
-affected other parts of the script.
-I think at this point if anyone has
+mempengaruhi bagian lain dari script.
+Saya pikir pada titik ini jika ada yang memiliki
 
 0:48:31.309,0:48:35.480
-any questions that are related to this,
-I'll be more than happy to answer
+pertanyaan yang terkait dengan ini,
+saya akan dengan senang hati menjawab
 
 0:48:35.480,0:48:37.509
-them, if anything was left unclear.
+mereka, jika ada yang masih belum jelas.
 
 0:48:37.509,0:48:42.859
-Otherwise, a there's a bunch of
-exercises that we wrote, kind of
+Jika tidak, ada banyak
+latihan yang kami tulis, yang
 
 0:48:42.859,0:48:46.549
-touching on these topics and we
-encourage you to try them and
+menyinggung topik-topik ini dan kami
+mendorong kalian untuk mencobanya dan
 
 0:48:46.549,0:48:48.559
-come to office hours, where we can help
+datang ke jam kantor, di mana kami bisa membantu
 
 0:48:48.559,0:48:54.569
-you figure out how to do them, or some
-bash quirks that are not clear.
+kalian mencari tahu cara melakukannya, atau beberapa
+keunikan bash yang tidak jelas.
 


### PR DESCRIPTION
## Masalah

Setelah merge PR sebelumnya, beberapa file kuliah masih dalam bahasa Inggris:
- _2026/agentic-coding.md
- _2026/beyond-code.md
- _2026/code-quality.md
- _2026/command-line-environment.md
- _2026/course-shell.md
- _2026/development-environment.md
- _2026/shipping-code.md
- _2020/command-line.md
- _2020/course-shell.md
- _2020/data-wrangling.md
- _2020/debugging-profiling.md
- _2020/editors.md
- _2020/security.md
- _2020/shell-tools.md

## Solusi

Terjemahkan seluruh konten file-file tersebut ke bahasa Indonesia:
- Terjemahkan semua heading dari bahasa Inggris ke bahasa Indonesia
- Terjemahkan semua prose dan penjelasan
- Pertahankan code blocks, commands, file paths, dan links dalam bahasa Inggris
- Gunakan 'Anda' untuk 'You' (formal)

## Verifikasi

- [x] Semua file sudah diterjemahkan
- [x] Heading sudah dalam bahasa Indonesia
- [x] Code blocks tetap dalam bahasa Inggris
- [x] Format markdown tetap intact