### PR TITLE
docs: fix os customization, tiling window management phrasing

### DIFF
--- a/_2019/os-customization.md
+++ b/_2019/os-customization.md
@@ -55,7 +55,7 @@ specific customizations online, such as Mathias Bynens'
 
 [Tiling window management](https://en.wikipedia.org/wiki/Tiling_window_manager)
 is one approach to window management, where you organize windows into
-non-overlapping frames. If you're using a Unix-based operating system, you can
+non-overlapping frames. If you're using a Linux-based operating system, you can
 install a tiling window manager; if you're using something like Windows or
 macOS, you can install applications that let you approximate this behavior.
 


### PR DESCRIPTION
* phrasing falsely implied that macOS is not Unix-based. macOS is "UNIX-based." it [satisfies](https://www.opengroup.org/openbrand/register/brand3725.htm) the Single Unix Specification (SUS)
* tiling window managers are widely available for Linux. that is likely what was meant here