### PR TITLE
replaced return with print

### DIFF
--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -187,7 +187,7 @@ $ python -c "from greet import greet; greet('World')"
 Hello, World!
 
 $ cd /tmp
-$ python -c "from greet import greet; print(greet('World'))"
+$ python -c "from greet import greet; greet('World')"
 ModuleNotFoundError: No module named 'greet'
 ```
 

--- a/_2026/shipping-code.md
+++ b/_2026/shipping-code.md
@@ -181,9 +181,9 @@ Consider this example where we have a Python file `greet.py` in our current dire
 ```console
 $ cat greet.py
 def greet(name):
-    return f"Hello, {name}!"
+    print(f"Hello, {name}!")
 
-$ python -c "from greet import greet; print(greet('World'))"
+$ python -c "from greet import greet; greet('World')"
 Hello, World!
 
 $ cd /tmp
@@ -225,7 +225,7 @@ import typer
 
 
 def greet(name: str) -> str:
-    return f"Hello, {name}!"
+    print(f"Hello, {name}!")
 
 
 def cli():


### PR DESCRIPTION
Using return with typer doesn't print it in the terminal, we just get a blank output. This is since, typer discards the output it receives, instead of printing it by default.

This also matches the code with the lecture.