### PR TITLE
fix(docs): correct typo and improve SSH documentation wording

### DIFF
--- a/_2019/remote-machines.md
+++ b/_2019/remote-machines.md
@@ -100,7 +100,7 @@ A downside of `mosh` is that is does not support roaming port/graphics forwardin
 
 ### Client
 
-We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like `alias my_serer="ssh -X -i ~/.id_rsa -L 9999:localhost:8888 foobar@remote_server`, however there is a better alternative, using `~/.ssh/config`.
+We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like `alias my_server="ssh -X -i ~/.id_rsa -L 9999:localhost:8888 foobar@remote_server`, however there is a better alternative, using `~/.ssh/config`.
 
 ```bash
 Host vm

--- a/_2020/command-line.md
+++ b/_2020/command-line.md
@@ -384,7 +384,7 @@ The most common scenario is local port forwarding, where a service in the remote
 
 ## SSH Configuration
 
-We have covered many many arguments that we can pass. A tempting alternative is to create shell aliases that look like
+We have covered many arguments that we can pass. A tempting alternative is to create shell aliases that look like
 ```bash
 alias my_server="ssh -i ~/.id_ed25519 --port 2222 -L 9999:localhost:8888 foobar@remote_server"
 ```


### PR DESCRIPTION
This PR fixes a small typo in the SSH documentation and improves a few wording issues for clarity. The changes are documentation-only and do not affect functionality.