### PR TITLE
fix: restore explicit terminal output in Typer CLI example (shipping-code.md)

### DIFF
--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -225,7 +225,7 @@ import typer
 
 
 def greet(name: str) -> str:
-    return f"Hello, {name}!"
+    typer.echo(f"Hello, {name}!")
 
 
 def cli():


### PR DESCRIPTION
### Summary of Changes
Restored explicit stdout output (`typer.echo`) in the Typer CLI example inside `shipping-code.md`.

### Context & Root Cause
In a previous commit, the script was updated to use `cli()` and `typer.run(greet)`, but `print()` was accidentally dropped. Because `greet()` only performs a `return f"Hello, {name}!"`, executing the configured entry point (`greet Alice`) causes `typer.run()` to invoke `greet()` without printing anything to stdout.

As a result, learners following the guide get no terminal output when testing their newly installed CLI tool, leading to confusion about whether their `project.scripts` or package installation is broken.

### Fix
Updated `greet()` to use `typer.echo()` so that running the command produces the expected terminal output:

```python
import typer

def greet(name: str):
    typer.echo(f"Hello, {name}!")

def cli():
    typer.run(greet)

if __name__ == "__main__":
    cli()